### PR TITLE
neovim configure

### DIFF
--- a/home-manager/programs/neovim/lua/keymaps.lua
+++ b/home-manager/programs/neovim/lua/keymaps.lua
@@ -217,8 +217,8 @@ keymap("n", "<leader>sk", ":Sidekick cli toggle<CR>", opts)
 -- ====================================================================================
 -- @keymap <tab> (insert): jump/apply Sidekick NES or insert literal <Tab>
 local function nes_tab_fallback()
- 	if not require("sidekick").nes_jump_or_apply() then
- 		return "<Tab>"
+	if not require("sidekick").nes_jump_or_apply() then
+		return "<Tab>"
 	end
 end
 keymap("i", "<tab>", nes_tab_fallback, { expr = true, desc = "Sidekick NES jump/apply" })

--- a/home-manager/programs/neovim/lua/keymaps.lua
+++ b/home-manager/programs/neovim/lua/keymaps.lua
@@ -206,7 +206,9 @@ keymap("n", "<leader>st", treesj.toggle, opts)
 keymap("n", "<leader>b", ":NvimTreeToggle<CR>", opts)
 
 -- @keymap <leader>sk: Toggle sidekick (symbols sidebar)
-keymap("n", "<leader>sk", ":SidekickToggle<CR>", opts)
+keymap("n", "<leader>sk", function()
+	require("sidekick.cli").toggle()
+end, opts)
 
 -- ====================================================================================
 -- WHICH-KEY GROUPS

--- a/home-manager/programs/neovim/lua/keymaps.lua
+++ b/home-manager/programs/neovim/lua/keymaps.lua
@@ -200,14 +200,59 @@ treesj.setup({ use_default_keymaps = false })
 keymap("n", "<leader>st", treesj.toggle, opts)
 
 -- ====================================================================================
--- NvimTree
+-- NVIMTREE
 -- ====================================================================================
 -- @keymap <leader>b: Toggle file tree (nvim-tree)
 keymap("n", "<leader>b", ":NvimTreeToggle<CR>", opts)
 
--- @keymap <leader>sk: Toggle sidekick (symbols sidebar)
-keymap("n", "<leader>sk", function()
+-- @keymap <leader>sk: Toggle Sidekick CLI (per docs)
+keymap("n", "<leader>sk", ":Sidekick cli toggle<CR>", opts)
+
+-- ====================================================================================
+-- SIDEKICK
+-- ====================================================================================
+-- @keymap <tab> (insert): jump/apply Sidekick NES or insert literal <Tab>
+local function nes_tab_fallback()
+ 	if not require("sidekick").nes_jump_or_apply() then
+ 		return "<Tab>"
+	end
+end
+keymap("i", "<tab>", nes_tab_fallback, { expr = true, desc = "Sidekick NES jump/apply" })
+-- @keymap <c-.>: Toggle Sidekick CLI in any mode
+keymap({ "n", "t", "i", "x" }, "<c-.>", function()
 	require("sidekick.cli").toggle()
+end, { desc = "Sidekick Toggle" })
+-- @keymap <leader>aa: Toggle Sidekick CLI window (alternate)
+keymap("n", "<leader>aa", function()
+	require("sidekick.cli").toggle()
+end, opts)
+-- @keymap <leader>as: Select a CLI tool
+keymap("n", "<leader>as", function()
+	require("sidekick.cli").select()
+end, opts)
+-- @keymap <leader>ad: Close detached CLI
+keymap("n", "<leader>ad", function()
+	require("sidekick.cli").close()
+end, opts)
+-- @keymap <leader>at: Send current context, per docs
+keymap({ "n", "x" }, "<leader>at", function()
+	require("sidekick.cli").send({ msg = "{this}" })
+end, opts)
+-- @keymap <leader>af: Send entire buffer
+keymap("n", "<leader>af", function()
+	require("sidekick.cli").send({ msg = "{file}" })
+end, opts)
+-- @keymap <leader>av: Send selection
+keymap("x", "<leader>av", function()
+	require("sidekick.cli").send({ msg = "{selection}" })
+end, opts)
+-- @keymap <leader>ap: Open Sidekick prompt/command picker
+keymap({ "n", "x" }, "<leader>ap", function()
+	require("sidekick.cli").prompt()
+end, opts)
+-- @keymap <leader>ac: Toggle Claude session and focus it
+keymap("n", "<leader>ac", function()
+	require("sidekick.cli").toggle({ name = "claude", focus = true })
 end, opts)
 
 -- ====================================================================================

--- a/home-manager/programs/neovim/lua/keymaps.lua
+++ b/home-manager/programs/neovim/lua/keymaps.lua
@@ -56,20 +56,24 @@ keymap("n", "ZZ", ":wa<CR>:q<CR>", opts)
 -- ====================================================================================
 -- TERMINAL
 -- ====================================================================================
--- @keymap <leader>j: Toggle terminal (show/hide)
-keymap({ "n", "t" }, "<leader>j", function()
-	TogglePrimaryTerm()
+-- @keymap <leader>u: Spawn a new managed terminal
+keymap({ "n", "t" }, "<leader>u", function()
+	SpawnTerminal()
 end, opts)
--- @keymap <leader>h: Toggle secondary terminal (show/hide)
+-- @keymap <leader>h: Close the current managed terminal
 keymap({ "n", "t" }, "<leader>h", function()
-	ToggleSecondaryTerm()
+	KillCurrentTerminal()
 end, opts)
--- @keymap <leader><space>]: Cycle to next managed terminal
-keymap({ "n", "t" }, "<leader><space>]", function()
+-- @keymap <leader>j: Toggle the focused managed terminal
+keymap({ "n", "t" }, "<leader>j", function()
+	ToggleTerminal()
+end, opts)
+-- @keymap <leader><S-]>: Jump to next managed terminal
+keymap({ "n", "t" }, "<leader><S-]>", function()
 	CycleNextTerm()
 end, opts)
--- @keymap <leader><space>[: Cycle to previous managed terminal
-keymap({ "n", "t" }, "<leader><space>[", function()
+-- @keymap <leader><S-[>: Jump to previous managed terminal
+keymap({ "n", "t" }, "<leader><S-[>", function()
 	CyclePreviousTerm()
 end, opts)
 

--- a/home-manager/programs/neovim/lua/lsp.lua
+++ b/home-manager/programs/neovim/lua/lsp.lua
@@ -1,15 +1,25 @@
 -- Keymaps for LSP actions in on_attach
 local on_attach = function(client, bufnr)
 	local opts = { buffer = bufnr, noremap = true, silent = true }
+	-- @keymap K: Show hover information
 	vim.keymap.set("n", "K", vim.lsp.buf.hover, opts)
+	-- @keymap gd: Go to definition
 	vim.keymap.set("n", "gd", vim.lsp.buf.definition, opts)
+	-- @keymap gD: Go to declaration
 	vim.keymap.set("n", "gD", vim.lsp.buf.declaration, opts)
+	-- @keymap gi: Go to implementation
 	vim.keymap.set("n", "gi", vim.lsp.buf.implementation, opts)
+	-- @keymap gr: Find references
 	vim.keymap.set("n", "gr", vim.lsp.buf.references, opts)
+	-- @keymap <leader>D: Go to type definition
 	vim.keymap.set("n", "<leader>D", vim.lsp.buf.type_definition, opts)
+	-- @keymap ca: Show code actions
 	vim.keymap.set("n", "ca", vim.lsp.buf.code_action, opts)
+	-- @keymap <leader>rn: Rename symbol
 	vim.keymap.set("n", "<leader>rn", vim.lsp.buf.rename, opts)
+	-- @keymap <C-k>: Show signature help (normal mode)
 	vim.keymap.set("n", "<C-k>", vim.lsp.buf.signature_help, opts)
+	-- @keymap <C-k>: Show signature help (insert mode)
 	vim.keymap.set("i", "<C-k>", vim.lsp.buf.signature_help, opts)
 end
 


### PR DESCRIPTION
- **feat(keymaps): update <leader>sk to toggle sidekick using CLI function**
- **feat(sidekick): enhance keymaps for Sidekick CLI functionality**
- **feat(terminal): update terminal keymaps and enhance terminal management functions**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Overhauls terminal management to support multiple managed terminals and adds comprehensive Sidekick CLI bindings, updating related keymaps.
> 
> - **Terminal management (`lua/terminal.lua`, `lua/keymaps.lua`)**:
>   - Replace fixed primary/secondary terminals with dynamic managed terminals: `SpawnTerminal`, `ToggleTerminal`, `KillCurrentTerminal`, `CycleNextTerm`, `CyclePreviousTerm` with sequencing, focused display, and auto-create behavior.
>   - Update keymaps:
>     - `<leader>u` spawn, `<leader>j` toggle focused, `<leader>h` close current.
>     - `<leader><S-]>` next, `<leader><S-[>` previous.
> - **Sidekick CLI (`lua/keymaps.lua`)**:
>   - Change `<leader>sk` to `:Sidekick cli toggle`.
>   - Add bindings: insert `<Tab>` NES fallback; `<c-.>` toggle; `<leader>aa` toggle, `<leader>as` select, `<leader>ad` close, `<leader>at` send `{this}`, `<leader>af` send `{file}`, `<leader>av` send `{selection}`, `<leader>ap` prompt picker, `<leader>ac` toggle Claude (focused).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd305bdaed00589dd9d2e7a3abdf634b0c8b726d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revamped terminal management and added Sidekick CLI keymaps to streamline multi-terminal workflows and make Sidekick actions accessible from any mode.

- **New Features**
  - Terminal keymaps: <leader>u spawn, <leader>h close current, <leader>j toggle focused, <leader><S-]> next, <leader><S-[> previous.
  - Sidekick CLI keymaps: <leader>sk toggle; <c-.> toggle in any mode; <leader>aa toggle; <leader>as select tool; <leader>ad close; <leader>at send {this}; <leader>af send {file}; <leader>av send {selection}; <leader>ap prompt; <leader>ac toggle/focus Claude; insert <tab> jumps/applies NES or inserts Tab.

- **Refactors**
  - Replaced fixed primary/secondary terminals with a managed pool: create on demand, keep only one open, remember current, and cycle reliably even when none exist.

<sup>Written for commit 6cbf7a34e65ae5accfc92df16a2ee7372a0394b4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



