### PR TITLE
feat(packages): add system monitoring tools

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -15,7 +15,6 @@ with pkgs;
   bat
   bun
   cloudflared
-  collectd
   curl
   curlie
   cursor-cli
@@ -71,6 +70,7 @@ with pkgs;
   below
   claude-code
   codex
+  collectd
   docker
   docker-compose
   gemini-cli

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -14,7 +14,6 @@ with pkgs;
   argocd
   ast-grep
   bat
-  below
   bun
   cloudflared
   collectd
@@ -69,6 +68,7 @@ with pkgs;
   zoxide
 ]
 ++ lib.optionals stdenv.isLinux [
+  below
   claude-code
   codex
   docker

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -13,6 +13,7 @@ with pkgs;
   argocd
   ast-grep
   bat
+  btop
   bun
   cloudflared
   curl

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -10,7 +10,6 @@ with pkgs;
   aichat
   aider-chat
   amp-cli
-  atop
   argocd
   ast-grep
   bat
@@ -68,6 +67,7 @@ with pkgs;
   zoxide
 ]
 ++ lib.optionals stdenv.isLinux [
+  atop
   below
   claude-code
   codex

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -10,11 +10,14 @@ with pkgs;
   aichat
   aider-chat
   amp-cli
+  atop
   argocd
   ast-grep
   bat
+  below
   bun
   cloudflared
+  collectd
   curl
   curlie
   cursor-cli
@@ -32,6 +35,7 @@ with pkgs;
   git
   goose-cli
   grc
+  htop
   httpie
   hyperfine
   jq


### PR DESCRIPTION
## Summary
- Add system monitoring packages: atop, below, collectd, htop
- Enhance home-manager package list with comprehensive monitoring tools











<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add system monitoring tools to home-manager to improve baseline observability and troubleshooting. Added btop and htop to the default package list; placed atop, below, and collectd under optional Linux packages.

<sup>Written for commit d95c2589e9e94966c6d4cfe92449d38aef1ee726. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











