### PR TITLE
Replace helm with kubernetes-helm in default.nix

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -40,5 +40,5 @@ with pkgs;
 ++ lib.optionals stdenv.isLinux [
   docker
   docker-compose
-  helm
+  kubernetes-helm
 ]


### PR DESCRIPTION
Update the default.nix file to use kubernetes-helm instead of helm.