### PR TITLE
chore(homebrew): add paradigmxyz tap and reorganize Ethereum tools

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -12,6 +12,7 @@
       "homebrew/cask"
       "kurtosis-tech/tap"
       "oven-sh/bun"
+      "paradigmxyz/brew"
       "sst/tap"
     ];
     brews = [
@@ -22,16 +23,18 @@
       "coreutils"
       "ffmpeg"
       "gemini-cli"
+      "geth"
       "gnupg"
       "helm"
       "kurtosis-cli"
       "mas"
+      "opencode"
       "pinentry-mac"
       "pnpm"
       "postgresql"
       "protobuf"
+      "reth"
       "sheldon"
-      "sst/tap/opencode"
       "temporal"
     ];
     casks = [


### PR DESCRIPTION
## Summary
- Add paradigmxyz/brew tap for Ethereum development tools
- Move geth and reth from paradigmxyz tap to main brews list
- Move opencode from sst/tap to main brews list
- Reorganize Ethereum tooling for better maintainability
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added the paradigmxyz/brew tap and moved geth, reth, and opencode to the main brews list to simplify installs and maintenance of Ethereum tooling.
This consolidates tooling sources and reduces tap-specific references in the nix-darwin Homebrew config.

<!-- End of auto-generated description by cubic. -->

