### PR TITLE
Add git checkout alias to fish shell abbreviations

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -29,6 +29,7 @@
       g = "git";
       ga = "git add";
       gaa = "git add -A";
+      gco = "git checkout (git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@') && git pull";
       lg = "lazygit";
       ta = "tmux new -A -s default";
       v = "nvim";

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -29,7 +29,7 @@
       g = "git";
       ga = "git add";
       gaa = "git add -A";
-      gco = "git checkout (git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@') && git pull";
+      gco = "_gco_function";
       lg = "lazygit";
       ta = "tmux new -A -s default";
       v = "nvim";

--- a/home-manager/programs/fish/functions/_gco_function.fish
+++ b/home-manager/programs/fish/functions/_gco_function.fish
@@ -1,0 +1,3 @@
+function _gco_function
+  git checkout (git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@') && git pull
+end


### PR DESCRIPTION
Introduce a new alias for `git checkout` in the fish shell configuration to streamline the workflow for checking out the current branch and pulling updates.