### PR TITLE
fix(fish): update jj key binding for exiting insert mode

### DIFF
--- a/home-manager/programs/fish/functions/fish_user_key_bindings.fish
+++ b/home-manager/programs/fish/functions/fish_user_key_bindings.fish
@@ -4,5 +4,5 @@
 # Fish automatically calls this function after fish_vi_key_bindings is set.
 function fish_user_key_bindings
   # Exit vim insert mode with jj (like in Vim)
-  bind -M insert -m default jj backward-char force-repaint
+  bind -M insert jj 'set fish_bind_mode default; commandline -f repaint-mode'
 end


### PR DESCRIPTION
- Changed the key binding for exiting Vim insert mode from 'jj backward-char force-repaint' to 'jj set fish_bind_mode default; commandline -f repaint-mode' for improved functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the Fish `jj` insert-mode binding to set `fish_bind_mode` to `default` and repaint, replacing the previous `backward-char force-repaint` approach.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9dffc24b6e655614c80fac40e98fd69374c7b71. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the jj keybinding in fish vi mode to exit insert mode reliably without moving the cursor. It now sets fish_bind_mode to default and repaints the mode prompt, replacing the old backward-char/force-repaint combo.

<sup>Written for commit f9dffc24b6e655614c80fac40e98fd69374c7b71. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

