### PR TITLE
feat: set vi mode as default key bindings in fish shell

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -27,6 +27,7 @@
       fish_add_path -p /etc/profiles/per-user/${config.home.username}/bin
       set -a fish_complete_path ~/.nix-profile/share/fish/completions/ ~/.nix-profile/share/fish/vendor_completions.d/
       set -x FISH_HISTFILE fish
+      fish_vi_key_bindings
     '';
     shellAliases = {
       neofetch = "fastfetch";
@@ -45,10 +46,6 @@
       lg = "lazygit";
       ta = "tmux new -A -s default";
       v = "nvim";
-
-      # Git abbreviations - provided by GitAlias (see shellInit)
-      # Only keeping custom ones that differ from GitAlias or have special behavior
-      gpn = "git push --no-verify"; # Custom: not in GitAlias
 
       # Function-based abbreviations
       cxe = "_cxe_function";


### PR DESCRIPTION
This change updates the fish shell configuration to set vi mode as the default key bindings, providing a more efficient editing experience for users familiar with vi/vim key bindings.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable vi mode as default in fish by adding fish_vi_key_bindings for Vim-style editing in the shell. Also removes a redundant git alias and related comments to keep the config clean.

<!-- End of auto-generated description by cubic. -->

