### PR TITLE
chore: update renovate configuration for npm dependencies and automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -48,6 +48,21 @@
       ]
     },
     {
+      "groupName": "Npm Dependencies",
+      "groupSlug": "npm",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchDepTypes": [
+        "flake-inputs"
+      ],
+      "automerge": true,
+      "platformAutomerge": true,
+      "schedule": [
+        "before 3am"
+      ]
+    },
+    {
       "groupName": "GitHub Actions Dependencies",
       "groupSlug": "github-actions",
       "matchManagers": [
@@ -93,6 +108,11 @@
       "groupSlug": "all-major",
       "matchUpdateTypes": [
         "major"
+      ],
+      "automerge": true,
+      "platformAutomerge": true,
+      "schedule": [
+        "before 3am"
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- Add npm dependencies grouping with automerge for flake-inputs
- Enable automerge for major dependency updates
- Update rules submodule to latest version

## Changes
- Configure npm dependency management with automerge
- Enable platform automerge for major updates
- Update rules documentation and workflows
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updates Renovate to group npm dependencies and enable automerge (including majors) on an overnight schedule to reduce manual work.

- **Dependencies**
  - Group npm deps (depType: flake-inputs) with automerge and platformAutomerge, scheduled before 3am.
  - Enable automerge and platformAutomerge for all major updates, scheduled before 3am.

<!-- End of auto-generated description by cubic. -->

