### PR TITLE
Update codex tooling configuration

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -14,7 +14,7 @@ with pkgs;
   bun
   cloudflared
   claude-code
-  codex
+  # codex
   curl
   curlie
   cursor-cli

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -33,7 +33,7 @@
       cc = "claude";
       cs = "claude-squad";
       cx = "codex exec";
-      cxe = "codex --model 'gpt-5-codex' --full-auto --model_reasoning_summary_format=experimental";
+      cxe = "codex --model 'gpt-5-codex' --full-auto -c model_reasoning_summary_format=experimental";
       e = "nvim";
       g = "git";
       ga = "git add";

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -17,6 +17,7 @@
       "bun"
       "claude-squad"
       "cmake"
+      "codex"
       "coreutils"
       "ffmpeg"
       "gnupg"


### PR DESCRIPTION
## Summary
- comment out codex from home-manager packages now managed via brew
- streamline fish alias for codex CLI args
- add codex to Homebrew bundle to manage installation centrally

Co-authored-by: Codex AI Agent <codex@example.com>
