### PR TITLE
feat: add Atuin integration and update terminal tools

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -128,16 +128,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760965567,
-        "narHash": "sha256-0JDOal5P7xzzAibvD0yTE3ptyvoVOAL0rcELmDdtSKg=",
+        "lastModified": 1761124052,
+        "narHash": "sha256-4nQi8dPl4WuhZdjTPK5IQeUrcvRqCKjFAPi2+nVVNqw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cb82756ecc37fa623f8cf3e88854f9bf7f64af93",
+        "rev": "3f441d5de033489fbd30beb172bf7bc0e3093af4",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -157,6 +156,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1760965567,
+        "narHash": "sha256-0JDOal5P7xzzAibvD0yTE3ptyvoVOAL0rcELmDdtSKg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cb82756ecc37fa623f8cf3e88854f9bf7f64af93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nur": {
       "inputs": {
         "flake-parts": "flake-parts_2",
@@ -165,11 +180,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1761119189,
-        "narHash": "sha256-BciFr+EXFfLwC6t+btpRc9DLjG9bH+TlHj+1B82lWo8=",
+        "lastModified": 1761123445,
+        "narHash": "sha256-4LtCsyJiUPYt5ma9LLNfxP1TLqL/BzPRareIYqb2Ja8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a1c2556ba99fcc8c87bbe48f10f9b1dc977759dd",
+        "rev": "1eb2cc11728c1461972b2a90c7a0f45253797af0",
         "type": "github"
       },
       "original": {
@@ -185,6 +200,7 @@
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "nur": "nur",
         "treefmt-nix": "treefmt-nix"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1760813311,
-        "narHash": "sha256-lbHQ7FXGzt6/IygWvJ1lCq+Txcut3xYYd6VIpF1ojkg=",
+        "lastModified": 1760948891,
+        "narHash": "sha256-TmWcdiUUaWk8J4lpjzu4gCGxWY6/Ok7mOK4fIFfBuU4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4e627ac2e1b8f1de7f5090064242de9a259dbbc8",
+        "rev": "864599284fc7c0ba6357ed89ed5e2cd5040f0c04",
         "type": "github"
       },
       "original": {
@@ -93,11 +93,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760887455,
-        "narHash": "sha256-/xU8iYZjolWbMUNBQF6af5zgGs73Qw21WMgz1tLs3Yw=",
+        "lastModified": 1761081701,
+        "narHash": "sha256-IwpfaKg5c/WWQiy8b5QGaVPMvoEQ2J6kpwRFdpVpBNQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "aeabc1ac63e6ebb8ba4714c4abdfe0556f2de765",
+        "rev": "9b4a2a7c4fbd75b422f00794af02d6edb4d9d315",
         "type": "github"
       },
       "original": {
@@ -128,11 +128,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1760872779,
-        "narHash": "sha256-c5C907Raf9eY8f1NUXYeju9aUDlm227s/V0OptEbypA=",
+        "lastModified": 1760965567,
+        "narHash": "sha256-0JDOal5P7xzzAibvD0yTE3ptyvoVOAL0rcELmDdtSKg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "63bdb5d90fa2fa11c42f9716ad1e23565613b07c",
+        "rev": "cb82756ecc37fa623f8cf3e88854f9bf7f64af93",
         "type": "github"
       },
       "original": {
@@ -165,11 +165,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760928013,
-        "narHash": "sha256-Na8xAUzj/mEb8/u61PG4HBYS7yTXZUYUWDVPTz6k9K4=",
+        "lastModified": 1761119189,
+        "narHash": "sha256-BciFr+EXFfLwC6t+btpRc9DLjG9bH+TlHj+1B82lWo8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b9619b15fdc41d80c21aa7fb9da7f10cdcc7cecf",
+        "rev": "a1c2556ba99fcc8c87bbe48f10f9b1dc977759dd",
         "type": "github"
       },
       "original": {
@@ -211,11 +211,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760889407,
-        "narHash": "sha256-ppIp04fmz+BaTpJs1nIOmPADg02asfQFrFbhb3SmxsE=",
+        "lastModified": 1760945191,
+        "narHash": "sha256-ZRVs8UqikBa4Ki3X4KCnMBtBW0ux1DaT35tgsnB1jM4=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "3f258dead9fed51f53862366d3a6bc1b622ee7cb",
+        "rev": "f56b1934f5f8fcab8deb5d38d42fd692632b47c2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,11 @@
   description = "Shun Kakinoki's Nix Configuration";
 
   inputs = {
-    nixpkgs = {
+    nixpkgs-unstable = {
       url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    };
+    nixpkgs = {
+      url = "github:NixOS/nixpkgs"; # HEAD to resolve nokogiri issue https://github.com/NixOS/nixpkgs/issues/449970
     };
     home-manager = {
       url = "github:nix-community/home-manager";

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -28,6 +28,7 @@ with pkgs;
   fastfetch
   fd
   fswatch
+  fzf-make
   gh
   git
   goose-cli

--- a/home-manager/programs/atuin/default.nix
+++ b/home-manager/programs/atuin/default.nix
@@ -1,5 +1,5 @@
 {
-  programs.fzf = {
+  programs.atuin = {
     enable = true;
     enableBashIntegration = true;
     enableFishIntegration = true;

--- a/home-manager/programs/default.nix
+++ b/home-manager/programs/default.nix
@@ -4,6 +4,7 @@
   sources,
 }:
 let
+  atuin = import ./atuin;
   bash = import ./bash { inherit lib pkgs; };
   bat = import ./bat;
   direnv = import ./direnv;
@@ -30,6 +31,7 @@ let
   zsh = import ./zsh { inherit lib pkgs; };
 in
 [
+  atuin
   bash
   bat
   direnv

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -28,6 +28,7 @@
       set -a fish_complete_path ~/.nix-profile/share/fish/completions/ ~/.nix-profile/share/fish/vendor_completions.d/
       set -x FISH_HISTFILE fish
       fish_vi_key_bindings
+
     '';
     shellAliases = {
       neofetch = "fastfetch";
@@ -75,10 +76,11 @@
         name = "done";
         src = pkgs.fishPlugins.done.src;
       }
-      {
-        name = "fzf";
-        src = pkgs.fishPlugins.fzf.src;
-      }
+      # Temporarily disabled due to bind -k syntax incompatibility with fish 4.x
+      # {
+      #   name = "fzf";
+      #   src = pkgs.fishPlugins.fzf.src;
+      # }
       {
         name = "fzf-fish";
         src = pkgs.fishPlugins.fzf-fish.src;

--- a/home-manager/programs/git/default.nix
+++ b/home-manager/programs/git/default.nix
@@ -2,11 +2,6 @@
 {
   programs.git = {
     enable = true;
-    delta = {
-      enable = true;
-    };
-    userName = "Shun Kakinoki";
-    userEmail = "shunkakinoki@gmail.com";
     lfs = {
       enable = true;
     };
@@ -14,12 +9,16 @@
       # Include GitAlias - update with: scripts/update-gitalias.sh
       { path = "${./gitalias.txt}"; }
     ];
-    aliases = {
-      co = "checkout";
-      lt = "log --tags --decorate --simplify-by-decoration --oneline";
-      unshallow = "fetch --prune --tags --unshallow";
-    };
-    extraConfig = {
+    settings = {
+      user = {
+        name = "Shun Kakinoki";
+        email = "shunkakinoki@gmail.com";
+      };
+      alias = {
+        co = "checkout";
+        lt = "log --tags --decorate --simplify-by-decoration --oneline";
+        unshallow = "fetch --prune --tags --unshallow";
+      };
       # commit.gpgSign = true;
       # gpg.format = "ssh";
       # gpg.ssh.allowedSignersFile = "~/.ssh/allowed_signers";
@@ -82,5 +81,9 @@
       };
     };
     ignores = lib.splitString "\n" (builtins.readFile ./.gitignore.global);
+  };
+  programs.delta = {
+    enable = true;
+    enableGitIntegration = true;
   };
 }

--- a/named-hosts/galactica/default.nix
+++ b/named-hosts/galactica/default.nix
@@ -40,9 +40,13 @@ inputs.nix-darwin.lib.darwinSystem {
               signByDefault = true;
               key = "shunkakinoki@gmail.com";
             };
-            extraConfig = {
-              commit.gpgSign = true;
-              tag.gpgSign = true;
+            settings = {
+              commit = {
+                gpgSign = true;
+              };
+              tag = {
+                gpgSign = true;
+              };
             };
           };
 

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -38,6 +38,7 @@
       "temporal"
     ];
     casks = [
+      "atuin-desktop"
       "beeper"
       "blender"
       "block-goose"
@@ -73,6 +74,7 @@
       "slack"
       "visual-studio-code"
       "warp"
+      "wezterm"
       "windsurf"
       "zed"
       "zoom"

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -40,6 +40,7 @@
     casks = [
       "atuin-desktop"
       "beeper"
+      "beekeeper-studio"
       "blender"
       "block-goose"
       "chatgpt"


### PR DESCRIPTION
## Summary
- Add Atuin shell history manager with desktop app integration
- Enable fzf integration across bash, fish, and zsh shells
- Add fzf-make package for enhanced build tooling
- Add WezTerm terminal emulator to Homebrew casks
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds Atuin shell history with bash, fish, and zsh integration, and enables fzf across all shells to speed up search and recall. Also adds fzf-make and installs WezTerm and Atuin Desktop.

- **New Features**
  - Enable Atuin in Home Manager with bash/fish/zsh integration.
  - Enable fzf bash/fish/zsh integration for consistent fuzzy finding.
  - Add fzf-make to packages for improved build tooling.

- **Dependencies**
  - Homebrew casks: atuin-desktop and wezterm.

<!-- End of auto-generated description by cubic. -->

