### PR TITLE
feat: add droid module for Factory AI CLI

### DIFF
--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -44,6 +44,7 @@ in
   home.stateVersion = "24.11";
 
   programs.yek.enable = true;
+  programs.droid.enable = true;
 
   accounts.email.accounts = {
     Gmail = {

--- a/home-manager/modules/default.nix
+++ b/home-manager/modules/default.nix
@@ -1,6 +1,7 @@
 [
   ./codex
   ./crush
+  ./droid
   ./dust
   ./ghostty
   ./npm-globals

--- a/home-manager/modules/droid/default.nix
+++ b/home-manager/modules/droid/default.nix
@@ -1,0 +1,79 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.programs.droid;
+
+  # Install script that uses the official Factory AI CLI installer
+  installScript = pkgs.writeShellScriptBin "install-droid" ''
+    set -euo pipefail
+
+    INSTALL_DIR="$HOME/.local/bin"
+
+    mkdir -p "$INSTALL_DIR"
+
+    echo "Installing droid CLI from Factory AI..."
+    cd "$(${pkgs.coreutils}/bin/mktemp -d)"
+
+    # Download and execute the official installer with curl in PATH
+    ${pkgs.curl}/bin/curl -fsSL https://app.factory.ai/cli > installer.sh
+
+    # Export PATH to include necessary tools for the installer
+    export PATH="${pkgs.curl}/bin:${pkgs.coreutils}/bin:${pkgs.gnused}/bin:${pkgs.gnutar}/bin:${pkgs.gzip}/bin:$PATH"
+
+    ${pkgs.bash}/bin/bash installer.sh
+
+    # Verify installation
+    if [ -f "''${INSTALL_DIR}/droid" ]; then
+      echo "✅ droid installed successfully to ''${INSTALL_DIR}/droid"
+      echo "Version: $(''${INSTALL_DIR}/droid --version 2>&1 || echo 'installed')"
+    else
+      echo "⚠️ droid installation completed but binary not found at expected location"
+    fi
+  '';
+
+  droidWrapper = pkgs.writeShellScriptBin "droid" ''
+    INSTALL_DIR="$HOME/.local/bin"
+    DROID_BIN="''${INSTALL_DIR}/droid"
+
+    # Install droid if not present
+    if [ ! -f "''${DROID_BIN}" ]; then
+      echo "droid not found. Installing latest version..."
+      ${installScript}/bin/install-droid
+    fi
+
+    # Execute droid with all arguments
+    exec "''${DROID_BIN}" "$@"
+  '';
+in
+{
+  options.programs.droid = {
+    enable = mkEnableOption "droid - Factory AI CLI for AI-powered development";
+
+    package = mkOption {
+      type = types.package;
+      default = droidWrapper;
+      description = "The droid wrapper package";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [
+      cfg.package
+      installScript
+    ];
+
+    # Install droid on activation
+    home.activation.installDroid = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      if [ ! -f "$HOME/.local/bin/droid" ]; then
+        $DRY_RUN_CMD ${installScript}/bin/install-droid || echo "⚠️ Failed to install droid. You can install it later by running: install-droid"
+      fi
+    '';
+  };
+}

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -8,6 +8,7 @@ with pkgs;
   inputs.agenix.packages.${system}.default
   inputs.nur.legacyPackages.${system}.repos.charmbracelet.crush
   age
+  aichat
   aider-chat
   amp-cli
   argocd
@@ -30,6 +31,7 @@ with pkgs;
   gemini-cli
   gh
   git
+  goose-cli
   grc
   httpie
   hyperfine


### PR DESCRIPTION
## Summary
- Adds a new home-manager module for the droid CLI tool from Factory AI
- The module includes automatic installation and wrapper script to ensure the CLI is always available
- Also adds aichat and goose-cli packages to home-manager packages

## Details
This PR introduces a new module for the droid CLI tool from Factory AI. The module automatically installs the CLI tool when enabled and provides a wrapper script that ensures the tool is always available. Additionally, this PR adds two new AI-related CLI tools (aichat and goose-cli) to the home-manager packages list.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a droid CLI module to home-manager with automatic installation and a wrapper so the binary is always available. Also adds aichat and goose-cli to the default packages.

- **New Features**
  - New programs.droid module with an install script and a wrapper that auto-installs and runs ~/.local/bin/droid.
  - Installs on home activation if missing; provides install-droid for manual runs.
  - Enabled by default and included in the modules list.

<!-- End of auto-generated description by cubic. -->

