### PR TITLE
refactor: improve formatting in service configurations

### DIFF
--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -27,7 +27,12 @@ in
     };
     Service = {
       Type = "simple";
-      Environment = "PATH=${lib.makeBinPath [ pkgs.gnused pkgs.bash ]}";
+      Environment = "PATH=${
+        lib.makeBinPath [
+          pkgs.gnused
+          pkgs.bash
+        ]
+      }";
       ExecStart = "${pkgs.bash}/bin/bash ${./start.sh}";
       Restart = "always";
       RestartSec = 3;

--- a/home-manager/services/neverssl-keepalive/default.nix
+++ b/home-manager/services/neverssl-keepalive/default.nix
@@ -29,7 +29,12 @@ in
     };
     Service = {
       Type = "oneshot";
-      Environment = "PATH=${lib.makeBinPath [ pkgs.curl pkgs.bash ]}";
+      Environment = "PATH=${
+        lib.makeBinPath [
+          pkgs.curl
+          pkgs.bash
+        ]
+      }";
       ExecStart = "${pkgs.bash}/bin/bash ${./keepalive.sh}";
     };
   };

--- a/home-manager/services/neverssl-keepalive/keepalive.sh
+++ b/home-manager/services/neverssl-keepalive/keepalive.sh
@@ -5,4 +5,4 @@
 set -euo pipefail
 
 # Silently ping neverssl.com - ignore failures (network may be unavailable)
-curl -fsS --max-time 10 http://neverssl.com > /dev/null 2>&1 || true
+curl -fsS --max-time 10 http://neverssl.com >/dev/null 2>&1 || true


### PR DESCRIPTION
Split multi-line expressions across multiple lines in cliproxyapi and neverssl-keepalive services for improved readability. Fixed whitespace formatting in keepalive.sh script to match code style standards.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved formatting in cliproxyapi and neverssl-keepalive service configs for readability and consistency. Split PATH Environment definitions into multi-line arrays and fixed shell redirect spacing in keepalive.sh; no functional changes.

<sup>Written for commit 954f6d0204f61a1d0a7901d8ff9a60f958656d27. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

