### PR TITLE
feat(neovim): add recommended settings from dmtrKovalenko/dotfiles

### DIFF
--- a/home-manager/programs/neovim/lua/keymaps.lua
+++ b/home-manager/programs/neovim/lua/keymaps.lua
@@ -110,6 +110,18 @@ keymap("n", "<leader>py", ':let @" = expand("%:p")<CR>', opts)
 -- @keymap <leader>d: Delete to blackhole register
 keymap({ "n", "v" }, "<leader>d", '"_d', opts)
 
+-- @keymap dd: Smart delete (uses blackhole register for empty lines)
+-- From: https://github.com/dmtrKovalenko/dotfiles
+keymap("n", "dd", function()
+	return utils.smart_delete("dd")
+end, { noremap = true, expr = true })
+
+-- @keymap <Esc>: Close floating windows
+keymap("n", "<Esc>", function()
+	utils.close_floating_wins()
+	vim.cmd("nohlsearch")
+end, opts)
+
 -- ====================================================================================
 -- GIT OPERATIONS
 -- ====================================================================================

--- a/home-manager/programs/neovim/lua/settings.lua
+++ b/home-manager/programs/neovim/lua/settings.lua
@@ -6,6 +6,30 @@ vim.opt.termsync = true
 vim.opt.hidden = true
 vim.opt.updatetime = 300
 vim.opt.mouse = "a"
+
+-- ====================================================================================
+-- SSH / OSC52 CLIPBOARD HANDLING
+-- From: https://github.com/dmtrKovalenko/dotfiles
+-- Uses OSC 52 protocol for clipboard when running over SSH
+-- ====================================================================================
+local function is_ssh()
+	return os.getenv("SSH_CLIENT") ~= nil or os.getenv("SSH_TTY") ~= nil
+end
+
+if is_ssh() then
+	-- Use OSC 52 for clipboard when in SSH session
+	vim.g.clipboard = {
+		name = "OSC 52",
+		copy = {
+			["+"] = require("vim.ui.clipboard.osc52").copy("+"),
+			["*"] = require("vim.ui.clipboard.osc52").copy("*"),
+		},
+		paste = {
+			["+"] = require("vim.ui.clipboard.osc52").paste("+"),
+			["*"] = require("vim.ui.clipboard.osc52").paste("*"),
+		},
+	}
+end
 vim.opt.inccommand = "nosplit"
 vim.opt.splitbelow = true
 vim.opt.splitright = true
@@ -44,6 +68,38 @@ vim.opt.cursorline = true
 vim.opt.grepprg = "rg --vimgrep --smart-case --follow"
 -- Background will be set automatically based on system theme
 vim.opt.termguicolors = true
+
+-- ====================================================================================
+-- VISIBLE WHITESPACE
+-- From: https://github.com/dmtrKovalenko/dotfiles
+-- ====================================================================================
+vim.opt.list = true
+vim.opt.listchars = {
+	tab = "→ ",
+	trail = "·",
+	extends = "»",
+	precedes = "«",
+	nbsp = "␣",
+}
+
+-- ====================================================================================
+-- DIAGNOSTIC DISPLAY SETTINGS
+-- From: https://github.com/dmtrKovalenko/dotfiles
+-- ====================================================================================
+vim.diagnostic.config({
+	virtual_text = {
+		prefix = "●",
+		spacing = 2,
+	},
+	signs = true,
+	underline = true,
+	update_in_insert = false,
+	severity_sort = true,
+	float = {
+		border = "rounded",
+		source = true,
+	},
+})
 vim.opt.shortmess:append("c")
 vim.opt.timeoutlen = 300
 vim.opt.winborder = "none"


### PR DESCRIPTION
- Add smart delete function (avoids polluting registers with whitespace-only lines)
- Add yank register rotation to preserve yank history (registers 1-9)
- Add SSH/OSC52 clipboard handling for remote sessions
- Add filetype-specific keyword extensions (TS/JS, CSS, HTML, JSON, YAML, etc.)
- Add auto-save on buffer leave and focus loss
- Add custom terminal title with file icons
- Add close floating windows utility
- Add visible whitespace rendering (tabs, trailing spaces, etc.)
- Add enhanced diagnostic display configuration

Reference: https://github.com/dmtrKovalenko/dotfiles

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopt recommended Neovim settings from dmtrKovalenko/dotfiles to polish editing UX and diagnostics. Improves remote clipboard, auto-save, yank history, and UI details.

- **New Features**
  - Editing UX: smart delete, yank register rotation, auto-save, visible whitespace
  - Remote clipboard: OSC52 clipboard when running over SSH
  - UI polish: terminal titles with file icons; Esc closes floating windows and clears search
  - Language-aware keywords: better word navigation in TS/JS, CSS, HTML/XML/Vue/Svelte, JSON, YAML/TOML, Markdown
  - Diagnostics: refined virtual text, signs, underline, and rounded float configuration

<sup>Written for commit adfab566d5560aa1ba5cd3fd2d43d8872ba0a5c8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

