### PR TITLE
chore(flake.lock): update lock file with latest revisions and hashes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -12,11 +12,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1761656077,
-        "narHash": "sha256-lsNWuj4Z+pE7s0bd2OKicOFq9bK86JE0ZGeKJbNqb94=",
+        "lastModified": 1762618334,
+        "narHash": "sha256-wyT7Pl6tMFbFrs8Lk/TlEs81N6L+VSybPfiIgzU8lbQ=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "9ba0d85de3eaa7afeab493fed622008b6e4924f5",
+        "rev": "fcdea223397448d35d9b31f798479227e80183f6",
         "type": "github"
       },
       "original": {
@@ -113,11 +113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762501326,
-        "narHash": "sha256-QbhsksHaIN6qU3oXhwUFbYycKX1GRxObpQSWAM5fhRY=",
+        "lastModified": 1762627886,
+        "narHash": "sha256-/QLk1bzmbcqJt9sU43+y/3tHtXhAy0l8Ck0MoO2+evQ=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "e2b82ebd0f990a5d1b68fcc761b3d6383c86ccfd",
+        "rev": "5125a3cd414dc98bbe2c528227aa6b62ee61f733",
         "type": "github"
       },
       "original": {
@@ -165,11 +165,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762567542,
-        "narHash": "sha256-jLH5dGY0LF1Z7FzpOPpphxDaqP2HhAq9jSL5unyMT4k=",
+        "lastModified": 1762637637,
+        "narHash": "sha256-I1VJjD9UGyEYf3NHevT/jN7ZRmjJo6Vv0rG5dOvUipw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5257c67c8a121da82b9ae31d7e0f8ffdfa8fce77",
+        "rev": "7903476649220c283744748e02d6d355cd5eda2c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- Updated the flake.lock file to reflect the latest lastModified timestamps, narHashes, and revisions for various dependencies, ensuring improved dependency management.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates pinned revisions and hashes for agenix, nix-darwin, and NUR in `flake.lock`.
> 
> - **Dependencies (`flake.lock`)**:
>   - Update `agenix`, `nix-darwin`, and `NUR` to newer commits (rev/lastModified/narHash).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e350ce445f0e0873b8b4573bc0e96aa9c8c3cd5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated flake.lock to the latest revisions, timestamps, and nar hashes for agenix, nix-darwin, and NUR to keep dependencies current and builds reproducible. No code changes or behavior impact.

<sup>Written for commit 4e350ce445f0e0873b8b4573bc0e96aa9c8c3cd5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

