### PR TITLE
homebrew: add coreutils

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -17,6 +17,7 @@
       "bun"
       "claude-squad"
       "cmake"
+      "coreutils"
       "ffmpeg"
       "gnupg"
       "helm"


### PR DESCRIPTION
Add coreutils to Homebrew packages to ensure GNU core utilities are available on macOS.

- Updates 
- No other changes