### PR TITLE
feat(packages): add yarn package manager

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -55,6 +55,7 @@ with pkgs;
   tree
   uv
   wget
+  yarn
   yq
   zoxide
 ]


### PR DESCRIPTION
## Summary
- Added yarn package manager to home-manager packages

## Details
This PR adds yarn (v1.22.22) to the list of installed packages in the home-manager configuration. This provides an alternative JavaScript package manager alongside the existing bun installation, giving more flexibility for projects that specifically require yarn.

## Test plan
- [x] Built configuration with `make build`
- [x] Applied configuration with `make switch`
- [x] Verified yarn installation with `yarn --version` (returns 1.22.22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds yarn to the home-manager package list to provide an alternative JavaScript package manager alongside bun. This enables projects that require yarn without manual installation.

<!-- End of auto-generated description by cubic. -->

