### PR TITLE
Add disk space cleanup step for Ubuntu in Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,6 +30,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+      - name: Free Disk Space (Ubuntu)
+        if: runner.os == 'Linux'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR


### PR DESCRIPTION
Introduce a step in the Docker workflow to free up disk space on Ubuntu runners, enhancing resource management during builds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a disk space cleanup step to the Docker workflow on Linux runners using jlumbroso/free-disk-space to reclaim storage from tool caches, Android, .NET, Haskell, large packages, Docker images, and swap before builds. This prevents space-related build failures and improves CI reliability.

<sup>Written for commit ac628452a022c82b59c3d99367ac1f4f02682c7d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

