### PR TITLE
feat: add automatic machine detection for galactica host

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,3 +1,4 @@
+# yamlfmt-disable-file
 name: Docker
 on:
   push:
@@ -18,14 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: >-
-          ${{
-
-
-            github.ref == 'refs/heads/main' && github.event_name == 'push'
-            && fromJSON('["linux/amd64", "linux/arm64"]')
-            || fromJSON('["linux/amd64"]')
-          }}
+        platform: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && fromJSON('["linux/amd64", "linux/arm64"]') || fromJSON('["linux/amd64"]') }}
     runs-on: ubuntu-latest
     timeout-minutes: 300
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,6 +21,7 @@ jobs:
         platform: >-
           ${{
 
+
             github.ref == 'refs/heads/main' && github.event_name == 'push'
             && fromJSON('["linux/amd64", "linux/arm64"]')
             || fromJSON('["linux/amd64"]')

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,3 @@
-# yamlfmt-disable-file
 name: Docker
 on:
   push:

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ help:
 	@echo "Available targets:"
 	@echo "  install      - Set up full environment"
 	@echo "  build        - Build Nix configuration"
-	@echo "  switch       - Apply Nix configuration (auto-detects galactica for shunkakinoki@macOS)"
+	@echo "  switch       - Apply Nix configuration"
 	@echo "  update       - Update Nix flake and configurations"
 	@echo "  format       - Format Nix files"
 	@echo "  format-check - Check Nix formatting"

--- a/Makefile
+++ b/Makefile
@@ -34,14 +34,6 @@ NIX_SYSTEM := $(shell if [ "$(OS)" = "Darwin" ] && [ "$(ARCH)" = "arm64" ]; then
 	else \
 		echo "unsupported"; \
 	fi)
-
-# Machine detection for automatic host mapping
-DETECTED_HOST := $(shell \
-	if [ "$(OS)" = "Darwin" ] && [ "$(shell whoami)" = "shunkakinoki" ] && [ "$(ARCH)" = "arm64" ]; then \
-		echo "galactica"; \
-	else \
-		echo ""; \
-	fi)
 NIX_CONFIG_TYPE := $(shell \
 	if [ "$(OS)" = "Darwin" ]; then \
 		echo "darwinConfigurations"; \
@@ -68,6 +60,19 @@ NIX_USERNAME := $(shell \
 	fi)
 NIX_ENV := $(shell . ~/.nix-profile/etc/profile.d/nix.sh 2>/dev/null || echo "not_found")
 NIX_FLAGS := --extra-experimental-features 'flakes nix-command'
+
+# Machine detection for automatic host mapping
+DETECTED_HOST := $(shell \
+	if [ "$(OS)" = "Darwin" ] && [ "$(shell whoami)" = "shunkakinoki" ] && [ "$(ARCH)" = "arm64" ]; then \
+		computer_name=$$(scutil --get ComputerName 2>/dev/null || echo ""); \
+		if echo "$$computer_name" | grep -q "Shun's MacBook M4"; then \
+			echo "galactica"; \
+		else \
+			echo ""; \
+		fi; \
+	else \
+		echo ""; \
+	fi)
 
 # User's home directory
 HOME_DIR := $(shell echo $$HOME)

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,14 @@ NIX_SYSTEM := $(shell if [ "$(OS)" = "Darwin" ] && [ "$(ARCH)" = "arm64" ]; then
 	else \
 		echo "unsupported"; \
 	fi)
+
+# Machine detection for automatic host mapping
+DETECTED_HOST := $(shell \
+	if [ "$(OS)" = "Darwin" ] && [ "$(shell whoami)" = "shunkakinoki" ] && [ "$(ARCH)" = "arm64" ]; then \
+		echo "galactica"; \
+	else \
+		echo ""; \
+	fi)
 NIX_CONFIG_TYPE := $(shell \
 	if [ "$(OS)" = "Darwin" ]; then \
 		echo "darwinConfigurations"; \
@@ -80,7 +88,7 @@ help:
 	@echo "Available targets:"
 	@echo "  install      - Set up full environment"
 	@echo "  build        - Build Nix configuration"
-	@echo "  switch       - Apply Nix configuration"
+	@echo "  switch       - Apply Nix configuration (auto-detects galactica for shunkakinoki@macOS)"
 	@echo "  update       - Update Nix flake and configurations"
 	@echo "  format       - Format Nix files"
 	@echo "  format-check - Check Nix formatting"
@@ -265,6 +273,9 @@ nix-switch:
 			if [ -n "$(HOST)" ]; then \
 				echo "Switching named host: $(HOST)"; \
 				sudo $(NIX_ALLOW_UNFREE) $(DARWIN_REBUILD) switch --flake .#$(HOST) --impure; \
+			elif [ -n "$(DETECTED_HOST)" ]; then \
+				echo "Auto-detected host: $(DETECTED_HOST)"; \
+				sudo $(NIX_ALLOW_UNFREE) $(DARWIN_REBUILD) switch --flake .#$(DETECTED_HOST) --impure; \
 			else \
 				sudo $(NIX_ALLOW_UNFREE) $(DARWIN_REBUILD) switch --flake .#$(NIX_SYSTEM) --impure; \
 			fi; \


### PR DESCRIPTION
## Summary
• Added machine detection logic to automatically identify shunkakinoki's macOS ARM64 machine as galactica
• Modified `make switch` to auto-detect and use galactica configuration when appropriate
• Maintains backward compatibility with explicit HOST parameter and other machines

## Test plan
- [x] Verify DETECTED_HOST variable correctly identifies galactica
- [x] Test that `make switch` automatically uses galactica configuration
- [x] Ensure explicit HOST parameter still takes precedence

🤖 Generated with [Claude Code](https://claude.ai/code)