### PR TITLE
Improve Nix setup clarity and daemon restart logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,13 @@ nix-connect:
 				echo "ℹ️ Docker environment is using a single-user Nix installation (no separate daemon)."; \
 			fi; \
 		else \
-			sudo systemctl restart nix-daemon.service; \
+			if [ -d /run/systemd/system ] && [ -S /run/systemd/private ]; then \
+				echo "🐧 systemd detected as PID 1. Attempting to restart nix-daemon.service..."; \
+				sudo systemctl restart nix-daemon.service; \
+			else \
+				echo "🏃‍♂️ systemd not detected as PID 1 or not fully operational. Nix daemon management via systemctl is skipped."; \
+				echo "ℹ️ This environment might be using a single-user Nix installation, require manual daemon setup, or be inside a container without full systemd."; \
+			fi; \
 		fi; \
 	else \
 		echo "❌ Unsupported OS: $(OS)"; \

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ nix-setup: nix-install nix-check nix-connect
 
 .PHONY: nix-connect
 nix-connect:
-	@echo "🔌 Ensuring Nix daemon is running for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH)"
+	@echo "🔌 Ensuring Nix daemon is running for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH) for USER=$(NIX_USERNAME)"
 	@if [ "$(OS)" = "Darwin" ]; then \
 		sudo launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist 2>/dev/null || true; \
 		sudo launchctl load -w /Library/LaunchDaemons/org.nixos.nix-daemon.plist; \
@@ -136,7 +136,7 @@ nix-connect:
 
 .PHONY: nix-check
 nix-check:
-	@echo "🔍 Verifying Nix environment setup for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH)"
+	@echo "🔍 Verifying Nix environment setup for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH) for USER=$(NIX_USERNAME)"
 	@if [ "$(NIX_ENV)" = "not_found" ]; then \
 		echo "❌ Nix environment not found. Please ensure Nix is installed and run:"; \
 		exit 1; \
@@ -146,7 +146,7 @@ nix-check:
 .PHONY: nix-install
 nix-install:
 	@if [ "$(NIX_ENV)" = "not_found" ]; then \
-		echo "🚀 Installing Nix environment for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH)"; \
+		echo "🚀 Installing Nix environment for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH) for USER=$(NIX_USERNAME)"; \
 		curl -L https://nixos.org/nix/install | sh; \
 	fi
 	@echo "✅ Nix environment installed!"
@@ -158,7 +158,7 @@ nix-update: nix-build nix-switch
 
 .PHONY: nix-backup
 nix-backup:
-	@echo "🗄️ Backing up configuration files for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH)"
+	@echo "🗄️ Backing up configuration files for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH) for USER=$(NIX_USERNAME)"
 	@backup_dir="$$HOME/.config/backups/$(shell date +%Y%m%d_%H%M%S)"; \
 	mkdir -p "$$backup_dir"; \
 	if [ -d "$$HOME/.config" ]; then \
@@ -168,7 +168,7 @@ nix-backup:
 
 .PHONY: nix-build
 nix-build: nix-connect
-	@echo "🏗️ Building Nix configuration for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH) by USER=$(NIX_USERNAME)"
+	@echo "🏗️ Building Nix configuration for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH) for USER=$(NIX_USERNAME)"
 	@if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \
 		echo "Running in CI"; \
 		if [ "$(OS)" = "Darwin" ]; then \
@@ -222,7 +222,7 @@ nix-format-check:
 
 .PHONY: nix-switch
 nix-switch:
-	@echo "🔧 Activating Nix configuration for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH) by USER=$(NIX_USERNAME)"
+	@echo "🔧 Activating Nix configuration for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH) for USER=$(NIX_USERNAME)"
 	@if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \
 		if [ "$(OS)" = "Darwin" ]; then \
 			sudo $(DARWIN_REBUILD) switch --flake .#runner --no-update-lock-file; \


### PR DESCRIPTION
Enhance clarity in Nix setup messages by including the USER variable. Improve the Nix daemon restart logic in the Makefile to better detect systemd environments.