### PR TITLE
Update Ghostty theme configuration for clarity and consistency

### DIFF
--- a/home-manager/modules/ghostty/config
+++ b/home-manager/modules/ghostty/config
@@ -3,4 +3,4 @@
 #
 
 auto-update-channel = tip
-theme = dark:Catppuccin Frappe,light:Catppuccin Latte
+theme = dark:Dracula,light:Catppuccin Latte

--- a/home-manager/modules/ghostty/config
+++ b/home-manager/modules/ghostty/config
@@ -4,7 +4,6 @@
 
 auto-update-channel = tip
 theme = dark:Dracula,light:Catppuccin Latte
-background-opacity = 0.8
 window-decoration = true
 window-save-state = always
 window-padding-balance = true

--- a/home-manager/modules/ghostty/config
+++ b/home-manager/modules/ghostty/config
@@ -5,6 +5,10 @@
 auto-update-channel = tip
 theme = dark:Dracula,light:Catppuccin Latte
 background-opacity = 0.8
+macos-option-as-alt = true
+macos-titlebar-style = "tabs"
+command = /etc/profiles/per-user/shunkakinoki/bin/fish
+shell-integration = fish
 cursor-style = bar
 cursor-style-blink = true
 mouse-hide-while-typing = true

--- a/home-manager/modules/ghostty/config
+++ b/home-manager/modules/ghostty/config
@@ -4,14 +4,8 @@
 
 auto-update-channel = tip
 theme = dark:Dracula,light:Catppuccin Latte
+background-opacity = 0.8
 window-decoration = true
-window-save-state = always
-window-padding-balance = true
-confirm-close-surface = true
-macos-option-as-alt = true
-macos-titlebar-style = "tabs"
-command = /etc/profiles/per-user/shunkakinoki/bin/fish
-shell-integration = fish
 cursor-style = bar
 cursor-style-blink = true
 mouse-hide-while-typing = true

--- a/home-manager/modules/ghostty/config
+++ b/home-manager/modules/ghostty/config
@@ -5,6 +5,7 @@
 auto-update-channel = tip
 theme = dark:Dracula,light:Catppuccin Latte
 background-opacity = 0.8
+confirm-close-surface = true
 macos-option-as-alt = true
 macos-titlebar-style = "tabs"
 command = /etc/profiles/per-user/shunkakinoki/bin/fish

--- a/home-manager/modules/ghostty/config
+++ b/home-manager/modules/ghostty/config
@@ -4,25 +4,3 @@
 
 auto-update-channel = tip
 theme = dark:Catppuccin Frappe,light:Catppuccin Latte
-background-opacity = 0.8
-window-decoration = true
-window-theme = "dark"
-window-save-state = always
-window-padding-balance = true
-confirm-close-surface = true
-macos-option-as-alt = true
-macos-titlebar-style = "tabs"
-command = /etc/profiles/per-user/shunkakinoki/bin/fish
-shell-integration = fish
-cursor-style = bar
-cursor-style-blink = true
-mouse-hide-while-typing = true
-clipboard-read = "allow"
-clipboard-paste-protection = false
-
-keybind = super+alt+left=previous_tab
-keybind = super+alt+right=next_tab
-keybind = super+shift+left=move_tab:-1
-keybind = super+shift+up=move_tab:-1
-keybind = super+shift+right=move_tab:1
-keybind = super+shift+down=move_tab:1

--- a/home-manager/modules/ghostty/config
+++ b/home-manager/modules/ghostty/config
@@ -3,7 +3,7 @@
 #
 
 auto-update-channel = tip
-theme = light:Catppuccin Latte,dark:Dracula
+theme = dark:Catppuccin Frappe,light:Catppuccin Latte
 background-opacity = 0.8
 window-decoration = true
 window-theme = "dark"

--- a/home-manager/modules/ghostty/config
+++ b/home-manager/modules/ghostty/config
@@ -3,7 +3,7 @@
 #
 
 auto-update-channel = tip
-theme = "light:Catppuccin Latte,dark:Dracula"
+theme = light:Catppuccin Latte,dark:Dracula
 background-opacity = 0.8
 window-decoration = true
 window-theme = "dark"

--- a/home-manager/modules/ghostty/config
+++ b/home-manager/modules/ghostty/config
@@ -4,3 +4,24 @@
 
 auto-update-channel = tip
 theme = dark:Dracula,light:Catppuccin Latte
+background-opacity = 0.8
+window-decoration = true
+window-save-state = always
+window-padding-balance = true
+confirm-close-surface = true
+macos-option-as-alt = true
+macos-titlebar-style = "tabs"
+command = /etc/profiles/per-user/shunkakinoki/bin/fish
+shell-integration = fish
+cursor-style = bar
+cursor-style-blink = true
+mouse-hide-while-typing = true
+clipboard-read = "allow"
+clipboard-paste-protection = false
+
+keybind = super+alt+left=previous_tab
+keybind = super+alt+right=next_tab
+keybind = super+shift+left=move_tab:-1
+keybind = super+shift+up=move_tab:-1
+keybind = super+shift+right=move_tab:1
+keybind = super+shift+down=move_tab:1

--- a/home-manager/modules/ghostty/config
+++ b/home-manager/modules/ghostty/config
@@ -5,7 +5,6 @@
 auto-update-channel = tip
 theme = dark:Dracula,light:Catppuccin Latte
 background-opacity = 0.8
-window-decoration = true
 cursor-style = bar
 cursor-style-blink = true
 mouse-hide-while-typing = true


### PR DESCRIPTION
Remove unnecessary quotes and clean up settings in the Ghostty theme configuration. Update the theme to use Catppuccin Frappe for dark mode.









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Ghostty theme to Dracula (dark) and Catppuccin Latte (light), and simplify the config.
Removed unnecessary quotes and redundant settings to rely on defaults.

<sup>Written for commit f977684bac92a9c3e9add4b7d2149e11fef17b66. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









