### PR TITLE
chore: update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -136,11 +136,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1757843276,
-        "narHash": "sha256-GNqrHTSABo9Fwvhcgq4hy4Us5OY368gIEJCI48lBWhM=",
+        "lastModified": 1757873102,
+        "narHash": "sha256-kYhNxLlYyJcUouNRazBufVfBInMWMyF+44xG/xar2yE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "af745796c2755d6f3a6d835967862184d53a17ff",
+        "rev": "88cef159e47c0dc56f151593e044453a39a6e547",
         "type": "github"
       },
       "original": {

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -48,7 +48,6 @@
       gco = "_gco_function";
       grco = "_grco_function";
       fch = "_fzf_cmd_history --allow-execute";
-      fchu = "_fzf_cmd_history --allow-execute --unique";
       fdp = "_fzf_directory_picker --allow-cd --prompt-name Projects ~/";
       ffp = "_fzf_file_picker --allow-open-in-editor --prompt-name Files";
       ffpf = "_fzf_file_picker --allow-open-in-editor --show-hidden-files --prompt-name Files+";

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -33,6 +33,7 @@
       cc = "claude";
       cs = "claude-squad";
       cx = "codex exec";
+      cxe = "codex --model 'gpt-5-codex' --full-auto --model_reasoning_summary_format=experimental";
       e = "nvim";
       g = "git";
       ga = "git add";

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -22,6 +22,7 @@
       fish_add_path -p /opt/homebrew/bin
       fish_add_path -p /etc/profiles/per-user/${config.home.username}/bin
       set -a fish_complete_path ~/.nix-profile/share/fish/completions/ ~/.nix-profile/share/fish/vendor_completions.d/
+      set -x FISH_HISTFILE fish
     '';
     shellAliases = {
       neofetch = "fastfetch";
@@ -46,6 +47,7 @@
       gco = "_gco_function";
       grco = "_grco_function";
       fch = "_fzf_cmd_history --allow-execute";
+      fchu = "_fzf_cmd_history --allow-execute --unique";
       fdp = "_fzf_directory_picker --allow-cd --prompt-name Projects ~/";
       ffp = "_fzf_file_picker --allow-open-in-editor --prompt-name Files";
       ffpf = "_fzf_file_picker --allow-open-in-editor --show-hidden-files --prompt-name Files+";


### PR DESCRIPTION
## Summary
- bump nixpkgs pin to 88cef159e47c0dc56f151593e044453a39a6e547
- refresh the associated narHash in flake.lock

Co-authored-by: Codex AI Agent