### PR TITLE
feat: add Claude Code hooks configuration with notifications

### DIFF
--- a/config/claude/default.nix
+++ b/config/claude/default.nix
@@ -1,0 +1,6 @@
+{ config, ... }:
+{
+  home.file.".claude/settings.local.json" = {
+    source = config.lib.file.mkOutOfStoreSymlink ./settings.local.json;
+  };
+}

--- a/config/claude/settings.local.json
+++ b/config/claude/settings.local.json
@@ -14,7 +14,9 @@
 			"Bash(scutil:*)",
 			"WebFetch(domain:docs.anthropic.com)",
 			"Bash(mkdir:*)",
-			"Bash(cp:*)"
+			"Bash(cp:*)",
+			"Bash(osascript:*)",
+			"Bash(cat:*)"
 		],
 		"deny": []
 	},
@@ -25,7 +27,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "cat | jq -r '\"display notification \\\"\" + .message + \"\\\" with title \\\"\" + .title + \"\\\" sound name \\\"Glass\\\"\"' | xargs -I {} osascript -e '{}'"
+						"command": "cat | jq -r '\"display notification \\\"\" + .message + \"\\\" with title \\\"\" + .title + \"\\\" sound name \\\"Sonar\\\"\"' | xargs -I {} osascript -e '{}'"
 					}
 				]
 			}
@@ -36,7 +38,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "osascript -e 'display notification \"Work has been completed.\" with title \"Claude Code\" sound name \"Glass\"'"
+						"command": "osascript -e 'display notification \"Work has been completed.\" with title \"Claude Code\" sound name \"Sonar\"'"
 					}
 				]
 			}

--- a/config/claude/settings.local.json
+++ b/config/claude/settings.local.json
@@ -38,7 +38,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "osascript -e 'display notification \"Work has been completed.\" with title \"Claude Code\" sound name \"Sonar\"'"
+						"command": "cat | jq -r '\"Work completed in \" + .cwd + \" (Session: \" + .session_id[0:8] + \")\"' | xargs -I {} osascript -e 'display notification \"{}\" with title \"Claude Code\" sound name \"Sonar\"'"
 					}
 				]
 			}

--- a/config/claude/settings.local.json
+++ b/config/claude/settings.local.json
@@ -1,0 +1,45 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(make:*)",
+      "Bash(grep:*)",
+      "Bash(gpg:*)",
+      "Bash(git checkout:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr create:*)",
+      "Bash(git worktree:*)",
+      "Bash(gh pr checkout:*)",
+      "Bash(scutil:*)",
+      "WebFetch(domain:docs.anthropic.com)",
+      "Bash(mkdir:*)",
+      "Bash(cp:*)"
+    ],
+    "deny": []
+  },
+  "hooks": {
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cat | jq -r '\"display notification \\\"\" + .message + \"\\\" with title \\\"\" + .title + \"\\\" sound name \\\"Glass\\\"\"' | xargs -I {} osascript -e '{}'"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "osascript -e 'display notification \"Work has been completed.\" with title \"Claude Code\" sound name \"Glass\"'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/config/claude/settings.local.json
+++ b/config/claude/settings.local.json
@@ -1,45 +1,45 @@
 {
-  "permissions": {
-    "allow": [
-      "Bash(git add:*)",
-      "Bash(git commit:*)",
-      "Bash(make:*)",
-      "Bash(grep:*)",
-      "Bash(gpg:*)",
-      "Bash(git checkout:*)",
-      "Bash(git push:*)",
-      "Bash(gh pr create:*)",
-      "Bash(git worktree:*)",
-      "Bash(gh pr checkout:*)",
-      "Bash(scutil:*)",
-      "WebFetch(domain:docs.anthropic.com)",
-      "Bash(mkdir:*)",
-      "Bash(cp:*)"
-    ],
-    "deny": []
-  },
-  "hooks": {
-    "Notification": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "cat | jq -r '\"display notification \\\"\" + .message + \"\\\" with title \\\"\" + .title + \"\\\" sound name \\\"Glass\\\"\"' | xargs -I {} osascript -e '{}'"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "osascript -e 'display notification \"Work has been completed.\" with title \"Claude Code\" sound name \"Glass\"'"
-          }
-        ]
-      }
-    ]
-  }
+	"permissions": {
+		"allow": [
+			"Bash(git add:*)",
+			"Bash(git commit:*)",
+			"Bash(make:*)",
+			"Bash(grep:*)",
+			"Bash(gpg:*)",
+			"Bash(git checkout:*)",
+			"Bash(git push:*)",
+			"Bash(gh pr create:*)",
+			"Bash(git worktree:*)",
+			"Bash(gh pr checkout:*)",
+			"Bash(scutil:*)",
+			"WebFetch(domain:docs.anthropic.com)",
+			"Bash(mkdir:*)",
+			"Bash(cp:*)"
+		],
+		"deny": []
+	},
+	"hooks": {
+		"Notification": [
+			{
+				"matcher": "",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "cat | jq -r '\"display notification \\\"\" + .message + \"\\\" with title \\\"\" + .title + \"\\\" sound name \\\"Glass\\\"\"' | xargs -I {} osascript -e '{}'"
+					}
+				]
+			}
+		],
+		"Stop": [
+			{
+				"matcher": "",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "osascript -e 'display notification \"Work has been completed.\" with title \"Claude Code\" sound name \"Glass\"'"
+					}
+				]
+			}
+		]
+	}
 }

--- a/config/claude/settings.local.json
+++ b/config/claude/settings.local.json
@@ -46,6 +46,6 @@
 	},
 	"statusLine": {
 		"type": "command",
-		"command": "input=$(cat); printf '\\033[32m%s@%s\\033[0m:\\033[34m%s\\033[0m [%s] %s' \"$(whoami)\" \"$(hostname -s)\" \"$(echo \"$input\" | jq -r '.workspace.current_dir' | sed \"s|$HOME|~|\")\" \"$(echo \"$input\" | jq -r '.model.display_name')\" \"$(date '+%H:%M:%S')\""
+		"command": "input=$(cat); transcript=$(echo \"$input\" | jq -r '.transcript_path'); tokens=0; if [ -f \"$transcript\" ]; then tokens=$(wc -c < \"$transcript\" 2>/dev/null | awk '{printf \"%.0f\", $1/4}'); fi; context_pct=$(awk \"BEGIN {printf \\\"%.0f\\\", ($tokens/200000)*100}\"); color='\\033[32m'; if [ $context_pct -gt 70 ]; then color='\\033[33m'; fi; if [ $context_pct -gt 90 ]; then color='\\033[31m'; fi; printf '\\033[34m%s@%s\\033[0m:\\033[34m%s\\033[0m [%s] 🪙 %s %s%d%%\\033[0m %s' \"$(whoami)\" \"$(hostname -s)\" \"$(echo \"$input\" | jq -r '.workspace.current_dir' | sed \"s|$HOME|~|\")\" \"$(echo \"$input\" | jq -r '.model.display_name')\" \"$(if [ $tokens -gt 1000 ]; then awk \"BEGIN {printf \\\"%.1fK\\\", $tokens/1000}\"; else echo \"${tokens}\"; fi)\" \"$color\" \"$context_pct\" \"$(date '+%H:%M:%S')\""
 	}
 }

--- a/config/claude/settings.local.json
+++ b/config/claude/settings.local.json
@@ -43,5 +43,9 @@
 				]
 			}
 		]
+	},
+	"statusLine": {
+		"type": "command",
+		"command": "input=$(cat); printf '\\033[32m%s@%s\\033[0m:\\033[34m%s\\033[0m [%s] %s' \"$(whoami)\" \"$(hostname -s)\" \"$(echo \"$input\" | jq -r '.workspace.current_dir' | sed \"s|$HOME|~|\")\" \"$(echo \"$input\" | jq -r '.model.display_name')\" \"$(date '+%H:%M:%S')\""
 	}
 }

--- a/config/default.nix
+++ b/config/default.nix
@@ -1,4 +1,5 @@
 [
+  ./claude
   ./hammerspoon
   ./karabiner
   ./starship


### PR DESCRIPTION
## Summary
- Add managed Claude Code configuration with notification hooks for enhanced development workflow awareness
- Configure intelligent notification and stop hooks with macOS native notifications using Sonar sound
- Integrate claude config module with existing config system structure

## Features Added
- **Dynamic Notification Hook**: Uses jq to parse JSON and display custom messages with configurable titles
- **Enhanced Stop Hook**: Shows contextual completion notifications with:
  - Current working directory where work was completed
  - Session ID (first 8 characters) for session tracking
  - Example: "Work completed in /Users/name/project (Session: abc12345)"
- **Config Management**: Claude Code settings now managed through dotfiles system like other configurations
- **Proper Permissions**: Includes osascript and cat permissions for notification functionality

## Technical Implementation
- **Sonar Sound**: Distinctive submarine-style ping for better audio feedback
- **JSON Processing**: Uses jq for dynamic message parsing and formatting
- **Session Context**: Leverages Claude Code's Stop hook data (session_id, cwd) for informative notifications
- **Nix Integration**: Fully integrated with home-manager configuration system

## Test plan
- [x] Configuration builds successfully with `make build`
- [x] Claude config module integrates properly with existing config structure
- [x] Settings file correctly symlinked to `~/.claude/settings.local.json`
- [x] Manual notification testing with osascript works correctly
- [x] Enhanced Stop hook shows contextual information
- [x] Test notification hooks work correctly during Claude Code usage sessions

🤖 Generated with [Claude Code](https://claude.ai/code)