### PR TITLE
fix: remove granola from homebrew casks

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -52,7 +52,6 @@
       "github"
       "google-chrome"
       "google-drive"
-      "granola"
       "hammerspoon"
       "karabiner-elements"
       "linear-linear"


### PR DESCRIPTION
## Changes Made
- Removed granola application from homebrew casks list in nix-darwin/config/homebrew.nix
- Cleaned up unused application from development environment configuration

## Technical Details
- Modified nix-darwin/config/homebrew.nix to remove the granola cask entry
- This application is no longer needed in the development environment
- Maintains consistency with current tool usage patterns

## Testing
- Verified nix configuration builds successfully with `make build`
- All pre-commit hooks pass (formatting checks)
- No breaking changes to existing homebrew configuration
- Configuration remains valid and functional

🤖 Generated with opencode