### PR TITLE
chore(deps): update bun package manager and nanocoder dependency vers…

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,13 +1,12 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "dotfiles",
       "dependencies": {
         "@github/copilot": "^0.0.354",
         "@google/jules": "^0.1.40",
-        "@nanocollective/nanocoder": "^1.15.0",
+        "@nanocollective/nanocoder": "^1.16.3",
         "cline": "^1.0.5",
         "open-composer": "^0.8.23",
       },

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "bun@1.2.23",
+  "packageManager": "bun@1.3.0",
   "dependencies": {
     "@github/copilot": "^0.0.354",
     "@google/jules": "^0.1.40",
-    "@nanocollective/nanocoder": "^1.15.0",
+    "@nanocollective/nanocoder": "^1.16.3",
     "cline": "^1.0.5",
     "open-composer": "^0.8.23"
   },


### PR DESCRIPTION
…ions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Bun to 1.3.0 and bumped @nanocollective/nanocoder to ^1.16.3 to keep tooling current and apply recent fixes.

- **Dependencies**
  - Bun: 1.3.0 (was 1.2.23)
  - @nanocollective/nanocoder: ^1.16.3 (was ^1.15.0)

- **Migration**
  - Upgrade local Bun to 1.3.0 and run bun install.

<sup>Written for commit 180f4cf5c44057a3d647b9188c3c9d3746e6cbd4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

