### PR TITLE
chore(flake.lock): update lock file with latest revisions and hashes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -12,11 +12,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1760836749,
-        "narHash": "sha256-wyT7Pl6tMFbFrs8Lk/TlEs81N6L+VSybPfiIgzU8lbQ=",
+        "lastModified": 1761656077,
+        "narHash": "sha256-lsNWuj4Z+pE7s0bd2OKicOFq9bK86JE0ZGeKJbNqb94=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "2f0f812f69f3eb4140157fe15e12739adf82e32a",
+        "rev": "9ba0d85de3eaa7afeab493fed622008b6e4924f5",
         "type": "github"
       },
       "original": {
@@ -52,11 +52,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1760813311,
-        "narHash": "sha256-lbHQ7FXGzt6/IygWvJ1lCq+Txcut3xYYd6VIpF1ojkg=",
+        "lastModified": 1762440070,
+        "narHash": "sha256-xxdepIcb39UJ94+YydGP221rjnpkDZUlykKuF54PsqI=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4e627ac2e1b8f1de7f5090064242de9a259dbbc8",
+        "rev": "26d05891e14c88eb4a5d5bee659c0db5afb609d8",
         "type": "github"
       },
       "original": {
@@ -93,11 +93,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760887455,
-        "narHash": "sha256-/xU8iYZjolWbMUNBQF6af5zgGs73Qw21WMgz1tLs3Yw=",
+        "lastModified": 1762463325,
+        "narHash": "sha256-33YUsWpPyeBZEWrKQ2a1gkRZ7i0XCC/2MYpU6BVeQSU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "aeabc1ac63e6ebb8ba4714c4abdfe0556f2de765",
+        "rev": "0562fef070a1027325dd4ea10813d64d2c967b39",
         "type": "github"
       },
       "original": {
@@ -113,11 +113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760721282,
-        "narHash": "sha256-aAHphQbU9t/b2RRy2Eb8oMv+I08isXv2KUGFAFn7nCo=",
+        "lastModified": 1762501326,
+        "narHash": "sha256-QbhsksHaIN6qU3oXhwUFbYycKX1GRxObpQSWAM5fhRY=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "c3211fcd0c56c11ff110d346d4487b18f7365168",
+        "rev": "e2b82ebd0f990a5d1b68fcc761b3d6383c86ccfd",
         "type": "github"
       },
       "original": {
@@ -144,11 +144,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1754788789,
-        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "lastModified": 1761765539,
+        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
         "type": "github"
       },
       "original": {
@@ -165,11 +165,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760928013,
-        "narHash": "sha256-Na8xAUzj/mEb8/u61PG4HBYS7yTXZUYUWDVPTz6k9K4=",
+        "lastModified": 1762554789,
+        "narHash": "sha256-85gEriuyJY4fOVKS54rxxbrD+Ptf1gA303mXZpV9hcM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b9619b15fdc41d80c21aa7fb9da7f10cdcc7cecf",
+        "rev": "68b01383f627a75b23633abcc72f71dde622f50f",
         "type": "github"
       },
       "original": {
@@ -211,11 +211,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760889407,
-        "narHash": "sha256-ppIp04fmz+BaTpJs1nIOmPADg02asfQFrFbhb3SmxsE=",
+        "lastModified": 1762410071,
+        "narHash": "sha256-aF5fvoZeoXNPxT0bejFUBXeUjXfHLSL7g+mjR/p5TEg=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "3f258dead9fed51f53862366d3a6bc1b622ee7cb",
+        "rev": "97a30861b13c3731a84e09405414398fbf3e109f",
         "type": "github"
       },
       "original": {

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -9,7 +9,7 @@
 }:
 let
   hmConfig = import ../config;
-  packages = import ./packages { inherit pkgs inputs system; };
+  packages = import ./packages { inherit pkgs inputs; };
   misc = import ./misc;
   modules = import ./modules;
   programs = import ./programs {

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -4,8 +4,8 @@
 }:
 with pkgs;
 [
-  inputs.agenix.packages.aarch64-darwin.default
-  inputs.nur.legacyPackages.aarch64-darwin.repos.charmbracelet.crush
+  inputs.agenix.packages.${pkgs.system}.default
+  inputs.nur.legacyPackages.${pkgs.system}.repos.charmbracelet.crush
   age
   aichat
   aider-chat

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -1,12 +1,11 @@
 {
   pkgs,
   inputs,
-  system,
 }:
 with pkgs;
 [
-  inputs.agenix.packages.${system}.default
-  inputs.nur.legacyPackages.${system}.repos.charmbracelet.crush
+  inputs.agenix.packages.aarch64-darwin.default
+  inputs.nur.legacyPackages.aarch64-darwin.repos.charmbracelet.crush
   age
   aichat
   aider-chat

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -4,8 +4,8 @@
 }:
 with pkgs;
 [
-  inputs.agenix.packages.${pkgs.system}.default
-  inputs.nur.legacyPackages.${pkgs.system}.repos.charmbracelet.crush
+  inputs.agenix.packages.${stdenv.hostPlatform.system}.default
+  inputs.nur.legacyPackages.${stdenv.hostPlatform.system}.repos.charmbracelet.crush
   age
   aichat
   aider-chat

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -107,50 +107,27 @@
     source = config.lib.file.mkOutOfStoreSymlink ./completions;
   };
 
-  # Individual function files
-  xdg.configFile."fish/functions/_clxe_function.fish" = {
-    source = ./functions/_clxe_function.fish;
-  };
-  xdg.configFile."fish/functions/_coxe_function.fish" = {
-    source = ./functions/_coxe_function.fish;
-  };
-  xdg.configFile."fish/functions/_coxel_function.fish" = {
-    source = ./functions/_coxel_function.fish;
-  };
-  xdg.configFile."fish/functions/_fish_shortcuts.fish" = {
-    source = ./functions/_fish_shortcuts.fish;
-  };
-  xdg.configFile."fish/functions/_fzf_cmd_history.fish" = {
-    source = ./functions/_fzf_cmd_history.fish;
-  };
-  xdg.configFile."fish/functions/_fzf_directory_picker.fish" = {
-    source = ./functions/_fzf_directory_picker.fish;
-  };
-  xdg.configFile."fish/functions/_fzf_file_picker.fish" = {
-    source = ./functions/_fzf_file_picker.fish;
-  };
-  xdg.configFile."fish/functions/_fzf_ghq_picker.fish" = {
-    source = ./functions/_fzf_ghq_picker.fish;
-  };
-  xdg.configFile."fish/functions/_fzf_preview_cmd.fish" = {
-    source = ./functions/_fzf_preview_cmd.fish;
-  };
-  xdg.configFile."fish/functions/_fzf_preview_name.fish" = {
-    source = ./functions/_fzf_preview_name.fish;
-  };
-  xdg.configFile."fish/functions/_gco_function.fish" = {
-    source = ./functions/_gco_function.fish;
-  };
-  xdg.configFile."fish/functions/_grco_function.fish" = {
-    source = ./functions/_grco_function.fish;
-  };
-  xdg.configFile."fish/functions/_grcr_function.fish" = {
-    source = ./functions/_grcr_function.fish;
-  };
-  xdg.configFile."fish/functions/_hm_load_env_file.fish" = {
-    source = ./functions/_hm_load_env_file.fish;
-  };
-  xdg.configFile."fish/functions/fish_user_key_bindings.fish" = {
-    source = ./functions/fish_user_key_bindings.fish;
-  };
+  # Individual function files (DRY approach)
+  xdg.configFile = lib.listToAttrs (
+    map (name: {
+      name = "fish/functions/${name}.fish";
+      value.source = ./functions/${name}.fish;
+    }) [
+      "_clxe_function"
+      "_coxe_function"
+      "_coxel_function"
+      "_fish_shortcuts"
+      "_fzf_cmd_history"
+      "_fzf_directory_picker"
+      "_fzf_file_picker"
+      "_fzf_ghq_picker"
+      "_fzf_preview_cmd"
+      "_fzf_preview_name"
+      "_gco_function"
+      "_grco_function"
+      "_grcr_function"
+      "_hm_load_env_file"
+      "fish_user_key_bindings"
+    ]
+  ) // xdg.configFile;
 }

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -45,7 +45,7 @@
       e = "nvim";
       g = "git";
       ld = "lazydocker";
-      # lg = "lazygit"; # Temporarily commented out to debug build issue
+      lzg = "lazygit";
       ta = "tmux new -A -s default";
       v = "nvim";
 

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 {
   programs.fish = {
     enable = true;
@@ -99,39 +104,32 @@
     ];
   };
 
-  xdg.configFile."fish/themes/dracula.theme" = {
-    source = ./dracula.theme;
-  };
-
-  xdg.configFile."fish/completions" = {
-    source = config.lib.file.mkOutOfStoreSymlink ./completions;
-  };
-
-  # Individual function files (DRY approach)
-  xdg.configFile =
-    lib.listToAttrs (
-      map
-        (name: {
-          name = "fish/functions/${name}.fish";
-          value.source = ./functions/${name}.fish;
-        })
-        [
-          "_clxe_function"
-          "_coxe_function"
-          "_coxel_function"
-          "_fish_shortcuts"
-          "_fzf_cmd_history"
-          "_fzf_directory_picker"
-          "_fzf_file_picker"
-          "_fzf_ghq_picker"
-          "_fzf_preview_cmd"
-          "_fzf_preview_name"
-          "_gco_function"
-          "_grco_function"
-          "_grcr_function"
-          "_hm_load_env_file"
-          "fish_user_key_bindings"
-        ]
-    )
-    // xdg.configFile;
+  xdg.configFile = {
+    "fish/themes/dracula.theme".source = ./dracula.theme;
+    "fish/completions".source = config.lib.file.mkOutOfStoreSymlink ./completions;
+  }
+  // lib.listToAttrs (
+    map
+      (name: {
+        name = "fish/functions/${name}.fish";
+        value.source = ./functions/${name}.fish;
+      })
+      [
+        "_clxe_function"
+        "_coxe_function"
+        "_coxel_function"
+        "_fish_shortcuts"
+        "_fzf_cmd_history"
+        "_fzf_directory_picker"
+        "_fzf_file_picker"
+        "_fzf_ghq_picker"
+        "_fzf_preview_cmd"
+        "_fzf_preview_name"
+        "_gco_function"
+        "_grco_function"
+        "_grcr_function"
+        "_hm_load_env_file"
+        "fish_user_key_bindings"
+      ]
+  );
 }

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -108,26 +108,30 @@
   };
 
   # Individual function files (DRY approach)
-  xdg.configFile = lib.listToAttrs (
-    map (name: {
-      name = "fish/functions/${name}.fish";
-      value.source = ./functions/${name}.fish;
-    }) [
-      "_clxe_function"
-      "_coxe_function"
-      "_coxel_function"
-      "_fish_shortcuts"
-      "_fzf_cmd_history"
-      "_fzf_directory_picker"
-      "_fzf_file_picker"
-      "_fzf_ghq_picker"
-      "_fzf_preview_cmd"
-      "_fzf_preview_name"
-      "_gco_function"
-      "_grco_function"
-      "_grcr_function"
-      "_hm_load_env_file"
-      "fish_user_key_bindings"
-    ]
-  ) // xdg.configFile;
+  xdg.configFile =
+    lib.listToAttrs (
+      map
+        (name: {
+          name = "fish/functions/${name}.fish";
+          value.source = ./functions/${name}.fish;
+        })
+        [
+          "_clxe_function"
+          "_coxe_function"
+          "_coxel_function"
+          "_fish_shortcuts"
+          "_fzf_cmd_history"
+          "_fzf_directory_picker"
+          "_fzf_file_picker"
+          "_fzf_ghq_picker"
+          "_fzf_preview_cmd"
+          "_fzf_preview_name"
+          "_gco_function"
+          "_grco_function"
+          "_grcr_function"
+          "_hm_load_env_file"
+          "fish_user_key_bindings"
+        ]
+    )
+    // xdg.configFile;
 }

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -45,7 +45,7 @@
       e = "nvim";
       g = "git";
       ld = "lazydocker";
-      lg = "lazygit";
+      # lg = "lazygit"; # Temporarily commented out to debug build issue
       ta = "tmux new -A -s default";
       v = "nvim";
 

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -44,7 +44,7 @@
       cx = "codex exec";
       e = "nvim";
       g = "git";
-      ld = "lazydocker";
+      lzd = "lazydocker";
       lzg = "lazygit";
       ta = "tmux new -A -s default";
       v = "nvim";

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -107,7 +107,50 @@
     source = config.lib.file.mkOutOfStoreSymlink ./completions;
   };
 
-  xdg.configFile."fish/functions" = {
-    source = config.lib.file.mkOutOfStoreSymlink ./functions;
+  # Individual function files
+  xdg.configFile."fish/functions/_clxe_function.fish" = {
+    source = ./functions/_clxe_function.fish;
+  };
+  xdg.configFile."fish/functions/_coxe_function.fish" = {
+    source = ./functions/_coxe_function.fish;
+  };
+  xdg.configFile."fish/functions/_coxel_function.fish" = {
+    source = ./functions/_coxel_function.fish;
+  };
+  xdg.configFile."fish/functions/_fish_shortcuts.fish" = {
+    source = ./functions/_fish_shortcuts.fish;
+  };
+  xdg.configFile."fish/functions/_fzf_cmd_history.fish" = {
+    source = ./functions/_fzf_cmd_history.fish;
+  };
+  xdg.configFile."fish/functions/_fzf_directory_picker.fish" = {
+    source = ./functions/_fzf_directory_picker.fish;
+  };
+  xdg.configFile."fish/functions/_fzf_file_picker.fish" = {
+    source = ./functions/_fzf_file_picker.fish;
+  };
+  xdg.configFile."fish/functions/_fzf_ghq_picker.fish" = {
+    source = ./functions/_fzf_ghq_picker.fish;
+  };
+  xdg.configFile."fish/functions/_fzf_preview_cmd.fish" = {
+    source = ./functions/_fzf_preview_cmd.fish;
+  };
+  xdg.configFile."fish/functions/_fzf_preview_name.fish" = {
+    source = ./functions/_fzf_preview_name.fish;
+  };
+  xdg.configFile."fish/functions/_gco_function.fish" = {
+    source = ./functions/_gco_function.fish;
+  };
+  xdg.configFile."fish/functions/_grco_function.fish" = {
+    source = ./functions/_grco_function.fish;
+  };
+  xdg.configFile."fish/functions/_grcr_function.fish" = {
+    source = ./functions/_grcr_function.fish;
+  };
+  xdg.configFile."fish/functions/_hm_load_env_file.fish" = {
+    source = ./functions/_hm_load_env_file.fish;
+  };
+  xdg.configFile."fish/functions/fish_user_key_bindings.fish" = {
+    source = ./functions/fish_user_key_bindings.fish;
   };
 }


### PR DESCRIPTION
- Updated the flake.lock file to reflect the latest lastModified timestamps, narHashes, and revisions for various dependencies, ensuring improved dependency management.
- Commented out the 'lazygit' configuration in fish's default.nix to debug a build issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates flake inputs to newer revisions and temporarily comments out the `lg` (lazygit) fish abbreviation.
> 
> - **Dependencies (flake.lock)**:
>   - Bump inputs to newer revisions/hashes: `agenix`, `flake-parts`, `home-manager`, `nix-darwin`, `nixpkgs.lib`, `NUR`, `treefmt-nix`.
> - **Shell config**:
>   - In `home-manager/programs/fish/default.nix`, comment out `shellAbbrs.lg` (lazygit).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a988f01f745be58adb806d347d5896e050abae70. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->











<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh flake.lock to the latest Nix inputs and streamline home-manager config. Use stdenv.hostPlatform.system for package imports and split fish functions into individual files; rename lazygit/lazydocker abbreviations.

- **Dependencies**
  - Updated agenix, flake-parts, home-manager, nix-darwin, nixpkgs-lib, NUR, and treefmt-nix entries in flake.lock (revs, hashes, timestamps).

- **Migration**
  - Fish abbreviations changed: ld → lzd and lg → lzg.

<sup>Written for commit 9a352874d410bed102a7a37ceba9da33941ad453. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











