### PR TITLE
fix: prevent Home Manager backup file conflicts

### DIFF
--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -26,6 +26,18 @@ in
     agenix.darwinModules.default
     {
       home-manager.backupFileExtension = "hm-backup";
+      home-manager.extraSpecialArgs = { inherit inputs; };
+      home-manager.sharedModules = [
+        {
+          home.activation.removeBackups = {
+            before = [ "checkLinkTargets" ];
+            after = [ ];
+            data = ''
+              find ~/.codex -name "*.hm-backup*" -delete 2>/dev/null || true
+            '';
+          };
+        }
+      ];
       home-manager.useUserPackages = true;
       home-manager.users."${username}" = import ../../home-manager {
         inherit inputs username system;

--- a/nix-darwin/config/dock.nix
+++ b/nix-darwin/config/dock.nix
@@ -26,6 +26,7 @@
       "/Applications/Notion.app"
       "/Applications/Cursor.app"
       "/Applications/Visual Studio Code.app"
+      "/Applications/Zed.app"
       "/System/Applications/Messages.app"
       "/Applications/Beeper Desktop.app"
       "/Applications/Slack.app"


### PR DESCRIPTION
## Summary
- Add automatic cleanup of existing Home Manager backup files to prevent conflicts during configuration switches
- Add Zed.app to dock persistent applications

## Test plan
- [x] Verify configuration builds successfully with `make build`
- [x] Test configuration applies without backup conflicts using `make switch`
- [x] Confirm removeBackups activation step runs before checkLinkTargets

🤖 Generated with [Claude Code](https://claude.ai/code)