### PR TITLE
fix(docker): remove existing manifest before creating new one

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -102,7 +102,8 @@ jobs:
             for arch in "${archs[@]}"; do
               refs+=("${tag}-${arch}")
             done
-            docker manifest create --amend "$tag" "${refs[@]}"
+            docker manifest rm "$tag" 2>/dev/null || true
+            docker manifest create "$tag" "${refs[@]}"
             for arch in "${archs[@]}"; do
               docker manifest annotate "$tag" "${tag}-${arch}" --arch "$arch" --os linux
             done


### PR DESCRIPTION
This PR fixes an issue in the Docker workflow where creating a manifest would fail if a manifest with the same tag already exists. The fix adds a command to remove any existing manifest before creating a new one, ensuring that the manifest creation process is idempotent and won't fail in CI environments where builds may be retried.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Remove any existing Docker manifest before creating a new one, fixing failures when a manifest with the same tag already exists. This makes the Docker workflow idempotent and reliable in CI retries.

<!-- End of auto-generated description by cubic. -->

