### PR TITLE
feat: add git push/pull aliases to fish shell

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -34,6 +34,9 @@
       g = "git";
       ga = "git add";
       gaa = "git add -A";
+      gp = "git push";
+      gpl = "git pull";
+      gpn = "git push --no-verify";
       lg = "lazygit";
       ta = "tmux new -A -s default";
       v = "nvim";


### PR DESCRIPTION
## Summary
• Add commonly used git aliases for push and pull operations to fish shell configuration
• Includes `gp` for git push, `gpl` for git pull, and `gpn` for git push --no-verify

## Test plan
- [x] Verify aliases are properly formatted in Nix configuration
- [ ] Test aliases work correctly after home-manager rebuild

🤖 Generated with [Claude Code](https://claude.ai/code)