### PR TITLE
chore(git): ignore *.deprecated in global gitignore

### DIFF
--- a/home-manager/programs/git/.gitignore.global
+++ b/home-manager/programs/git/.gitignore.global
@@ -35,3 +35,6 @@ Temporary Items
 tmp
 .tmp*
 tmp*
+ 
+# Ignore deprecated files
+*.deprecated


### PR DESCRIPTION
Add global ignore pattern for deprecated files: `*.deprecated`.\n\n- Keeps repo clean from obsolete artifacts\n- Safe, local-only ignore via global config file