### PR TITLE
Restore Ollama service and update Homebrew configuration

### DIFF
--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -24,10 +24,8 @@ jobs:
         uses: cachix/install-nix-action@v31
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install Neovim
-        run: nix profile install nixpkgs#neovim
-      - name: Validate Neovim Configuration
-        run: make lua-check-neovim
+      - name: Validate Neovim Configuration (Dev Shell)
+        run: nix develop .# --command make lua-check-neovim
   lua-hammerspoon:
     runs-on: macos-latest
     timeout-minutes: 300
@@ -38,8 +36,8 @@ jobs:
         uses: cachix/install-nix-action@v31
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Validate Hammerspoon Configuration
-        run: make lua-check-hammerspoon
+      - name: Validate Hammerspoon Configuration (Dev Shell)
+        run: nix develop .# --command make lua-check-hammerspoon
   lua-check:
     if: always()
     needs:

--- a/flake.nix
+++ b/flake.nix
@@ -146,7 +146,7 @@
 
           devShells.default = devPkgs.mkShell {
             packages = [
-              devPkgs.nodejs_20
+              devPkgs.nodejs
               devPkgs.bun
               devPkgs.neovim
             ];

--- a/flake.nix
+++ b/flake.nix
@@ -118,8 +118,19 @@
         };
 
       perSystem =
-        { system, pkgs, ... }:
+        { system, ... }:
+        let
+          overlays = import ./overlays { inherit inputs; };
+          nixpkgsConfig = import ./lib/nixpkgs-config.nix {
+            nixpkgsLib = inputs.nixpkgs.lib;
+          };
+          devPkgs = import inputs.nixpkgs {
+            inherit system overlays;
+            config = nixpkgsConfig;
+          };
+        in
         {
+          _module.args.pkgs = devPkgs;
           treefmt = {
             projectRootFile = "flake.nix";
             programs = {
@@ -133,13 +144,14 @@
             };
           };
 
-          devShells.default = pkgs.mkShell {
+          devShells.default = devPkgs.mkShell {
             packages = [
-              pkgs.nodejs_20
-              pkgs.bun
+              devPkgs.nodejs_20
+              devPkgs.bun
+              devPkgs.neovim
             ];
             shellHook = ''
-              echo "Dev shell ready: Node.js + bun available."
+              echo "Dev shell ready: Node.js, bun, and Neovim available."
             '';
           };
         };

--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -3,7 +3,7 @@ let
   codeSyncer = import ./code-syncer { inherit pkgs; };
   dotfilesUpdater = import ./dotfiles-updater { inherit pkgs; };
   neversslKeepalive = import ./neverssl-keepalive { inherit pkgs; };
-  # ollama = import ./ollama { inherit pkgs; };  # FIXME: ollama 0.12.11 has build issues with UI assets, uncomment when fixed
+  ollama = import ./ollama { inherit pkgs; };
   brewUpgrader = import ./brew-upgrader { inherit pkgs; };
 in
 [
@@ -11,5 +11,5 @@ in
   codeSyncer
   dotfilesUpdater
   neversslKeepalive
-  # ollama
+  ollama
 ]

--- a/home-manager/services/ollama/default.nix
+++ b/home-manager/services/ollama/default.nix
@@ -1,13 +1,30 @@
 { pkgs }:
 let
-  inherit (pkgs) lib;
+  inherit (pkgs) lib writeShellApplication;
+
+  # launchd wrapper so we can reuse the Homebrew-installed ollama binary
+  ollamaHomebrew = writeShellApplication {
+    name = "ollama-homebrew";
+    text = ''
+      set -euo pipefail
+
+      if [ -x /opt/homebrew/bin/ollama ]; then
+        exec /opt/homebrew/bin/ollama "$@"
+      elif [ -x /usr/local/bin/ollama ]; then
+        exec /usr/local/bin/ollama "$@"
+      else
+        echo "ollama binary not found; install it with \"brew install ollama\"" >&2
+        exit 1
+      fi
+    '';
+  };
 in
 lib.mkIf pkgs.stdenv.isDarwin {
   launchd.agents.ollama = {
     enable = true;
     config = {
       ProgramArguments = [
-        "${pkgs.ollama}/bin/ollama"
+        (lib.getExe ollamaHomebrew)
         "serve"
       ];
       KeepAlive = true;

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -31,6 +31,7 @@
       "kurtosis-cli"
       "mas"
       "opencode"
+      "ollama"
       "pandoc"
       "pinentry-mac"
       "pnpm"
@@ -71,7 +72,6 @@
       "linear-linear"
       "lm-studio"
       "notion"
-      # "ollama-app"  # FIXME: conflicts_with formula is disabled, uncomment when Homebrew fixes conflict
       "raycast"
       "rescuetime"
       "screen-studio"

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -72,6 +72,7 @@
       "linear-linear"
       "lm-studio"
       "notion"
+      "ollama-app"
       "raycast"
       "rescuetime"
       "screen-studio"


### PR DESCRIPTION
Restore the Ollama service and ensure it is correctly integrated with Homebrew. Update CI workflow validation steps for Neovim and Hammerspoon configurations, enhancing the development shell to include Neovim and improve readiness messaging.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the Ollama service on macOS and integrate it with Homebrew for reliable binary management. CI Lua checks now run via the dev shell, which includes Neovim.

- **New Features**
  - Re-enable the Ollama launchd agent via home-manager.
  - Add a wrapper to run the Homebrew-installed ollama binary, with /opt/homebrew and /usr/local fallbacks.
  - Install Homebrew “ollama” and enable “ollama-app” in masApps.
  - Run Neovim and Hammerspoon Lua checks through `nix develop`; dev shell now includes Neovim.

- **Migration**
  - Run `nix-darwin switch` to apply changes; Homebrew will install the required packages.

<sup>Written for commit 0f566a9fefde59c3fa300b64af74b6d347565e24. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



