### PR TITLE
Replace 'nix' with '$(NIX_EXEC)' for command consistency in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ NIX_CONFIG_TYPE := $(shell \
 		echo "homeConfigurations"; \
 	fi)
 NIX_USERNAME := $(shell \
-	if [ "$$CI" = "true" ]; then \
+	if [ "$$IN_DOCKER" = "true" ] || [ "$$CI" = "true" ]; then \
 		echo "runner"; \
 	else \
 		echo "$(shell whoami)"; \

--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,6 @@ NIX_CONFIG_TYPE := $(shell \
 NIX_USERNAME := $(shell \
 	if [ "$$CI" = "true" ]; then \
 		echo "runner"; \
-	elif [ "$(OS)" = "Linux" ] && [ ! -f /etc/NIXOS ]; then \
-		echo "ubuntu"; \
 	else \
 		echo "$(shell whoami)"; \
 	fi)

--- a/Makefile
+++ b/Makefile
@@ -171,11 +171,11 @@ nix-build: nix-connect
 	@if [ "$$CI" = "true" ]; then \
 		echo "Running in CI"; \
 		if [ "$(OS)" = "Darwin" ]; then \
-			nix build .#$(NIX_CONFIG_TYPE).runner.system $(NIX_FLAGS) --no-update-lock-file --show-trace; \
+			$(NIX_EXEC) build .#$(NIX_CONFIG_TYPE).runner.system $(NIX_FLAGS) --no-update-lock-file --show-trace; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "nixosConfigurations" ]; then \
-			nix run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- build --flake .#runner --no-update-lock-file; \
+			$(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- build --flake .#runner --no-update-lock-file; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "homeConfigurations" ]; then \
-			nix build .#$(NIX_CONFIG_TYPE)."runner@$(NIX_SYSTEM)".activationPackage $(NIX_FLAGS) --no-update-lock-file --show-trace; \
+			$(NIX_EXEC) build .#$(NIX_CONFIG_TYPE)."runner@$(NIX_SYSTEM)".activationPackage $(NIX_FLAGS) --no-update-lock-file --show-trace; \
 		else \
 			echo "Unsupported OS $(OS) for non-CI build"; \
 			exit 1; \
@@ -185,11 +185,11 @@ nix-build: nix-connect
 			echo "❌ Unsupported system architecture: $(OS) $(ARCH)"; \
 			exit 1; \
 		elif [ "$(OS)" = "Darwin" ]; then \
-			nix build .#$(NIX_CONFIG_TYPE).$(NIX_SYSTEM).system $(NIX_FLAGS) --show-trace; \
+			$(NIX_EXEC) build .#$(NIX_CONFIG_TYPE).$(NIX_SYSTEM).system $(NIX_FLAGS) --show-trace; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "nixosConfigurations" ]; then \
 			sudo $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- build --flake .#$(NIX_SYSTEM); \
 		elif [ "$(NIX_CONFIG_TYPE)" = "homeConfigurations" ]; then \
-			nix build .#$(NIX_CONFIG_TYPE)."$(NIX_USERNAME)@$(NIX_SYSTEM)".activationPackage $(NIX_FLAGS) --show-trace; \
+			$(NIX_EXEC) build .#$(NIX_CONFIG_TYPE)."$(NIX_USERNAME)@$(NIX_SYSTEM)".activationPackage $(NIX_FLAGS) --show-trace; \
 		else \
 			echo "Unsupported OS $(OS) for non-CI build"; \
 			exit 1; \
@@ -203,20 +203,20 @@ nix-flake-update: nix-connect
 	@if [ "$$CI" = "true" ]; then \
 		echo "Bypassing flake update in CI"; \
 	else \
-		nix flake update $(NIX_FLAGS); \
+		$(NIX_EXEC) flake update $(NIX_FLAGS); \
 	fi
 	@echo "✅ flake.lock updated!"
 
 .PHONY: nix-format
 nix-format:
 	@echo "🧹 Formatting Nix files..."
-	@nix fmt
+	@$(NIX_EXEC) fmt
 	@echo "✅ Formatting complete"
 
 .PHONY: nix-format-check
 nix-format-check:
 	@echo "🔍 Checking Nix file formatting..."
-	@nix fmt -- --fail-on-change
+	@$(NIX_EXEC) fmt -- --fail-on-change
 	@echo "✅ All Nix files are properly formatted"
 
 .PHONY: nix-switch
@@ -229,7 +229,7 @@ nix-switch:
 			echo "⏭️ NixOS switch skipped in CI as the runner is not a NixOS system"; \
 			sudo $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- switch --flake .#runner --no-update-lock-file || exit 0; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "homeConfigurations" ]; then \
-			nix run $(NIX_FLAGS) .#$(NIX_CONFIG_TYPE)."$(NIX_USERNAME)@$(NIX_SYSTEM)".activationPackage; \
+			USER=$(NIX_USERNAME) $(NIX_EXEC) run $(NIX_FLAGS) .#$(NIX_CONFIG_TYPE)."$(NIX_USERNAME)@$(NIX_SYSTEM)".activationPackage; \
 		else \
 			echo "Unsupported OS $(OS) for non-CI switch"; \
 			exit 1; \
@@ -243,7 +243,7 @@ nix-switch:
 		elif [ "$(NIX_CONFIG_TYPE)" = "nixosConfigurations" ]; then \
 			sudo $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- switch --flake .#$(NIX_SYSTEM); \
 		elif [ "$(NIX_CONFIG_TYPE)" = "homeConfigurations" ]; then \
-			nix run $(NIX_FLAGS) .#$(NIX_CONFIG_TYPE)."$(NIX_USERNAME)@$(NIX_SYSTEM)".activationPackage; \
+			USER=$(NIX_USERNAME) $(NIX_EXEC) run $(NIX_FLAGS) .#$(NIX_CONFIG_TYPE)."$(NIX_USERNAME)@$(NIX_SYSTEM)".activationPackage; \
 		else \
 			echo "Unsupported OS $(OS) for non-CI switch"; \
 			exit 1; \
@@ -258,7 +258,7 @@ nix-switch-vm:
 		exit 0; \
 	fi; \
 	export QEMU_OPTS="-m 4096 -smp 2"; \
-	printf "sleep 5\nmkdir -p /tmp/test && cd /tmp/test\ncp -r /mnt/shared/* .\nnix run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- switch --flake .#runner --no-update-lock-file\npoweroff\n" > vm_commands.txt; \
+	printf "sleep 5\nmkdir -p /tmp/test && cd /tmp/test\ncp -r /mnt/shared/* .\n$(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- switch --flake .#runner --no-update-lock-file\npoweroff\n" > vm_commands.txt; \
 	timeout 600 ./result/bin/run-nixos-vm -nographic < vm_commands.txt || exit 1; \
 	rm -f vm_commands.txt
 

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,9 @@ NIX_CONFIG_TYPE := $(shell \
 		echo "homeConfigurations"; \
 	fi)
 NIX_USERNAME := $(shell \
-	if [ "$$IN_DOCKER" = "true" ] || [ "$$CI" = "true" ]; then \
+	if [ "$$IN_DOCKER" = "true" ]; then \
+		echo "runner"; \
+	elif [ "$$CI" = "true" ]; then \
 		echo "runner"; \
 	else \
 		echo "$(shell whoami)"; \
@@ -168,7 +170,7 @@ nix-backup:
 
 .PHONY: nix-build
 nix-build: nix-connect
-	@echo "🏗️ Building Nix configuration for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH)"
+	@echo "🏗️ Building Nix configuration for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH) by USER=$(NIX_USERNAME)"
 	@if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \
 		echo "Running in CI"; \
 		if [ "$(OS)" = "Darwin" ]; then \
@@ -222,7 +224,7 @@ nix-format-check:
 
 .PHONY: nix-switch
 nix-switch:
-	@echo "🔧 Activating Nix configuration for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH)"
+	@echo "🔧 Activating Nix configuration for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH) by USER=$(NIX_USERNAME)"
 	@if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \
 		if [ "$(OS)" = "Darwin" ]; then \
 			sudo $(DARWIN_REBUILD) switch --flake .#runner --no-update-lock-file; \

--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ nix-backup:
 .PHONY: nix-build
 nix-build: nix-connect
 	@echo "🏗️ Building Nix configuration for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH)"
-	@if [ "$$CI" = "true" ]; then \
+	@if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \
 		echo "Running in CI"; \
 		if [ "$(OS)" = "Darwin" ]; then \
 			$(NIX_EXEC) build .#$(NIX_CONFIG_TYPE).runner.system $(NIX_FLAGS) --no-update-lock-file --show-trace; \
@@ -223,7 +223,7 @@ nix-format-check:
 .PHONY: nix-switch
 nix-switch:
 	@echo "🔧 Activating Nix configuration for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH)"
-	@if [ "$$CI" = "true" ]; then \
+	@if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \
 		if [ "$(OS)" = "Darwin" ]; then \
 			sudo $(DARWIN_REBUILD) switch --flake .#runner --no-update-lock-file; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "nixosConfigurations" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,7 @@ NIX_CONFIG_TYPE := $(shell \
 		echo "homeConfigurations"; \
 	fi)
 NIX_USERNAME := $(shell \
-	if [ "$$IN_DOCKER" = "true" ]; then \
-		echo "runner"; \
-	elif [ "$$CI" = "true" ]; then \
+	if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \
 		echo "runner"; \
 	else \
 		echo "$(shell whoami)"; \

--- a/install.sh
+++ b/install.sh
@@ -29,23 +29,13 @@ if ! command -v nix >/dev/null 2>&1; then
     if [ "$IN_DOCKER" = "true" ]; then
       echo "Performing single-user Nix installation (Docker environment)..."
       curl -L https://nixos.org/nix/install | bash -s -- --no-daemon
-      # Source the Nix profile for single-user installation
-      # shellcheck disable=SC1090 disable=SC1091
-      . "$HOME/.nix-profile/etc/profile.d/nix.sh"
     else
       echo "Performing multi-user Nix installation..."
       curl -L https://nixos.org/nix/install | bash -s -- --daemon
-      # For Linux multi-user installations, source the Nix profile script
-      # This makes 'nix' command available in the current script execution.
-      NIX_DAEMON_PROFILE="/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
-      if [ -f "$NIX_DAEMON_PROFILE" ]; then
-        # shellcheck disable=SC1090 disable=SC1091
-        . "$NIX_DAEMON_PROFILE"
-      fi
     fi
-    # The sourcing above handles PATH and other environment variables.
-    # The old line below is removed:
-    # export PATH=/nix/var/nix/profiles/default/bin:$PATH
+    # For Linux multi-user installations, add the default Nix path.
+    # For single-user, the installer handles PATH or prompts the user.
+    export PATH=/nix/var/nix/profiles/default/bin:$PATH
   fi
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -29,13 +29,23 @@ if ! command -v nix >/dev/null 2>&1; then
     if [ "$IN_DOCKER" = "true" ]; then
       echo "Performing single-user Nix installation (Docker environment)..."
       curl -L https://nixos.org/nix/install | bash -s -- --no-daemon
+      # Source the Nix profile script to add Nix to PATH for the current session
+      # This is crucial for the subsequent 'make install' to find 'nix'
+      if [ -f "$HOME/.nix-profile/etc/profile.d/nix.sh" ]; then
+        . "$HOME/.nix-profile/etc/profile.d/nix.sh"
+        echo "Sourced Nix profile for single-user (Docker) setup."
+      else
+        echo "Warning: Nix profile script ($HOME/.nix-profile/etc/profile.d/nix.sh) not found after installation."
+        # As an additional fallback, try adding the common single-user bin path
+        export PATH="$HOME/.nix-profile/bin:$PATH"
+      fi
     else
       echo "Performing multi-user Nix installation..."
       curl -L https://nixos.org/nix/install | bash -s -- --daemon
+      # For Linux multi-user installations, add the default Nix path.
+      # For single-user, the installer handles PATH or prompts the user.
+      export PATH=/nix/var/nix/profiles/default/bin:$PATH
     fi
-    # For Linux multi-user installations, add the default Nix path.
-    # For single-user, the installer handles PATH or prompts the user.
-    export PATH=/nix/var/nix/profiles/default/bin:$PATH
   fi
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,6 @@
 
 # Exit on error
 set -e
-NIX_PROFILE_TO_SOURCE=""
 
 # Determine OS using uname
 OS_NAME=$(uname)
@@ -25,30 +24,28 @@ if ! command -v nix >/dev/null 2>&1; then
   if [ "$OS" = "macos" ]; then
     curl -L https://nixos.org/nix/install | bash
     # For macOS, source the Nix profile immediately to update PATH in CI.
-    # shellcheck disable=SC1090 disable=SC1091
     . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-    NIX_PROFILE_TO_SOURCE="/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
-  else # Linux
+  else
     if [ "$IN_DOCKER" = "true" ]; then
       echo "Performing single-user Nix installation (Docker environment)..."
       curl -L https://nixos.org/nix/install | bash -s -- --no-daemon
       # Source the Nix profile for single-user installation
       # shellcheck disable=SC1090 disable=SC1091
       . "$HOME/.nix-profile/etc/profile.d/nix.sh"
-      NIX_PROFILE_TO_SOURCE="$HOME/.nix-profile/etc/profile.d/nix.sh"
     else
       echo "Performing multi-user Nix installation..."
       curl -L https://nixos.org/nix/install | bash -s -- --daemon
       # For Linux multi-user installations, source the Nix profile script
       # This makes 'nix' command available in the current script execution.
-      _NIX_DAEMON_PROFILE="/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
-      if [ -f "$_NIX_DAEMON_PROFILE" ]; then
+      NIX_DAEMON_PROFILE="/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
+      if [ -f "$NIX_DAEMON_PROFILE" ]; then
         # shellcheck disable=SC1090 disable=SC1091
-        . "$_NIX_DAEMON_PROFILE"
-        NIX_PROFILE_TO_SOURCE="$_NIX_DAEMON_PROFILE"
+        . "$NIX_DAEMON_PROFILE"
       fi
     fi
     # The sourcing above handles PATH and other environment variables.
+    # The old line below is removed:
+    # export PATH=/nix/var/nix/profiles/default/bin:$PATH
   fi
 fi
 
@@ -100,10 +97,4 @@ fi
 
 # Install Nix packages
 echo "Running installation commands..."
-if [ -n "$NIX_PROFILE_TO_SOURCE" ] && [ -f "$NIX_PROFILE_TO_SOURCE" ]; then
-  echo "Running make install within a bash subshell with Nix profile $NIX_PROFILE_TO_SOURCE sourced..."
-  bash -c ". "$NIX_PROFILE_TO_SOURCE" && make install"
-else
-  echo "Running make install directly (Nix presumed to be in PATH or not needed by make)..."
-  make install
-fi
+make install

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,8 @@ Linux)
   ;;
 esac
 
-NIX_EFFECTIVE_BIN_PATH="" # Initialize
+# Initialize
+NIX_EFFECTIVE_BIN_PATH="" 
 
 # Install Nix if not already installed
 if ! command -v nix >/dev/null 2>&1; then
@@ -67,7 +68,7 @@ else
     else
       NIX_EFFECTIVE_BIN_PATH="/nix/var/nix/profiles/default/bin"
     fi
-     echo "Using fallback NIX_EFFECTIVE_BIN_PATH: $NIX_EFFECTIVE_BIN_PATH"
+    echo "Using fallback NIX_EFFECTIVE_BIN_PATH: $NIX_EFFECTIVE_BIN_PATH"
   fi
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -29,13 +29,23 @@ if ! command -v nix >/dev/null 2>&1; then
     if [ "$IN_DOCKER" = "true" ]; then
       echo "Performing single-user Nix installation (Docker environment)..."
       curl -L https://nixos.org/nix/install | bash -s -- --no-daemon
+      # Source the Nix profile for single-user installation
+      # shellcheck disable=SC1090 disable=SC1091
+      . "$HOME/.nix-profile/etc/profile.d/nix.sh"
     else
       echo "Performing multi-user Nix installation..."
       curl -L https://nixos.org/nix/install | bash -s -- --daemon
+      # For Linux multi-user installations, source the Nix profile script
+      # This makes 'nix' command available in the current script execution.
+      NIX_DAEMON_PROFILE="/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
+      if [ -f "$NIX_DAEMON_PROFILE" ]; then
+        # shellcheck disable=SC1090 disable=SC1091
+        . "$NIX_DAEMON_PROFILE"
+      fi
     fi
-    # For Linux multi-user installations, add the default Nix path.
-    # For single-user, the installer handles PATH or prompts the user.
-    export PATH=/nix/var/nix/profiles/default/bin:$PATH
+    # The sourcing above handles PATH and other environment variables.
+    # The old line below is removed:
+    # export PATH=/nix/var/nix/profiles/default/bin:$PATH
   fi
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,8 @@ Linux)
   ;;
 esac
 
+NIX_EFFECTIVE_BIN_PATH="" # Initialize
+
 # Install Nix if not already installed
 if ! command -v nix >/dev/null 2>&1; then
   echo "Installing Nix..."
@@ -25,27 +27,47 @@ if ! command -v nix >/dev/null 2>&1; then
     curl -L https://nixos.org/nix/install | bash
     # For macOS, source the Nix profile immediately to update PATH in CI.
     . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-  else
+    NIX_EFFECTIVE_BIN_PATH="/nix/var/nix/profiles/default/bin"
+  else # Linux
     if [ "$IN_DOCKER" = "true" ]; then
       echo "Performing single-user Nix installation (Docker environment)..."
       curl -L https://nixos.org/nix/install | bash -s -- --no-daemon
-      # Source the Nix profile script to add Nix to PATH for the current session
-      # This is crucial for the subsequent 'make install' to find 'nix'
+      # Source the Nix profile script to add Nix to PATH for the current shell
       if [ -f "$HOME/.nix-profile/etc/profile.d/nix.sh" ]; then
         . "$HOME/.nix-profile/etc/profile.d/nix.sh"
         echo "Sourced Nix profile for single-user (Docker) setup."
       else
         echo "Warning: Nix profile script ($HOME/.nix-profile/etc/profile.d/nix.sh) not found after installation."
-        # As an additional fallback, try adding the common single-user bin path
+        # Fallback PATH export for the current shell
         export PATH="$HOME/.nix-profile/bin:$PATH"
       fi
-    else
+      NIX_EFFECTIVE_BIN_PATH="$HOME/.nix-profile/bin"
+    else # Linux multi-user
       echo "Performing multi-user Nix installation..."
       curl -L https://nixos.org/nix/install | bash -s -- --daemon
-      # For Linux multi-user installations, add the default Nix path.
-      # For single-user, the installer handles PATH or prompts the user.
+      # For Linux multi-user installations, add the default Nix path for the current shell.
       export PATH=/nix/var/nix/profiles/default/bin:$PATH
+      NIX_EFFECTIVE_BIN_PATH="/nix/var/nix/profiles/default/bin"
     fi
+  fi
+else
+  echo "Nix is already installed."
+  # Determine NIX_EFFECTIVE_BIN_PATH from existing Nix installation
+  _nix_executable_path=$(command -v nix)
+  if [ -n "$_nix_executable_path" ]; then
+    NIX_EFFECTIVE_BIN_PATH=$(dirname "$_nix_executable_path")
+    echo "Determined existing NIX_EFFECTIVE_BIN_PATH as: $NIX_EFFECTIVE_BIN_PATH"
+  else
+    echo "Warning: Nix is installed but 'command -v nix' failed to find it. PATH issues might persist."
+    # Fallback for safety, though 'command -v nix' in the outer 'if' should have caught this.
+    if [ "$OS" = "macos" ]; then
+      NIX_EFFECTIVE_BIN_PATH="/nix/var/nix/profiles/default/bin"
+    elif [ "$IN_DOCKER" = "true" ]; then
+      NIX_EFFECTIVE_BIN_PATH="$HOME/.nix-profile/bin"
+    else
+      NIX_EFFECTIVE_BIN_PATH="/nix/var/nix/profiles/default/bin"
+    fi
+     echo "Using fallback NIX_EFFECTIVE_BIN_PATH: $NIX_EFFECTIVE_BIN_PATH"
   fi
 fi
 
@@ -97,4 +119,12 @@ fi
 
 # Install Nix packages
 echo "Running installation commands..."
-make install
+if [ -n "$NIX_EFFECTIVE_BIN_PATH" ] && [ -d "$NIX_EFFECTIVE_BIN_PATH" ]; then
+  echo "Prepending $NIX_EFFECTIVE_BIN_PATH to PATH for 'make install' command."
+  env PATH="$NIX_EFFECTIVE_BIN_PATH:$PATH" make install
+else
+  echo "Warning: NIX_EFFECTIVE_BIN_PATH ('$NIX_EFFECTIVE_BIN_PATH') is not set or not a directory."
+  echo "Running 'make install' with potentially incomplete PATH. Current PATH: $PATH"
+  echo "Attempting to find nix via 'command -v nix': $(command -v nix || echo 'nix not found in current PATH')"
+  make install
+fi


### PR DESCRIPTION
Ensure consistent usage of the `$(NIX_EXEC)` variable in commands throughout the Makefile for improved clarity and maintainability.