### PR TITLE
feat(nix): enhance unfree package configuration in home-manager and NixOS

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,6 +26,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+      - name: Free Disk Space (Ubuntu)
+        if: runner.os == 'Linux'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
       - name: KVM Linux Virtualization
         if: runner.os == 'Linux'
         run: |

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ nix-build: nix-connect
 		if [ "$(OS)" = "Darwin" ]; then \
 			$(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#$(NIX_CONFIG_TYPE).runner.system $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "nixosConfigurations" ]; then \
-			$(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- build --flake .#runner --impure --no-update-lock-file; \
+			$(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#nixosConfigurations.runner.config.system.build.toplevel $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "homeConfigurations" ]; then \
 			$(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#$(NIX_CONFIG_TYPE)."$(NIX_USERNAME)@$(NIX_SYSTEM)".activationPackage $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
 		else \

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -31,12 +31,16 @@ in
       inputs.agenix.homeManagerModules.default
     ];
 
-  nixpkgs.config.allowUnfreePredicate =
-    pkg:
-    builtins.elem (lib.getName pkg) [
-      "claude-code"
-      "qwen-code"
-    ];
+  nixpkgs.config = {
+    allowUnfree = true;
+    allowUnfreePredicate =
+      pkg:
+      builtins.elem (lib.getName pkg) [
+        "claude-code"
+        "qwen-code"
+        "crush"
+      ];
+  };
 
   home.username = username;
   home.homeDirectory = lib.mkIf pkgs.stdenv.isLinux "/home/${username}";

--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -7,7 +7,10 @@
 let
   inherit (inputs) nixpkgs home-manager;
   system = "x86_64-linux";
-  pkgs = nixpkgs.legacyPackages.${system};
+  pkgs = import nixpkgs {
+    inherit system;
+    config.allowUnfree = true;
+  };
   configuration =
     { config, lib, ... }:
     {
@@ -104,7 +107,6 @@ nixpkgs.lib.nixosSystem {
         fsType = "ext4";
       };
 
-      nixpkgs.config.allowUnfree = true;
       nixpkgs.pkgs = pkgs;
 
       fonts.packages = with pkgs; [
@@ -118,7 +120,7 @@ nixpkgs.lib.nixosSystem {
       home-manager.users."${username}" = import ../../home-manager {
         inherit inputs username system;
         lib = nixpkgs.lib;
-        pkgs = nixpkgs.legacyPackages.${system};
+        pkgs = pkgs;
         config = { };
       };
     }


### PR DESCRIPTION
- Updated the Nix configuration to allow unfree packages by setting `nixpkgs.config.allowUnfree = true;`.
- Expanded the `allowUnfreePredicate` to include "crush" alongside existing packages "claude-code" and "qwen-code" for improved package management.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable unfree packages across Home Manager and NixOS, add "crush" to allowed unfree list, and import `pkgs` with unfree enabled instead of `legacyPackages`.
> 
> - **Home Manager (`home-manager/default.nix`)**:
>   - Configure `nixpkgs.config` with `allowUnfree = true` and extend `allowUnfreePredicate` to include `"crush"` alongside `"claude-code"` and `"qwen-code"`.
> - **NixOS Host (`hosts/nixos/default.nix`)**:
>   - Import `pkgs` via `import nixpkgs { system; config.allowUnfree = true; }` (replacing `legacyPackages`).
>   - Remove inline `nixpkgs.config.allowUnfree` in modules and pass the new `pkgs` through to Home Manager.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47799411a349b434591a39d4dbb5f240191e2e1f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables unfree packages across Home Manager and NixOS and adds “crush” to the allowed list alongside “claude-code” and “qwen-code.” Also updates the NixOS build command and adds a disk cleanup step to the e2e workflow for more reliable builds.

- **Refactors**
  - Import nixpkgs with config.allowUnfree in hosts/nixos/default.nix and remove duplicate per-module setting.
  - Define nixpkgs.config in Home Manager with allowUnfree and updated allowUnfreePredicate.
  - Pass the unified pkgs to home-manager.users for consistency.
  - Update Makefile to build the NixOS runner toplevel directly.

- **New Features**
  - Add disk space cleanup step for Ubuntu runners in the e2e workflow.

<sup>Written for commit 81f9b7b7180cddb0d6c773798e5f9fb3f9551e7f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



