### PR TITLE
feat(home-manager/codex): add codex module and config

### DIFF
--- a/home-manager/modules/codex/config.toml
+++ b/home-manager/modules/codex/config.toml
@@ -1,7 +1,6 @@
 notify = [
-    "bash",
-    "-lc",
-    "JSON=\"$1\"; LAST_MESSAGE=$(echo \"$JSON\" | jq -r '.\"last-assistant-message\" // \"Codex task completed\"'); osascript -e \"display notification \\\"$LAST_MESSAGE\\\" with title \\\"Codex\\\"\"",
-    "notify",
+  "bash",
+  "-lc",
+  "JSON=\"$1\"; LAST_MESSAGE=$(echo \"$JSON\" | jq -r '.\"last-assistant-message\" // \"Codex task completed\"'); osascript -e \"display notification \\\"$LAST_MESSAGE\\\" with title \\\"Codex\\\"\"",
+  "notify",
 ]
-

--- a/home-manager/modules/codex/config.toml
+++ b/home-manager/modules/codex/config.toml
@@ -1,0 +1,7 @@
+notify = [
+    "bash",
+    "-lc",
+    "JSON=\"$1\"; LAST_MESSAGE=$(echo \"$JSON\" | jq -r '.\"last-assistant-message\" // \"Codex task completed\"'); osascript -e \"display notification \\\"$LAST_MESSAGE\\\" with title \\\"Codex\\\"\"",
+    "notify",
+]
+

--- a/home-manager/modules/codex/default.nix
+++ b/home-manager/modules/codex/default.nix
@@ -1,0 +1,6 @@
+{ config, ... }:
+{
+  home.file.".codex/config.toml" = {
+    source = config.lib.file.mkOutOfStoreSymlink ./config.toml;
+  };
+}

--- a/home-manager/modules/default.nix
+++ b/home-manager/modules/default.nix
@@ -1,4 +1,5 @@
 [
+  ./codex
   ./dust
   ./ghostty
 ]


### PR DESCRIPTION
Adds the Codex module and configuration under `home-manager/modules/codex` and updates `home-manager/modules/default.nix` to include it.

- Adds `home-manager/modules/codex/default.nix`
- Adds `home-manager/modules/codex/config.toml`
- Updates module aggregation to include Codex