### PR TITLE
Fix Determinate and nix-darwin conflict

### DIFF
--- a/nix-darwin/config/nix.nix
+++ b/nix-darwin/config/nix.nix
@@ -1,24 +1,6 @@
 {
-  nix = {
-    optimise.automatic = true;
-    settings = {
-      experimental-features = "nix-command flakes";
-      max-jobs = 8;
-      substituters = [
-        "https://cache.nixos.org"
-        "https://devenv.cachix.org"
-        "https://cachix.cachix.org"
-      ];
-      trusted-public-keys = [
-        "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
-        "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
-        "cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM="
-      ];
-      trusted-users = [
-        "root"
-        "shunkakinoki"
-      ];
-    };
-  };
-
+  # Disable nix-darwin's Nix management to allow Determinate Nix to manage the daemon.
+  # Determinate uses its own daemon that conflicts with nix-darwin's native Nix management.
+  # Note: This disables nix.* options like nix.settings and nix.optimise.
+  nix.enable = false;
 }


### PR DESCRIPTION
…lity

Determinate uses its own daemon that conflicts with nix-darwin's native Nix management. Setting nix.enable = false allows nix-darwin to work alongside Determinate Nix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled nix-darwin’s Nix management (nix.enable = false) to resolve conflicts with Determinate Nix’s daemon. nix-darwin now coexists with Determinate Nix; nix.* options like nix.settings and nix.optimise are no longer applied by nix-darwin.

<sup>Written for commit 917d161b46ed1c33be302b7a7150670070d6a080. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

