### PR TITLE
feat: add direnv configuration module

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -1,5 +1,6 @@
 [
   ./claude
+  ./direnv
   ./hammerspoon
   ./karabiner
   ./starship

--- a/config/direnv/default.nix
+++ b/config/direnv/default.nix
@@ -1,0 +1,6 @@
+{ config, ... }:
+{
+  home.file.".config/direnv/direnvrc" = {
+    source = config.lib.file.mkOutOfStoreSymlink ./direnvrc;
+  };
+}

--- a/config/direnv/direnvrc
+++ b/config/direnv/direnvrc
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Global direnv settings
+export DIRENV_LOG_FORMAT="-"
+export DIRENV_LOG_FILTER="^$"
+export DIRENV_HIDE_ENV_DIFF=0
+
+# Whitelist exact directories
+export DIRENV_DIR="$HOME/dotfiles:$HOME/ghq/github.com/shunkakinoki"


### PR DESCRIPTION
## Changes Made
- Added direnv configuration module following the same pattern as other config modules (starship, hammerspoon, claude)
- Created separate direnvrc file for global direnv settings with shebang
- Configured DIRENV_DIR whitelist for enhanced security
- Updated config/default.nix to include the new direnv module

## Technical Details
- Uses mkOutOfStoreSymlink pattern for editable configuration file
- Follows existing config module structure and conventions
- Includes global direnv settings (log format, filters, hide env diff)
- Sets up directory whitelist for direnv security

## Testing
- Verified Nix configuration builds successfully
- Confirmed direnvrc file is properly linked to ~/.config/direnv/direnvrc
- All pre-commit hooks pass (formatting, linting)
- No breaking changes to existing configuration

🤖 Generated with Cursor by Claude

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a direnv configuration module that installs a global direnvrc with minimal logging and a strict directory whitelist for better security.

- **New Features**
  - New config/direnv module, added to config/default.nix.
  - Installs ~/.config/direnv/direnvrc via mkOutOfStoreSymlink.
  - Sets global settings (log format/filter, do not hide env diff) and whitelists directories via DIRENV_DIR.

<sup>Written for commit 484211820be0d69f4e25bbf366635a862a511b2c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

