### PR TITLE
feat(docker): refactor Docker workflow to use environment variable fo…

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,8 @@ concurrency:
 permissions:
   contents: read
   packages: write
+env:
+  REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
 jobs:
   docker-build-push:
     strategy:
@@ -53,7 +55,7 @@ jobs:
         id: metadata
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+          images: ${{ env.REGISTRY_IMAGE }}
           flavor: |
             suffix=-${{ matrix.build.arch }}
             latest=${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && 'false' || 'auto' }}
@@ -70,6 +72,7 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.pr-number=${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
       - name: Build and Push Docker
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -83,6 +86,18 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.build.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
   docker-merge-manifests:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs:
@@ -90,41 +105,56 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Set Metadata
         id: metadata
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+          images: ${{ env.REGISTRY_IMAGE }}
           tags: |
             type=sha,format=short
             type=semver,pattern={{version}}
             type=semver,pattern={{raw}}
             type=raw,value=latest
-      - name: Create and push multi-arch manifests
+      - name: Create manifest list and push
         env:
-          TAGS: ${{ steps.metadata.outputs.tags }}
+          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.metadata.outputs.json }}
+        working-directory: ${{ runner.temp }}/digests
         run: |
           set -euo pipefail
-          archs=(amd64 arm64)
+          shopt -s nullglob
+          tag_args=()
           while IFS= read -r tag; do
-            [ -n "$tag" ] || continue
-            refs=()
-            for arch in "${archs[@]}"; do
-              refs+=("${tag}-${arch}")
-            done
-            docker manifest rm "$tag" 2>/dev/null || true
-            docker manifest create "$tag" "${refs[@]}"
-            for arch in "${archs[@]}"; do
-              docker manifest annotate "$tag" "${tag}-${arch}" --arch "$arch" --os linux
-            done
-            docker manifest push "$tag"
-          done <<< "${TAGS}"
+            tag_args+=("-t" "$tag")
+          done < <(jq -cr '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          refs=()
+          for digest_file in *; do
+            refs+=("${REGISTRY_IMAGE}@sha256:${digest_file}")
+          done
+          if [ ${#refs[@]} -eq 0 ]; then
+            echo "No digests found" >&2
+            exit 1
+          fi
+          docker buildx imagetools create "${tag_args[@]}" "${refs[@]}"
+      - name: Inspect image
+        env:
+          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.metadata.outputs.json }}
+        run: |
+          ref=$(jq -r '.tags[0]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          docker buildx imagetools inspect "$ref"
   docker-check:
     if: always()
     needs:


### PR DESCRIPTION
…r registry image and enhance digest handling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the Docker workflow to use a REGISTRY_IMAGE env var and create multi-arch manifests from build digests for more reliable GHCR pushes. This improves consistency across jobs and ensures correct tags and manifests.

- **Refactors**
  - Centralized registry image via REGISTRY_IMAGE and used it in metadata steps.
  - Exported per-arch build digests, uploaded as artifacts, then used buildx imagetools to assemble and push manifest lists from those digests and metadata tags.
  - Added an image inspection step to verify the manifest after push.

<sup>Written for commit 91dd5d9da735f18fa719ca03382489f5f3a550e0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

