### PR TITLE
feat: update nixpkgs from nixpkgs-unstable to master branch

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -107,16 +107,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757034884,
-        "narHash": "sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao=",
+        "lastModified": 1757296433,
+        "narHash": "sha256-RtHIYELe4S8GNajmG8D3Ngq29MLYEi6k8PmO8C3m8IY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ca77296380960cd497a765102eeb1356eb80fed0",
+        "rev": "d44f2e86707bae01ecce6af5d4da3674529d183c",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "master",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs = {
-      url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+      url = "github:NixOS/nixpkgs/master";
     };
     home-manager = {
       url = "github:nix-community/home-manager";


### PR DESCRIPTION
## Summary

- Updates nixpkgs input from `nixpkgs-unstable` to `master` branch for access to latest packages
- Updates flake.lock with new nixpkgs revision (d44f2e86707bae01ecce6af5d4da3674529d183c)

## Changes

- **flake.nix**: Changed nixpkgs URL from `nixpkgs-unstable` to `master` branch
- **flake.lock**: Updated nixpkgs lock with latest revision from master branch

## Test plan

- [ ] Verify configuration builds successfully with `make build`
- [ ] Test system switch with `make switch` 
- [ ] Ensure all applications and services function correctly
- [ ] Run formatting checks with `make format-check`

🤖 Generated with [Claude Code](https://claude.ai/code)