### PR TITLE
chore: sync chore-v2 branch with main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ setup: nix-setup ## Basic Nix setup (alias for nix-setup).
 setup-dev: nix-setup git-submodule-sync shell-install ## Set up local development environment (Nix + submodules + shell).
 
 .PHONY: switch
-switch: nix-switch ## Apply Nix configuration (alias for nix-switch).
+switch: nix-switch launchctl ## Apply Nix configuration and restart launchd agents.
 
 .PHONY: update
 update: nix-update shell-update neovim-update ## Update Nix flake and configurations.
@@ -566,6 +566,47 @@ lua-check-hammerspoon: ## Check Hammerspoon configuration.
 lua-check-hammerspoon-dev: ## Run the Hammerspoon Lua check inside the Nix dev shell (mirrors CI).
 	@echo "🧪 Running Hammerspoon Lua check inside the Nix dev shell..."
 	@DEVENV_ROOT=$(CURDIR) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) develop $(NIX_FLAGS) .# --command $(MAKE) lua-check-hammerspoon
+
+##@ Launchd Services
+
+.PHONY: launchctl
+launchctl: launchctl-brew-upgrader launchctl-cliproxyapi launchctl-code-syncer launchctl-dotfiles-updater launchctl-neverssl-keepalive launchctl-ollama ## Restart all launchd agents.
+
+.PHONY: launchctl-brew-upgrader
+launchctl-brew-upgrader: ## Restart brew-upgrader launchd agent.
+	@echo "🔄 Restarting brew-upgrader..."
+	@launchctl kickstart -k gui/$$(id -u)/org.nix-community.home.brew-upgrader || true
+	@echo "✅ brew-upgrader restarted"
+
+.PHONY: launchctl-cliproxyapi
+launchctl-cliproxyapi: ## Restart cliproxyapi launchd agent.
+	@echo "🔄 Restarting cliproxyapi..."
+	@launchctl kickstart -k gui/$$(id -u)/org.nix-community.home.cliproxyapi || true
+	@echo "✅ cliproxyapi restarted"
+
+.PHONY: launchctl-code-syncer
+launchctl-code-syncer: ## Restart code-syncer launchd agent.
+	@echo "🔄 Restarting code-syncer..."
+	@launchctl kickstart -k gui/$$(id -u)/org.nix-community.home.code-syncer || true
+	@echo "✅ code-syncer restarted"
+
+.PHONY: launchctl-dotfiles-updater
+launchctl-dotfiles-updater: ## Restart dotfiles-updater launchd agent.
+	@echo "🔄 Restarting dotfiles-updater..."
+	@launchctl kickstart -k gui/$$(id -u)/org.nix-community.home.dotfiles-updater || true
+	@echo "✅ dotfiles-updater restarted"
+
+.PHONY: launchctl-neverssl-keepalive
+launchctl-neverssl-keepalive: ## Restart neverssl-keepalive launchd agent.
+	@echo "🔄 Restarting neverssl-keepalive..."
+	@launchctl kickstart -k gui/$$(id -u)/org.nix-community.home.neverssl-keepalive || true
+	@echo "✅ neverssl-keepalive restarted"
+
+.PHONY: launchctl-ollama
+launchctl-ollama: ## Restart ollama launchd agent.
+	@echo "🔄 Restarting ollama..."
+	@launchctl kickstart -k gui/$$(id -u)/org.nix-community.home.ollama || true
+	@echo "✅ ollama restarted"
 
 ##@ Git Submodule
 

--- a/home-manager/programs/neovim/lua/keymaps.lua
+++ b/home-manager/programs/neovim/lua/keymaps.lua
@@ -117,6 +117,12 @@ keymap({ "n", "v" }, "<leader>d", '"_d', opts)
 keymap("n", "<leader>gs", ":tab Git<cr>", opts)
 -- @keymap <F9>: Open Git mergetool in new tab
 keymap("n", "<F9>", ":tab Git mergetool<cr>", opts)
+-- @keymap <leader>gg: Open LazyGit
+keymap("n", "<leader>gg", ":LazyGit<cr>", opts)
+-- @keymap <leader>gD: Open VS Code style diff
+keymap("n", "<leader>gD", function()
+	require("vscode-diff").diff()
+end, opts)
 -- @keymap <leader>gd: Preview hunk inline
 keymap("n", "<leader>gd", ":Gitsigns preview_hunk_inline<cr>", opts)
 -- @keymap <leader>hs: Stage hunk (Gitsigns)

--- a/home-manager/programs/neovim/lua/keymaps.lua
+++ b/home-manager/programs/neovim/lua/keymaps.lua
@@ -118,7 +118,7 @@ keymap("n", "<leader>gs", ":tab Git<cr>", opts)
 -- @keymap <F9>: Open Git mergetool in new tab
 keymap("n", "<F9>", ":tab Git mergetool<cr>", opts)
 -- @keymap <leader>gg: Open LazyGit
-keymap("n", "<leader>gg", ":LazyGit<cr>", opts)
+keymap("n", "<leader>lg", ":LazyGit<cr>", opts)
 -- @keymap <leader>gD: Open VS Code style diff
 keymap("n", "<leader>gD", function()
 	require("vscode-diff").diff()

--- a/home-manager/programs/neovim/lua/plugins.lua
+++ b/home-manager/programs/neovim/lua/plugins.lua
@@ -88,6 +88,10 @@ vim.pack.add({
 
 	-- TERMINAL
 	{ src = "https://github.com/akinsho/toggleterm.nvim" },
+
+	-- GIT
+	{ src = "https://github.com/kdheepak/lazygit.nvim" },
+	{ src = "https://github.com/esmuellert/vscode-diff.nvim" },
 })
 
 require("other-nvim").setup({ mappings = { "golang" } })

--- a/home-manager/programs/neovim/nvim-pack-lock.json
+++ b/home-manager/programs/neovim/nvim-pack-lock.json
@@ -65,6 +65,10 @@
       "rev": "2d7c2db2507fa3c4956142ee607431ddb2828639",
       "src": "https://github.com/stevearc/dressing.nvim"
     },
+    "fff.nvim": {
+      "rev": "9edf195c8fe71f1ab8f84e863fb27b469d2342bf",
+      "src": "https://github.com/dmtrKovalenko/fff.nvim"
+    },
     "fidget.nvim": {
       "rev": "e32b672d8fd343f9d6a76944fedb8c61d7d8111a",
       "src": "https://github.com/j-hui/fidget.nvim"

--- a/home-manager/services/brew-upgrader/upgrade.sh
+++ b/home-manager/services/brew-upgrader/upgrade.sh
@@ -2,4 +2,4 @@
 
 set -euo pipefail
 
-brew upgrade
+/opt/homebrew/bin/brew upgrade

--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -1,6 +1,9 @@
 { pkgs, ... }:
+let
+  inherit (pkgs) lib;
+in
 {
-  launchd.agents.cliproxyapi = pkgs.lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.cliproxyapi = lib.mkIf pkgs.stdenv.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [
@@ -8,12 +11,29 @@
         "${./start.sh}"
       ];
       Environment = {
-        PATH = "${pkgs.lib.makeBinPath [ pkgs.gnused ]}:/opt/homebrew/bin:/usr/local/bin";
+        PATH = "${lib.makeBinPath [ pkgs.gnused ]}:/opt/homebrew/bin:/usr/local/bin";
       };
       KeepAlive = true;
       RunAtLoad = true;
       StandardOutPath = "/tmp/cliproxyapi.log";
       StandardErrorPath = "/tmp/cliproxyapi.error.log";
+    };
+  };
+
+  systemd.user.services.cliproxyapi = lib.mkIf pkgs.stdenv.isLinux {
+    Unit = {
+      Description = "CLI Proxy API server";
+      After = [ "network.target" ];
+    };
+    Service = {
+      Type = "simple";
+      Environment = "PATH=${lib.makeBinPath [ pkgs.gnused pkgs.bash ]}";
+      ExecStart = "${pkgs.bash}/bin/bash ${./start.sh}";
+      Restart = "always";
+      RestartSec = 3;
+    };
+    Install = {
+      WantedBy = [ "default.target" ];
     };
   };
 }

--- a/home-manager/services/dotfiles-updater/default.nix
+++ b/home-manager/services/dotfiles-updater/default.nix
@@ -1,25 +1,52 @@
-{ pkgs }:
+{ pkgs, ... }:
+let
+  inherit (pkgs) lib;
+in
 {
-  systemd.user.services.dotfiles-updater = {
+  launchd.agents.dotfiles-updater = lib.mkIf pkgs.stdenv.isDarwin {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "${pkgs.bash}/bin/bash"
+        "${./update.sh}"
+      ];
+      Environment = {
+        PATH = "${
+          lib.makeBinPath [
+            pkgs.git
+            pkgs.bash
+            pkgs.coreutils
+          ]
+        }:/opt/homebrew/bin:/usr/local/bin";
+      };
+      StartCalendarInterval = [
+        {
+          Hour = 0;
+          Minute = 0;
+        }
+      ];
+      StandardOutPath = "/tmp/dotfiles-updater.log";
+      StandardErrorPath = "/tmp/dotfiles-updater.error.log";
+    };
+  };
+
+  systemd.user.services.dotfiles-updater = lib.mkIf pkgs.stdenv.isLinux {
     Unit = {
       Description = "Dotfiles auto-updater service";
     };
     Service = {
       Type = "oneshot";
       Environment = "PATH=${
-        pkgs.lib.makeBinPath (
-          with pkgs;
-          [
-            git
-            bash
-          ]
-        )
+        lib.makeBinPath [
+          pkgs.git
+          pkgs.bash
+        ]
       }";
       ExecStart = "${./update.sh}";
     };
   };
 
-  systemd.user.timers.dotfiles-updater = {
+  systemd.user.timers.dotfiles-updater = lib.mkIf pkgs.stdenv.isLinux {
     Unit = {
       Description = "Timer for dotfiles auto-updater";
     };

--- a/home-manager/services/neverssl-keepalive/default.nix
+++ b/home-manager/services/neverssl-keepalive/default.nix
@@ -12,7 +12,7 @@ in
         "${./keepalive.sh}"
       ];
       Environment = {
-        PATH = "${lib.makeBinPath [ pkgs.curl ]}:/opt/homebrew/bin:/usr/local/bin";
+        PATH = lib.makeBinPath [ pkgs.curl ];
       };
       StartInterval = 3;
       StandardOutPath = "/tmp/neverssl-keepalive.log";

--- a/home-manager/services/neverssl-keepalive/default.nix
+++ b/home-manager/services/neverssl-keepalive/default.nix
@@ -1,29 +1,26 @@
 { pkgs, ... }:
 let
   inherit (pkgs) lib;
-
-  keepaliveScript = pkgs.writeShellApplication {
-    name = "neverssl-keepalive";
-    runtimeInputs = [ pkgs.curl ];
-    text = ''
-      set -euo pipefail
-      curl -fsS --max-time 10 http://neverssl.com > /dev/null 2>&1 || true
-    '';
-  };
 in
 {
+  # macOS (launchd)
   launchd.agents.neverssl-keepalive = lib.mkIf pkgs.stdenv.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [
-        "${keepaliveScript}/bin/neverssl-keepalive"
+        "${pkgs.bash}/bin/bash"
+        "${./keepalive.sh}"
       ];
+      Environment = {
+        PATH = "${lib.makeBinPath [ pkgs.curl ]}:/opt/homebrew/bin:/usr/local/bin";
+      };
       StartInterval = 3;
       StandardOutPath = "/tmp/neverssl-keepalive.log";
       StandardErrorPath = "/tmp/neverssl-keepalive.error.log";
     };
   };
 
+  # Linux (systemd)
   systemd.user.services.neverssl-keepalive = lib.mkIf pkgs.stdenv.isLinux {
     Unit = {
       Description = "Keep captive portal alive via neverssl.com";
@@ -32,7 +29,8 @@ in
     };
     Service = {
       Type = "oneshot";
-      ExecStart = "${keepaliveScript}/bin/neverssl-keepalive";
+      Environment = "PATH=${lib.makeBinPath [ pkgs.curl pkgs.bash ]}";
+      ExecStart = "${pkgs.bash}/bin/bash ${./keepalive.sh}";
     };
   };
 

--- a/home-manager/services/neverssl-keepalive/keepalive.sh
+++ b/home-manager/services/neverssl-keepalive/keepalive.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Keep captive portal connections alive by periodically hitting neverssl.com
+
+set -euo pipefail
+
+# Silently ping neverssl.com - ignore failures (network may be unavailable)
+curl -fsS --max-time 10 http://neverssl.com > /dev/null 2>&1 || true


### PR DESCRIPTION
Add plenary.nvim-based testing with CI/CD integration and fff.nvim plugin for fast fuzzy file finding.







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Neovim Git tooling and faster fuzzy finding, and adds Makefile targets to restart launchd agents. Also updates macOS/Linux Home Manager services (dotfiles-updater, neverssl-keepalive, ollama, cliproxyapi) and fixes the brew upgrader path for reliable upgrades.

- **New Features**
  - Neovim: Added LazyGit and VS Code diff plugins with keymaps (<leader>lg, <leader>gD), plus fff.nvim for faster file search.
  - Makefile: Added launchctl targets and made switch restart launchd agents.

- **Bug Fixes**
  - Updated brew-upgrader to call /opt/homebrew/bin/brew upgrade to avoid PATH issues on macOS.

<sup>Written for commit 85f29de7fb665beaa457e32f335755732bc8ba07. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







