### PR TITLE
Add pandoc to Homebrew installation list

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -30,6 +30,7 @@
       "kurtosis-cli"
       "mas"
       "opencode"
+      "pandoc"
       "pinentry-mac"
       "pnpm"
       "postgresql"


### PR DESCRIPTION
Include pandoc in the list of installed Homebrew packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add pandoc to the nix-darwin Homebrew package list so document conversion tooling is installed by default.
This ensures pandoc is available on macOS machines managed by nix-darwin.

<sup>Written for commit 88af0dfa52f7cdb94639fbcab3d61bea5dfc3ea2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

