### PR TITLE
Add graphviz to Homebrew brews list

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -26,6 +26,7 @@
       "gemini-cli"
       "geth"
       "gnupg"
+      "graphviz"
       "helm"
       "kurtosis-cli"
       "mas"


### PR DESCRIPTION
Include graphviz in the list of available Homebrew brews.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added graphviz to the nix-darwin Homebrew brews list so DOT diagram rendering is available by default on macOS dev machines.

<sup>Written for commit 3e86e00ab46b05413c957d295f964ddea648322b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

