### PR TITLE
feat: add zellij to NixOS configuration

### DIFF
--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -60,6 +60,7 @@ let
         home-manager
         vim
         wget
+        zellij
       ];
 
       services.getty.autologinUser = lib.mkIf isRunner "root";


### PR DESCRIPTION
## Summary
• Add zellij terminal multiplexer to NixOS system packages

## Test plan
- [x] Configuration builds successfully
- [x] No conflicts with existing packages
- [x] Follows existing package organization patterns

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added zellij to the system packages. Users now have a modern terminal workspace manager with panes, tabs, and persistent sessions available out of the box. No additional setup required—launch with “zellij”. This complements existing terminal workflows (e.g., tmux/screen) and can improve multitasking and productivity immediately after upgrade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->