### PR TITLE
feat(packages): add kubeconform to home-manager

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -23,6 +23,7 @@ with pkgs;
   jq
   k9s
   kind
+  kubeconform
   kubectl
   kubectx
   kustomize


### PR DESCRIPTION
Adds kubeconform to home-manager packages for Kubernetes manifest validation.