### PR TITLE
refactor(docker): enhance Docker workflow for multi-architecture builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,11 +20,9 @@ jobs:
       matrix:
         build:
           - platform: linux/amd64
-            suffix: -amd64
             arch: amd64
             runner: ubuntu-latest
           - platform: linux/arm64
-            suffix: -arm64
             arch: arm64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.build.runner }}
@@ -46,11 +44,11 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
           flavor: |
-            suffix=${{ matrix.build.suffix }}
+            suffix=-${{ matrix.build.arch }}
             latest=${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && 'false' || 'auto' }}
           tags: |
-            type=sha,format=short,suffix=${{ matrix.build.suffix }},enable=${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
-            type=raw,value=latest,suffix=${{ matrix.build.suffix }},enable=${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+            type=sha,format=short,suffix=-${{ matrix.build.arch }},enable=${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+            type=raw,value=latest,suffix=-${{ matrix.build.arch }},enable=${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
             type=sha,format=short,enable=${{ !(github.ref == 'refs/heads/main' && github.event_name == 'push') }}
             type=semver,pattern={{version}},enable=${{ !(github.ref == 'refs/heads/main' && github.event_name == 'push') }}
             type=semver,pattern={{raw}},enable=${{ !(github.ref == 'refs/heads/main' && github.event_name == 'push') }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,9 +32,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-      - name: Start Docker daemon
-        if: runner.os == 'macOS'
-        run: sudo launchctl start com.docker.docker
+      - name: Setup Docker on macOS
+        if: matrix.build.runner == 'macos-latest'
+        id: setup-docker
+        uses: douglascamata/setup-docker-macos-action@v1.0.1
+        with:
+          colima: latest
+          colima-network-address: false
+          colima-additional-options: --cpu 4 --memory 8 --vm-type vz --vz-rosetta --mount-type virtiofs --headless
       - name: Set up QEMU
         if: matrix.build.runner == 'ubuntu-latest'
         uses: docker/setup-qemu-action@v3
@@ -80,7 +85,6 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          qemu-version: ${{ matrix.build.arch == 'amd64' && '7' || '' }}
   docker-merge-manifests:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -72,6 +72,7 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
           build-args: |
             COMMIT_SHA=${{ github.sha }}
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           qemu-version: ${{ matrix.build.arch == 'amd64' && '7' || '' }}
@@ -128,5 +129,5 @@ jobs:
       - name: Alls Green
         uses: re-actors/alls-green@release/v1
         with:
-          allowed-skips: docker-merge-manifests
+          allowed-skips: docker-build-push,docker-merge-manifests
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,7 @@ jobs:
             arch: arm64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.build.runner }}
-    timeout-minutes: 180
+    timeout-minutes: 300
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,27 +22,16 @@ jobs:
           - platform: linux/amd64
             suffix: -amd64
             arch: amd64
-            runner: macos-latest
+            runner: ubuntu-latest
           - platform: linux/arm64
             suffix: -arm64
             arch: arm64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.build.runner }}
-    timeout-minutes: ${{ matrix.build.arch == 'arm64' && 300 || 120 }}
+    timeout-minutes: 180
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-      - name: Setup Docker on macOS
-        if: matrix.build.runner == 'macos-latest'
-        id: setup-docker
-        uses: douglascamata/setup-docker-macos-action@v1.0.1
-        with:
-          colima: latest
-          colima-network-address: false
-          colima-additional-options: --cpu 4 --memory 8 --vm-type vz --vz-rosetta --mount-type virtiofs --headless
-      - name: Set up QEMU
-        if: matrix.build.runner == 'ubuntu-latest'
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,14 +17,21 @@ jobs:
   docker-build-push:
     strategy:
       fail-fast: false
-      matrix:
-        build: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && fromJSON('[{"platform":"linux/amd64","suffix":"-amd64","arch":"amd64"},{"platform":"linux/arm64","suffix":"-arm64","arch":"arm64"}]') || fromJSON('[{"platform":"linux/amd64","suffix":"-amd64","arch":"amd64"}]') }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 300
+    matrix:
+      build:
+        - platform: linux/amd64
+          suffix: -amd64
+          arch: amd64
+        - platform: linux/arm64
+          suffix: -arm64
+          arch: arm64
+    runs-on: ${{ matrix.build.arch == 'arm64' && 'macos-latest' || 'ubuntu-latest' }}
+    timeout-minutes: ${{ matrix.build.arch == 'arm64' && 120 || 300 }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Set up QEMU
+        if: matrix.build.arch == 'amd64'
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -67,6 +74,7 @@ jobs:
             COMMIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          qemu-version: ${{ matrix.build.arch == 'amd64' && '7' || '' }}
   docker-merge-manifests:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,14 +17,14 @@ jobs:
   docker-build-push:
     strategy:
       fail-fast: false
-    matrix:
-      build:
-        - platform: linux/amd64
-          suffix: -amd64
-          arch: amd64
-        - platform: linux/arm64
-          suffix: -arm64
-          arch: arm64
+      matrix:
+        build:
+          - platform: linux/amd64
+            suffix: -amd64
+            arch: amd64
+          - platform: linux/arm64
+            suffix: -arm64
+            arch: arm64
     runs-on: ${{ matrix.build.arch == 'arm64' && 'macos-latest' || 'ubuntu-latest' }}
     timeout-minutes: ${{ matrix.build.arch == 'arm64' && 120 || 300 }}
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,16 +22,21 @@ jobs:
           - platform: linux/amd64
             suffix: -amd64
             arch: amd64
+            runner: macos-latest
           - platform: linux/arm64
             suffix: -arm64
             arch: arm64
-    runs-on: ${{ matrix.build.arch == 'arm64' && 'macos-latest' || 'ubuntu-latest' }}
-    timeout-minutes: ${{ matrix.build.arch == 'arm64' && 120 || 300 }}
+            runner: ubuntu-latest
+    runs-on: ${{ matrix.build.runner }}
+    timeout-minutes: ${{ matrix.build.arch == 'arm64' && 300 || 120 }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+      - name: Start Docker daemon
+        if: runner.os == 'macOS'
+        run: sudo launchctl start com.docker.docker
       - name: Set up QEMU
-        if: matrix.build.arch == 'amd64'
+        if: matrix.build.runner == 'ubuntu-latest'
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ ARG USER=runner
 ARG USER_UID=1001
 ARG USER_GID=$USER_UID
 ARG COMMIT_SHA=main
+ARG GITHUB_TOKEN
 
 RUN set -e; \
     groupadd --gid $USER_GID $USER; \
@@ -49,6 +50,10 @@ RUN mkdir -p /etc/nix && \
 
 RUN /usr/bin/nix-daemon & \
     sleep 5 && \
+    if [ -n "$GITHUB_TOKEN" ]; then \
+      export GITHUB_TOKEN="$GITHUB_TOKEN" && \
+      git config --global url."https://$GITHUB_TOKEN@github.com/".insteadOf "https://github.com/" ; \
+    fi && \
     # Run your dotfiles installation script.
     # This script is expected to install fish and other tools.
     # Make sure this script is idempotent or handles being run in a fresh environment.

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,14 +46,13 @@ RUN mkdir -p /etc/nix && \
     echo "trusted-users = root $USER" > /etc/nix/nix.conf && \
     echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf && \
     echo "filter-syscalls = false" >> /etc/nix/nix.conf && \
-    echo "sandbox = false" >> /etc/nix/nix.conf
+    echo "sandbox = false" >> /etc/nix/nix.conf && \
+    if [ -n "$GITHUB_TOKEN" ]; then \
+      echo "access-tokens = github.com=https://$GITHUB_TOKEN" >> /etc/nix/nix.conf ; \
+    fi
 
 RUN /usr/bin/nix-daemon & \
     sleep 5 && \
-    if [ -n "$GITHUB_TOKEN" ]; then \
-      export GITHUB_TOKEN="$GITHUB_TOKEN" && \
-      git config --global url."https://$GITHUB_TOKEN@github.com/".insteadOf "https://github.com/" ; \
-    fi && \
     # Run your dotfiles installation script.
     # This script is expected to install fish and other tools.
     # Make sure this script is idempotent or handles being run in a fresh environment.

--- a/Makefile
+++ b/Makefile
@@ -244,8 +244,8 @@ nix-flake-check:
 .PHONY: nix-flake-update
 nix-flake-update: nix-connect
 	@echo "♻️ Refreshing flake.lock file..."
-	@if [ "$$CI" = "true" ]; then \
-		echo "Bypassing flake update in CI"; \
+	@if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \
+		echo "Bypassing flake update in CI/Docker"; \
 	else \
 		$(NIX_EXEC) flake update $(NIX_FLAGS); \
 	fi

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -20,6 +20,7 @@
       "claude-squad"
       "cmake"
       "codex"
+      "colima"
       "coreutils"
       "ffmpeg"
       "gemini-cli"


### PR DESCRIPTION
- Updated the Docker workflow to define a clearer matrix for building images on both amd64 and arm64 platforms.
- Adjusted the runner environment based on architecture, using macOS for arm64 and Ubuntu for amd64.
- Modified timeout settings to optimize build times for different architectures.
- Enhanced QEMU setup and specified QEMU version conditionally based on architecture.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors the Docker GitHub Actions workflow to use an explicit amd64/arm64 matrix with arch-specific runners, timeouts, and QEMU settings.
> 
> - **CI/GitHub Actions**:
>   - **Docker workflow (`.github/workflows/docker.yml`)**:
>     - Replace dynamic JSON-based matrix with explicit `build` matrix for `linux/amd64` and `linux/arm64`.
>     - Select runner per arch: `macos-latest` for `arm64`, `ubuntu-latest` for `amd64`.
>     - Set arch-specific timeouts: `120` (arm64) vs `300` (amd64).
>     - Gate QEMU setup to `amd64` and pass `qemu-version: 7` to build when `amd64`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a6e21f630cae2cbfe1ef479dd36d7079902cb2c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

















<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the Docker workflow to build amd64 and arm64 with a clear matrix on native Ubuntu runners. Enabled authenticated Git during Docker builds.

- **Refactors**
  - Explicit matrix for linux/amd64 and linux/arm64.
  - Native Ubuntu runners: amd64 → ubuntu-latest; arm64 → ubuntu-24.04-arm.
  - Unified timeout to 300 minutes; removed QEMU setup.

- **New Features**
  - Pass GITHUB_TOKEN to builds and conditionally inject into Nix config for secure Git access.

<sup>Written for commit 2a7f2c3efcbf08db25d2656f6232090db0535e1e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

















