### PR TITLE
Use Dracula for Ghostty dark theme

### DIFF
--- a/home-manager/modules/ghostty/config
+++ b/home-manager/modules/ghostty/config
@@ -3,6 +3,7 @@
 #
 
 auto-update-channel = tip
+theme = "light:Catppuccin Latte,dark:Dracula"
 background-opacity = 0.8
 window-decoration = true
 window-theme = "dark"


### PR DESCRIPTION
## Summary
- set Ghostty combined theme syntax to use Dracula for dark mode
- keep Catppuccin Latte as the light theme

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692406259230832496ca48a6901b2fc8)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Ghostty to Dracula for dark mode while keeping Catppuccin Latte for light. Updates home-manager/modules/ghostty/config to set theme = "light:Catppuccin Latte,dark:Dracula" for better dark-mode contrast.

<sup>Written for commit c958524fd58d42b7c4995dab7fd6005cbef9a424. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

