### PR TITLE
chore/merge docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -86,6 +86,7 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         run: |
           mkdir -p ${{ runner.temp }}/digests
@@ -125,36 +126,21 @@ jobs:
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
+            type=ref,event=branch
+            type=ref,event=pr
             type=sha,format=short
             type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{raw}}
             type=raw,value=latest
       - name: Create manifest list and push
-        env:
-          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.metadata.outputs.json }}
         working-directory: ${{ runner.temp }}/digests
         run: |
-          set -euo pipefail
-          shopt -s nullglob
-          tag_args=()
-          while IFS= read -r tag; do
-            tag_args+=("-t" "$tag")
-          done < <(jq -cr '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-          refs=()
-          for digest_file in *; do
-            refs+=("${REGISTRY_IMAGE}@sha256:${digest_file}")
-          done
-          if [ ${#refs[@]} -eq 0 ]; then
-            echo "No digests found" >&2
-            exit 1
-          fi
-          docker buildx imagetools create "${tag_args[@]}" "${refs[@]}"
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
       - name: Inspect image
-        env:
-          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.metadata.outputs.json }}
         run: |
-          ref=$(jq -r '.tags[0]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-          docker buildx imagetools inspect "$ref"
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
   docker-check:
     if: always()
     needs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -120,26 +120,37 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Set Metadata
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         id: metadata
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=sha,format=short
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{raw}}
             type=raw,value=latest
+      - name: Set Metadata for PRs
+        if: github.event_name == 'pull_request'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=ref,event=pr
+            type=ref,event=branch
+            type=sha,format=short
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
       - name: Inspect image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.metadata.outputs.version }}
   docker-check:
     if: always()
     needs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -100,7 +100,6 @@ jobs:
           if-no-files-found: error
           retention-days: 1
   docker-merge-manifests:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs:
       - docker-build-push
     runs-on: ubuntu-latest


### PR DESCRIPTION
- **feat(docker): enhance Docker workflow with improved tag handling and digest export**
- **fix(workflow): remove conditional for docker-merge-manifests job on push to main**
- **feat(docker): enhance metadata handling for Docker builds with separate PR and push conditions**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the Docker workflow to push images by digest and create consistent manifests with clearer tag handling. Adds distinct metadata for main and PR builds and lets the merge-manifests job run across events.

- **New Features**
  - Enable push-by-digest and export/upload digests for multi-arch manifest creation.
  - Separate tag metadata for pushes to main vs PRs (branch/PR/sha tags; semver incl. major.minor; latest only on main).
  - Remove job-level conditional so manifest creation runs on pushes and PRs; keep image inspect gated to main.

<sup>Written for commit b8dc439fe0fd22a256b049703f186a871e62276b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

