### PR TITLE
home-manager: add cloudflared to packages

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -8,6 +8,7 @@ with pkgs;
   inputs.agenix.packages.${system}.default
   aider-chat
   argocd
+  cloudflared
   claude-code
   codex
   curlie


### PR DESCRIPTION
Add cloudflared to Home Manager packages so it’s installed via the flake for Linux/NixOS environments.

- Adds `cloudflared` to `home-manager/packages/default.nix`

If you’d prefer Linux-only scoping or a NixOS service for tunnels, I can follow up.