### PR TITLE
ci: use ubuntu arm64 runner for linux/arm64 build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && fromJSON('["linux/amd64", "linux/arm64"]') || fromJSON('["linux/amd64"]') }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-22.04-arm64' || 'ubuntu-latest' }}
     timeout-minutes: 300
     steps:
       - name: Checkout


### PR DESCRIPTION
Switch linux/arm64 builds to run on GitHub's native Ubuntu ARM64 runners instead of macOS.\n\n- macOS runners do not support Docker\n- Uses ubuntu-22.04-arm64 for linux/arm64 matrix entries\n- Keeps ubuntu-latest for linux/amd64\n\nThis preserves multi-arch images while avoiding macOS Docker limitations.