### PR TITLE
Refactor Docker setup for single-user Nix installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update && apt-get install -y \
     xz-utils \
     make \
     daemon \
-    systemd \
     # Add any other system-level dependencies your script needs here
     && rm -rf /var/lib/apt/lists/*
 
@@ -38,7 +37,7 @@ RUN mkdir -p /etc/nix && \
     echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf
 
 ENV NIX_BUILD_GROUP_ID=1001
-ENV NIX_REMOTE=daemon
+ENV IN_DOCKER=true
 
 # Switch to the non-root user
 USER $USERNAME

--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,11 @@ nix-connect:
 		sudo launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist 2>/dev/null || true; \
 		sudo launchctl load -w /Library/LaunchDaemons/org.nixos.nix-daemon.plist; \
 	elif [ "$(OS)" = "Linux" ]; then \
-		if [ "$$CI" = "true" ] || [ -f /.dockerenv ]; then \
-			echo "🏃‍♂️ Skipping systemctl for Nix daemon in CI/Docker environment as it should already be configured."; \
+		if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \
+			echo "🏃‍♂️ Nix daemon management (e.g., systemctl) is skipped in CI/Docker environments."; \
+			if [ "$$IN_DOCKER" = "true" ]; then \
+				echo "ℹ️ Docker environment is using a single-user Nix installation (no separate daemon)."; \
+			fi; \
 		else \
 			sudo systemctl restart nix-daemon.service; \
 		fi; \

--- a/install.sh
+++ b/install.sh
@@ -26,8 +26,15 @@ if ! command -v nix >/dev/null 2>&1; then
     # For macOS, source the Nix profile immediately to update PATH in CI.
     . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
   else
-    curl -L https://nixos.org/nix/install | bash -s -- --daemon
+    if [ "$IN_DOCKER" = "true" ]; then
+      echo "Performing single-user Nix installation (Docker environment)..."
+      curl -L https://nixos.org/nix/install | bash -s -- --no-daemon
+    else
+      echo "Performing multi-user Nix installation..."
+      curl -L https://nixos.org/nix/install | bash -s -- --daemon
+    fi
     # For Linux multi-user installations, add the default Nix path.
+    # For single-user, the installer handles PATH or prompts the user.
     export PATH=/nix/var/nix/profiles/default/bin:$PATH
   fi
 fi


### PR DESCRIPTION
Update the Docker setup to support a single-user Nix installation and modify the Makefile for environment checks, ensuring proper handling in CI and Docker environments.