### PR TITLE
feat(nix-darwin): add Conductor.app to dock configuration

### DIFF
--- a/nix-darwin/config/dock.nix
+++ b/nix-darwin/config/dock.nix
@@ -26,6 +26,7 @@
       "/Applications/Notion.app"
       "/Applications/Ghostty.app"
       "/Applications/Linear.app"
+      "/Applications/Conductor.app"
       "/Applications/Cursor.app"
       "/Applications/Visual Studio Code.app"
       "/Applications/Xcode.app"


### PR DESCRIPTION
## Summary
- Add Conductor.app to the macOS dock configuration

This change adds Conductor.app to the list of applications in the macOS dock configuration file.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add Conductor.app to the macOS Dock configuration to ensure it’s pinned by default. This updates nix-darwin’s dock.nix to include /Applications/Conductor.app.

<!-- End of auto-generated description by cubic. -->

