### PR TITLE
feat(fish): add grco to hard reset default branch

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -39,6 +39,7 @@
       v = "nvim";
 
       gco = "_gco_function";
+      grco = "_grco_function";
       fch = "_fzf_cmd_history --allow-execute";
       fdp = "_fzf_directory_picker --allow-cd --prompt-name Projects ~/";
       ffp = "_fzf_file_picker --allow-open-in-editor --prompt-name Files";

--- a/home-manager/programs/fish/functions/_grco_function.fish
+++ b/home-manager/programs/fish/functions/_grco_function.fish
@@ -1,0 +1,10 @@
+function _grco_function
+  # Determine the default branch (e.g., main or master) from origin/HEAD
+  set -l default_branch (git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+
+  # Ensure we have the latest refs, then hard reset local default to remote
+  git fetch origin $default_branch
+  git checkout $default_branch
+  git reset --hard origin/$default_branch
+end
+


### PR DESCRIPTION
- Add `_grco_function` to detect `origin/HEAD` default branch
- Hard reset local default branch to `origin/<default>`
- Register `grco` abbreviation in Fish config

Usage: run `grco` inside a git repo to force your default branch to match the remote.