### PR TITLE
Add grct fish helper for resetting current branch

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -47,7 +47,7 @@
 
       gco = "_gco_function";
       grco = "_grco_function";
-      grct = "_grct_function";
+      grcr = "_grcr_function";
       fch = "_fzf_cmd_history --allow-execute";
       fdp = "_fzf_directory_picker --allow-cd --prompt-name Projects ~/";
       ffp = "_fzf_file_picker --allow-open-in-editor --prompt-name Files";

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -47,6 +47,7 @@
 
       gco = "_gco_function";
       grco = "_grco_function";
+      grct = "_grct_function";
       fch = "_fzf_cmd_history --allow-execute";
       fdp = "_fzf_directory_picker --allow-cd --prompt-name Projects ~/";
       ffp = "_fzf_file_picker --allow-open-in-editor --prompt-name Files";

--- a/home-manager/programs/fish/functions/_grco_function.fish
+++ b/home-manager/programs/fish/functions/_grco_function.fish
@@ -7,4 +7,3 @@ function _grco_function
   git checkout $default_branch
   git reset --hard origin/$default_branch
 end
-

--- a/home-manager/programs/fish/functions/_grcr_function.fish
+++ b/home-manager/programs/fish/functions/_grcr_function.fish
@@ -1,4 +1,4 @@
-function _grct_function
+function _grcr_function
   # Determine the current branch; abort if detached HEAD
   set -l current_branch (git branch --show-current)
   if test -z "$current_branch"

--- a/home-manager/programs/fish/functions/_grct_function.fish
+++ b/home-manager/programs/fish/functions/_grct_function.fish
@@ -1,0 +1,12 @@
+function _grct_function
+  # Determine the current branch; abort if detached HEAD
+  set -l current_branch (git branch --show-current)
+  if test -z "$current_branch"
+    echo "Not on a branch; cannot reset to remote." >&2
+    return 1
+  end
+
+  # Ensure we have the latest refs, then hard reset local branch to remote state
+  git fetch origin $current_branch
+  git reset --hard origin/$current_branch
+end


### PR DESCRIPTION
## Summary
- add _grct_function to hard reset the current branch to its remote
- expose the helper via the grct abbreviation

Co-authored-by: Codex AI Agent <codex@example.com>