### PR TITLE
Refactor command abbreviations for clarity and consistency

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -31,11 +31,11 @@
       g = "git";
       ga = "git add";
       gaa = "git add -A";
-      gco = "_gco_function";
       lg = "lazygit";
       ta = "tmux new -A -s default";
       v = "nvim";
 
+      gco = "_gco_function";
       fch = "_fzf_cmd_history --allow-execute";
       fdp = "_fzf_directory_picker --allow-cd --prompt-name Projects ~/";
       ffp = "_fzf_file_picker --allow-open-in-editor --prompt-name Files";

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -25,7 +25,8 @@
     '';
     shellAbbrs = {
       c = "clear";
-      cs = "claude squad";
+      cc = "claude";
+      cs = "claude-squad";
       e = "nvim";
       g = "git";
       ga = "git add";


### PR DESCRIPTION
Update command abbreviations for improved readability and reintroduce the 'gco' abbreviation for git checkout to maintain consistency with previous configurations.