### PR TITLE
Update Nix executable path for cross-platform compatibility

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,8 +28,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64,amd64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,amd64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR

--- a/Makefile
+++ b/Makefile
@@ -17,26 +17,18 @@ DOCKER_IMAGE_LATEST := $(DOCKER_IMAGE_NAME_BASE):latest
 DOCKER_IMAGE_TAGGED := $(DOCKER_IMAGE_NAME_BASE):$(GIT_COMMIT_SHA)
 
 # Nix executable path
-NIX_EXEC := $(shell \\
-	path_to_nix=""; \\
-	if [ "$(OS)" = "Darwin" ]; then \\
-		if [ -x "/nix/var/nix/profiles/default/bin/nix" ]; then \\
-			path_to_nix="/nix/var/nix/profiles/default/bin/nix"; \\
-		elif command -v nix 2>/dev/null; then \\
-			path_to_nix=$$(command -v nix); \\
-		else \\
-			path_to_nix="nix"; \\
-		fi; \\
-	elif [ "$(OS)" = "Linux" ]; then \\
-		if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \\
-			if [ -x "$${HOME}/.nix-profile/bin/nix" ]; then \\
-				path_to_nix="$${HOME}/.nix-profile/bin/nix"; \\
-			elif command -v nix 2>/dev/null; then \\
-				path_to_nix=$$(command -v nix); \\
-			else \\
-				path_to_nix="nix"; \\
-			fi; \\
+NIX_EXEC := $(shell \
+	path_to_nix=""; \
+	if [ "$(OS)" = "Darwin" ]; then \
+		if [ -x "/nix/var/nix/profiles/default/bin/nix" ]; then \
+			path_to_nix="/nix/var/nix/profiles/default/bin/nix"; \
+		elif command -v nix 2>/dev/null; then \
+			path_to_nix=$$(command -v nix); \
 		else \
+			path_to_nix="nix"; \
+		fi; \
+	elif [ "$(OS)" = "Linux" ]; then \
+		if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \
 			if [ -x "$${HOME}/.nix-profile/bin/nix" ]; then \
 				path_to_nix="$${HOME}/.nix-profile/bin/nix"; \
 			elif command -v nix 2>/dev/null; then \
@@ -44,14 +36,22 @@ NIX_EXEC := $(shell \\
 			else \
 				path_to_nix="nix"; \
 			fi; \
+		else \
+			if [ -x "$${HOME}/.nix-profile/bin/nix" ]; then \
+				path_to_nix="$${HOME}/.nix-profile/bin/nix"; \
+			elif command -v nix 2>/dev/null; then \
+				path_to_nix=$$(command -v nix); \
+			else \
+				path_to_nix=$$(command -v nix 2>/dev/null || echo "nix"); \
+			fi; \
 		fi; \
 	else \
 		if command -v nix 2>/dev/null; then \
 			path_to_nix=$$(command -v nix); \
 		else \
-			path_to_nix="nix"; \
+			path_to_nix=$$(command -v nix 2>/dev/null || echo "nix"); \
 		fi; \
-	fi; \\
+	fi; \
 	echo "$$path_to_nix")
 
 # Nix configuration system

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ NIX_EXEC := $(shell \
 		elif command -v nix 2>/dev/null; then \
 			command -v nix; \
 		else \
-			$(shell which nix); \
+			which nix; \
 		fi; \
 	else \
 		if [ -x "$(HOME)/.nix-profile/bin/nix" ]; then \
@@ -32,7 +32,7 @@ NIX_EXEC := $(shell \
 		elif command -v nix 2>/dev/null; then \
 			command -v nix; \
 		else \
-			$(shell which nix); \
+			which nix; \
 		fi; \
 	fi)
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,12 @@ DOCKER_IMAGE_LATEST := $(DOCKER_IMAGE_NAME_BASE):latest
 DOCKER_IMAGE_TAGGED := $(DOCKER_IMAGE_NAME_BASE):$(GIT_COMMIT_SHA)
 
 # Nix executable path
-NIX_EXEC := $(shell which nix)
+NIX_EXEC := $(shell \
+	if [ "$(OS)" = "Darwin" ]; then \
+		echo "/nix/var/nix/profiles/default/bin/nix"; \
+	else \
+		echo "$(HOME)/.nix-profile/bin/nix"; \
+	fi)
 
 # Nix configuration system
 NIX_SYSTEM := $(shell if [ "$(OS)" = "Darwin" ] && [ "$(ARCH)" = "arm64" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,20 @@ NIX_EXEC := $(shell \
 		else \
 			which nix; \
 		fi; \
-	else if [ "$(OS)" = "Linux" ]; then \
+	elif [ "$(OS)" = "Linux" ]; then \
 		if [ "$$CI" = "true" ]; then \
 			echo "nix"; \
-		else if [ -x "$(HOME)/.nix-profile/bin/nix" ]; then \
-			echo "$(HOME)/.nix-profile/bin/nix"; \
-		elif command -v nix 2>/dev/null; then \
+		else \
+			if [ -x "$(HOME)/.nix-profile/bin/nix" ]; then \
+				echo "$(HOME)/.nix-profile/bin/nix"; \
+			elif command -v nix 2>/dev/null; then \
+				command -v nix; \
+			else \
+				which nix; \
+			fi; \
+		fi; \
+	else \
+		if command -v nix 2>/dev/null; then \
 			command -v nix; \
 		else \
 			which nix; \

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,34 @@ DOCKER_IMAGE_LATEST := $(DOCKER_IMAGE_NAME_BASE):latest
 DOCKER_IMAGE_TAGGED := $(DOCKER_IMAGE_NAME_BASE):$(GIT_COMMIT_SHA)
 
 # Nix executable path
-NIX_EXEC := $(shell which nix)
+NIX_EXEC := $(shell \
+	if [ "$(OS)" = "Darwin" ]; then \
+		if [ -x "/nix/var/nix/profiles/default/bin/nix" ]; then \
+			echo "/nix/var/nix/profiles/default/bin/nix"; \
+		elif command -v nix 2>/dev/null; then \
+			command -v nix; \
+		else \
+			which nix; \
+		fi; \
+	elif [ "$(OS)" = "Linux" ]; then \
+		if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \
+			echo "nix"; \
+		else \
+			if [ -x "$(HOME)/.nix-profile/bin/nix" ]; then \
+				echo "$(HOME)/.nix-profile/bin/nix"; \
+			elif command -v nix 2>/dev/null; then \
+				command -v nix; \
+			else \
+				which nix; \
+			fi; \
+		fi; \
+	else \
+		if command -v nix 2>/dev/null; then \
+			command -v nix; \
+		else \
+			which nix; \
+		fi; \
+	fi)
 
 # Nix configuration system
 NIX_SYSTEM := $(shell if [ "$(OS)" = "Darwin" ] && [ "$(ARCH)" = "arm64" ]; then \
@@ -151,11 +178,39 @@ nix-check:
 
 .PHONY: nix-install
 nix-install:
+	@echo "NIX_ENV current value: $(NIX_ENV)" # Debugging
 	@if [ "$(NIX_ENV)" = "not_found" ]; then \
-		echo "🚀 Installing Nix environment for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH) for USER=$(NIX_USERNAME)"; \
-		curl -L https://nixos.org/nix/install | sh; \
+		echo "🚀 Attempting to install Nix..."; \
+		# Using a subshell with pipefail to ensure the pipeline's success is checked
+		# Pass --no-daemon for typical single-user installs in ephemeral environments like Docker
+		if (set -o pipefail; curl -fSL https://nixos.org/nix/install | sh -s -- --no-daemon); then \
+			echo "✅ Nix installation script executed successfully."; \
+			echo "Attempting to source Nix profile to update PATH for this session..."; \
+			if [ -f "$${HOME}/.nix-profile/etc/profile.d/nix.sh" ]; then \
+				. "$${HOME}/.nix-profile/etc/profile.d/nix.sh"; \
+				echo "Nix profile sourced."; \
+				# Update NIX_ENV Makefile variable for the current make execution if possible
+				$(eval NIX_ENV := $(shell . $${HOME}/.nix-profile/etc/profile.d/nix.sh 2>/dev/null && echo "found" || echo "not_found")) \
+				echo "NIX_ENV re-evaluated to: $(NIX_ENV)"; \
+			else \
+				echo "⚠️ Nix profile script not found at $${HOME}/.nix-profile/etc/profile.d/nix.sh after install attempt."; \
+			fi; \
+			# Verify Nix installation by checking for the command
+			if command -v nix >/dev/null 2>&1; then \
+				echo "✅ Nix command is now available in PATH."; \
+			else \
+				echo "❌ ERROR: Nix installation script ran, but 'nix' command is not available in PATH."; \
+				echo "Current NIX_EXEC is: '$(NIX_EXEC)'"; \
+				echo "Current PATH: $$PATH"; \
+				exit 1; \
+			fi; \
+		else \
+			echo "❌ ERROR: Nix installation script failed (curl or sh error). Exit code: $$?"; \
+			exit 1; \
+		fi; \
+	else \
+		echo "✅ Nix environment previously detected (NIX_ENV='$(NIX_ENV)'). Skipping installation."; \
 	fi
-	@echo "✅ Nix environment installed!"
 
 ##@ Nix
 

--- a/Makefile
+++ b/Makefile
@@ -203,18 +203,24 @@ nix-backup:
 nix-build: nix-connect
 	@echo "🏗️ Building Nix configuration for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH) for USER=$(NIX_USERNAME)"
 	@if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \
-		echo "Running in CI"; \
+		echo "🤖 Running in CI/Docker environment"; \
+		echo "DEBUG: NIX_EXEC is [$(NIX_EXEC)]"; \
+		echo "DEBUG: PATH is [$$PATH]"; \
+		command -v $(NIX_EXEC) >/dev/null 2>&1 || { echo "DEBUG: $(NIX_EXEC) not found in PATH via command -v"; $(NIX_EXEC) --version || echo "DEBUG: Attempt to run $(NIX_EXEC) --version failed"; }; \
 		if [ "$(OS)" = "Darwin" ]; then \
 			$(NIX_EXEC) build .#$(NIX_CONFIG_TYPE).runner.system $(NIX_FLAGS) --no-update-lock-file --show-trace; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "nixosConfigurations" ]; then \
 			$(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- build --flake .#runner --no-update-lock-file; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "homeConfigurations" ]; then \
-			$(NIX_EXEC) build .#$(NIX_CONFIG_TYPE)."runner@$(NIX_SYSTEM)".activationPackage $(NIX_FLAGS) --no-update-lock-file --show-trace; \
+			echo "DEBUG: Executing: $(NIX_EXEC) build .#$(NIX_CONFIG_TYPE).\"$(NIX_USERNAME)@$(NIX_SYSTEM)\".activationPackage $(NIX_FLAGS) --no-update-lock-file --show-trace"; \
+			$(NIX_EXEC) build .#$(NIX_CONFIG_TYPE)."$(NIX_USERNAME)@$(NIX_SYSTEM)".activationPackage $(NIX_FLAGS) --no-update-lock-file --show-trace; \
 		else \
 			echo "Unsupported OS $(OS) for non-CI build"; \
 			exit 1; \
 		fi; \
 	else \
+		echo "DEBUG: NIX_EXEC is [$(NIX_EXEC)]"; \
+		echo "DEBUG: PATH is [$$PATH]"; \
 		if [ "$(NIX_SYSTEM)" = "unsupported" ]; then \
 			echo "❌ Unsupported system architecture: $(OS) $(ARCH)"; \
 			exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -17,34 +17,42 @@ DOCKER_IMAGE_LATEST := $(DOCKER_IMAGE_NAME_BASE):latest
 DOCKER_IMAGE_TAGGED := $(DOCKER_IMAGE_NAME_BASE):$(GIT_COMMIT_SHA)
 
 # Nix executable path
-NIX_EXEC := $(shell \
-	if [ "$(OS)" = "Darwin" ]; then \
-		if [ -x "/nix/var/nix/profiles/default/bin/nix" ]; then \
-			echo "/nix/var/nix/profiles/default/bin/nix"; \
-		elif command -v nix 2>/dev/null; then \
-			command -v nix; \
+NIX_EXEC := $(shell \\
+	path_to_nix=""; \\
+	if [ "$(OS)" = "Darwin" ]; then \\
+		if [ -x "/nix/var/nix/profiles/default/bin/nix" ]; then \\
+			path_to_nix="/nix/var/nix/profiles/default/bin/nix"; \\
+		elif command -v nix 2>/dev/null; then \\
+			path_to_nix=$$(command -v nix); \\
+		else \\
+			path_to_nix="nix"; \\
+		fi; \\
+	elif [ "$(OS)" = "Linux" ]; then \\
+		if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \\
+			if [ -x "$${HOME}/.nix-profile/bin/nix" ]; then \\
+				path_to_nix="$${HOME}/.nix-profile/bin/nix"; \\
+			elif command -v nix 2>/dev/null; then \\
+				path_to_nix=$$(command -v nix); \\
+			else \\
+				path_to_nix="nix"; \\
+			fi; \\
 		else \
-			which nix; \
-		fi; \
-	elif [ "$(OS)" = "Linux" ]; then \
-		if [ "$$CI" = "true" ]; then \
-			echo "nix"; \
-		else \
-			if [ -x "$(HOME)/.nix-profile/bin/nix" ]; then \
-				echo "$(HOME)/.nix-profile/bin/nix"; \
+			if [ -x "$${HOME}/.nix-profile/bin/nix" ]; then \
+				path_to_nix="$${HOME}/.nix-profile/bin/nix"; \
 			elif command -v nix 2>/dev/null; then \
-				command -v nix; \
+				path_to_nix=$$(command -v nix); \
 			else \
-				which nix; \
+				path_to_nix="nix"; \
 			fi; \
 		fi; \
 	else \
 		if command -v nix 2>/dev/null; then \
-			command -v nix; \
+			path_to_nix=$$(command -v nix); \
 		else \
-			which nix; \
+			path_to_nix="nix"; \
 		fi; \
-	fi)
+	fi; \\
+	echo "$$path_to_nix")
 
 # Nix configuration system
 NIX_SYSTEM := $(shell if [ "$(OS)" = "Darwin" ] && [ "$(ARCH)" = "arm64" ]; then \
@@ -178,11 +186,39 @@ nix-check:
 
 .PHONY: nix-install
 nix-install:
+	@echo "NIX_ENV current value: $(NIX_ENV)" # Debugging
 	@if [ "$(NIX_ENV)" = "not_found" ]; then \
-		echo "🚀 Installing Nix environment for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH) for USER=$(NIX_USERNAME)"; \
-		curl -L https://nixos.org/nix/install | sh; \
+		echo "🚀 Attempting to install Nix..."; \
+		# Using a subshell with pipefail to ensure the pipeline's success is checked
+		# Pass --no-daemon for typical single-user installs in ephemeral environments like Docker
+		if (set -o pipefail; curl -fSL https://nixos.org/nix/install | sh -s -- --no-daemon); then \
+			echo "✅ Nix installation script executed successfully."; \
+			echo "Attempting to source Nix profile to update PATH for this session..."; \
+			if [ -f "$${HOME}/.nix-profile/etc/profile.d/nix.sh" ]; then \
+				. "$${HOME}/.nix-profile/etc/profile.d/nix.sh"; \
+				echo "Nix profile sourced."; \
+				# Update NIX_ENV Makefile variable for the current make execution if possible
+				$(eval NIX_ENV := $(shell . $${HOME}/.nix-profile/etc/profile.d/nix.sh 2>/dev/null && echo "found" || echo "not_found")) \
+				echo "NIX_ENV re-evaluated to: $(NIX_ENV)"; \
+			else \
+				echo "⚠️ Nix profile script not found at $${HOME}/.nix-profile/etc/profile.d/nix.sh after install attempt."; \
+			fi; \
+			# Verify Nix installation by checking for the command
+			if command -v nix >/dev/null 2>&1; then \
+				echo "✅ Nix command is now available in PATH."; \
+			else \
+				echo "❌ ERROR: Nix installation script ran, but 'nix' command is not available in PATH."; \
+				echo "Current NIX_EXEC is: '$(NIX_EXEC)'"; \
+				echo "Current PATH: $$PATH"; \
+				exit 1; \
+			fi; \
+		else \
+			echo "❌ ERROR: Nix installation script failed (curl or sh error). Exit code: $$?"; \
+			exit 1; \
+		fi; \
+	else \
+		echo "✅ Nix environment previously detected (NIX_ENV='$(NIX_ENV)'). Skipping installation."; \
 	fi
-	@echo "✅ Nix environment installed!"
 
 ##@ Nix
 

--- a/Makefile
+++ b/Makefile
@@ -178,39 +178,11 @@ nix-check:
 
 .PHONY: nix-install
 nix-install:
-	@echo "NIX_ENV current value: $(NIX_ENV)" # Debugging
 	@if [ "$(NIX_ENV)" = "not_found" ]; then \
-		echo "🚀 Attempting to install Nix..."; \
-		# Using a subshell with pipefail to ensure the pipeline's success is checked
-		# Pass --no-daemon for typical single-user installs in ephemeral environments like Docker
-		if (set -o pipefail; curl -fSL https://nixos.org/nix/install | sh -s -- --no-daemon); then \
-			echo "✅ Nix installation script executed successfully."; \
-			echo "Attempting to source Nix profile to update PATH for this session..."; \
-			if [ -f "$${HOME}/.nix-profile/etc/profile.d/nix.sh" ]; then \
-				. "$${HOME}/.nix-profile/etc/profile.d/nix.sh"; \
-				echo "Nix profile sourced."; \
-				# Update NIX_ENV Makefile variable for the current make execution if possible
-				$(eval NIX_ENV := $(shell . $${HOME}/.nix-profile/etc/profile.d/nix.sh 2>/dev/null && echo "found" || echo "not_found")) \
-				echo "NIX_ENV re-evaluated to: $(NIX_ENV)"; \
-			else \
-				echo "⚠️ Nix profile script not found at $${HOME}/.nix-profile/etc/profile.d/nix.sh after install attempt."; \
-			fi; \
-			# Verify Nix installation by checking for the command
-			if command -v nix >/dev/null 2>&1; then \
-				echo "✅ Nix command is now available in PATH."; \
-			else \
-				echo "❌ ERROR: Nix installation script ran, but 'nix' command is not available in PATH."; \
-				echo "Current NIX_EXEC is: '$(NIX_EXEC)'"; \
-				echo "Current PATH: $$PATH"; \
-				exit 1; \
-			fi; \
-		else \
-			echo "❌ ERROR: Nix installation script failed (curl or sh error). Exit code: $$?"; \
-			exit 1; \
-		fi; \
-	else \
-		echo "✅ Nix environment previously detected (NIX_ENV='$(NIX_ENV)'). Skipping installation."; \
+		echo "🚀 Installing Nix environment for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH) for USER=$(NIX_USERNAME)"; \
+		curl -L https://nixos.org/nix/install | sh; \
 	fi
+	@echo "✅ Nix environment installed!"
 
 ##@ Nix
 

--- a/Makefile
+++ b/Makefile
@@ -17,42 +17,7 @@ DOCKER_IMAGE_LATEST := $(DOCKER_IMAGE_NAME_BASE):latest
 DOCKER_IMAGE_TAGGED := $(DOCKER_IMAGE_NAME_BASE):$(GIT_COMMIT_SHA)
 
 # Nix executable path
-NIX_EXEC := $(shell \
-	path_to_nix=""; \
-	if [ "$(OS)" = "Darwin" ]; then \
-		if [ -x "/nix/var/nix/profiles/default/bin/nix" ]; then \
-			path_to_nix="/nix/var/nix/profiles/default/bin/nix"; \
-		elif command -v nix 2>/dev/null; then \
-			path_to_nix=$$(command -v nix); \
-		else \
-			path_to_nix="nix"; \
-		fi; \
-	elif [ "$(OS)" = "Linux" ]; then \
-		if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \
-			if [ -x "$${HOME}/.nix-profile/bin/nix" ]; then \
-				path_to_nix="$${HOME}/.nix-profile/bin/nix"; \
-			elif command -v nix 2>/dev/null; then \
-				path_to_nix=$$(command -v nix); \
-			else \
-				path_to_nix="nix"; \
-			fi; \
-		else \
-			if [ -x "$${HOME}/.nix-profile/bin/nix" ]; then \
-				path_to_nix="$${HOME}/.nix-profile/bin/nix"; \
-			elif command -v nix 2>/dev/null; then \
-				path_to_nix=$$(command -v nix); \
-			else \
-				path_to_nix=$$(command -v nix 2>/dev/null || echo "nix"); \
-			fi; \
-		fi; \
-	else \
-		if command -v nix 2>/dev/null; then \
-			path_to_nix=$$(command -v nix); \
-		else \
-			path_to_nix=$$(command -v nix 2>/dev/null || echo "nix"); \
-		fi; \
-	fi; \
-	echo "$$path_to_nix")
+NIX_EXEC := $(shell which nix)
 
 # Nix configuration system
 NIX_SYSTEM := $(shell if [ "$(OS)" = "Darwin" ] && [ "$(ARCH)" = "arm64" ]; then \
@@ -186,39 +151,11 @@ nix-check:
 
 .PHONY: nix-install
 nix-install:
-	@echo "NIX_ENV current value: $(NIX_ENV)" # Debugging
 	@if [ "$(NIX_ENV)" = "not_found" ]; then \
-		echo "🚀 Attempting to install Nix..."; \
-		# Using a subshell with pipefail to ensure the pipeline's success is checked
-		# Pass --no-daemon for typical single-user installs in ephemeral environments like Docker
-		if (set -o pipefail; curl -fSL https://nixos.org/nix/install | sh -s -- --no-daemon); then \
-			echo "✅ Nix installation script executed successfully."; \
-			echo "Attempting to source Nix profile to update PATH for this session..."; \
-			if [ -f "$${HOME}/.nix-profile/etc/profile.d/nix.sh" ]; then \
-				. "$${HOME}/.nix-profile/etc/profile.d/nix.sh"; \
-				echo "Nix profile sourced."; \
-				# Update NIX_ENV Makefile variable for the current make execution if possible
-				$(eval NIX_ENV := $(shell . $${HOME}/.nix-profile/etc/profile.d/nix.sh 2>/dev/null && echo "found" || echo "not_found")) \
-				echo "NIX_ENV re-evaluated to: $(NIX_ENV)"; \
-			else \
-				echo "⚠️ Nix profile script not found at $${HOME}/.nix-profile/etc/profile.d/nix.sh after install attempt."; \
-			fi; \
-			# Verify Nix installation by checking for the command
-			if command -v nix >/dev/null 2>&1; then \
-				echo "✅ Nix command is now available in PATH."; \
-			else \
-				echo "❌ ERROR: Nix installation script ran, but 'nix' command is not available in PATH."; \
-				echo "Current NIX_EXEC is: '$(NIX_EXEC)'"; \
-				echo "Current PATH: $$PATH"; \
-				exit 1; \
-			fi; \
-		else \
-			echo "❌ ERROR: Nix installation script failed (curl or sh error). Exit code: $$?"; \
-			exit 1; \
-		fi; \
-	else \
-		echo "✅ Nix environment previously detected (NIX_ENV='$(NIX_ENV)'). Skipping installation."; \
+		echo "🚀 Installing Nix environment for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH) for USER=$(NIX_USERNAME)"; \
+		curl -L https://nixos.org/nix/install | sh; \
 	fi
+	@echo "✅ Nix environment installed!"
 
 ##@ Nix
 

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,10 @@ NIX_EXEC := $(shell \
 		else \
 			which nix; \
 		fi; \
-	else \
-		if [ -x "$(HOME)/.nix-profile/bin/nix" ]; then \
+	else if [ "$(OS)" = "Linux" ]; then \
+		if [ "$$CI" = "true" ]; then \
+			echo "nix"; \
+		else if [ -x "$(HOME)/.nix-profile/bin/nix" ]; then \
 			echo "$(HOME)/.nix-profile/bin/nix"; \
 		elif command -v nix 2>/dev/null; then \
 			command -v nix; \

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,24 @@ DOCKER_IMAGE_LATEST := $(DOCKER_IMAGE_NAME_BASE):latest
 DOCKER_IMAGE_TAGGED := $(DOCKER_IMAGE_NAME_BASE):$(GIT_COMMIT_SHA)
 
 # Nix executable path
-NIX_EXEC := $(shell which nix)
+NIX_EXEC := $(shell \
+	if [ "$(OS)" = "Darwin" ]; then \
+		if [ -x "/nix/var/nix/profiles/default/bin/nix" ]; then \
+			echo "/nix/var/nix/profiles/default/bin/nix"; \
+		elif command -v nix 2>/dev/null; then \
+			command -v nix; \
+		else \
+			$(shell which nix); \
+		fi; \
+	else \
+		if [ -x "$(HOME)/.nix-profile/bin/nix" ]; then \
+			echo "$(HOME)/.nix-profile/bin/nix"; \
+		elif command -v nix 2>/dev/null; then \
+			command -v nix; \
+		else \
+			$(shell which nix); \
+		fi; \
+	fi)
 
 # Nix configuration system
 NIX_SYSTEM := $(shell if [ "$(OS)" = "Darwin" ] && [ "$(ARCH)" = "arm64" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,7 @@ DOCKER_IMAGE_LATEST := $(DOCKER_IMAGE_NAME_BASE):latest
 DOCKER_IMAGE_TAGGED := $(DOCKER_IMAGE_NAME_BASE):$(GIT_COMMIT_SHA)
 
 # Nix executable path
-NIX_EXEC := $(shell \
-	if [ "$(OS)" = "Darwin" ]; then \
-		echo "/nix/var/nix/profiles/default/bin/nix"; \
-	else \
-		echo "$(HOME)/.nix-profile/bin/nix"; \
-	fi)
+NIX_EXEC := $(shell which nix)
 
 # Nix configuration system
 NIX_SYSTEM := $(shell if [ "$(OS)" = "Darwin" ] && [ "$(ARCH)" = "arm64" ]; then \


### PR DESCRIPTION
Adjust the Makefile to set the Nix executable path based on the operating system, ensuring compatibility across different environments.