### PR TITLE
Update Neovim and Hammerspoon validation commands

### DIFF
--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -13,8 +13,6 @@ jobs:
   lua-neovim:
     runs-on: ubuntu-latest
     timeout-minutes: 300
-    env:
-      DEVENV_ROOT: ${{ github.workspace }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -27,8 +25,6 @@ jobs:
   lua-hammerspoon:
     runs-on: macos-latest
     timeout-minutes: 300
-    env:
-      DEVENV_ROOT: ${{ github.workspace }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Validate Neovim Configuration (Dev Shell)
-        run: nix develop .# --command make lua-check-neovim
+        run: make lua-check-neovim-dev
   lua-hammerspoon:
     runs-on: macos-latest
     timeout-minutes: 300
@@ -37,7 +37,7 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Validate Hammerspoon Configuration (Dev Shell)
-        run: nix develop .# --command make lua-check-hammerspoon
+        run: make lua-check-hammerspoon-dev
   lua-check:
     if: always()
     needs:

--- a/Makefile
+++ b/Makefile
@@ -532,6 +532,11 @@ lua-check-neovim: ## Check Neovim configuration.
 		exit $$EXIT_CODE; \
 	fi
 
+.PHONY: lua-check-neovim-dev
+lua-check-neovim-dev: ## Run the Neovim Lua check inside the Nix dev shell (mirrors CI).
+	@echo "🧪 Running Neovim Lua check inside the Nix dev shell..."
+	@DEVENV_ROOT=$(CURDIR) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) develop $(NIX_FLAGS) .# --command $(MAKE) lua-check-neovim
+
 .PHONY: lua-check-hammerspoon
 lua-check-hammerspoon: ## Check Hammerspoon configuration.
 	@echo "🔍 Checking Hammerspoon configuration..."
@@ -553,6 +558,11 @@ lua-check-hammerspoon: ## Check Hammerspoon configuration.
 		echo "⚠️  Neither lua nor nix is available for syntax checking"; \
 		exit 1; \
 	fi
+
+.PHONY: lua-check-hammerspoon-dev
+lua-check-hammerspoon-dev: ## Run the Hammerspoon Lua check inside the Nix dev shell (mirrors CI).
+	@echo "🧪 Running Hammerspoon Lua check inside the Nix dev shell..."
+	@DEVENV_ROOT=$(CURDIR) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) develop $(NIX_FLAGS) .# --command $(MAKE) lua-check-hammerspoon
 
 ##@ Git Submodule
 


### PR DESCRIPTION
Modify validation commands for Neovim and Hammerspoon to utilize new development shell targets, enhancing the configuration check process.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized Neovim and Hammerspoon Lua validation by adding dev-shell Makefile targets and updating CI to use them. This makes local and CI checks consistent and simpler.

- **Refactors**
  - Added lua-check-neovim-dev and lua-check-hammerspoon-dev targets to run checks inside the Nix dev shell.
  - Updated GitHub Actions to call these targets instead of raw nix develop commands.
  - Removed unused DEVENV_ROOT from Lua workflows.

<sup>Written for commit 056d98e031d7d1e569765b3fff1c51a70226e84a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



