### PR TITLE
chore(ci): update Docker workflow to use wrretry action for improved build reliability

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,16 +52,19 @@ jobs:
       - name: Build and Push Docker
         uses: Wandalen/wretry.action@v3.5.0
         with:
-          context: .
-          file: ./Dockerfile
-          platforms: ${{ matrix.platform }}
-          push: true
-          tags: ${{ steps.metadata.outputs.tags }}
-          labels: ${{ steps.metadata.outputs.labels }}
-          build-args: |
-            COMMIT_SHA=${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          action: docker/build-push-action@v6
+          with: |
+            context: .
+            file: ./Dockerfile
+            platforms: ${{ matrix.platform }}
+            push: true
+            tags: ${{ steps.metadata.outputs.tags }}
+            labels: ${{ steps.metadata.outputs.labels }}
+            build-args: COMMIT_SHA=${{ github.sha }}
+            cache-from: type=gha
+            cache-to: type=gha,mode=max
+          attempt_limit: 3
+          attempt_delay: 30000
   docker-check:
     if: always()
     needs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,9 +58,12 @@ jobs:
             file: ./Dockerfile
             platforms: ${{ matrix.platform }}
             push: true
-            tags: ${{ steps.metadata.outputs.tags }}
-            labels: ${{ steps.metadata.outputs.labels }}
-            build-args: COMMIT_SHA=${{ github.sha }}
+            tags: |
+              ${{ steps.metadata.outputs.tags }}
+            labels: |
+              ${{ steps.metadata.outputs.labels }}
+            build-args: |
+              COMMIT_SHA=${{ github.sha }}
             cache-from: type=gha
             cache-to: type=gha,mode=max
           attempt_limit: 3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,20 +52,16 @@ jobs:
       - name: Build and Push Docker
         uses: Wandalen/wretry.action@v3.5.0
         with:
-          action: docker/build-push-action@v6
-          with: |
-            context: .
-            file: ./Dockerfile
-            platforms: ${{ matrix.platform }}
-            push: true
-            tags: ${{ steps.metadata.outputs.tags }}
-            labels: ${{ steps.metadata.outputs.labels }}
-            build-args: |
-              COMMIT_SHA=${{ github.sha }}
-            cache-from: type=gha
-            cache-to: type=gha,mode=max
-          attempt_limit: 3
-          attempt_delay: 30000
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          build-args: |
+            COMMIT_SHA=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
   docker-check:
     if: always()
     needs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,18 +50,22 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.pr-number=${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
       - name: Build and Push Docker
-        uses: docker/build-push-action@v6
+        uses: Wandalen/wretry.action@v3.5.0
         with:
-          context: .
-          file: ./Dockerfile
-          platforms: ${{ matrix.platform }}
-          push: true
-          tags: ${{ steps.metadata.outputs.tags }}
-          labels: ${{ steps.metadata.outputs.labels }}
-          build-args: |
-            COMMIT_SHA=${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          action: docker/build-push-action@v6
+          with: |
+            context: .
+            file: ./Dockerfile
+            platforms: ${{ matrix.platform }}
+            push: true
+            tags: ${{ steps.metadata.outputs.tags }}
+            labels: ${{ steps.metadata.outputs.labels }}
+            build-args: |
+              COMMIT_SHA=${{ github.sha }}
+            cache-from: type=gha
+            cache-to: type=gha,mode=max
+          attempt_limit: 3
+          attempt_delay: 30000
   docker-check:
     if: always()
     needs:


### PR DESCRIPTION
- Replaced docker/build-push-action with Wandalen/wretry.action to enhance build reliability with retry logic.
- Added attempt limit and delay settings to manage build retries effectively.