### PR TITLE
Remove shared SSH key for GitHub authentication

### DIFF
--- a/named-hosts/galactica/secrets.nix
+++ b/named-hosts/galactica/secrets.nix
@@ -10,12 +10,6 @@ let
   ];
 in
 {
-  # Shared SSH key for GitHub authentication (accessible on all machines)
-  # This is ~/.ssh/id_github on galactica, the GitHub CLI-authorized key
-  "keys/id_github.age" = {
-    file = ./keys/id_github.age;
-    publicKeys = allMachines;
-  };
   # GPG key (shared with all machines for commit signing)
   "keys/gpg.age" = {
     file = ./keys/gpg.age;


### PR DESCRIPTION
Eliminate the shared SSH key configuration to enhance security and prevent unauthorized access.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the shared GitHub SSH key (keys/id_github.age) from named-hosts/galactica/secrets.nix to stop distributing a single key across machines and tighten security. GPG signing remains unchanged.

- **Migration**
  - Use per-user or per-host SSH keys for GitHub and add them to your GitHub account.
  - Update any scripts that referenced ~/.ssh/id_github to use your own key (e.g., ~/.ssh/id_ed25519).

<sup>Written for commit c052be1c920ff95fe93965018b094f735ca1e12f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

