### PR TITLE
feat: add Apollo app and git submodule management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,6 @@ help:
 	@echo "  format       - Format Nix files"
 	@echo "  format-check - Check Nix formatting"
 	@echo "  docker-build - Build the Docker image"
-	@echo "  submodules   - Sync and update git submodules"
 	@echo "  switch-HOST      - Switch to a named host configuration (e.g., make switch-galactica)"
 	@echo "  encrypt-key-HOST - Encrypt a key for a named host (e.g., make encrypt-key-galactica KEY_FILE=~/.ssh/id_ed25519)"
 	@echo "  decrypt-key-HOST - Decrypt a key for a named host (e.g., make decrypt-key-galactica KEY_FILE=id_ed25519)"

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ help:
 	@echo "  format       - Format Nix files"
 	@echo "  format-check - Check Nix formatting"
 	@echo "  docker-build - Build the Docker image"
+	@echo "  submodules   - Sync and update git submodules"
 	@echo "  switch-HOST      - Switch to a named host configuration (e.g., make switch-galactica)"
 	@echo "  encrypt-key-HOST - Encrypt a key for a named host (e.g., make encrypt-key-galactica KEY_FILE=~/.ssh/id_ed25519)"
 	@echo "  decrypt-key-HOST - Decrypt a key for a named host (e.g., make decrypt-key-galactica KEY_FILE=id_ed25519)"
@@ -403,3 +404,12 @@ docker-build:
 	@echo "🐳 Building Docker image: $(DOCKER_IMAGE_LATEST) and $(DOCKER_IMAGE_TAGGED)..."
 	@docker build -t $(DOCKER_IMAGE_LATEST) -t $(DOCKER_IMAGE_TAGGED) -f Dockerfile .
 	@echo "✅ Docker image built: $(DOCKER_IMAGE_LATEST) and $(DOCKER_IMAGE_TAGGED)"
+
+##@ Git Submodule
+
+.PHONY: git-submodule-sync
+git-submodule-sync:
+	@echo "🔁 Syncing and updating git submodules..."
+	@git submodule sync
+	@git submodule update --init --recursive
+	@echo "✅ Submodules synced and updated"

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -68,6 +68,7 @@
       "zoom"
     ];
     masApps = {
+      "Apollo" = 6448019325;
       "Final Cut Pro" = 424389933;
       "Line" = 539883307;
       "Notability" = 360593530;


### PR DESCRIPTION
## Changes Made
- Added Apollo app (ID: 6448019325) to macOS App Store apps in homebrew.nix
- Added git-submodule-sync command to Makefile for managing git submodules
- Updated Makefile help documentation to include new submodules command

## Technical Details
- Apollo app is added to the masApps section of nix-darwin homebrew configuration
- New git-submodule-sync target automates `git submodule sync` and `git submodule update --init --recursive`
- Follows existing Makefile patterns with proper phony target declaration and echo formatting
- Maintains alphabetical ordering in masApps section

## Testing
- All pre-commit hooks pass (nixfmt formatting, treefmt checks)
- Makefile syntax verified with dry run
- Apollo app ID confirmed as valid Mac App Store identifier
- New submodule command tested and works correctly
- No breaking changes to existing functionality

🤖 Generated with Claude Code