### PR TITLE
chore: code-syncer-update

### DIFF
--- a/home-manager/services/code-syncer/sync.sh
+++ b/home-manager/services/code-syncer/sync.sh
@@ -79,7 +79,7 @@ ensure_dirs() {
 # Filter out proprietary and AI extensions from the list
 # Input can be from stdin (pipe) or a file
 clean_extension_list() {
-  local input_source="$1"  # Can be a file path or "-" for stdin
+  local input_source="$1" # Can be a file path or "-" for stdin
   local clean_file="$2"
 
   # Read from stdin if input_source is "-", otherwise from file
@@ -247,9 +247,9 @@ install_extensions() {
   # Log extensions that will be synced
   local extension_count=$(wc -l <"$clean_list" 2>/dev/null | tr -d ' ' || echo "0")
   extension_count=${extension_count:-0}
-  
+
   echo "📦 Found $extension_count extension(s) to sync:"
-  
+
   if [ "$extension_count" -gt 0 ]; then
     while IFS= read -r extension; do
       if [ -n "$extension" ]; then

--- a/home-manager/services/code-syncer/sync.sh
+++ b/home-manager/services/code-syncer/sync.sh
@@ -17,6 +17,8 @@ EXTENSIONS_FILE="extensions.list"
 # These are MS proprietary extensions that typically fail on forks or crash them.
 # We filter these out to prevent errors.
 PROPRIETARY_EXTENSIONS=(
+  "anysphere.pyright"
+  "anysphere.cursorpyright"
   "github.codespaces"
   "github.copilot"
   "github.copilot-chat"
@@ -54,8 +56,9 @@ AI_EXTENSIONS=(
 # Check if a command exists, if not, try to find it in Applications
 resolve_cli() {
   local cmd=$1
-  if command -v "$cmd" >/dev/null 2>&1; then
-    echo "$cmd"
+  local resolved_path=$(command -v "$cmd" 2>/dev/null)
+  if [ -n "$resolved_path" ]; then
+    echo "$resolved_path"
   else
     # Fallback paths for Mac apps if not in PATH
     case $cmd in

--- a/home-manager/services/code-syncer/sync.sh
+++ b/home-manager/services/code-syncer/sync.sh
@@ -17,130 +17,135 @@ EXTENSIONS_FILE="extensions.list"
 # These are MS proprietary extensions that typically fail on forks or crash them.
 # We filter these out to prevent errors.
 PROPRIETARY_EXTENSIONS=(
-    "github.codespaces"
-    "github.copilot" 
-    "github.copilot-chat"
-    "ms-python.debugpy"
-    "ms-python.python"
-    "ms-python.vscode-pylance"
-    "ms-python.vscode-python-envs"
-    "ms-vscode-remote.remote-containers"
-    "ms-vscode-remote.remote-ssh-edit"
-    "ms-vscode-remote.remote-ssh"
-    "ms-vscode-remote.remote-wsl"
-    "ms-vscode.remote-explorer"
-    "ms-vsliveshare.vsliveshare"
+  "github.codespaces"
+  "github.copilot"
+  "github.copilot-chat"
+  "ms-python.debugpy"
+  "ms-python.python"
+  "ms-python.vscode-pylance"
+  "ms-python.vscode-python-envs"
+  "ms-vscode-remote.remote-containers"
+  "ms-vscode-remote.remote-ssh-edit"
+  "ms-vscode-remote.remote-ssh"
+  "ms-vscode-remote.remote-wsl"
+  "ms-vscode.remote-explorer"
+  "ms-vsliveshare.vsliveshare"
 )
 
 AI_EXTENSIONS=(
-    "anthropic.claude-code"
-    "coderabbit.coderabbit-vscode"
-    "github.copilot"
-    "github.copilot-chat"
-    "google.gemini-cli-vscode-ide-companion"
-    "google.geminicodeassist"
-    "ggml-org.llama-vscode"
-    "kilocode.kilo-code"
-    "openai.chatgpt"
-    "rooveterinaryinc.roo-cline"
-    "saoudrizwan.claude-dev"
-    "sourcegraph.amp"
-    "sst-dev.opencode"
-    "sweetpad.sweetpad"
+  "anthropic.claude-code"
+  "coderabbit.coderabbit-vscode"
+  "github.copilot"
+  "github.copilot-chat"
+  "google.gemini-cli-vscode-ide-companion"
+  "google.geminicodeassist"
+  "ggml-org.llama-vscode"
+  "kilocode.kilo-code"
+  "openai.chatgpt"
+  "rooveterinaryinc.roo-cline"
+  "saoudrizwan.claude-dev"
+  "sourcegraph.amp"
+  "sst-dev.opencode"
+  "sweetpad.sweetpad"
 )
 
 # --- HELPER FUNCTIONS ---
 
 # Check if a command exists, if not, try to find it in Applications
 resolve_cli() {
-    local cmd=$1
-    if command -v "$cmd" >/dev/null 2>&1; then
-        echo "$cmd"
-    else
-        # Fallback paths for Mac apps if not in PATH
-        case $cmd in
-            "antigravity") echo "/Applications/Antigravity.app/Contents/Resources/app/bin/antigravity" ;;
-            "windsurf") echo "/Applications/Windsurf.app/Contents/Resources/app/bin/windsurf" ;;
-            "cursor") echo "/Applications/Cursor.app/Contents/Resources/app/bin/cursor" ;;
-            *) echo "" ;;
-        esac
-    fi
+  local cmd=$1
+  if command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd"
+  else
+    # Fallback paths for Mac apps if not in PATH
+    case $cmd in
+    "antigravity") echo "/Applications/Antigravity.app/Contents/Resources/app/bin/antigravity" ;;
+    "windsurf") echo "/Applications/Windsurf.app/Contents/Resources/app/bin/windsurf" ;;
+    "cursor") echo "/Applications/Cursor.app/Contents/Resources/app/bin/cursor" ;;
+    *) echo "" ;;
+    esac
+  fi
 }
 
 ensure_dirs() {
-    mkdir -p "$ANTIGRAVITY_USER_DIR"
-    mkdir -p "$CURSOR_USER_DIR"
-    mkdir -p "$WINDSURF_USER_DIR"
+  mkdir -p "$ANTIGRAVITY_USER_DIR"
+  mkdir -p "$CURSOR_USER_DIR"
+  mkdir -p "$WINDSURF_USER_DIR"
 }
 
 # Filter out proprietary and AI extensions from the list
 clean_extension_list() {
-    local input_file="$1"
-    local clean_file="$2"
-    
-    cp "$input_file" "$clean_file"
-    
-    for bad_ext in "${PROPRIETARY_EXTENSIONS[@]}"; do
-        # Remove the line containing the bad extension
-        sed -i '' "/$bad_ext/d" "$clean_file"
-    done
-    
-    for ai_ext in "${AI_EXTENSIONS[@]}"; do
-        # Remove the line containing the AI extension
-        sed -i '' "/$ai_ext/d" "$clean_file"
-    done
+  local input_file="$1"
+  local clean_file="$2"
+
+  cp "$input_file" "$clean_file"
+
+  for bad_ext in "${PROPRIETARY_EXTENSIONS[@]}"; do
+    # Remove the line containing the bad extension
+    sed -i '' "/$bad_ext/d" "$clean_file"
+  done
+
+  for ai_ext in "${AI_EXTENSIONS[@]}"; do
+    # Remove the line containing the AI extension
+    sed -i '' "/$ai_ext/d" "$clean_file"
+  done
 }
 
 install_extensions() {
-    local target_name=$1
-    local cli_cmd=$(resolve_cli "$target_name")
-    local source_list="$VSCODE_USER_DIR/$EXTENSIONS_FILE"
-    local clean_list="/tmp/${target_name}_extensions_clean.list"
+  local target_name=$1
+  local cli_cmd=$(resolve_cli "$target_name")
+  local source_list="$VSCODE_USER_DIR/$EXTENSIONS_FILE"
+  local clean_list="/tmp/${target_name}_extensions_clean.list"
 
-    if [ -z "$cli_cmd" ] || [ ! -f "$cli_cmd" ]; then
-        echo "⚠️  CLI for $target_name not found. Skipping extension sync."
-        return
+  if [ -z "$cli_cmd" ] || [ ! -f "$cli_cmd" ]; then
+    echo "⚠️  CLI for $target_name not found. Skipping extension sync."
+    return
+  fi
+
+  echo "--- Syncing Extensions for $target_name ---"
+
+  # create a clean list without proprietary MS extensions
+  clean_extension_list "$source_list" "$clean_list"
+
+  # Log extensions that will be synced
+  local extension_count=$(wc -l <"$clean_list" | tr -d ' ')
+  echo "📦 Found $extension_count extension(s) to sync:"
+  while IFS= read -r extension; do
+    if [ -n "$extension" ]; then
+      echo "   • $extension"
     fi
+  done <"$clean_list"
+  echo ""
 
-    echo "--- Syncing Extensions for $target_name ---"
-    
-    # create a clean list without proprietary MS extensions
-    clean_extension_list "$source_list" "$clean_list"
-
-    # Log extensions that will be synced
-    local extension_count=$(wc -l < "$clean_list" | tr -d ' ')
-    echo "📦 Found $extension_count extension(s) to sync:"
-    while IFS= read -r extension; do
-        if [ -n "$extension" ]; then
-            echo "   • $extension"
-        fi
-    done <"$clean_list"
-    echo ""
-
-    while IFS= read -r extension; do
-        if [ -n "$extension" ]; then
-            # Try to install, log failures but don't stop
-            $cli_cmd --install-extension "$extension" >/dev/null 2>&1
-            if [ $? -ne 0 ]; then
-                echo "   ❌ Failed: $extension (Likely missing from Open VSX)"
-            else
-                # Optional: verify it's actually installed
-                echo "   ✅ Synced: $extension"
-            fi
-        fi
-    done <"$clean_list"
+  while IFS= read -r extension; do
+    if [ -n "$extension" ]; then
+      # Try to install, log failures but don't stop
+      $cli_cmd --install-extension "$extension" >/dev/null 2>&1
+      if [ $? -ne 0 ]; then
+        echo "   ❌ Failed: $extension (Likely missing from Open VSX)"
+      else
+        # Optional: verify it's actually installed
+        echo "   ✅ Synced: $extension"
+      fi
+    fi
+  done <"$clean_list"
 }
 
 sync_config_file() {
-    local filename=$1
-    local source="$VSCODE_USER_DIR/$filename"
-    
-    if [ -f "$source" ]; then
-        echo "Copying $filename to all editors..."
-        cp "$source" "$ANTIGRAVITY_USER_DIR/$filename"
-        cp "$source" "$CURSOR_USER_DIR/$filename"
-        cp "$source" "$WINDSURF_USER_DIR/$filename"
-    fi
+  local filename=$1
+  local source="$VSCODE_USER_DIR/$filename"
+
+  if [ -f "$source" ]; then
+    echo "Copying $filename to all editors..."
+    echo "   📋 Source: $source"
+    echo "   📤 Destinations:"
+    echo "      → $ANTIGRAVITY_USER_DIR/$filename"
+    cp "$source" "$ANTIGRAVITY_USER_DIR/$filename"
+    echo "      → $CURSOR_USER_DIR/$filename"
+    cp "$source" "$CURSOR_USER_DIR/$filename"
+    echo "      → $WINDSURF_USER_DIR/$filename"
+    cp "$source" "$WINDSURF_USER_DIR/$filename"
+  fi
 }
 
 # --- MAIN EXECUTION ---
@@ -150,10 +155,10 @@ ensure_dirs
 
 # 1. Export VS Code Extensions
 if command -v code >/dev/null; then
-    code --list-extensions > "$VSCODE_USER_DIR/$EXTENSIONS_FILE"
+  code --list-extensions >"$VSCODE_USER_DIR/$EXTENSIONS_FILE"
 else
-    echo "VS Code CLI not found in path!"
-    exit 1
+  echo "VS Code CLI not found in path!"
+  exit 1
 fi
 
 # 2. Sync Config Files
@@ -161,7 +166,7 @@ sync_config_file "$SETTINGS_FILE"
 sync_config_file "$KEYBINDINGS_FILE"
 
 # 3. Sync Extensions (with filtering)
-install_extensions "antigravity" 
+install_extensions "antigravity"
 install_extensions "cursor"
 install_extensions "windsurf"
 
@@ -169,12 +174,12 @@ echo "Initial Sync Complete."
 
 # 4. Watcher (Mac only)
 if command -v fswatch >/dev/null; then
-    echo "Watching for changes in VS Code settings..."
-    fswatch -o "$VSCODE_USER_DIR/$SETTINGS_FILE" "$VSCODE_USER_DIR/$KEYBINDINGS_FILE" | while read num; do
-        sync_config_file "$SETTINGS_FILE"
-        sync_config_file "$KEYBINDINGS_FILE"
-        echo "Updated at $(date)"
-    done
+  echo "Watching for changes in VS Code settings..."
+  fswatch -o "$VSCODE_USER_DIR/$SETTINGS_FILE" "$VSCODE_USER_DIR/$KEYBINDINGS_FILE" | while read num; do
+    sync_config_file "$SETTINGS_FILE"
+    sync_config_file "$KEYBINDINGS_FILE"
+    echo "Updated at $(date)"
+  done
 else
-    echo "fswatch not found. Auto-sync disabled."
+  echo "fswatch not found. Auto-sync disabled."
 fi

--- a/home-manager/services/code-syncer/sync.sh
+++ b/home-manager/services/code-syncer/sync.sh
@@ -1,94 +1,180 @@
 #!/usr/bin/env bash
 
-# Base directories
-VSCODE_USER_DIR="/Users/shunkakinoki/Library/Application Support/Code/User"
-ANTIGRAVITY_USER_DIR="/Users/shunkakinoki/Library/Application Support/Antigravity/User"
-CURSOR_USER_DIR="/Users/shunkakinoki/Library/Application Support/Cursor/User"
-WINDSURF_USER_DIR="/Users/shunkakinoki/Library/Application Support/Windsurf/User"
+# --- CONFIGURATION ---
 
-# Files to sync
+# Base directories
+VSCODE_USER_DIR="$HOME/Library/Application Support/Code/User"
+ANTIGRAVITY_USER_DIR="$HOME/Library/Application Support/Antigravity/User"
+CURSOR_USER_DIR="$HOME/Library/Application Support/Cursor/User"
+WINDSURF_USER_DIR="$HOME/Library/Application Support/Windsurf/User"
+
+# Files
 SETTINGS_FILE="settings.json"
 KEYBINDINGS_FILE="keybindings.json"
 EXTENSIONS_FILE="extensions.list"
 
-# Ensure target directories exist
-mkdir -p "$ANTIGRAVITY_USER_DIR"
-mkdir -p "$CURSOR_USER_DIR"
-mkdir -p "$WINDSURF_USER_DIR"
+# --- BLOCKLIST ---
+# These are MS proprietary extensions that typically fail on forks or crash them.
+# We filter these out to prevent errors.
+PROPRIETARY_EXTENSIONS=(
+    "github.codespaces"
+    "github.copilot" 
+    "github.copilot-chat"
+    "ms-python.debugpy"
+    "ms-python.python"
+    "ms-python.vscode-pylance"
+    "ms-python.vscode-python-envs"
+    "ms-vscode-remote.remote-containers"
+    "ms-vscode-remote.remote-ssh-edit"
+    "ms-vscode-remote.remote-ssh"
+    "ms-vscode-remote.remote-wsl"
+    "ms-vscode.remote-explorer"
+    "ms-vsliveshare.vsliveshare"
+)
 
-# Function to export VSCode extensions
-export_extensions() {
-  code --list-extensions >"$VSCODE_USER_DIR/$EXTENSIONS_FILE"
+AI_EXTENSIONS=(
+    "anthropic.claude-code"
+    "coderabbit.coderabbit-vscode"
+    "github.copilot"
+    "github.copilot-chat"
+    "google.gemini-cli-vscode-ide-companion"
+    "google.geminicodeassist"
+    "ggml-org.llama-vscode"
+    "kilocode.kilo-code"
+    "openai.chatgpt"
+    "rooveterinaryinc.roo-cline"
+    "saoudrizwan.claude-dev"
+    "sourcegraph.amp"
+    "sst-dev.opencode"
+    "sweetpad.sweetpad"
+)
+
+# --- HELPER FUNCTIONS ---
+
+# Check if a command exists, if not, try to find it in Applications
+resolve_cli() {
+    local cmd=$1
+    if command -v "$cmd" >/dev/null 2>&1; then
+        echo "$cmd"
+    else
+        # Fallback paths for Mac apps if not in PATH
+        case $cmd in
+            "antigravity") echo "/Applications/Antigravity.app/Contents/Resources/app/bin/antigravity" ;;
+            "windsurf") echo "/Applications/Windsurf.app/Contents/Resources/app/bin/windsurf" ;;
+            "cursor") echo "/Applications/Cursor.app/Contents/Resources/app/bin/cursor" ;;
+            *) echo "" ;;
+        esac
+    fi
 }
 
-# Function to install extensions
+ensure_dirs() {
+    mkdir -p "$ANTIGRAVITY_USER_DIR"
+    mkdir -p "$CURSOR_USER_DIR"
+    mkdir -p "$WINDSURF_USER_DIR"
+}
+
+# Filter out proprietary and AI extensions from the list
+clean_extension_list() {
+    local input_file="$1"
+    local clean_file="$2"
+    
+    cp "$input_file" "$clean_file"
+    
+    for bad_ext in "${PROPRIETARY_EXTENSIONS[@]}"; do
+        # Remove the line containing the bad extension
+        sed -i '' "/$bad_ext/d" "$clean_file"
+    done
+    
+    for ai_ext in "${AI_EXTENSIONS[@]}"; do
+        # Remove the line containing the AI extension
+        sed -i '' "/$ai_ext/d" "$clean_file"
+    done
+}
+
 install_extensions() {
-  local target_editor=$1
-  local cli_command
+    local target_name=$1
+    local cli_cmd=$(resolve_cli "$target_name")
+    local source_list="$VSCODE_USER_DIR/$EXTENSIONS_FILE"
+    local clean_list="/tmp/${target_name}_extensions_clean.list"
 
-  case $target_editor in
-  # "antigravity")
-  #   cli_command="antigravity"
-  #   ;;
-  "cursor")
-    cli_command="cursor"
-    ;;
-  "windsurf")
-    cli_command="windsurf"
-    ;;
-  *)
-    echo "Unknown editor: $target_editor"
-    return 1
-    ;;
-  esac
+    if [ -z "$cli_cmd" ] || [ ! -f "$cli_cmd" ]; then
+        echo "⚠️  CLI for $target_name not found. Skipping extension sync."
+        return
+    fi
 
-  if [ -f "$VSCODE_USER_DIR/$EXTENSIONS_FILE" ]; then
+    echo "--- Syncing Extensions for $target_name ---"
+    
+    # create a clean list without proprietary MS extensions
+    clean_extension_list "$source_list" "$clean_list"
+
+    # Log extensions that will be synced
+    local extension_count=$(wc -l < "$clean_list" | tr -d ' ')
+    echo "📦 Found $extension_count extension(s) to sync:"
     while IFS= read -r extension; do
-      $cli_command --install-extension "$extension" >/dev/null 2>&1
-    done <"$VSCODE_USER_DIR/$EXTENSIONS_FILE"
-    echo "Extensions synced to $target_editor at $(date)"
-  else
-    echo "Extensions list not found"
-  fi
+        if [ -n "$extension" ]; then
+            echo "   • $extension"
+        fi
+    done <"$clean_list"
+    echo ""
+
+    while IFS= read -r extension; do
+        if [ -n "$extension" ]; then
+            # Try to install, log failures but don't stop
+            $cli_cmd --install-extension "$extension" >/dev/null 2>&1
+            if [ $? -ne 0 ]; then
+                echo "   ❌ Failed: $extension (Likely missing from Open VSX)"
+            else
+                # Optional: verify it's actually installed
+                echo "   ✅ Synced: $extension"
+            fi
+        fi
+    done <"$clean_list"
 }
 
-# Function to sync files
-sync_files() {
-  local file=$1
-  local source_path="$VSCODE_USER_DIR/$file"
-
-  if [ -f "$source_path" ]; then
-    cp "$source_path" "$ANTIGRAVITY_USER_DIR/$file"
-    cp "$source_path" "$CURSOR_USER_DIR/$file"
-    cp "$source_path" "$WINDSURF_USER_DIR/$file"
-    echo "$file synced at $(date)"
-  else
-    echo "VSCode $file not found"
-  fi
+sync_config_file() {
+    local filename=$1
+    local source="$VSCODE_USER_DIR/$filename"
+    
+    if [ -f "$source" ]; then
+        echo "Copying $filename to all editors..."
+        cp "$source" "$ANTIGRAVITY_USER_DIR/$filename"
+        cp "$source" "$CURSOR_USER_DIR/$filename"
+        cp "$source" "$WINDSURF_USER_DIR/$filename"
+    fi
 }
 
-# Function to sync everything
-sync_all() {
-  export_extensions
-  sync_files "$SETTINGS_FILE"
-  sync_files "$KEYBINDINGS_FILE"
-  sync_files "$EXTENSIONS_FILE"
-  install_extensions "cursor"
-  install_extensions "windsurf"
-}
+# --- MAIN EXECUTION ---
 
-# Initial sync for all files and extensions
-sync_all
+echo "Starting Sync..."
+ensure_dirs
 
-# Watch for changes in configuration files
-echo "Starting to watch for changes in configuration files..."
+# 1. Export VS Code Extensions
+if command -v code >/dev/null; then
+    code --list-extensions > "$VSCODE_USER_DIR/$EXTENSIONS_FILE"
+else
+    echo "VS Code CLI not found in path!"
+    exit 1
+fi
 
-fswatch "$VSCODE_USER_DIR/$SETTINGS_FILE" "$VSCODE_USER_DIR/$KEYBINDINGS_FILE" | while read -r changed_file; do
-  if [[ $changed_file == *"$SETTINGS_FILE" ]]; then
-    echo "Settings file changed, syncing..."
-    sync_files "$SETTINGS_FILE"
-  elif [[ $changed_file == *"$KEYBINDINGS_FILE" ]]; then
-    echo "Keybindings file changed, syncing..."
-    sync_files "$KEYBINDINGS_FILE"
-  fi
-done
+# 2. Sync Config Files
+sync_config_file "$SETTINGS_FILE"
+sync_config_file "$KEYBINDINGS_FILE"
+
+# 3. Sync Extensions (with filtering)
+install_extensions "antigravity" 
+install_extensions "cursor"
+install_extensions "windsurf"
+
+echo "Initial Sync Complete."
+
+# 4. Watcher (Mac only)
+if command -v fswatch >/dev/null; then
+    echo "Watching for changes in VS Code settings..."
+    fswatch -o "$VSCODE_USER_DIR/$SETTINGS_FILE" "$VSCODE_USER_DIR/$KEYBINDINGS_FILE" | while read num; do
+        sync_config_file "$SETTINGS_FILE"
+        sync_config_file "$KEYBINDINGS_FILE"
+        echo "Updated at $(date)"
+    done
+else
+    echo "fswatch not found. Auto-sync disabled."
+fi

--- a/home-manager/services/code-syncer/sync.sh
+++ b/home-manager/services/code-syncer/sync.sh
@@ -60,8 +60,8 @@ resolve_cli() {
     # Fallback paths for Mac apps if not in PATH
     case $cmd in
     "antigravity") echo "/Applications/Antigravity.app/Contents/Resources/app/bin/antigravity" ;;
-    "windsurf") echo "/Applications/Windsurf.app/Contents/Resources/app/bin/windsurf" ;;
-    "cursor") echo "/Applications/Cursor.app/Contents/Resources/app/bin/cursor" ;;
+    "windsurf") echo "/opt/homebrew/bin/windsurf" ;;
+    "cursor") echo "/opt/homebrew/bin/cursor" ;;
     *) echo "" ;;
     esac
   fi


### PR DESCRIPTION
- Enhanced the clean_extension_list function to accept input from stdin or a file, improving flexibility.
- Updated remove_unnecessary_extensions and install_extensions functions to directly retrieve VS Code extensions via CLI, ensuring accurate syncing.
- Added checks for VS Code CLI availability and extension presence, with appropriate logging for better user feedback.
- Refined the logic for filtering and syncing extensions, ensuring only necessary extensions are retained.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revamps the code-syncer to reliably mirror VS Code settings and extensions to Cursor, Windsurf, and Antigravity. Uses the VS Code CLI, filters blocked extensions, removes extras on targets, and adds clearer logs plus auto-watch.

- **New Features**
  - Sync extensions directly from the VS Code CLI; filter proprietary and AI lists.
  - Uninstall extensions on targets that shouldn’t be kept.
  - Resolve editor CLIs (Antigravity, Cursor, Windsurf) and ensure user dirs; use HOME-based paths.
  - Auto-watch settings and keybindings with fswatch; copy updates to all editors.
  - Clear, concise logs for installs, removals, and skipped steps.

- **Bug Fixes**
  - Corrected fallback paths for Cursor and Windsurf (Homebrew).
  - Better handling of missing CLIs: skip missing target editors; fail fast if VS Code CLI is unavailable.

<sup>Written for commit 958dd234e0bcbee386c532ab8fc5398ef1991dca. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



