### PR TITLE
Update platform matrix and runner for Docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,8 +18,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && fromJSON('["linux/amd64", "linux/arm64"]') || fromJSON('["linux/amd64"]') }}
-    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-22.04-arm64' || 'ubuntu-latest' }}
+        platform: 
+          - linux/amd64
+          - linux/arm64
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'macos-latest' || 'ubuntu-latest' }}
     timeout-minutes: 300
     steps:
       - name: Checkout

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
         platform: 
           - linux/amd64
           - linux/arm64
-    runs-on: ${{ matrix.platform == 'linux/arm64' && 'macos-latest' || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm64-4core' || 'ubuntu-latest' }}
     timeout-minutes: 300
     steps:
       - name: Checkout

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,10 +18,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: 
+        platform:
           - linux/amd64
           - linux/arm64
-    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm64-4core' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 300
     steps:
       - name: Checkout

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,9 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        platform: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && fromJSON('["linux/amd64", "linux/arm64"]') || fromJSON('["linux/amd64"]') }}
     runs-on: ubuntu-latest
     timeout-minutes: 300
     steps:


### PR DESCRIPTION
Revise the platform matrix to explicitly include both `linux/amd64` and `linux/arm64`, and change the runner for `linux/arm64` to use `macos-latest`.