### PR TITLE
feat(home-manager): add yek module for LLM file serialization

### DIFF
--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -43,6 +43,8 @@ in
   home.packages = packages;
   home.stateVersion = "24.11";
 
+  programs.yek.enable = true;
+
   accounts.email.accounts = {
     Gmail = {
       primary = true;

--- a/home-manager/modules/default.nix
+++ b/home-manager/modules/default.nix
@@ -6,4 +6,5 @@
   ./npm-globals
   ./opencode
   ./serena
+  ./yek
 ]

--- a/home-manager/modules/yek/default.nix
+++ b/home-manager/modules/yek/default.nix
@@ -47,7 +47,7 @@ let
     ${pkgs.curl}/bin/curl -L -o "''${ASSET_NAME}" "''${LATEST_URL}"
 
     echo "Extracting archive..."
-    ${pkgs.gnutar}/bin/tar xzf "''${ASSET_NAME}"
+    PATH="${pkgs.gzip}/bin:$PATH" ${pkgs.gnutar}/bin/tar xzf "''${ASSET_NAME}"
 
     echo "Installing binary to ''${INSTALL_DIR}..."
     ${pkgs.coreutils}/bin/install -Dm755 yek-''${TARGET}/yek "''${INSTALL_DIR}/yek"

--- a/home-manager/modules/yek/default.nix
+++ b/home-manager/modules/yek/default.nix
@@ -1,0 +1,97 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.programs.yek;
+
+  # Determine the target platform string
+  target =
+    if pkgs.stdenv.isDarwin then
+      (if pkgs.stdenv.isAarch64 then "aarch64-apple-darwin" else "x86_64-apple-darwin")
+    else
+      (if pkgs.stdenv.isAarch64 then "aarch64-unknown-linux-gnu" else "x86_64-unknown-linux-gnu");
+
+  # Install script that downloads the latest release
+  installScript = pkgs.writeShellScriptBin "install-yek" ''
+    set -euo pipefail
+
+    REPO_OWNER="bodo-run"
+    REPO_NAME="yek"
+    TARGET="${target}"
+    ASSET_NAME="yek-''${TARGET}.tar.gz"
+    INSTALL_DIR="$HOME/.local/bin"
+
+    mkdir -p "$INSTALL_DIR"
+
+    echo "Fetching latest release info from GitHub..."
+    LATEST_URL=$(
+        ${pkgs.curl}/bin/curl -s "https://api.github.com/repos/''${REPO_OWNER}/''${REPO_NAME}/releases/latest" |
+            ${pkgs.gnugrep}/bin/grep "browser_download_url" |
+            ${pkgs.gnugrep}/bin/grep "''${ASSET_NAME}" |
+            ${pkgs.coreutils}/bin/cut -d '"' -f 4
+    )
+
+    if [ -z "''${LATEST_URL}" ]; then
+        echo "Failed to find a release asset named ''${ASSET_NAME} in the latest release."
+        exit 1
+    fi
+
+    echo "Downloading from: ''${LATEST_URL}"
+    cd "$(${pkgs.coreutils}/bin/mktemp -d)"
+    ${pkgs.curl}/bin/curl -L -o "''${ASSET_NAME}" "''${LATEST_URL}"
+
+    echo "Extracting archive..."
+    ${pkgs.gnutar}/bin/tar xzf "''${ASSET_NAME}"
+
+    echo "Installing binary to ''${INSTALL_DIR}..."
+    ${pkgs.coreutils}/bin/install -Dm755 yek-''${TARGET}/yek "''${INSTALL_DIR}/yek"
+
+    echo "✅ yek installed successfully to ''${INSTALL_DIR}/yek"
+    echo "Version: $(''${INSTALL_DIR}/yek --version)"
+  '';
+
+  yekWrapper = pkgs.writeShellScriptBin "yek" ''
+    INSTALL_DIR="$HOME/.local/bin"
+    YEK_BIN="''${INSTALL_DIR}/yek"
+
+    # Install yek if not present
+    if [ ! -f "''${YEK_BIN}" ]; then
+      echo "yek not found. Installing latest version..."
+      ${installScript}/bin/install-yek
+    fi
+
+    # Execute yek with all arguments
+    exec "''${YEK_BIN}" "$@"
+  '';
+in
+{
+  options.programs.yek = {
+    enable = mkEnableOption "yek - serialize text files for LLM consumption";
+
+    package = mkOption {
+      type = types.package;
+      default = yekWrapper;
+      description = "The yek wrapper package";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [
+      cfg.package
+      installScript
+    ];
+
+    # Install yek on activation
+    home.activation.installYek = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      if [ ! -f "$HOME/.local/bin/yek" ]; then
+        $DRY_RUN_CMD ${installScript}/bin/install-yek
+      fi
+    '';
+  };
+}


### PR DESCRIPTION
## Summary

Add a new home-manager module for [yek](https://github.com/bodo-run/yek), a fast Rust-based tool that serializes text-based files in a repository for LLM consumption.

## Features

- ✅ **Auto-downloads latest release** - No hardcoded versions or SHA hashes
- ✅ **Platform-aware installer** - Supports macOS (Intel & Apple Silicon) and Linux (x86_64 & ARM64)
- ✅ **Self-installing wrapper** - Automatically installs on first use
- ✅ **Easy updates** - Run `install-yek` to fetch the latest version
- ✅ **Pure Nix implementation** - Uses shell scripts with full Nix store paths

## Usage

The module is enabled via `programs.yek.enable = true` and provides:
- `yek` - Main command (auto-installs if needed)
- `install-yek` - Manual installer/updater

## How it works

1. Module provides a wrapper script that checks if yek is installed
2. On first use or during home-manager activation, it fetches the latest release from GitHub
3. Downloads the appropriate binary for the current platform
4. Installs to `~/.local/bin/yek`

## Example

```bash
# Serialize current directory
yek

# Serialize with tree header
yek --tree-header

# Pipe to clipboard
yek src/ | pbcopy

# Cap output to 128K tokens
yek --tokens 128k
```

## Test plan

- [x] Module builds successfully on macOS ARM64
- [x] Installer downloads and installs latest yek version (v0.25.0)
- [x] `yek` command works correctly
- [x] Platform detection works for aarch64-darwin

🤖 Generated with [Claude Code](https://claude.com/claude-code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a home-manager module for yek that auto-installs the latest platform-specific release and enables LLM-ready file serialization out of the box. Enabled by default to make `yek` available without manual setup.

- **New Features**
  - Adds `programs.yek` module with `yek` (wrapper) and `install-yek` commands.
  - Platform-aware download for macOS (Intel/ARM) and Linux (x86_64/ARM64) via pure Nix scripts.
  - Activation hook installs to `~/.local/bin/yek` if missing.

- **Migration**
  - To opt out, set `programs.yek.enable = false`.

<!-- End of auto-generated description by cubic. -->

