### PR TITLE
feat: add watchexec to Homebrew brews

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -42,6 +42,7 @@
       "reth"
       "sheldon"
       "temporal"
+      "watchexec"
     ];
     casks = [
       "antigravity"


### PR DESCRIPTION
Add watchexec to the macOS Homebrew brews configuration for easy access to the file-watching utility

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added watchexec to the nix-darwin Homebrew brews list so it’s installed and available by default as a file-watching utility on macOS. This makes it easier to use watchexec across developer environments.

<sup>Written for commit 5cd25a2b9a848142d581bfb70535024feb24a16c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

