### PR TITLE
feat: Add mcp__serena permission to allow list

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -39,7 +39,8 @@
       "Bash(osascript:*)",
       "Bash(scutil:*)",
       "Bash(timeout:*)",
-      "WebFetch(domain:docs.anthropic.com)"
+      "WebFetch(domain:docs.anthropic.com)",
+      "mcp__serena"
     ],
     "deny": [
       "Bash(sudo:*)"


### PR DESCRIPTION
Introduce the mcp__serena permission to the allow list in settings, enhancing the permission management capabilities.