### PR TITLE
chore: Add support for root user configurations on x86_64 and aarch64 Linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,20 @@
             pkgs = inputs.nixpkgs.legacyPackages."x86_64-linux";
             lib = inputs.nixpkgs.legacyPackages."x86_64-linux".lib;
           };
+          "root@x86_64-linux" = import ./hosts/linux {
+            inherit inputs;
+            username = "root";
+            system = "x86_64-linux";
+            pkgs = inputs.nixpkgs.legacyPackages."x86_64-linux";
+            lib = inputs.nixpkgs.legacyPackages."x86_64-linux".lib;
+          };
+          "root@aarch64-linux" = import ./hosts/linux {
+            inherit inputs;
+            username = "root";
+            system = "aarch64-linux";
+            pkgs = inputs.nixpkgs.legacyPackages."aarch64-linux";
+            lib = inputs.nixpkgs.legacyPackages."aarch64-linux".lib;
+          };
           "runner@x86_64-linux" = import ./hosts/linux {
             inherit inputs;
             isRunner = true;


### PR DESCRIPTION
Introduce configurations for root users on both x86_64 and aarch64 Linux systems to enhance compatibility and usability.