### PR TITLE
Refactor Docker workflow for improved digest handling and registry image management

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -70,6 +70,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ nix-check:
 
 .PHONY: nix-develop
 nix-develop:
-	nix develop
+	$(NIX_ALLOW_UNFREE) $(NIX_EXEC) develop $(NIX_FLAGS)
 
 .PHONY: nix-install
 nix-install:

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ help:
 	@echo "  install      - Set up full environment"
 	@echo "  setup        - Basic Nix setup"
 	@echo "  setup-dev    - Set up local development environment (Nix + submodules + shell)"
+	@echo "  dev          - Enter the Nix dev shell"
 	@echo "  build        - Build Nix configuration"
 	@echo "  switch       - Apply Nix configuration"
 	@echo "  update       - Update Nix flake and configurations"
@@ -136,6 +137,9 @@ switch: nix-switch
 
 .PHONY: update
 update: nix-update shell-update
+
+.PHONY: dev
+dev: nix-develop
 
 ##@ Nix Setup
 
@@ -179,6 +183,10 @@ nix-check:
 		exit 1; \
 	fi
 	@echo "✅ Nix environment found!"
+
+.PHONY: nix-develop
+nix-develop:
+	nix develop
 
 .PHONY: nix-install
 nix-install:

--- a/flake.lock
+++ b/flake.lock
@@ -93,11 +93,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762463325,
-        "narHash": "sha256-33YUsWpPyeBZEWrKQ2a1gkRZ7i0XCC/2MYpU6BVeQSU=",
+        "lastModified": 1762721397,
+        "narHash": "sha256-E428EuouA4nFTNlLuqlL4lVR78X+EbBIqDqsBFnB79w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0562fef070a1027325dd4ea10813d64d2c967b39",
+        "rev": "b8645b18b0f5374127bbade6de7381ef0b3d5720",
         "type": "github"
       },
       "original": {
@@ -128,11 +128,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762361079,
-        "narHash": "sha256-lz718rr1BDpZBYk7+G8cE6wee3PiBUpn8aomG/vLLiY=",
+        "lastModified": 1762482733,
+        "narHash": "sha256-g/da4FzvckvbiZT075Sb1/YDNDr+tGQgh4N8i5ceYMg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffcdcf99d65c61956d882df249a9be53e5902ea5",
+        "rev": "e1ebeec86b771e9d387dd02d82ffdc77ac753abc",
         "type": "github"
       },
       "original": {
@@ -165,11 +165,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762656948,
-        "narHash": "sha256-3beTth5xo+o7eEY/ie3drOklUznWFle+u1LLMPRPRHU=",
+        "lastModified": 1762724684,
+        "narHash": "sha256-B24ywaTUd9BYkK3qHfl0MubCLnO4Bk8cRSQmIvfofco=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f9c2719f104bb344043cc7435e62d876be479251",
+        "rev": "efc27c839b15d0ff15d58fb09035a93dea7f85f5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -129,8 +129,7 @@
           treefmt = {
             projectRootFile = "flake.nix";
             programs = {
-              actionlint.enable = false;
-              biome.enable = false; # Temporarily disabled due to schema hash mismatch
+              biome.enable = true;
               nixfmt.enable = true;
               shfmt.enable = true;
               stylua.enable = true;


### PR DESCRIPTION
Enhance the Docker workflow by using an environment variable for the registry image and improving the handling of image digests during the build and push process.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the Docker workflow to use REGISTRY_IMAGE and reuse build/push digests, improving release reliability; added a disk cleanup step to Ubuntu CI runners.

- **New Features**
  - Add a Makefile dev target to enter the Nix dev shell (nix develop).
  - Enable biome in treefmt for formatting.

- **Dependencies**
  - Update flake.lock to newer home-manager, nixpkgs, and NUR revisions.

<sup>Written for commit 0869e2b93f5a9e07c516b17f37023062aec3287a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





