### PR TITLE
feat(fish): add ocd alias for open-composer CLI

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -26,6 +26,8 @@
     '';
     shellAliases = {
       neofetch = "fastfetch";
+
+      ocd = "bun run ~/ghq/github.com/shunkakinoki/open-composer/apps/cli/src/index.ts";
     };
     shellAbbrs = {
       c = "clear";

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -27,7 +27,7 @@
     shellAliases = {
       neofetch = "fastfetch";
 
-      ocd = "bun run ~/ghq/github.com/shunkakinoki/open-composer/apps/cli/src/index.ts";
+      ocd = "bun run ${config.home.homeDirectory}/ghq/github.com/shunkakinoki/open-composer/apps/cli/src/index.ts";
     };
     shellAbbrs = {
       c = "clear";


### PR DESCRIPTION
Adds a fish shell alias 'ocd' to run the open-composer CLI via bun.\n\n- File: home-manager/programs/fish/default.nix\n- Alias: ocd = "bun run ~/ghq/github.com/shunkakinoki/open-composer/apps/cli/src/index.ts"\n\nThis streamlines launching open-composer from the terminal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduces a new Fish shell alias, ocd, providing a quick terminal shortcut to run the associated command. This reduces typing and speeds up access in interactive Fish sessions by default, without altering or removing any existing aliases or behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->