### PR TITLE
Add ripgrep to installed packages in default.nix

### DIFF
--- a/home-manager/modules/ghostty/config
+++ b/home-manager/modules/ghostty/config
@@ -16,3 +16,10 @@ cursor-style-blink = true
 mouse-hide-while-typing = true
 clipboard-read = "allow"
 clipboard-paste-protection = false
+
+key-bindings = [
+  { key = "left",  mods = "cmd|opt", action = "previous_tab" },
+  { key = "right", mods = "cmd|opt", action = "next_tab" },
+  { key = "up",    mods = "cmd|opt", action = "move_tab_left" },
+  { key = "down",  mods = "cmd|opt", action = "move_tab_right" },
+]

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -26,6 +26,7 @@ with pkgs;
   kustomize
   neofetch
   pulumi-bin
+  ripgrep
   rustup
   stern
   uv

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -11,6 +11,7 @@
     taps = [
       "homebrew/cask"
       "kurtosis-tech/tap"
+      "oven-sh/bun"
     ];
     brews = [
       "bun"

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -13,6 +13,7 @@
       "kurtosis-tech/tap"
     ];
     brews = [
+      "bun"
       "claude-squad"
       "cmake"
       "ffmpeg"


### PR DESCRIPTION
Include ripgrep in the list of packages to be installed via default.nix.