### PR TITLE
homebrew: add sst/tap/opencode

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -31,7 +31,7 @@
       "protobuf"
       "sheldon"
       "temporal"
-      "sst/tap/opencode" # macOS and Linux
+      "sst/tap/opencode"
     ];
     casks = [
       "beeper"

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -12,6 +12,7 @@
       "homebrew/cask"
       "kurtosis-tech/tap"
       "oven-sh/bun"
+      "sst/tap"
     ];
     brews = [
       "bun"
@@ -30,6 +31,7 @@
       "protobuf"
       "sheldon"
       "temporal"
+      "sst/tap/opencode" # macOS and Linux
     ];
     casks = [
       "beeper"


### PR DESCRIPTION
Add `sst/tap/opencode` to Homebrew brews and tap `sst/tap` in `nix-darwin/config/homebrew.nix`.\n- Adds formula for macOS and Linux\n- Keeps unrelated files unchanged\n\nRef: /pr-create