### PR TITLE
feat: Update home directory configuration for root user in Nix setup

### DIFF
--- a/hosts/linux/default.nix
+++ b/hosts/linux/default.nix
@@ -25,7 +25,7 @@ home-manager.lib.homeManagerConfiguration {
     {
       home = {
         username = username;
-        homeDirectory = if username == "root" then "/root" else "/home/${username}";
+        homeDirectory = lib.mkForce (if username == "root" then "/root" else "/home/${username}");
       };
       programs.home-manager.enable = true;
     }

--- a/hosts/linux/default.nix
+++ b/hosts/linux/default.nix
@@ -25,7 +25,7 @@ home-manager.lib.homeManagerConfiguration {
     {
       home = {
         username = username;
-        homeDirectory = "/home/${username}";
+        homeDirectory = if username == "root" then "/root" else "/home/${username}";
       };
       programs.home-manager.enable = true;
     }


### PR DESCRIPTION
Force the assignment of the home directory for the root user in the Nix configuration to ensure proper setup.