### PR TITLE
feat: add Figma to dock and create workspace file

### DIFF
--- a/dotfiles.code-workspace
+++ b/dotfiles.code-workspace
@@ -1,0 +1,12 @@
+{
+  "folders": [
+    {
+      "name": "rules",
+      "path": "../ghq/github.com/shunkakinoki/rules"
+    },
+    {
+      "name": "dotfiles",
+      "path": "."
+    }
+  ]
+}

--- a/nix-darwin/config/dock.nix
+++ b/nix-darwin/config/dock.nix
@@ -21,6 +21,7 @@
       "/Applications/Docker.app/Contents/MacOS/Docker Desktop.app"
       "/Applications/Ghostty.app"
       "/Applications/Linear.app"
+      "/Applications/Figma.app"
       "/Applications/Notion.app"
       "/Applications/Cursor.app"
       "/Applications/Visual Studio Code.app"


### PR DESCRIPTION
This PR adds Figma to the dock configuration and creates a VS Code workspace file.