### PR TITLE
feat: add LM Studio integration and update AI tooling

### DIFF
--- a/home-manager/modules/codex/config.toml
+++ b/home-manager/modules/codex/config.toml
@@ -8,6 +8,10 @@ notify = [
 [tools]
 web_search = true
 
+[model_providers.lmstudio]
+name = "LMStudio"
+base_url = "http://127.0.0.1:1234/v1"
+
 [model_providers.ollama]
 name = "Ollama"
 base_url = "http://127.0.0.1:11434/v1"
@@ -22,5 +26,5 @@ model = "gpt-oss:20b"
 model_provider = "ollama"
 
 [profiles.gpt-oss-120b]
-model = "gpt-oss:120b"
-model_provider = "ollama"
+model = "openai/gpt-oss-120b"
+model_provider = "lmstudio"

--- a/home-manager/modules/codex/config.toml
+++ b/home-manager/modules/codex/config.toml
@@ -28,3 +28,7 @@ model_provider = "ollama"
 [profiles.gpt-oss-120b]
 model = "openai/gpt-oss-120b"
 model_provider = "lmstudio"
+
+[profiles.qwen3-coder-30b]
+model = "qwen/qwen3-coder-30b"
+model_provider = "lmstudio"

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -44,7 +44,6 @@ with pkgs;
   kustomize
   llama-cpp
   mariadb
-  opencode
   postgresql
   procs
   pulumi-bin
@@ -70,5 +69,7 @@ with pkgs;
   codex
   docker
   docker-compose
+  gemini-cli
   kubernetes-helm
+  opencode
 ]

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -49,8 +49,9 @@
       v = "nvim";
 
       # Function-based abbreviations
-      cxe = "_cxe_function";
       clxe = "_clxe_function";
+      coxe = "_coxe_function";
+      coxel = "_coxel_function";
       gco = "_gco_function";
       grco = "_grco_function";
       grcr = "_grcr_function";

--- a/home-manager/programs/fish/functions/_clxe_function.fish
+++ b/home-manager/programs/fish/functions/_clxe_function.fish
@@ -1,11 +1,11 @@
-function _clxe_function --description "Run Codex with a free-form prompt using the local gpt-oss:120b model"
-  # Run Codex with a free-form prompt (spaces allowed) using the local gpt-oss:120b model
+function _clxe_function --description "Run Claude Code with a free-form prompt while skipping permissions"
+  # Run Claude Code with a free-form prompt (spaces allowed) and bypass permission checks
   # Usage: clxe [<prompt words...>]
 
   if test (count $argv) -eq 0
-    codex --profile 'gpt-oss-120b' --full-auto -c model_reasoning_summary_format=experimental
+    claude code --dangerously-skip-permissions
   else
     set -l prompt (string join " " -- $argv)
-    codex --profile 'gpt-oss-120b' --full-auto -c model_reasoning_summary_format=experimental -- "$prompt"
+    claude code --dangerously-skip-permissions --print -- "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_coxe_function.fish
+++ b/home-manager/programs/fish/functions/_coxe_function.fish
@@ -1,4 +1,4 @@
-function _cxe_function --description "Run Codex with a free-form prompt"
+function _coxe_function --description "Run Codex with a free-form prompt"
   # Run Codex with a free-form prompt (spaces allowed)
   # Usage: cxe [<prompt words...>]
 

--- a/home-manager/programs/fish/functions/_coxel_function.fish
+++ b/home-manager/programs/fish/functions/_coxel_function.fish
@@ -1,0 +1,11 @@
+function _coxel_function --description "Run Codex with a free-form prompt using the local gpt-oss:120b model"
+  # Run Codex with a free-form prompt (spaces allowed) using the local gpt-oss:120b model
+  # Usage: cxel [<prompt words...>]
+
+  if test (count $argv) -eq 0
+    codex --profile 'gpt-oss-120b' --full-auto -c model_reasoning_summary_format=experimental
+  else
+    set -l prompt (string join " " -- $argv)
+    codex --profile 'gpt-oss-120b' --full-auto -c model_reasoning_summary_format=experimental -- "$prompt"
+  end
+end

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -12,7 +12,6 @@
       "homebrew/cask"
       "kurtosis-tech/tap"
       "oven-sh/bun"
-      "sst/tap"
     ];
     brews = [
       "bun"

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -12,6 +12,7 @@
       "homebrew/cask"
       "kurtosis-tech/tap"
       "oven-sh/bun"
+      "sst/tap"
     ];
     brews = [
       "bun"
@@ -30,6 +31,7 @@
       "postgresql"
       "protobuf"
       "sheldon"
+      "sst/tap/opencode"
       "temporal"
     ];
     casks = [
@@ -61,7 +63,6 @@
       "lm-studio"
       "notion"
       "ollama-app"
-      "opencode"
       "raycast"
       "rescuetime"
       "screen-studio"

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -31,11 +31,11 @@
       "postgresql"
       "protobuf"
       "sheldon"
-      "sst/tap/opencode"
       "temporal"
     ];
     casks = [
       "beeper"
+      "blender"
       "block-goose"
       "chatgpt"
       "claude"
@@ -62,6 +62,7 @@
       "lm-studio"
       "notion"
       "ollama-app"
+      "opencode"
       "raycast"
       "rescuetime"
       "screen-studio"


### PR DESCRIPTION
## Summary
- Add LM Studio as model provider in Codex configuration with local models
- Update Fish shell functions for Claude Code and Codex interactions
- Add new packages: gemini-cli and opencode; reorganize package ordering
- Add Blender to Homebrew casks for 3D modeling capabilities
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds LM Studio as a Codex provider and updates Fish aliases to streamline local model and Claude Code workflows. Also adds gemini-cli, opencode, and Blender.

- **New Features**
  - LM Studio provider in Codex config (http://127.0.0.1:1234/v1).
  - Switch gpt-oss-120b profile to LM Studio; add qwen3-coder-30b profile.
  - Fish aliases: clxe runs Claude Code with skipped permissions; new coxe for Codex prompts; new coxel for local gpt-oss:120b.

- **Dependencies**
  - Add gemini-cli and opencode to packages.
  - Add Blender to Homebrew casks.

<!-- End of auto-generated description by cubic. -->

