### PR TITLE
feat(opencode): add OpenAI Codex models and plugin support

### DIFF
--- a/home-manager/modules/opencode/opencode.jsonc
+++ b/home-manager/modules/opencode/opencode.jsonc
@@ -28,6 +28,72 @@
 				}
 			}
 		},
+		"openai": {
+			"options": {
+				"reasoningEffort": "medium",
+				"reasoningSummary": "auto",
+				"textVerbosity": "medium",
+				"include": ["reasoning.encrypted_content"]
+			},
+			"models": {
+				"gpt-5-codex-low-oauth": {
+					"name": "GPT-5 Codex Low (OAuth)",
+					"options": {
+						"reasoningEffort": "low",
+						"reasoningSummary": "auto",
+						"textVerbosity": "medium"
+					}
+				},
+				"gpt-5-codex-medium-oauth": {
+					"name": "GPT-5 Codex Medium (OAuth)",
+					"options": {
+						"reasoningEffort": "medium",
+						"reasoningSummary": "auto",
+						"textVerbosity": "medium"
+					}
+				},
+				"gpt-5-codex-high-oauth": {
+					"name": "GPT-5 Codex High (OAuth)",
+					"options": {
+						"reasoningEffort": "high",
+						"reasoningSummary": "detailed",
+						"textVerbosity": "medium"
+					}
+				},
+				"gpt-5-minimal-oauth": {
+					"name": "GPT-5 Minimal (OAuth)",
+					"options": {
+						"reasoningEffort": "minimal",
+						"reasoningSummary": "auto",
+						"textVerbosity": "low"
+					}
+				},
+				"gpt-5-low-oauth": {
+					"name": "GPT-5 Low (OAuth)",
+					"options": {
+						"reasoningEffort": "low",
+						"reasoningSummary": "auto",
+						"textVerbosity": "low"
+					}
+				},
+				"gpt-5-medium-oauth": {
+					"name": "GPT-5 Medium (OAuth)",
+					"options": {
+						"reasoningEffort": "medium",
+						"reasoningSummary": "auto",
+						"textVerbosity": "medium"
+					}
+				},
+				"gpt-5-high-oauth": {
+					"name": "GPT-5 High (OAuth)",
+					"options": {
+						"reasoningEffort": "high",
+						"reasoningSummary": "detailed",
+						"textVerbosity": "high"
+					}
+				}
+			}
+		},
 		"openrouter": {
 			"models": {
 				"deepseek/deepseek-chat-v3.1:free": {
@@ -72,5 +138,6 @@
 				}
 			}
 		}
-	}
+	},
+	"plugin": ["opencode-openai-codex-auth"]
 }


### PR DESCRIPTION
## Summary
- Add OpenAI Codex models with different reasoning efforts (minimal, low, medium, high)
- Configure model options for reasoning effort, summary, and text verbosity
- Add opencode-openai-codex-auth plugin by [numman-ali](https://github.com/numman-ali) to enable OpenAI Codex authentication [here](https://github.com/numman-ali/opencode-openai-codex-auth)

This enhancement adds support for various OpenAI Codex models with different reasoning capabilities, allowing users to select the appropriate model based on their needs.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds OpenAI Codex model presets with configurable reasoning profiles and text verbosity. This lets users choose minimal, low, medium, or high reasoning as needed.

- **New Features**
  - Set openai defaults: reasoningEffort=medium, reasoningSummary=auto, textVerbosity=medium; include reasoning.encrypted_content.
  - Added OAuth presets: gpt-5-codex-(low|medium|high)-oauth and gpt-5-(minimal|low|medium|high)-oauth with matching options.
  - Enabled OpenAI Codex authentication via plugin: opencode-openai-codex-auth.

<!-- End of auto-generated description by cubic. -->

