### PR TITLE
fix: correct lmstudio homebrew cask name

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -56,7 +56,7 @@
       "hammerspoon"
       "karabiner-elements"
       "linear-linear"
-      "lmstudio"
+      "lm-studio"
       "notion"
       "ollama-app"
       "raycast"


### PR DESCRIPTION
## Changes Made
- Updated Homebrew cask name from 'lmstudio' to 'lm-studio'
- Fixed installation issue with outdated cask naming

## Technical Details
- Homebrew recently updated the LM Studio cask name from 'lmstudio' to 'lm-studio'
- This change ensures proper installation and updates of the LM Studio application
- Follows current Homebrew naming conventions for the application

## Testing
- Verified the correct cask name exists in Homebrew repository
- All pre-commit hooks pass (Nix formatting checks)
- Configuration builds successfully with updated cask name

🤖 Generated with opencode