### PR TITLE
feat(fish): prioritize ~/.local/bin in PATH

### DIFF
--- a/home-manager/modules/npm-globals/default.nix
+++ b/home-manager/modules/npm-globals/default.nix
@@ -20,7 +20,7 @@
     fi
   '';
 
-  # Add local and bun bins to PATH (local bin prioritized)
+  # Add local and bun bins to PATH
   home.sessionPath = [
     "$HOME/.local/bin"
     "$HOME/.bun/bin"

--- a/home-manager/modules/npm-globals/default.nix
+++ b/home-manager/modules/npm-globals/default.nix
@@ -20,8 +20,9 @@
     fi
   '';
 
-  # Add bun bin to PATH
+  # Add local and bun bins to PATH (local bin prioritized)
   home.sessionPath = [
+    "$HOME/.local/bin"
     "$HOME/.bun/bin"
   ];
 }

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -6,6 +6,7 @@
       direnv hook fish | source
     '';
     loginShellInit = ''
+      fish_add_path -p ~/.local/bin
       fish_add_path -p ~/.bun/bin
       fish_add_path -p ~/.nix-profile/bin
       fish_add_path -p /nix/var/nix/profiles/default/bin
@@ -17,6 +18,7 @@
       _hm_load_env_file
       set fish_greeting
       set fish_theme dracula
+      fish_add_path -p ~/.local/bin
       fish_add_path -p ~/.bun/bin
       fish_add_path -p ~/.nix-profile/bin
       fish_add_path -p /nix/var/nix/profiles/default/bin


### PR DESCRIPTION
## Summary

- Add `~/.local/bin` as the first entry in Fish shell PATH configuration
- Ensures standalone binaries take precedence over wrapper scripts from package managers

## Problem

The `open-composer` command was failing because:
1. `~/.bun/bin/open-composer` (wrapper script) appears first in PATH
2. The wrapper fails to locate node_modules binary
3. `~/.local/bin/open-composer` (standalone binary) works correctly but appears later

## Solution

Prioritize `~/.local/bin` in both `loginShellInit` and `interactiveShellInit` by adding it before `~/.bun/bin` in the PATH.

## Test plan

- [ ] Apply configuration with `make switch`
- [ ] Verify `which open-composer` returns `~/.local/bin/open-composer`
- [ ] Test `open-composer --version` runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prioritized ~/.local/bin at the front of PATH in Fish login and interactive shells so standalone binaries are used before wrapper scripts. Fixes open-composer resolving to a failing Bun wrapper by selecting ~/.local/bin/open-composer.

- **Bug Fixes**
  - Prepend ~/.local/bin via fish_add_path -p in loginShellInit and interactiveShellInit.
  - Ensures tools like open-composer resolve to ~/.local/bin first.

- **Migration**
  - Run make switch.
  - which open-composer should return ~/.local/bin/open-composer.

<!-- End of auto-generated description by cubic. -->

