### PR TITLE
Add ShellSpec harness and coverage

### DIFF
--- a/spec/notify_spec.sh
+++ b/spec/notify_spec.sh
@@ -20,18 +20,14 @@ End
 
 Describe 'Notification hook (no Pushover)'
 setup() {
-  # Create mock osascript that does nothing
-  MOCK_BIN=$(mktemp -d)
-  printf '#!/bin/sh\nexit 0\n' >"$MOCK_BIN/osascript"
-  chmod +x "$MOCK_BIN/osascript"
-  export PATH="$MOCK_BIN:$PATH"
+  mock_bin_setup osascript
 
   # Unset Pushover credentials to ensure clean test environment
   unset PUSHOVER_API_TOKEN
   unset PUSHOVER_USER_KEY
 }
 cleanup() {
-  rm -rf "$MOCK_BIN"
+  mock_bin_cleanup
 }
 Before 'setup'
 After 'cleanup'
@@ -47,22 +43,25 @@ It 'exits 0 for waiting notification'
 When run bash -c 'echo "{\"message\": \"Claude is waiting for your input\"}" | env HOME=/nonexistent bash '"$SCRIPT"
 The status should be success
 End
+
+It 'sends Basso notification for permission request'
+When run bash -c 'echo "{\"message\": \"Claude needs your permission to use Bash\"}" | env HOME=/nonexistent bash '"$SCRIPT"'; cat "$MOCK_LOG"'
+The status should be success
+The output should include 'Bash permission required'
+The output should include 'sound name "Basso"'
+End
 End
 
 Describe 'SessionEnd hook (no Pushover)'
 setup() {
-  # Create mock osascript that does nothing
-  MOCK_BIN=$(mktemp -d)
-  printf '#!/bin/sh\nexit 0\n' >"$MOCK_BIN/osascript"
-  chmod +x "$MOCK_BIN/osascript"
-  export PATH="$MOCK_BIN:$PATH"
+  mock_bin_setup osascript
 
   # Unset Pushover credentials to ensure clean test environment
   unset PUSHOVER_API_TOKEN
   unset PUSHOVER_USER_KEY
 }
 cleanup() {
-  rm -rf "$MOCK_BIN"
+  mock_bin_cleanup
 }
 Before 'setup'
 After 'cleanup'
@@ -71,6 +70,47 @@ It 'exits 0 for session end'
 # Use fake HOME so script cannot source real .env file
 When run bash -c 'echo "{\"reason\": \"user_exit\"}" | env HOME=/nonexistent bash '"$SCRIPT"
 The status should be success
+End
+End
+
+Describe 'other hooks (no Pushover)'
+setup() {
+  mock_bin_setup osascript
+  TEMP_HOME=$(mktemp -d)
+
+  unset PUSHOVER_API_TOKEN
+  unset PUSHOVER_USER_KEY
+}
+cleanup() {
+  rm -rf "$TEMP_HOME"
+  mock_bin_cleanup
+}
+Before 'setup'
+After 'cleanup'
+
+It 'notifies on PreCompact auto trigger'
+When run bash -c 'echo "{\"trigger\": \"auto\"}" | env HOME=/nonexistent bash '"$SCRIPT"'; cat "$MOCK_LOG"'
+The status should be success
+The output should include 'Auto-compacting context'
+End
+
+It 'notifies on SubagentStop'
+When run bash -c 'echo "{\"stop_hook_active\": true}" | env HOME=/nonexistent bash '"$SCRIPT"'; cat "$MOCK_LOG"'
+The status should be success
+The output should include 'Subagent task completed'
+End
+
+It 'notifies on Stop with cwd and session id'
+When run bash -c 'echo "{\"cwd\": \"'"$TEMP_HOME"'/work\", \"session_id\": \"abcdef0123456789\"}" | env HOME="'"$TEMP_HOME"'" bash '"$SCRIPT"'; cat "$MOCK_LOG"'
+The status should be success
+The output should include 'Work completed in ~/work (abcdef01)'
+End
+
+It 'warns on risky PreToolUse Bash command'
+When run bash -c 'echo "{\"tool\": {\"name\": \"Bash\", \"input\": \"rm -rf /\"}}" | env HOME=/nonexistent bash '"$SCRIPT"'; cat "$MOCK_LOG"'
+The status should be success
+The output should include 'Risky: rm -rf /'
+The output should include 'sound name "Basso"'
 End
 End
 End

--- a/spec/notify_spec.sh
+++ b/spec/notify_spec.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2329
+# shellcheck disable=SC2329,SC2016
 
 Describe 'notify.sh'
 SCRIPT="$PWD/config/claude/notify.sh"

--- a/spec/pushover_spec.sh
+++ b/spec/pushover_spec.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2329
+# shellcheck disable=SC2329,SC2016
 
 Describe 'pushover.sh'
 SCRIPT="$PWD/config/claude/pushover.sh"

--- a/spec/security_spec.sh
+++ b/spec/security_spec.sh
@@ -77,6 +77,20 @@ When run bash -c "HOME='$TEMP_HOME' bash '$SCRIPT'"
 The status should eq 2
 The stderr should include 'BLOCKED'
 End
+
+It 'blocks sudo with arguments (legacy sudo:* pattern)'
+Data '{"tool": {"name": "Bash", "input": {"command": "sudo rm -rf /"}}}'
+When run bash -c "HOME='$TEMP_HOME' bash '$SCRIPT'"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+It 'blocks hidden dangerous command after semicolon'
+Data '{"tool": {"name": "Bash", "input": {"command": "echo ok; rm -rf /*"}}}'
+When run bash -c "HOME='$TEMP_HOME' bash '$SCRIPT'"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
 End
 
 Describe 'edge cases'

--- a/spec/security_spec.sh
+++ b/spec/security_spec.sh
@@ -91,6 +91,27 @@ When run bash -c "HOME='$TEMP_HOME' bash '$SCRIPT'"
 The status should eq 2
 The stderr should include 'BLOCKED'
 End
+
+It 'blocks hidden dangerous command after &&'
+Data '{"tool": {"name": "Bash", "input": {"command": "echo ok && rm -rf /*"}}}'
+When run bash -c "HOME='$TEMP_HOME' bash '$SCRIPT'"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+It 'blocks dd if=... (legacy dd if=:* pattern)'
+Data '{"tool": {"name": "Bash", "input": {"command": "dd if=/dev/zero of=/tmp/zero bs=1 count=1"}}}'
+When run bash -c "HOME='$TEMP_HOME' bash '$SCRIPT'"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+It 'blocks chmod -R 777'
+Data '{"tool": {"name": "Bash", "input": {"command": "chmod -R 777 /tmp"}}}'
+When run bash -c "HOME='$TEMP_HOME' bash '$SCRIPT'"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
 End
 
 Describe 'edge cases'

--- a/spec/shell_files_spec.sh
+++ b/spec/shell_files_spec.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'all tracked shell files'
+
+syntax_check() {
+  local file="$1"
+  local first_line=""
+
+  IFS= read -r first_line <"$file" || first_line=""
+
+  case "$first_line" in
+  '#!'*bash*) bash -n "$file" ;;
+  '#!'*sh*) sh -n "$file" ;;
+  *) bash -n "$file" ;;
+  esac
+}
+
+Parameters:dynamic
+for file in $(git ls-files '*.sh'); do
+  %data "$file"
+done
+
+for file in $(git ls-files); do
+  case "$file" in
+  *.sh) continue ;;
+  esac
+
+  [ -f "$file" ] || continue
+
+  IFS= read -r first_line <"$file" || first_line=""
+  case "$first_line" in
+  '#!'*bash* | '#!'*sh*)
+    %data "$file"
+    ;;
+  esac
+done
+End
+
+It "has valid shell syntax: $1"
+When call syntax_check "$1"
+The status should be success
+End
+
+End

--- a/spec/shell_files_spec.sh
+++ b/spec/shell_files_spec.sh
@@ -3,42 +3,69 @@
 
 Describe 'all tracked shell files'
 
-syntax_check() {
+detect_shell_type() {
   local file="$1"
   local first_line=""
 
-  IFS= read -r first_line <"$file" || first_line=""
+  case "$file" in
+  *.fish) printf '%s\n' fish && return 0 ;;
+  esac
 
+  IFS= read -r first_line <"$file" || first_line=""
   case "$first_line" in
-  '#!'*bash*) bash -n "$file" ;;
-  '#!'*sh*) sh -n "$file" ;;
-  *) bash -n "$file" ;;
+  '#!'*fish*) printf '%s\n' fish ;;
+  '#!'*zsh*) printf '%s\n' zsh ;;
+  '#!'*ksh*) printf '%s\n' ksh ;;
+  '#!'*bash*) printf '%s\n' bash ;;
+  '#!'*sh*) printf '%s\n' sh ;;
+  *) printf '%s\n' bash ;;
+  esac
+}
+
+syntax_check() {
+  local shell_type="$1"
+  local file="$2"
+
+  case "$shell_type" in
+  fish) fish -n "$file" ;;
+  zsh) zsh -n "$file" ;;
+  ksh) ksh -n "$file" ;;
+  sh) sh -n "$file" ;;
+  bash | *) bash -n "$file" ;;
   esac
 }
 
 Parameters:dynamic
 for file in $(git ls-files '*.sh'); do
-  %data "$file"
+  %data "$(detect_shell_type "$file")" "$file"
 done
 
 for file in $(git ls-files); do
   case "$file" in
   *.sh) continue ;;
+  *.fish) continue ;;
   esac
 
   [ -f "$file" ] || continue
 
   IFS= read -r first_line <"$file" || first_line=""
   case "$first_line" in
-  '#!'*bash* | '#!'*sh*)
-    %data "$file"
+  '#!'*bash* | '#!'*sh* | '#!'*zsh* | '#!'*ksh* | '#!'*fish*)
+    %data "$(detect_shell_type "$file")" "$file"
     ;;
   esac
 done
+
+for file in $(git ls-files '*.fish'); do
+  %data fish "$file"
+done
 End
 
-It "has valid shell syntax: $1"
-When call syntax_check "$1"
+It "has valid shell syntax: $2 ($1)"
+if ! command -v "$1" >/dev/null 2>&1; then
+  Skip "$1 is not installed"
+fi
+When call syntax_check "$1" "$2"
 The status should be success
 End
 

--- a/spec/shell_files_spec.sh
+++ b/spec/shell_files_spec.sh
@@ -50,7 +50,7 @@ for file in $(git ls-files); do
 
   IFS= read -r first_line <"$file" || first_line=""
   case "$first_line" in
-  '#!'*bash* | '#!'*sh* | '#!'*zsh* | '#!'*ksh* | '#!'*fish*)
+  '#!'*bash* | '#!'*zsh* | '#!'*ksh* | '#!'*fish* | '#!'*sh*)
     %data "$(detect_shell_type "$file")" "$file"
     ;;
   esac

--- a/spec/support/custom_matcher.sh
+++ b/spec/support/custom_matcher.sh
@@ -25,10 +25,10 @@ EOF
 }
 
 mock_bin_cleanup() {
-  if [[ -n "${MOCK_ORIGINAL_PATH:-}" ]]; then
+  if [[ -n ${MOCK_ORIGINAL_PATH:-} ]]; then
     export PATH="$MOCK_ORIGINAL_PATH"
   fi
-  if [[ -n "${MOCK_BIN:-}" ]]; then
+  if [[ -n ${MOCK_BIN:-} ]]; then
     rm -rf "$MOCK_BIN"
   fi
   unset MOCK_BIN MOCK_LOG MOCK_ORIGINAL_PATH

--- a/spec/support/custom_matcher.sh
+++ b/spec/support/custom_matcher.sh
@@ -1,1 +1,35 @@
 #!/usr/bin/env bash
+
+set -euo pipefail
+
+mock_bin_setup() {
+  MOCK_BIN="$(mktemp -d)"
+  MOCK_LOG="$MOCK_BIN/mock.log"
+  : >"$MOCK_LOG"
+
+  MOCK_ORIGINAL_PATH="${PATH:-}"
+  export MOCK_BIN MOCK_LOG MOCK_ORIGINAL_PATH
+  export PATH="$MOCK_BIN:$MOCK_ORIGINAL_PATH"
+
+  local cmd
+  for cmd in "$@"; do
+    cat >"$MOCK_BIN/$cmd" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+: "${MOCK_LOG:?MOCK_LOG must be set}"
+printf '%s\n' "$0 $*" >>"$MOCK_LOG"
+exit 0
+EOF
+    chmod +x "$MOCK_BIN/$cmd"
+  done
+}
+
+mock_bin_cleanup() {
+  if [[ -n "${MOCK_ORIGINAL_PATH:-}" ]]; then
+    export PATH="$MOCK_ORIGINAL_PATH"
+  fi
+  if [[ -n "${MOCK_BIN:-}" ]]; then
+    rm -rf "$MOCK_BIN"
+  fi
+  unset MOCK_BIN MOCK_LOG MOCK_ORIGINAL_PATH
+}


### PR DESCRIPTION
Adds a reusable mock harness for ShellSpec and expands test coverage for the Claude hook scripts. Also fixes security hook parsing for legacy deny patterns and command chaining on macOS.













<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable ShellSpec mock harness and expands tests for Claude hook scripts to improve reliability and coverage. Fixes security command parsing for legacy patterns and command chaining on macOS.

- **New Features**
  - Added mock_bin_setup/cleanup to stub commands and log calls; replaced ad‑hoc temp binaries with the shared harness.
  - Expanded notify/pushover tests: permission alerts, auto-compact, subagent stop, risky Bash warnings, and Stop/plan-mode via transcript/priority; plus shell script syntax checks for all tracked files.
  - Added coverage for credential sourcing via HOME/dotfiles/.env (prefer env vars; skip when incomplete or invalid).

- **Bug Fixes**
  - Legacy deny patterns like Bash(sudo:*) now match correctly as prefix globs (sudo*).
  - Properly split chained commands (;, &&, ||, |) with sed -E to catch hidden dangerous operations.

<sup>Written for commit 9d8b256acd6fb7ee581249006f9d4b7fa7905190. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->













