### PR TITLE
Chore/atuin-config

### DIFF
--- a/home-manager/programs/atuin/default.nix
+++ b/home-manager/programs/atuin/default.nix
@@ -6,7 +6,7 @@
     enableZshIntegration = true;
     settings = {
       auto_sync = true;
-      sync_frequency = "5m";
+      sync_frequency = "3m";
       sync_address = "https://api.atuin.sh";
       search_mode = "fuzzy";
     };

--- a/home-manager/programs/atuin/default.nix
+++ b/home-manager/programs/atuin/default.nix
@@ -4,5 +4,11 @@
     enableBashIntegration = true;
     enableFishIntegration = true;
     enableZshIntegration = true;
+    settings = {
+      auto_sync = true;
+      sync_frequency = "5m";
+      sync_address = "https://api.atuin.sh";
+      search_mode = "fuzzy";
+    };
   };
 }

--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -104,6 +104,7 @@ nixpkgs.lib.nixosSystem {
         fsType = "ext4";
       };
 
+      nixpkgs.config.allowUnfree = true;
       nixpkgs.pkgs = pkgs;
 
       fonts.packages = with pkgs; [

--- a/nix-darwin/config/nix.nix
+++ b/nix-darwin/config/nix.nix
@@ -6,4 +6,6 @@
       max-jobs = 8;
     };
   };
+
+  nixpkgs.config.allowUnfree = true;
 }


### PR DESCRIPTION
- Added `nixpkgs.config.allowUnfree = true;` to both NixOS and Nix-Darwin configurations to allow the installation of unfree packages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures Atuin sync settings and enables unfree packages on NixOS and nix-darwin.
> 
> - **Home Manager / Atuin**:
>   - Configure `programs.atuin.settings`: `auto_sync=true`, `sync_frequency="5m"`, `sync_address="https://api.atuin.sh"`, `search_mode="fuzzy"` in `home-manager/programs/atuin/default.nix`.
> - **System Config**:
>   - Enable unfree packages via `nixpkgs.config.allowUnfree = true;` in `hosts/nixos/default.nix` and `nix-darwin/config/nix.nix`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5260b1f42d2a8394bfb2bfb54c547eb7f11a3d6e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configured Atuin to auto-sync every 3 minutes with fuzzy search, using https://api.atuin.sh as the sync server. Enabled unfree packages in NixOS and Nix-Darwin (nixpkgs.config.allowUnfree = true) to allow installing unfree software.

<sup>Written for commit 5260b1f42d2a8394bfb2bfb54c547eb7f11a3d6e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

