### PR TITLE
Update home directory configuration for root user in Nix setup

### DIFF
--- a/hosts/linux/default.nix
+++ b/hosts/linux/default.nix
@@ -25,7 +25,7 @@ home-manager.lib.homeManagerConfiguration {
     {
       home = {
         username = username;
-        homeDirectory = "/home/${username}";
+        homeDirectory = if username == "root" then "/root" else "/home/${username}";
       };
       programs.home-manager.enable = true;
     }


### PR DESCRIPTION
Adjust the home directory path for the root user in the Nix configuration to point to `/root` instead of the default `/home/root`.