### PR TITLE
Enhance macOS setup with conditional system file backup

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,9 +46,18 @@ jobs:
             max-jobs = auto
             cores = 0
       - name: Prepare System Files
+        if: runner.os == 'macOS'
         run: |
-          sudo mv /etc/nix/nix.conf /etc/nix/nix.conf.before-nix-darwin || true
-          sudo mv /etc/shells /etc/shells.before-nix-darwin || true
+          for file in \
+            /etc/nix/nix.conf \
+            /etc/shells \
+            /etc/bashrc \
+            /etc/zshrc
+          do
+            if [ -e "$file" ]; then
+              sudo mv "$file" "${file}.before-nix-darwin"
+            fi
+          done
       - name: Run Install Command
         run: |
           curl -fsSL https://raw.githubusercontent.com/shunkakinoki/dotfiles/${{ github.sha }}/install.sh | sh


### PR DESCRIPTION
Implement conditional backup of system files during the macOS setup process to improve safety and prevent data loss.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Make the macOS e2e setup safer by backing up common system config files only when present and only on macOS runners. This reduces risk of data loss and avoids cross-OS errors.

- **Refactors**
  - Run "Prepare System Files" only when runner.os == 'macOS'.
  - Back up /etc/nix/nix.conf, /etc/shells, /etc/bashrc, and /etc/zshrc to *.before-nix-darwin if they exist.

<!-- End of auto-generated description by cubic. -->

