### PR TITLE
chore: flake cleanup, dock addition, and Makefile tweak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ nix-install:
 ##@ Nix
 
 .PHONY: nix-update
-nix-update: nix-build nix-switch
+nix-update: nix-flake-update nix-build nix-switch
 
 .PHONY: nix-backup
 nix-backup:

--- a/dotfiles.code-workspace
+++ b/dotfiles.code-workspace
@@ -2,7 +2,7 @@
   "folders": [
     {
       "name": "rules",
-      "path": "../ghq/github.com/shunkakinoki/rules"
+      "path": "~/ghq/github.com/shunkakinoki/rules"
     },
     {
       "name": "dotfiles",

--- a/flake.lock
+++ b/flake.lock
@@ -107,15 +107,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757177463,
-        "narHash": "sha256-+0iaqsEjfaIZMuRNGO+wC0uVazT5b+W38wB7Uv0kA5Y=",
+        "lastModified": 1756911493,
+        "narHash": "sha256-6n/n1GZQ/vi+LhFXMSyoseKdNfc2QQaSBXJdgamrbkE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9aaf71a4a74d835ec05ac3ddf5fc1b859e005c41",
+        "rev": "c6a788f552b7b7af703b1a29802a7233c0067908",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -3,7 +3,9 @@
     "agenix": {
       "inputs": {
         "darwin": "darwin",
-        "home-manager": "home-manager",
+        "home-manager": [
+          "home-manager"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -66,27 +68,6 @@
     "home-manager": {
       "inputs": {
         "nixpkgs": [
-          "agenix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1745494811,
-        "narHash": "sha256-YZCh2o9Ua1n9uCvrvi5pRxtuVNml8X2a03qIFfRKpFs=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "abfad3d2958c9e6300a883bd443512c55dfeb1be",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "home-manager_2": {
-      "inputs": {
-        "nixpkgs": [
           "nixpkgs"
         ]
       },
@@ -111,11 +92,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757015938,
-        "narHash": "sha256-1qBXNK/QxEjCqIoA2DxWn5gqM8rVxt+OxKodXu1GLTY=",
+        "lastModified": 1757130842,
+        "narHash": "sha256-4i7KKuXesSZGUv0cLPLfxbmF1S72Gf/3aSypgvVkwuA=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "eaacfa1101b84225491d2ceae9549366d74dc214",
+        "rev": "15f067638e2887c58c4b6ba1bdb65a0b61dc58c5",
         "type": "github"
       },
       "original": {
@@ -155,30 +136,13 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1735563628,
-        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "agenix": "agenix",
         "flake-parts": "flake-parts",
-        "home-manager": "home-manager_2",
+        "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-stable": "nixpkgs-stable",
         "treefmt-nix": "treefmt-nix"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -107,16 +107,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756911493,
-        "narHash": "sha256-6n/n1GZQ/vi+LhFXMSyoseKdNfc2QQaSBXJdgamrbkE=",
+        "lastModified": 1757177463,
+        "narHash": "sha256-+0iaqsEjfaIZMuRNGO+wC0uVazT5b+W38wB7Uv0kA5Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c6a788f552b7b7af703b1a29802a7233c0067908",
+        "rev": "9aaf71a4a74d835ec05ac3ddf5fc1b859e005c41",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,6 @@
   description = "Shun Kakinoki's Nix Configuration";
 
   inputs = {
-    # Track nixpkgs master; lockfile + Renovate keep it fresh nightly
     nixpkgs.url = "github:NixOS/nixpkgs";
     home-manager = {
       url = "github:nix-community/home-manager";
@@ -19,7 +18,6 @@
     };
     agenix = {
       url = "github:ryantm/agenix";
-      # Keep agenix on the same nixpkgs and home-manager as the root
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.home-manager.follows = "home-manager";
     };

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,6 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-24.05";
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -19,7 +18,9 @@
     };
     agenix = {
       url = "github:ryantm/agenix";
+      # Keep agenix on the same nixpkgs and home-manager as the root
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.home-manager.follows = "home-manager";
     };
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,9 @@
   description = "Shun Kakinoki's Nix Configuration";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs";
+    nixpkgs = {
+      url = "github:nix-community/nixpkgs";
+    };
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -11,7 +13,9 @@
       url = "github:LnL7/nix-darwin";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    flake-parts.url = "github:hercules-ci/flake-parts";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+    };
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs = {
-      url = "github:nix-community/nixpkgs";
+      url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     };
     home-manager = {
       url = "github:nix-community/home-manager";

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,8 @@
   description = "Shun Kakinoki's Nix Configuration";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    # Track nixpkgs master; lockfile + Renovate keep it fresh nightly
+    nixpkgs.url = "github:NixOS/nixpkgs";
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/nix-darwin/config/dock.nix
+++ b/nix-darwin/config/dock.nix
@@ -32,6 +32,7 @@
       "/Applications/Discord.app"
       "/System/Applications/Music.app"
       "/System/Applications/Podcasts.app"
+      "/System/Applications/iPhone Mirroring.app"
       "/System/Applications/System Settings.app"
     ];
   };


### PR DESCRIPTION
This PR makes several small but related updates:

- Makefile: ensure `nix-update` runs `nix-flake-update` before build/switch
- Workspace: fix `rules` workspace folder path to use `~` for home expansion
- Flake: drop `nixpkgs-stable` input; align `agenix` to follow `home-manager`
- Darwin: add iPhone Mirroring app to the Dock
- Lockfile: update `flake.lock` inputs accordingly

Impact:
- Keeps inputs consistent and reduces maintenance
- Improves developer ergonomics (workspace path)
- Minor quality-of-life tweak for macOS Dock