### PR TITLE
feat: Add 'zed' to Homebrew cask list

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -59,6 +59,7 @@
       "slack"
       "visual-studio-code"
       "windsurf"
+      "zed"
       "zoom"
     ];
     masApps = {


### PR DESCRIPTION
Include 'zed' in the list of applications for Homebrew cask installation.