### PR TITLE
fix(docker): correct GITHUB_TOKEN usage in Nix configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN mkdir -p /etc/nix && \
     echo "filter-syscalls = false" >> /etc/nix/nix.conf && \
     echo "sandbox = false" >> /etc/nix/nix.conf && \
     if [ -n "$GITHUB_TOKEN" ]; then \
-      echo "access-tokens = github.com=https://$GITHUB_TOKEN" >> /etc/nix/nix.conf ; \
+      echo "access-tokens = github.com=$GITHUB_TOKEN" >> /etc/nix/nix.conf ; \
     fi
 
 RUN /usr/bin/nix-daemon & \


### PR DESCRIPTION
- Updated the Dockerfile to ensure the GITHUB_TOKEN is appended correctly to the Nix configuration without the URL prefix, enhancing security and functionality during the build process.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the Dockerfile to write the GitHub token to Nix config without the https:// prefix. This makes GitHub auth work during Nix builds and avoids exposing the token as a URL.

<sup>Written for commit 24cf31927c24782fefabe842cbfc47897641bf5d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

