### PR TITLE
Add custom key bindings for exiting vim insert mode in Fish shell

### DIFF
--- a/home-manager/programs/fish/functions/_fish_user_key_bindings.fish
+++ b/home-manager/programs/fish/functions/_fish_user_key_bindings.fish
@@ -1,4 +1,0 @@
-function fish_user_key_bindings
-  # Exit vim insert mode with jj
-  bind -M insert -m default jj backward-char force-repaint
-end

--- a/home-manager/programs/fish/functions/fish_user_key_bindings.fish
+++ b/home-manager/programs/fish/functions/fish_user_key_bindings.fish
@@ -1,0 +1,8 @@
+# Custom key bindings for Fish shell
+# Note: This filename must NOT have an underscore prefix (_) because Fish's
+# autoloading mechanism requires the filename to match the function name exactly.
+# Fish automatically calls this function after fish_vi_key_bindings is set.
+function fish_user_key_bindings
+  # Exit vim insert mode with jj (like in Vim)
+  bind -M insert -m default jj backward-char force-repaint
+end


### PR DESCRIPTION
Introduce a function to enable exiting vim insert mode using the 'jj' key combination in the Fish shell. This enhances user experience for those familiar with Vim.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a Fish key binding to exit Vim insert mode by typing "jj". The function now autoloads correctly by using the proper filename.

- **New Features**
  - Bind "jj" in insert mode to return to default mode (Vim-style).

- **Bug Fixes**
  - Renamed _fish_user_key_bindings.fish to fish_user_key_bindings.fish so Fish autoloads the function after fish_vi_key_bindings.

<!-- End of auto-generated description by cubic. -->

