### PR TITLE
Fix code-syncer watch path

### DIFF
--- a/home-manager/services/code-syncer/sync.sh
+++ b/home-manager/services/code-syncer/sync.sh
@@ -77,7 +77,7 @@ sync_all
 # Watch for changes in configuration files
 echo "Starting to watch for changes in configuration files..."
 
-fswatch -o "$VSCODE_USER_DIR/$SETTINGS_FILE" "$VSCODE_USER_DIR/$KEYBINDINGS_FILE" | while read -r changed_file; do
+fswatch "$VSCODE_USER_DIR/$SETTINGS_FILE" "$VSCODE_USER_DIR/$KEYBINDINGS_FILE" | while read -r changed_file; do
   if [[ $changed_file == *"$SETTINGS_FILE" ]]; then
     echo "Settings file changed, syncing..."
     sync_files "$SETTINGS_FILE"


### PR DESCRIPTION
## Summary
- fix fswatch invocation so we get file paths

## Testing
- `npx --yes treefmt --no-cache` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f3b54cc2883249eca4a88abc01470