### PR TITLE
Add fzf ghq repository picker

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -39,6 +39,7 @@
       fpf = "_fzf_file_picker --allow-open-in-editor --prompt-name Files";
       fpfh = "_fzf_file_picker --allow-open-in-editor --show-hidden-files --prompt-name Files+";
       fpp = "_fzf_directory_picker --allow-cd --prompt-name Projects ~/";
+      fpr = "_fzf_ghq_picker";
     };
     plugins = [
       {

--- a/home-manager/programs/fish/functions/_fzf_ghq_picker.fish
+++ b/home-manager/programs/fish/functions/_fzf_ghq_picker.fish
@@ -1,0 +1,9 @@
+function _fzf_ghq_picker --description="fzf ghq repository picker"
+    set -l selected_repo (ghq list | fzf --prompt=(_fzf_preview_name "Repository") --preview 'ghq look {} --dry-run | head -1' --preview-window right:30%)
+    
+    if test -n "$selected_repo"
+        cd (ghq root)/$selected_repo
+    end
+    
+    commandline --function repaint
+end


### PR DESCRIPTION
## Summary
- Add `_fzf_ghq_picker` function to quickly navigate to ghq-managed repositories
- Add `fpr` shell abbreviation for easy access
- Includes fzf preview showing repository paths

## Test plan
- [ ] Build configuration with `make build`
- [ ] Test `fpr` command opens repository picker
- [ ] Verify navigation to selected repository works

🤖 Generated with [Claude Code](https://claude.ai/code)