### PR TITLE
Update Docker workflow for multi-arch manifest

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -108,7 +108,7 @@ jobs:
   docker-check:
     if: always()
     needs:
-      - docker-build-and-push
+      - docker-build-push
       - docker-merge-manifests
     runs-on: ubuntu-latest
     timeout-minutes: 3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && fromJSON('["linux/amd64", "linux/arm64"]') || fromJSON('["linux/amd64"]') }}
+        build: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && fromJSON('[{"platform":"linux/amd64","suffix":"-amd64","arch":"amd64"},{"platform":"linux/arm64","suffix":"-arm64","arch":"arm64"}]') || fromJSON('[{"platform":"linux/amd64","suffix":"-amd64","arch":"amd64"}]') }}
     runs-on: ubuntu-latest
     timeout-minutes: 300
     steps:
@@ -39,6 +39,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+          flavor: |
+            suffix=${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && matrix.build.suffix || '' }}
           tags: |
             type=sha,format=short
             type=semver,pattern={{version}}
@@ -54,7 +56,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: ${{ matrix.platform }}
+          platforms: ${{ matrix.build.platform }}
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
@@ -62,10 +64,52 @@ jobs:
             COMMIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+  merge-manifests:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs:
+      - build-and-push
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set Metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+          tags: |
+            type=sha,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern={{raw}}
+            type=raw,value=latest
+      - name: Create and push multi-arch manifests
+        env:
+          TAGS: ${{ steps.metadata.outputs.tags }}
+        run: |
+          set -euo pipefail
+          archs=(amd64 arm64)
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            refs=()
+            for arch in "${archs[@]}"; do
+              refs+=("${tag}-${arch}")
+            done
+            docker manifest create --amend "$tag" "${refs[@]}"
+            for arch in "${archs[@]}"; do
+              docker manifest annotate "$tag" "${tag}-${arch}" --arch "$arch" --os linux
+            done
+            docker manifest push "$tag"
+          done <<< "${TAGS}"
   docker-check:
     if: always()
     needs:
       - build-and-push
+      - merge-manifests
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
   packages: write
 jobs:
-  build-and-push:
+  docker-build-push:
     strategy:
       fail-fast: false
       matrix:
@@ -64,10 +64,10 @@ jobs:
             COMMIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-  merge-manifests:
+  docker-merge-manifests:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs:
-      - build-and-push
+      - docker-build-push
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -108,12 +108,13 @@ jobs:
   docker-check:
     if: always()
     needs:
-      - build-and-push
-      - merge-manifests
+      - docker-build-and-push
+      - docker-merge-manifests
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
       - name: Alls Green
         uses: re-actors/alls-green@release/v1
         with:
+          allowed-skips: docker-merge-manifests
           jobs: ${{ toJSON(needs) }}

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -33,6 +33,7 @@
     ];
     casks = [
       "beeper"
+      "block-goose"
       "chatgpt"
       "claude"
       "copilot-money"


### PR DESCRIPTION
## Summary
- adjust the Docker build matrix to carry per-architecture metadata and append suffixes to tags on multi-arch pushes
- add a manifest merge job that reuses metadata tags to publish annotated multi-architecture manifests
- ensure the overall workflow waits for the manifest merge so status reporting reflects the full publication process

## Testing
- make format

------
https://chatgpt.com/codex/tasks/task_e_68cd2d447cd0832488506137f55910f0