### PR TITLE
Convert rules directory from git submodule to regular directory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "rules"]
-	path = rules
-	url = https://github.com/shunkakinoki/rules

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -63,6 +63,7 @@
       "sf-symbols"
       "slack"
       "visual-studio-code"
+      "warp-dev"
       "windsurf"
       "zed"
       "zoom"


### PR DESCRIPTION
## Summary
- Convert rules directory from git submodule to regular repository directory for simplified maintenance and version control
- Add Warp dev terminal (warp-dev) to Homebrew casks for enhanced terminal development experience
- Update rules configuration to latest version with improved AI assistant and development tool settings

## Changes
- **.gitmodules**: Removed rules submodule configuration
- **rules**: Converted from git submodule to regular directory with latest content
- **nix-darwin/config/homebrew.nix**: Added warp-dev cask