### PR TITLE
feat(packages): add database development tools

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -44,16 +44,20 @@ with pkgs;
   kubectx
   kustomize
   llama-cpp
+  mariadb
   opencode
+  postgresql
   procs
   pulumi-bin
   qwen-code
   ripgrep
   rustup
   sccache
+  sqlite
   stern
   tokei
   tree
+  turso-cli
   uv
   wget
   yarn


### PR DESCRIPTION
## Summary
- Add mariadb, postgresql, sqlite, and turso-cli to home-manager packages for database development
- Enhance development environment with comprehensive database tooling support
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added MariaDB, PostgreSQL, SQLite, and Turso CLI to home-manager packages to support database development. This makes it easy to test and manage databases locally across projects.

<!-- End of auto-generated description by cubic. -->

