### PR TITLE
fix: Fix comment typo

### DIFF
--- a/config/hammerspoon/init.lua
+++ b/config/hammerspoon/init.lua
@@ -3,7 +3,7 @@ local hotkey = require("hs.hotkey")
 -- hyper key
 local hyper = { "alt", "ctrl", "cmd", "shift" }
 
--- disable anymations
+-- disable animations
 hs.window.animationDuration = 0
 
 hotkey.bind(hyper, "\\", function()


### PR DESCRIPTION
## Summary
- fix small typo in Hammerspoon config comment

## Testing
- `nix fmt`
- `nix fmt -- --fail-on-change`


------
https://chatgpt.com/codex/tasks/task_e_683f700e552c8324828345911d5a914e