### PR TITLE
Add PR metadata to Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,11 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{raw}}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+          labels: |
+            org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.source=${{ github.event.pull_request.html_url || github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.pr-number=${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
       - name: Build and Push Docker
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
## Summary
- only label Docker images with PR number when running on a pull request

## Testing
- `nix run nixpkgs#treefmt -- --fail-on-change` *(fails: formatter command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684035946bf883249d51964995ba9c91