### PR TITLE
feat: add cs abbreviation for claude squad

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -25,6 +25,7 @@
     '';
     shellAbbrs = {
       c = "clear";
+      cs = "claude squad";
       e = "nvim";
       g = "git";
       ga = "git add";


### PR DESCRIPTION
## Summary
• Added `cs` abbreviation for "claude squad" to fish shell configuration
• Provides quick access to claude squad command in terminal

## Test plan
- [ ] Verify fish shell loads without errors after configuration change
- [ ] Test that `cs` abbreviation expands to "claude squad" in fish terminal
- [ ] Confirm existing abbreviations still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)