### PR TITLE
Add amp-cli package to home-manager packages

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -9,6 +9,7 @@ with pkgs;
   inputs.nur.legacyPackages.${system}.repos.charmbracelet.crush
   age
   aider-chat
+  amp-cli
   argocd
   ast-grep
   bat


### PR DESCRIPTION
## Summary
- add the amp-cli package to the shared home-manager package set

## Testing
- make nix-format-check

------
https://chatgpt.com/codex/tasks/task_e_68d4675abbd48324a1074f394e152772