### PR TITLE
Coder

### DIFF
--- a/config/amp/default.nix
+++ b/config/amp/default.nix
@@ -1,0 +1,6 @@
+{ config, ... }:
+{
+  xdg.configFile."amp/settings.json" = {
+    source = config.lib.file.mkOutOfStoreSymlink ./settings.json;
+  };
+}

--- a/config/amp/settings.json
+++ b/config/amp/settings.json
@@ -1,0 +1,3 @@
+{
+  "amp.url": "http://localhost:8317"
+}

--- a/config/cliproxyapi/config.yaml
+++ b/config/cliproxyapi/config.yaml
@@ -72,8 +72,8 @@ openai-compatibility:
     models:
       - name: "moonshotai/kimi-k2:free"
         alias: "kimi-k2"
-      - name: "zhipu/glm-4"
-        alias: "glm4"
+      - name: "z-ai/glm-4.6"
+        alias: "glm-4.6"
 
 # payload: # Optional payload configuration
 #   default: # Default rules only set parameters when they are missing in the payload.

--- a/config/cliproxyapi/config.yaml
+++ b/config/cliproxyapi/config.yaml
@@ -72,6 +72,8 @@ openai-compatibility:
     models:
       - name: "moonshotai/kimi-k2:free"
         alias: "kimi-k2"
+      - name: "zhipu/glm-4"
+        alias: "glm4"
 
 # payload: # Optional payload configuration
 #   default: # Default rules only set parameters when they are missing in the payload.

--- a/config/cliproxyapi/config.yaml
+++ b/config/cliproxyapi/config.yaml
@@ -70,8 +70,6 @@ openai-compatibility:
     api-keys:
       - "__OPENROUTER_API_KEY__"
     models:
-      - name: "moonshotai/kimi-k2:free"
-        alias: "kimi-k2"
       - name: "z-ai/glm-4.6"
         alias: "glm-4.6"
 

--- a/config/cliproxyapi/config.yaml
+++ b/config/cliproxyapi/config.yaml
@@ -28,6 +28,10 @@ usage-statistics-enabled: true
 proxy-url: ""
 # Number of times to retry a request. Retries will occur if the HTTP response code is 403, 408, 500, 502, 503, or 504.
 request-retry: 3
+# AMP upstream settings
+amp-upstream-url: "https://ampcode.com"
+amp-restrict-management-to-localhost: true
+# amp-upstream-api-key: "" # Optional - use AMP_API_KEY env var or ~/.local/share/amp/secrets.json
 # Quota exceeded behavior
 quota-exceeded:
   switch-project: true # Whether to automatically switch to another project when a quota is exceeded

--- a/config/cliproxyapi/config.yaml
+++ b/config/cliproxyapi/config.yaml
@@ -1,0 +1,100 @@
+# Server port
+port: 8317
+
+# Management API settings
+remote-management:
+  # Whether to allow remote (non-localhost) management access.
+  # When false, only localhost can access management endpoints (a key is still required).
+  allow-remote: false
+
+  # Management key. If a plaintext value is provided here, it will be hashed on startup.
+  # All management requests (even from localhost) require this key.
+  # Leave empty to disable the Management API entirely (404 for all /v0/management routes).
+  secret-key: ""
+
+  # Disable the bundled management control panel asset download and HTTP route when true.
+  disable-control-panel: false
+
+# Authentication directory (supports ~ for home directory). If you use Windows, please set the directory like this: `C:/cli-proxy-api/`
+auth-dir: "~/.cli-proxy-api"
+
+# API keys for authentication
+# api-keys:
+#   - "your-api-key-1"
+#   - "your-api-key-2"
+
+# Enable debug logging
+debug: true
+
+# When true, write application logs to rotating files instead of stdout
+logging-to-file: false
+
+# When false, disable in-memory usage statistics aggregation
+usage-statistics-enabled: true
+
+# Proxy URL. Supports socks5/http/https protocols. Example: socks5://user:pass@192.168.1.1:1080/
+proxy-url: ""
+
+# Number of times to retry a request. Retries will occur if the HTTP response code is 403, 408, 500, 502, 503, or 504.
+request-retry: 3
+
+# Quota exceeded behavior
+quota-exceeded:
+  switch-project: true # Whether to automatically switch to another project when a quota is exceeded
+  switch-preview-model: true # Whether to automatically switch to a preview model when a quota is exceeded
+
+# When true, enable authentication for the WebSocket API (/v1/ws).
+ws-auth: false
+
+# Gemini API keys (preferred)
+# gemini-api-key:
+#   - api-key: "AIzaSy...01"
+#     base-url: "https://generativelanguage.googleapis.com"
+#     headers:
+#       X-Custom-Header: "custom-value"
+#     proxy-url: "socks5://proxy.example.com:1080"
+#   - api-key: "AIzaSy...02"
+
+# Codex API keys
+# codex-api-key:
+#   - api-key: "sk-atSM..."
+#     base-url: "https://www.example.com" # use the custom codex API endpoint
+#     headers:
+#       X-Custom-Header: "custom-value"
+#     proxy-url: "socks5://proxy.example.com:1080" # optional: per-key proxy override
+
+# Claude API keys
+# claude-api-key:
+#   - api-key: "sk-atSM..." # use the official claude API key, no need to set the base url
+#   - api-key: "sk-atSM..."
+#     base-url: "https://www.example.com" # use the custom claude API endpoint
+#     headers:
+#       X-Custom-Header: "custom-value"
+#     proxy-url: "socks5://proxy.example.com:1080" # optional: per-key proxy override
+#     models:
+#       - name: "claude-3-5-sonnet-20241022" # upstream model name
+#        alias: "claude-sonnet-latest" # client alias mapped to the upstream model
+
+# OpenAI compatibility providers
+openai-compatibility:
+  - name: "openrouter"
+    base-url: "https://openrouter.ai/api/v1"
+    api-keys:
+      - "__OPENROUTER_API_KEY__"
+    models:
+      - name: "moonshotai/kimi-k2:free"
+        alias: "kimi-k2"
+
+# payload: # Optional payload configuration
+#   default: # Default rules only set parameters when they are missing in the payload.
+#     - models:
+#         - name: "gemini-2.5-pro" # Supports wildcards (e.g., "gemini-*")
+#           protocol: "gemini" # restricts the rule to a specific protocol, options: openai, gemini, claude, codex
+#       params: # JSON path (gjson/sjson syntax) -> value
+#         "generationConfig.thinkingConfig.thinkingBudget": 32768
+#   override: # Override rules always set parameters, overwriting any existing values.
+#     - models:
+#         - name: "gpt-*" # Supports wildcards (e.g., "gpt-*")
+#           protocol: "codex" # restricts the rule to a specific protocol, options: openai, gemini, claude, codex
+#       params: # JSON path (gjson/sjson syntax) -> value
+#         "reasoning.effort": "high"

--- a/config/cliproxyapi/config.yaml
+++ b/config/cliproxyapi/config.yaml
@@ -30,7 +30,7 @@ proxy-url: ""
 request-retry: 3
 # AMP upstream settings
 amp-upstream-url: "https://ampcode.com"
-amp-restrict-management-to-localhost: true
+amp-restrict-management-to-localhost: false
 # amp-upstream-api-key: "" # Optional - use AMP_API_KEY env var or ~/.local/share/amp/secrets.json
 # Quota exceeded behavior
 quota-exceeded:

--- a/config/cliproxyapi/config.yaml
+++ b/config/cliproxyapi/config.yaml
@@ -29,7 +29,6 @@ proxy-url: ""
 # Number of times to retry a request. Retries will occur if the HTTP response code is 403, 408, 500, 502, 503, or 504.
 request-retry: 3
 
-# amp-upstream-api-key: "" # Optional - use AMP_API_KEY env var or ~/.local/share/amp/secrets.json
 # Quota exceeded behavior
 quota-exceeded:
   switch-project: true # Whether to automatically switch to another project when a quota is exceeded
@@ -41,6 +40,7 @@ ws-auth: false
 ampcode:
   upstream-url: "https://ampcode.com"
   restrict-management-to-localhost: true
+# amp-upstream-api-key: "" # Optional - use AMP_API_KEY env var or ~/.local/share/amp/secrets.json
 
 # Gemini API keys (preferred)
 # gemini-api-key:

--- a/config/cliproxyapi/config.yaml
+++ b/config/cliproxyapi/config.yaml
@@ -28,9 +28,7 @@ usage-statistics-enabled: true
 proxy-url: ""
 # Number of times to retry a request. Retries will occur if the HTTP response code is 403, 408, 500, 502, 503, or 504.
 request-retry: 3
-# AMP upstream settings
-amp-upstream-url: "https://ampcode.com"
-amp-restrict-management-to-localhost: false
+
 # amp-upstream-api-key: "" # Optional - use AMP_API_KEY env var or ~/.local/share/amp/secrets.json
 # Quota exceeded behavior
 quota-exceeded:
@@ -38,6 +36,12 @@ quota-exceeded:
   switch-preview-model: true # Whether to automatically switch to a preview model when a quota is exceeded
 # When true, enable authentication for the WebSocket API (/v1/ws).
 ws-auth: false
+
+# AMP
+ampcode:
+  upstream-url: "https://ampcode.com"
+  restrict-management-to-localhost: true
+
 # Gemini API keys (preferred)
 # gemini-api-key:
 #   - api-key: "AIzaSy...01"

--- a/config/cliproxyapi/config.yaml
+++ b/config/cliproxyapi/config.yaml
@@ -1,23 +1,18 @@
 # Server port
 port: 8317
-
 # Management API settings
 remote-management:
   # Whether to allow remote (non-localhost) management access.
   # When false, only localhost can access management endpoints (a key is still required).
   allow-remote: false
-
   # Management key. If a plaintext value is provided here, it will be hashed on startup.
   # All management requests (even from localhost) require this key.
   # Leave empty to disable the Management API entirely (404 for all /v0/management routes).
   secret-key: ""
-
   # Disable the bundled management control panel asset download and HTTP route when true.
   disable-control-panel: false
-
 # Authentication directory (supports ~ for home directory). If you use Windows, please set the directory like this: `C:/cli-proxy-api/`
 auth-dir: "~/.cli-proxy-api"
-
 # API keys for authentication
 # api-keys:
 #   - "your-api-key-1"
@@ -25,27 +20,20 @@ auth-dir: "~/.cli-proxy-api"
 
 # Enable debug logging
 debug: true
-
 # When true, write application logs to rotating files instead of stdout
 logging-to-file: true
-
 # When false, disable in-memory usage statistics aggregation
 usage-statistics-enabled: true
-
 # Proxy URL. Supports socks5/http/https protocols. Example: socks5://user:pass@192.168.1.1:1080/
 proxy-url: ""
-
 # Number of times to retry a request. Retries will occur if the HTTP response code is 403, 408, 500, 502, 503, or 504.
 request-retry: 3
-
 # Quota exceeded behavior
 quota-exceeded:
   switch-project: true # Whether to automatically switch to another project when a quota is exceeded
   switch-preview-model: true # Whether to automatically switch to a preview model when a quota is exceeded
-
 # When true, enable authentication for the WebSocket API (/v1/ws).
 ws-auth: false
-
 # Gemini API keys (preferred)
 # gemini-api-key:
 #   - api-key: "AIzaSy...01"

--- a/config/cliproxyapi/config.yaml
+++ b/config/cliproxyapi/config.yaml
@@ -27,7 +27,7 @@ auth-dir: "~/.cli-proxy-api"
 debug: true
 
 # When true, write application logs to rotating files instead of stdout
-logging-to-file: false
+logging-to-file: true
 
 # When false, disable in-memory usage statistics aggregation
 usage-statistics-enabled: true

--- a/config/cliproxyapi/config.yaml
+++ b/config/cliproxyapi/config.yaml
@@ -28,14 +28,12 @@ usage-statistics-enabled: true
 proxy-url: ""
 # Number of times to retry a request. Retries will occur if the HTTP response code is 403, 408, 500, 502, 503, or 504.
 request-retry: 3
-
 # Quota exceeded behavior
 quota-exceeded:
   switch-project: true # Whether to automatically switch to another project when a quota is exceeded
   switch-preview-model: true # Whether to automatically switch to a preview model when a quota is exceeded
 # When true, enable authentication for the WebSocket API (/v1/ws).
 ws-auth: false
-
 # AMP
 ampcode:
   upstream-url: "https://ampcode.com"

--- a/config/cliproxyapi/config.yaml
+++ b/config/cliproxyapi/config.yaml
@@ -71,7 +71,6 @@ openai-compatibility:
       - "__OPENROUTER_API_KEY__"
     models:
       - name: "z-ai/glm-4.6"
-        alias: "glm-4.6"
 
 # payload: # Optional payload configuration
 #   default: # Default rules only set parameters when they are missing in the payload.

--- a/config/cliproxyapi/default.nix
+++ b/config/cliproxyapi/default.nix
@@ -1,0 +1,7 @@
+{ config, ... }:
+{
+  # Template config - the service wrapper injects secrets and writes to config.yaml
+  home.file.".cli-proxy-api/config.template.yaml" = {
+    source = config.lib.file.mkOutOfStoreSymlink ./config.yaml;
+  };
+}

--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -8,6 +8,10 @@ notify = [
 [features]
 web_search_request = true
 
+[model_providers.cliproxyapi]
+name = "CLIProxyAPI"
+base_url = "http://localhost:8317/v0"
+
 [model_providers.lmstudio]
 name = "LMStudio"
 base_url = "http://127.0.0.1:1234/v1"
@@ -32,3 +36,7 @@ model_provider = "lmstudio"
 [profiles.qwen3-coder-30b]
 model = "qwen/qwen3-coder-30b"
 model_provider = "lmstudio"
+
+[profiles.kimi-k2]
+model = "kimi-k2"
+model_provider = "cliproxyapi"

--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -10,7 +10,7 @@ web_search_request = true
 
 [model_providers.cliproxyapi]
 name = "CLIProxyAPI"
-base_url = "http://localhost:8317/v0"
+base_url = "http://localhost:8317/v1"
 
 [model_providers.lmstudio]
 name = "LMStudio"

--- a/config/default.nix
+++ b/config/default.nix
@@ -1,4 +1,5 @@
 [
+  ./cliproxyapi
   ./codex
   ./crush
   ./claude

--- a/config/default.nix
+++ b/config/default.nix
@@ -1,4 +1,5 @@
 [
+  ./amp
   ./cliproxyapi
   ./codex
   ./crush

--- a/config/default.nix
+++ b/config/default.nix
@@ -5,6 +5,7 @@
   ./crush
   ./claude
   ./direnv
+  ./factory
   ./ghostty
   ./hammerspoon
   ./karabiner

--- a/config/factory/config.json
+++ b/config/factory/config.json
@@ -13,6 +13,18 @@
       "provider": "openai"
     },
     {
+      "model": "gpt-5.1-codex",
+      "base_url": "http://127.0.0.1:8317/v1",
+      "api_key": "sk-dummy",
+      "provider": "openai"
+    },
+    {
+      "model": "gpt-5.1-codex-max",
+      "base_url": "http://127.0.0.1:8317/v1",
+      "api_key": "sk-dummy",
+      "provider": "openai"
+    },
+    {
       "model": "claude-opus-4-5-20251101",
       "base_url": "http://127.0.0.1:8317/v1",
       "api_key": "sk-dummy",

--- a/config/factory/config.json
+++ b/config/factory/config.json
@@ -13,13 +13,13 @@
       "provider": "openai"
     },
     {
-      "model": "claude-opus-4-5-20250929",
+      "model": "claude-opus-4.5",
       "base_url": "http://127.0.0.1:8317/v1",
       "api_key": "sk-dummy",
       "provider": "anthropic"
     },
     {
-      "model": "claude-haiku-3-5-20250929",
+      "model": "claude-haiku-4.5",
       "base_url": "http://127.0.0.1:8317/v1",
       "api_key": "sk-dummy",
       "provider": "anthropic"

--- a/config/factory/config.json
+++ b/config/factory/config.json
@@ -13,13 +13,13 @@
       "provider": "openai"
     },
     {
-      "model": "claude-opus-4.5",
+      "model": "claude-opus-4-5",
       "base_url": "http://127.0.0.1:8317/v1",
       "api_key": "sk-dummy",
       "provider": "anthropic"
     },
     {
-      "model": "claude-haiku-4.5",
+      "model": "claude-haiku-4-5",
       "base_url": "http://127.0.0.1:8317/v1",
       "api_key": "sk-dummy",
       "provider": "anthropic"

--- a/config/factory/config.json
+++ b/config/factory/config.json
@@ -2,13 +2,13 @@
   "custom_models": [
     {
       "model": "gemini-2.5-pro",
-      "base_url": "http://127.0.0.1:8317",
+      "base_url": "http://127.0.0.1:8317/v1",
       "api_key": "sk-dummy",
       "provider": "openai"
     },
     {
       "model": "gemini-2.5-flash",
-      "base_url": "http://127.0.0.1:8317",
+      "base_url": "http://127.0.0.1:8317/v1",
       "api_key": "sk-dummy",
       "provider": "openai"
     },
@@ -26,13 +26,13 @@
     },
     {
       "model": "gpt-4o",
-      "base_url": "http://127.0.0.1:8317",
+      "base_url": "http://127.0.0.1:8317/v1",
       "api_key": "sk-dummy",
       "provider": "openai"
     },
     {
       "model": "o3",
-      "base_url": "http://127.0.0.1:8317",
+      "base_url": "http://127.0.0.1:8317/v1",
       "api_key": "sk-dummy",
       "provider": "openai"
     }

--- a/config/factory/config.json
+++ b/config/factory/config.json
@@ -1,22 +1,16 @@
 {
   "custom_models": [
     {
-      "model": "gemini-2.5-pro",
+      "model": "gemini-3.0-pro",
       "base_url": "http://127.0.0.1:8317/v1",
       "api_key": "sk-dummy",
       "provider": "openai"
     },
     {
-      "model": "gemini-2.5-flash",
+      "model": "gpt-5.1",
       "base_url": "http://127.0.0.1:8317/v1",
       "api_key": "sk-dummy",
       "provider": "openai"
-    },
-    {
-      "model": "claude-sonnet-4-5-20250929",
-      "base_url": "http://127.0.0.1:8317/v1",
-      "api_key": "sk-dummy",
-      "provider": "anthropic"
     },
     {
       "model": "claude-opus-4-5-20250929",
@@ -25,16 +19,10 @@
       "provider": "anthropic"
     },
     {
-      "model": "gpt-4o",
+      "model": "claude-haiku-3-5-20250929",
       "base_url": "http://127.0.0.1:8317/v1",
       "api_key": "sk-dummy",
-      "provider": "openai"
-    },
-    {
-      "model": "o3",
-      "base_url": "http://127.0.0.1:8317/v1",
-      "api_key": "sk-dummy",
-      "provider": "openai"
+      "provider": "anthropic"
     }
   ]
 }

--- a/config/factory/config.json
+++ b/config/factory/config.json
@@ -1,7 +1,7 @@
 {
   "custom_models": [
     {
-      "model": "gemini-3.0-pro",
+      "model": "gemini-3-pro-preview",
       "base_url": "http://127.0.0.1:8317/v1",
       "api_key": "sk-dummy",
       "provider": "openai"

--- a/config/factory/config.json
+++ b/config/factory/config.json
@@ -1,0 +1,40 @@
+{
+  "custom_models": [
+    {
+      "model": "gemini-2.5-pro",
+      "base_url": "http://127.0.0.1:8317",
+      "api_key": "sk-dummy",
+      "provider": "openai"
+    },
+    {
+      "model": "gemini-2.5-flash",
+      "base_url": "http://127.0.0.1:8317",
+      "api_key": "sk-dummy",
+      "provider": "openai"
+    },
+    {
+      "model": "claude-sonnet-4-5-20250929",
+      "base_url": "http://127.0.0.1:8317/v1",
+      "api_key": "sk-dummy",
+      "provider": "anthropic"
+    },
+    {
+      "model": "claude-opus-4-5-20250929",
+      "base_url": "http://127.0.0.1:8317/v1",
+      "api_key": "sk-dummy",
+      "provider": "anthropic"
+    },
+    {
+      "model": "gpt-4o",
+      "base_url": "http://127.0.0.1:8317",
+      "api_key": "sk-dummy",
+      "provider": "openai"
+    },
+    {
+      "model": "o3",
+      "base_url": "http://127.0.0.1:8317",
+      "api_key": "sk-dummy",
+      "provider": "openai"
+    }
+  ]
+}

--- a/config/factory/config.json
+++ b/config/factory/config.json
@@ -13,13 +13,13 @@
       "provider": "openai"
     },
     {
-      "model": "claude-opus-4-5",
+      "model": "claude-opus-4-5-20251001",
       "base_url": "http://127.0.0.1:8317/v1",
       "api_key": "sk-dummy",
       "provider": "anthropic"
     },
     {
-      "model": "claude-haiku-4-5",
+      "model": "claude-haiku-4-5-20251001",
       "base_url": "http://127.0.0.1:8317/v1",
       "api_key": "sk-dummy",
       "provider": "anthropic"

--- a/config/factory/config.json
+++ b/config/factory/config.json
@@ -13,7 +13,7 @@
       "provider": "openai"
     },
     {
-      "model": "claude-opus-4-5-20251001",
+      "model": "claude-opus-4-5-20251101",
       "base_url": "http://127.0.0.1:8317/v1",
       "api_key": "sk-dummy",
       "provider": "anthropic"

--- a/config/factory/default.nix
+++ b/config/factory/default.nix
@@ -1,0 +1,6 @@
+{ config, ... }:
+{
+  home.file.".factory/config.json" = {
+    source = config.lib.file.mkOutOfStoreSymlink ./config.json;
+  };
+}

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -30,11 +30,11 @@
 				"gpt-5.1": {
 					"name": "GPT-5.1 (via CLIProxyAPI)"
 				},
-				"claude-opus-4-5-20250929": {
+				"claude-opus-4.5": {
 					"name": "Claude Opus 4.5 (via CLIProxyAPI)"
 				},
-				"claude-haiku-3-5-20250929": {
-					"name": "Claude Haiku 3.5 (via CLIProxyAPI)"
+				"claude-haiku-4.5": {
+					"name": "Claude Haiku 4.5 (via CLIProxyAPI)"
 				},
 				"z-ai/glm-4.6": {
 					"name": "GLM-4.6 (via OpenRouter)",

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -24,7 +24,7 @@
 				"baseURL": "http://localhost:8317/v1"
 			},
 			"models": {
-				"gemini-3.0-pro": {
+				"gemini-3-pro-preview": {
 					"name": "Gemini 3.0 Pro (via CLIProxyAPI)"
 				},
 				"gpt-5.1": {

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -25,7 +25,10 @@
 			},
 			"models": {
 				"z-ai/glm-4.6": {
-					"name": "GLM-4.6 (via OpenRouter)"
+					"name": "GLM-4.6 (via OpenRouter)",
+					"options": {
+						"stream": false
+					}
 				}
 			}
 		},

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -24,8 +24,17 @@
 				"baseURL": "http://localhost:8317/v1"
 			},
 			"models": {
-				"o3": {
-					"name": "OpenAI o3 (via CLIProxyAPI)"
+				"gemini-3.0-pro": {
+					"name": "Gemini 3.0 Pro (via CLIProxyAPI)"
+				},
+				"gpt-5.1": {
+					"name": "GPT-5.1 (via CLIProxyAPI)"
+				},
+				"claude-opus-4-5-20250929": {
+					"name": "Claude Opus 4.5 (via CLIProxyAPI)"
+				},
+				"claude-haiku-3-5-20250929": {
+					"name": "Claude Haiku 3.5 (via CLIProxyAPI)"
 				},
 				"z-ai/glm-4.6": {
 					"name": "GLM-4.6 (via OpenRouter)",

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -30,7 +30,7 @@
 				"gpt-5.1": {
 					"name": "GPT-5.1 (via CLIProxyAPI)"
 				},
-				"claude-opus-4-5-20251001": {
+				"claude-opus-4-5-20251101": {
 					"name": "Claude Opus 4.5 (via CLIProxyAPI)"
 				},
 				"claude-haiku-4-5-20251001": {

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -24,10 +24,7 @@
 				"baseURL": "http://localhost:8317/v1"
 			},
 			"models": {
-				"kimi-k2": {
-					"name": "Kimi K2 (via OpenRouter)"
-				},
-				"z-ai/glm-4.6": {
+				"glm-4.6": {
 					"name": "GLM-4.6 (via OpenRouter)"
 				}
 			}

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -30,10 +30,10 @@
 				"gpt-5.1": {
 					"name": "GPT-5.1 (via CLIProxyAPI)"
 				},
-				"claude-opus-4.5": {
+				"claude-opus-4-5": {
 					"name": "Claude Opus 4.5 (via CLIProxyAPI)"
 				},
-				"claude-haiku-4.5": {
+				"claude-haiku-4-5": {
 					"name": "Claude Haiku 4.5 (via CLIProxyAPI)"
 				},
 				"z-ai/glm-4.6": {

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -185,7 +185,6 @@
 			}
 		}
 	},
-	"plugin": ["opencode-openai-codex-auth"],
 	"tui": {
 		"scroll_speed": 3
 	}

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -17,6 +17,18 @@
 		}
 	},
 	"provider": {
+		"cliproxyapi": {
+			"npm": "@ai-sdk/openai-compatible",
+			"name": "CLIProxyAPI (local)",
+			"options": {
+				"baseURL": "http://localhost:8317/v0"
+			},
+			"models": {
+				"kimi-k2": {
+					"name": "Kimi K2 (via OpenRouter)"
+				}
+			}
+		},
 		"lmstudio": {
 			"npm": "@ai-sdk/openai-compatible",
 			"name": "LM Studio (local)",

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -26,6 +26,9 @@
 			"models": {
 				"kimi-k2": {
 					"name": "Kimi K2 (via OpenRouter)"
+				},
+				"glm4": {
+					"name": "GLM-4 (via OpenRouter)"
 				}
 			}
 		},

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -30,6 +30,12 @@
 				"gpt-5.1": {
 					"name": "GPT-5.1 (via CLIProxyAPI)"
 				},
+				"gpt-5.1-codex": {
+					"name": "GPT-5.1 Codex (via CLIProxyAPI)"
+				},
+				"gpt-5.1-codex-max": {
+					"name": "GPT-5.1 Codex Max (via CLIProxyAPI)"
+				},
 				"claude-opus-4-5-20251101": {
 					"name": "Claude Opus 4.5 (via CLIProxyAPI)"
 				},

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -21,7 +21,7 @@
 			"npm": "@ai-sdk/openai-compatible",
 			"name": "CLIProxyAPI (local)",
 			"options": {
-				"baseURL": "http://localhost:8317/v0"
+				"baseURL": "http://localhost:8317/v1"
 			},
 			"models": {
 				"kimi-k2": {

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -30,10 +30,10 @@
 				"gpt-5.1": {
 					"name": "GPT-5.1 (via CLIProxyAPI)"
 				},
-				"claude-opus-4-5": {
+				"claude-opus-4-5-20251001": {
 					"name": "Claude Opus 4.5 (via CLIProxyAPI)"
 				},
-				"claude-haiku-4-5": {
+				"claude-haiku-4-5-20251001": {
 					"name": "Claude Haiku 4.5 (via CLIProxyAPI)"
 				},
 				"z-ai/glm-4.6": {

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -24,7 +24,7 @@
 				"baseURL": "http://localhost:8317/v1"
 			},
 			"models": {
-				"glm-4.6": {
+				"z-ai/glm-4.6": {
 					"name": "GLM-4.6 (via OpenRouter)"
 				}
 			}

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -24,6 +24,9 @@
 				"baseURL": "http://localhost:8317/v1"
 			},
 			"models": {
+				"o3": {
+					"name": "OpenAI o3 (via CLIProxyAPI)"
+				},
 				"z-ai/glm-4.6": {
 					"name": "GLM-4.6 (via OpenRouter)",
 					"options": {

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -27,8 +27,8 @@
 				"kimi-k2": {
 					"name": "Kimi K2 (via OpenRouter)"
 				},
-				"glm4": {
-					"name": "GLM-4 (via OpenRouter)"
+				"z-ai/glm-4.6": {
+					"name": "GLM-4.6 (via OpenRouter)"
 				}
 			}
 		},

--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -43,6 +43,7 @@
       export PATH="$HOME/.nix-profile/bin:$PATH"
       export PATH="/nix/var/nix/profiles/default/bin:$PATH"
       export PATH="/opt/homebrew/bin:$PATH"
+      export PATH="/opt/homebrew/opt/postgresql@18/bin:$PATH"
     '';
 
     profileExtra = ''

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -17,6 +17,7 @@
       fish_add_path -p /nix/var/nix/profiles/default/bin
       fish_add_path -p ~/.foundry/bin
       fish_add_path -p /opt/homebrew/bin
+      fish_add_path -p /opt/homebrew/opt/postgresql@18/bin
       fish_add_path -p /etc/profiles/per-user/${config.home.username}/bin
     '';
     interactiveShellInit = ''
@@ -30,6 +31,7 @@
       fish_add_path -p /nix/var/nix/profiles/default/bin
       fish_add_path -p ~/.foundry/bin
       fish_add_path -p /opt/homebrew/bin
+      fish_add_path -p /opt/homebrew/opt/postgresql@18/bin
       fish_add_path -p /etc/profiles/per-user/${config.home.username}/bin
       set -a fish_complete_path ~/.nix-profile/share/fish/completions/ ~/.nix-profile/share/fish/vendor_completions.d/
       set -x FISH_HISTFILE fish

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -29,6 +29,7 @@
       export PATH="$HOME/.nix-profile/bin:$PATH"
       export PATH="/nix/var/nix/profiles/default/bin:$PATH"
       export PATH="/opt/homebrew/bin:$PATH"
+      export PATH="/opt/homebrew/opt/postgresql@18/bin:$PATH"
 
       # FNM (Fast Node Manager) configuration
       export FNM_DIR="$HOME/Library/Application Support/fnm"

--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -1,0 +1,34 @@
+{ pkgs }:
+let
+  inherit (pkgs) lib writeShellApplication;
+
+  cliproxyapiHomebrew = writeShellApplication {
+    name = "cliproxyapi-homebrew";
+    text = ''
+      set -euo pipefail
+
+      if [ -x /opt/homebrew/bin/cliproxyapi ]; then
+        exec /opt/homebrew/bin/cliproxyapi "$@"
+      elif [ -x /usr/local/bin/cliproxyapi ]; then
+        exec /usr/local/bin/cliproxyapi "$@"
+      else
+        echo "cliproxyapi binary not found; install it with \"brew install cliproxyapi\"" >&2
+        exit 1
+      fi
+    '';
+  };
+in
+lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.cliproxyapi = {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        (lib.getExe cliproxyapiHomebrew)
+      ];
+      KeepAlive = true;
+      RunAtLoad = true;
+      StandardOutPath = "/tmp/cliproxyapi.log";
+      StandardErrorPath = "/tmp/cliproxyapi.error.log";
+    };
+  };
+}

--- a/home-manager/services/cliproxyapi/start.sh
+++ b/home-manager/services/cliproxyapi/start.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CONFIG_DIR="$HOME/.cli-proxy-api"
+TEMPLATE="$CONFIG_DIR/config.template.yaml"
+CONFIG="$CONFIG_DIR/config.yaml"
+ENV_FILE="$HOME/dotfiles/.env"
+
+# Source .env file to get API keys
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$ENV_FILE"
+  set +a
+fi
+
+# Generate config from template with secrets injected
+if [ -f "$TEMPLATE" ]; then
+  sed "s|__OPENROUTER_API_KEY__|${OPENROUTER_API_KEY:-}|g" "$TEMPLATE" >"$CONFIG"
+fi
+
+# Find and exec cliproxyapi with config file
+if [ -x /opt/homebrew/bin/cliproxyapi ]; then
+  exec /opt/homebrew/bin/cliproxyapi -config "$CONFIG" "$@"
+elif [ -x /usr/local/bin/cliproxyapi ]; then
+  exec /usr/local/bin/cliproxyapi -config "$CONFIG" "$@"
+else
+  echo 'cliproxyapi binary not found; install it with "brew install cliproxyapi"' >&2
+  exit 1
+fi

--- a/home-manager/services/cliproxyapi/start.sh
+++ b/home-manager/services/cliproxyapi/start.sh
@@ -23,6 +23,12 @@ fi
 # Change to config dir so logs are created there
 cd "$CONFIG_DIR"
 
+# Export S3-compatible object storage env vars (for R2 or any S3-compatible storage)
+export OBJECTSTORE_ENDPOINT="${OBJECTSTORE_ENDPOINT:-${AWS_S3_ENDPOINT:-}}"
+export OBJECTSTORE_BUCKET="${OBJECTSTORE_BUCKET:-${AWS_S3_BUCKET:-}}"
+export OBJECTSTORE_ACCESS_KEY="${OBJECTSTORE_ACCESS_KEY:-${AWS_ACCESS_KEY_ID:-}}"
+export OBJECTSTORE_SECRET_KEY="${OBJECTSTORE_SECRET_KEY:-${AWS_SECRET_ACCESS_KEY:-}}"
+
 # Find and exec cliproxyapi with config file
 if [ -x /opt/homebrew/bin/cliproxyapi ]; then
   exec /opt/homebrew/bin/cliproxyapi -config "$CONFIG" "$@"

--- a/home-manager/services/cliproxyapi/start.sh
+++ b/home-manager/services/cliproxyapi/start.sh
@@ -20,6 +20,9 @@ if [ -f "$TEMPLATE" ]; then
   sed "s|__OPENROUTER_API_KEY__|${OPENROUTER_API_KEY:-}|g" "$TEMPLATE" >"$CONFIG"
 fi
 
+# Change to config dir so logs are created there
+cd "$CONFIG_DIR"
+
 # Find and exec cliproxyapi with config file
 if [ -x /opt/homebrew/bin/cliproxyapi ]; then
   exec /opt/homebrew/bin/cliproxyapi -config "$CONFIG" "$@"

--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -1,5 +1,6 @@
 { pkgs }:
 let
+  cliproxyapi = import ./cliproxyapi { inherit pkgs; };
   codeSyncer = import ./code-syncer { inherit pkgs; };
   dotfilesUpdater = import ./dotfiles-updater { inherit pkgs; };
   neversslKeepalive = import ./neverssl-keepalive { inherit pkgs; };
@@ -8,6 +9,7 @@ let
 in
 [
   brewUpgrader
+  cliproxyapi
   codeSyncer
   dotfilesUpdater
   neversslKeepalive

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -18,6 +18,7 @@
     brews = [
       "bun"
       "claude-squad"
+      "cliproxyapi"
       "cmake"
       "coder"
       "colima"

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -19,6 +19,7 @@
       "bun"
       "claude-squad"
       "cmake"
+      "coder"
       "colima"
       "coreutils"
       "ffmpeg"

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -37,6 +37,7 @@
       "pinentry-mac"
       "pnpm"
       "postgresql"
+      "postgresql@18"
       "protobuf"
       "reth"
       "sheldon"


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set up CLIProxyAPI as a local service and wired Codex, OpenCode, AMP, and Factory to use http://localhost:8317/v1 for unified model access. Also added brew packages and Postgres 18 PATH updates needed to run the service.

- **New Features**
  - Added a launchd agent for CLIProxyAPI with a start script that injects secrets from .env and exports S3-compatible env vars; logs to files; runs on port 8317.
  - Introduced cliproxyapi config template and YAML; remote management disabled; OpenRouter key substitution supported.
  - Updated Codex and OpenCode to use CLIProxyAPI, exposing models like gemini-3-pro-preview, gpt-5.1 (incl. codex variants), Claude Opus/Haiku 4.5, and GLM-4.6 via OpenRouter.
  - Added AMP settings pointing to the local proxy and Factory custom models targeting the same endpoint.

- **Dependencies**
  - Homebrew: added cliproxyapi, coder, and postgresql@18.
  - PATH: appended postgresql@18/bin for bash, fish, and zsh.

<sup>Written for commit ad394347cf4f64b46a57115714c83d9dfad1f0bd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



