### PR TITLE
Add USERNAME build argument and support for aarch64-linux runner

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,6 +49,7 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
           build-args: |
             COMMIT_SHA=${{ github.sha }}
+            USERNAME=runner
           cache-from: type=gha
           cache-to: type=gha,mode=max
   docker-check:

--- a/Makefile
+++ b/Makefile
@@ -293,5 +293,5 @@ shell-update: shell-install
 .PHONY: docker-build
 docker-build:
 	@echo "🐳 Building Docker image: $(DOCKER_IMAGE_LATEST) and $(DOCKER_IMAGE_TAGGED)..."
-	@docker build -t $(DOCKER_IMAGE_LATEST) -t $(DOCKER_IMAGE_TAGGED) -f Dockerfile .
+	@docker build --build-arg USERNAME=runner -t $(DOCKER_IMAGE_LATEST) -t $(DOCKER_IMAGE_TAGGED) -f Dockerfile .
 	@echo "✅ Docker image built: $(DOCKER_IMAGE_LATEST) and $(DOCKER_IMAGE_TAGGED)"

--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,12 @@
             isRunner = true;
             username = "runner";
           };
+          "runner@aarch64-linux" = import ./hosts/linux {
+            inherit inputs;
+            isRunner = true;
+            username = "runner";
+            hostname = "aarch64-linux";
+          };
         };
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -62,17 +62,19 @@
           "ubuntu@x86_64-linux" = import ./hosts/linux {
             inherit inputs;
             username = "ubuntu";
+            system = "x86_64-linux";
           };
           "runner@x86_64-linux" = import ./hosts/linux {
             inherit inputs;
             isRunner = true;
             username = "runner";
+            system = "x86_64-linux";
           };
           "runner@aarch64-linux" = import ./hosts/linux {
             inherit inputs;
             isRunner = true;
             username = "runner";
-            hostname = "aarch64-linux";
+            system = "aarch64-linux";
           };
         };
       };

--- a/hosts/linux/default.nix
+++ b/hosts/linux/default.nix
@@ -10,7 +10,12 @@ in
 home-manager.lib.homeManagerConfiguration {
   pkgs = inputs.nixpkgs.legacyPackages.${system};
   extraSpecialArgs = {
-    inherit inputs username isRunner system;
+    inherit
+      inputs
+      username
+      isRunner
+      system
+      ;
   };
   modules = [
     ../../home-manager/default.nix

--- a/hosts/linux/default.nix
+++ b/hosts/linux/default.nix
@@ -1,17 +1,16 @@
 {
   inputs,
   username,
-  hostname ? "x86_64-linux",
+  system,
   isRunner ? false,
 }:
 let
   inherit (inputs) home-manager;
-  system = "x86_64-linux";
 in
 home-manager.lib.homeManagerConfiguration {
   pkgs = inputs.nixpkgs.legacyPackages.${system};
   extraSpecialArgs = {
-    inherit inputs username isRunner;
+    inherit inputs username isRunner system;
   };
   modules = [
     ../../home-manager/default.nix
@@ -22,5 +21,6 @@ home-manager.lib.homeManagerConfiguration {
       };
       programs.home-manager.enable = true;
     }
+    { nixpkgs.system = system; }
   ];
 }


### PR DESCRIPTION
Introduce a USERNAME build argument for the Docker image and add support for the aarch64-linux runner in the flake.nix configuration.