### PR TITLE
feat(make): add setup-dev target for local development environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,8 @@ default: help
 help:
 	@echo "Available targets:"
 	@echo "  install      - Set up full environment"
+	@echo "  setup        - Basic Nix setup"
+	@echo "  setup-dev    - Set up local development environment (Nix + submodules + shell)"
 	@echo "  build        - Build Nix configuration"
 	@echo "  switch       - Apply Nix configuration"
 	@echo "  update       - Update Nix flake and configurations"
@@ -125,6 +127,9 @@ format: nix-format
 
 .PHONY: setup
 setup: nix-setup
+
+.PHONY: setup-dev
+setup-dev: nix-setup git-submodule-sync shell-install
 
 .PHONY: switch
 switch: nix-switch

--- a/conductor.json
+++ b/conductor.json
@@ -1,5 +1,5 @@
 {
-  "scripts": {
-    "setup": "make setup"
-  }
+    "scripts": {
+        "setup": "bash -c 'make setup'"
+    }
 }

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,5 @@
+{
+    "scripts": {
+        "setup": "make setup"
+    }
+}

--- a/conductor.json
+++ b/conductor.json
@@ -1,5 +1,5 @@
 {
-    "scripts": {
-        "setup": "make setup"
-    }
+  "scripts": {
+    "setup": "make setup"
+  }
 }

--- a/conductor.json
+++ b/conductor.json
@@ -1,5 +1,5 @@
 {
-    "scripts": {
-        "setup": "bash -c 'make setup'"
-    }
+  "scripts": {
+    "setup": "bash -c 'make setup'"
+  }
 }


### PR DESCRIPTION
## Summary
- Adds a new `setup-dev` make target that combines `nix-setup`, `git-submodule-sync`, and `shell-install` to provide a complete local development environment setup
- Adds a `conductor.json` file with setup script configuration for easier bootstrapping

This new target simplifies the process for new developers to get a complete local development environment up and running with a single command.