### PR TITLE
feat(fish): add gpu abbreviation for git push upstream

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -40,6 +40,7 @@
       gp = "git push";
       gpl = "git pull";
       gpn = "git push --no-verify";
+      gpu = "git push -u";
       lg = "lazygit";
       ta = "tmux new -A -s default";
       v = "nvim";


### PR DESCRIPTION
## Changes Made
- Added 'gpu' abbreviation that maps to 'git push -u' command
- Provides convenient shortcut for pushing and setting upstream in one command
- Follows existing fish shell abbreviation patterns in the configuration

## Technical Details
- Added to shellAbbrs section in home-manager/programs/fish/default.nix
- Uses consistent naming convention with existing git abbreviations (gp, gpl, gpn)
- Integrates seamlessly with existing fish shell configuration structure
- No breaking changes to existing functionality

## Testing
- Verified syntax correctness of Nix configuration
- Confirmed abbreviation follows existing patterns in the codebase
- All pre-commit hooks would pass (formatting, linting)
- Change is minimal and focused on single functionality addition

This improves developer workflow by reducing typing for common git operations where users frequently need to push and set upstream tracking in one command.

🤖 Generated with opencode