### PR TITLE
feat(homebrew): add Warp cask and reorder Temporal

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -30,8 +30,8 @@
       "postgresql"
       "protobuf"
       "sheldon"
-      "temporal"
       "sst/tap/opencode"
+      "temporal"
     ];
     casks = [
       "beeper"
@@ -63,6 +63,7 @@
       "sf-symbols"
       "slack"
       "visual-studio-code"
+      "warp"
       "windsurf"
       "zed"
       "zoom"


### PR DESCRIPTION
- Add `warp` to `homebrew.casks`.
- Move `temporal` below `sst/tap/opencode` in `homebrew.brews` for consistency.

Generated by Codex CLI.