### PR TITLE
chore: Uncomment linux/arm64 platform in Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         platform:
           - linux/amd64
-          # - linux/arm64
+          - linux/arm64
     runs-on: ubuntu-latest
     timeout-minutes: 300
     steps:

--- a/install.sh
+++ b/install.sh
@@ -49,7 +49,7 @@ if ! command -v nix >/dev/null 2>&1; then
   else # Linux
     if [ "$IN_DOCKER" = "true" ]; then
       echo "Performing single-user Nix installation (Docker environment)..."
-      curl -L https://nixos.org/nix/install | sh -s -- --no-daemon --init none
+      curl -L https://nixos.org/nix/install | sh -s -- --yes --no-daemon
       # Source the Nix profile script to add Nix to PATH for the current shell
       if [ -f "$HOME/.nix-profile/etc/profile.d/nix.sh" ]; then
         . "$HOME/.nix-profile/etc/profile.d/nix.sh"

--- a/install.sh
+++ b/install.sh
@@ -49,7 +49,7 @@ if ! command -v nix >/dev/null 2>&1; then
   else # Linux
     if [ "$IN_DOCKER" = "true" ]; then
       echo "Performing single-user Nix installation (Docker environment)..."
-      curl -L https://nixos.org/nix/install | bash -s -- --no-daemon
+      curl -L https://nixos.org/nix/install | sh -s -- --no-daemon --init none
       # Source the Nix profile script to add Nix to PATH for the current shell
       if [ -f "$HOME/.nix-profile/etc/profile.d/nix.sh" ]; then
         . "$HOME/.nix-profile/etc/profile.d/nix.sh"


### PR DESCRIPTION
Enable compatibility with the linux/arm64 platform in the Docker workflow by uncommenting the relevant line.