### PR TITLE
Add multi-platform support for Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,12 @@ permissions:
   packages: write
 jobs:
   build-and-push:
+    strategy:
+      matrix:
+        fail-fast: false
+        platform:
+          - linux/amd64
+          - linux/arm64
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -44,6 +50,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,8 +16,8 @@ permissions:
 jobs:
   build-and-push:
     strategy:
+      fail-fast: false
       matrix:
-        fail-fast: false
         platform:
           - linux/amd64
           - linux/arm64


### PR DESCRIPTION
Introduce a matrix strategy to enable building and pushing Docker images for multiple platforms, specifically linux/amd64 and linux/arm64.