### PR TITLE
Integrate fff.nvim plugin with key bindings

### DIFF
--- a/home-manager/programs/neovim/lua/keymaps.lua
+++ b/home-manager/programs/neovim/lua/keymaps.lua
@@ -178,6 +178,19 @@ keymap("n", "[d", vim.diagnostic.goto_prev, { desc = "Previous Diagnostic" })
 keymap("n", "<leader>dl", vim.diagnostic.open_float, { desc = "Line Diagnostics" })
 
 -- ====================================================================================
+-- FFF.NVIM (Fast Fuzzy File Finder)
+-- ====================================================================================
+-- @keymap <leader>ff: Open fff file picker
+keymap("n", "<leader>ff", function()
+	require("fff").open()
+end, { desc = "FFF File Picker" })
+
+-- @keymap <leader>fp: Open fff file picker (alternate)
+keymap("n", "<leader>fp", function()
+	require("fff").open()
+end, { desc = "FFF File Picker" })
+
+-- ====================================================================================
 -- CODE NAVIGATION & EDITING
 -- ====================================================================================
 -- @keymap -: Open parent directory (Oil)
@@ -268,7 +281,7 @@ local wk = require("which-key")
 wk.add({
 	{ "<leader>g", group = "Git" },
 	{ "<leader>l", group = "LSP" },
-	{ "<leader>f", group = "Find/Telescope" },
+	{ "<leader>f", group = "Find/Files" },
 	{ "<leader>x", group = "Trouble/Diagnostics" },
 	{ "<leader>c", group = "Code" },
 	{ "<leader>h", group = "Hunk (Git)" },

--- a/home-manager/programs/neovim/lua/plugins.lua
+++ b/home-manager/programs/neovim/lua/plugins.lua
@@ -23,6 +23,14 @@ vim.pack.add({
 	{ src = "https://github.com/stevearc/oil.nvim" },
 	{ src = "https://github.com/folke/flash.nvim" },
 
+	-- FILE PICKER
+	{
+		src = "https://github.com/dmtrKovalenko/fff.nvim",
+		build = function()
+			require("fff.download").download_or_build_binary()
+		end,
+	},
+
 	-- TELESCOPE
 	{ src = "https://github.com/nvim-lua/plenary.nvim" },
 	{ src = "https://github.com/nvim-telescope/telescope-github.nvim" },
@@ -90,6 +98,12 @@ require("auto-hlsearch").setup({})
 require("grug-far").setup({})
 require("flash").setup({})
 require("illuminate").configure({})
+
+-- fff.nvim setup - fast fuzzy file finder with Rust backend
+require("fff").setup({
+	max_results = 100,
+	lazy_sync = true,
+})
 
 require("conform").setup({
 	formatters_by_ft = {


### PR DESCRIPTION
Add fff.nvim plugin with Rust backend for fast file searching. Keybindings: <leader>ff and <leader>fp to open the file picker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates fff.nvim, a Rust-powered fuzzy file finder, to speed up file search in Neovim. Adds <leader>ff and <leader>fp to open the picker and configures automatic binary setup.

- **New Features**
  - Add fff.nvim with auto download/build of the native binary.
  - Configure max_results=100 and lazy_sync=true.
  - Map <leader>ff and <leader>fp to open the picker.
  - Rename which-key group from “Find/Telescope” to “Find/Files”.

<sup>Written for commit e4f4f6ee2aa6cd10c7439b37996f385508a4dfd5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

