### PR TITLE
feat: Add CMake to Homebrew installations

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -14,6 +14,7 @@
     ];
     brews = [
       "claude-squad"
+      "cmake"
       "ffmpeg"
       "gnupg"
       "helm"


### PR DESCRIPTION
Include CMake in the list of installed Homebrew packages.