### PR TITLE
feat(packages): add zellij to home-manager package list

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -57,6 +57,7 @@ with pkgs;
   wget
   yarn
   yq
+  zellij
   zoxide
 ]
 ++ lib.optionals stdenv.isLinux [


### PR DESCRIPTION
## Summary
- Add zellij terminal multiplexer to home-manager package list
- This change adds the zellij package to the default package list for home-manager configurations

Zellij is a terminal workspace manager that provides a productive environment for developers, similar to tmux but with a more modern interface and additional features.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added zellij to the home-manager default package list to provide a modern terminal multiplexer out of the box. It will be installed by default for users using our home-manager configuration.

<!-- End of auto-generated description by cubic. -->

