### PR TITLE
Simplify neverssl FAQ entry

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -12,3 +12,15 @@ killall Dock
 After running these commands, you may need to re-add your desired applications to the Dock. Subsequent reboots should then persist your Dock configuration.
 
 For more details, see [nix-darwin issue #789](https://github.com/LnL7/nix-darwin/issues/789).
+
+## Auto renew neverssl on private wifi
+
+Send a lightweight HTTP GET to `http://neverssl.com` on a short cadence to keep the captive portal session alive.
+
+**Systemd (Linux):** define a `neverssl-keepalive.service` oneshot that runs curl, then pair it with a timer using `OnBootSec=3s` and `OnUnitActiveSec=3s`, finally `systemctl enable --now neverssl-keepalive.timer`.
+
+**Cron or launchd:** schedule the same curl command (`curl -fsS --max-time 10 http://neverssl.com >/dev/null 2>&1 || true`) at your preferred interval.
+
+**NixOS/Home Manager:** use the bundled `home-manager/services/neverssl-keepalive` module to install a 3-second systemd user timer.
+
+If the network still expires sessions, the captive portal may require additional headers, JavaScript heartbeats, or manual sign-ins.

--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -2,10 +2,12 @@
 let
   codeSyncer = import ./code-syncer { inherit pkgs; };
   dotfilesUpdater = import ./dotfiles-updater { inherit pkgs; };
+  neversslKeepalive = import ./neverssl-keepalive { inherit pkgs; };
   ollama = import ./ollama { inherit pkgs; };
 in
 [
   codeSyncer
   dotfilesUpdater
+  neversslKeepalive
   ollama
 ]

--- a/home-manager/services/neverssl-keepalive/default.nix
+++ b/home-manager/services/neverssl-keepalive/default.nix
@@ -1,0 +1,41 @@
+{ pkgs }:
+let
+  keepaliveScript = pkgs.writeShellApplication {
+    name = "neverssl-keepalive";
+    runtimeInputs = [ pkgs.curl ];
+    text = ''
+      set -euo pipefail
+      if ! curl -fsS --max-time 10 http://neverssl.com > /dev/null 2>&1; then
+        exit 0
+      fi
+    '';
+  };
+in
+{
+  systemd.user.services.neverssl-keepalive = {
+    Unit = {
+      Description = "Keep captive portal alive via neverssl.com";
+      Wants = [ "network-online.target" ];
+      After = [ "network-online.target" ];
+    };
+    Service = {
+      Type = "oneshot";
+      ExecStart = "${keepaliveScript}/bin/neverssl-keepalive";
+    };
+  };
+
+  systemd.user.timers.neverssl-keepalive = {
+    Unit = {
+      Description = "Timer for neverssl captive portal keepalive";
+    };
+    Timer = {
+      OnBootSec = "3s";
+      OnUnitActiveSec = "3s";
+      AccuracySec = "1s";
+      Unit = "neverssl-keepalive.service";
+    };
+    Install = {
+      WantedBy = [ "timers.target" ];
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- condense the neverssl captive portal FAQ entry to focus on the essential automation options

## Testing
- make format

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fdcc8d9b083249bf2df47a12bfc90)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the neverssl captive portal FAQ and added a Home Manager service to auto-renew sessions with a 3-second systemd user timer.

- **New Features**
  - Added home-manager/services/neverssl-keepalive: a curl-based oneshot service with a user timer (OnBootSec=3s, OnUnitActiveSec=3s) to ping neverssl.com.
  - Registered the service in home-manager/services/default.nix.

<sup>Written for commit 95e370742d88aeb37d23c6c567d29d1b3249db07. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

