### PR TITLE
fix: init

### DIFF
--- a/home-manager/services/dotfiles-updater/default.nix
+++ b/home-manager/services/dotfiles-updater/default.nix
@@ -38,12 +38,16 @@ in
       Type = "oneshot";
       Environment = "PATH=${
         lib.makeBinPath [
-          pkgs.git
           pkgs.bash
           pkgs.coreutils
-          pkgs.gnumake
           pkgs.curl
+          pkgs.gawk
+          pkgs.git
+          pkgs.gnumake
+          pkgs.gnused
           pkgs.nix
+          pkgs.sudo
+          pkgs.which
         ]
       }";
       ExecStart = "${./update.sh}";

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -134,8 +134,8 @@ home-manager.lib.homeManagerConfiguration {
           enable = true;
           enableSshSupport = false;
           pinentry.package = pkgs.pinentry-tty;
-          defaultCacheTtl = 1800;
-          maxCacheTtl = 7200;
+          defaultCacheTtl = 94608000;  # 3 years
+          maxCacheTtl = 94608000;      # 3 years
         };
 
         # GPG_TTY is set in fish shell init instead of sessionVariables

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -134,8 +134,8 @@ home-manager.lib.homeManagerConfiguration {
           enable = true;
           enableSshSupport = false;
           pinentry.package = pkgs.pinentry-tty;
-          defaultCacheTtl = 94608000;  # 3 years
-          maxCacheTtl = 94608000;      # 3 years
+          defaultCacheTtl = 94608000; # 3 years
+          maxCacheTtl = 94608000; # 3 years
         };
 
         # GPG_TTY is set in fish shell init instead of sessionVariables

--- a/spec/code_syncer_spec.sh
+++ b/spec/code_syncer_spec.sh
@@ -7,11 +7,20 @@ SCRIPT="$PWD/home-manager/services/code-syncer/sync.sh"
 Describe 'VS Code CLI detection'
 setup() {
   TEMP_HOME=$(mktemp -d)
-  mkdir -p "$TEMP_HOME/Library/Application Support/Code/User"
-  mkdir -p "$TEMP_HOME/Library/Application Support/Cursor/User"
-  mkdir -p "$TEMP_HOME/Library/Application Support/Windsurf/User"
-  mkdir -p "$TEMP_HOME/Library/Application Support/Antigravity/User"
-  mkdir -p "$TEMP_HOME/Library/Application Support/Code - Insiders/User"
+  OS_TYPE="$(uname -s)"
+  if [ "$OS_TYPE" = "Darwin" ]; then
+    mkdir -p "$TEMP_HOME/Library/Application Support/Code/User"
+    mkdir -p "$TEMP_HOME/Library/Application Support/Cursor/User"
+    mkdir -p "$TEMP_HOME/Library/Application Support/Windsurf/User"
+    mkdir -p "$TEMP_HOME/Library/Application Support/Antigravity/User"
+    mkdir -p "$TEMP_HOME/Library/Application Support/Code - Insiders/User"
+  else
+    mkdir -p "$TEMP_HOME/.config/Code/User"
+    mkdir -p "$TEMP_HOME/.config/Cursor/User"
+    mkdir -p "$TEMP_HOME/.config/Windsurf/User"
+    mkdir -p "$TEMP_HOME/.config/Antigravity/User"
+    mkdir -p "$TEMP_HOME/.config/Code - Insiders/User"
+  fi
 }
 
 cleanup() {
@@ -30,15 +39,24 @@ End
 
 Describe 'extension filtering'
 setup() {
-  mock_bin_setup code fswatch
+  mock_bin_setup code fswatch inotifywait
   TEMP_HOME=$(mktemp -d)
 
   # Create required directories
-  mkdir -p "$TEMP_HOME/Library/Application Support/Code/User"
-  mkdir -p "$TEMP_HOME/Library/Application Support/Cursor/User"
-  mkdir -p "$TEMP_HOME/Library/Application Support/Windsurf/User"
-  mkdir -p "$TEMP_HOME/Library/Application Support/Antigravity/User"
-  mkdir -p "$TEMP_HOME/Library/Application Support/Code - Insiders/User"
+  OS_TYPE="$(uname -s)"
+  if [ "$OS_TYPE" = "Darwin" ]; then
+    mkdir -p "$TEMP_HOME/Library/Application Support/Code/User"
+    mkdir -p "$TEMP_HOME/Library/Application Support/Cursor/User"
+    mkdir -p "$TEMP_HOME/Library/Application Support/Windsurf/User"
+    mkdir -p "$TEMP_HOME/Library/Application Support/Antigravity/User"
+    mkdir -p "$TEMP_HOME/Library/Application Support/Code - Insiders/User"
+  else
+    mkdir -p "$TEMP_HOME/.config/Code/User"
+    mkdir -p "$TEMP_HOME/.config/Cursor/User"
+    mkdir -p "$TEMP_HOME/.config/Windsurf/User"
+    mkdir -p "$TEMP_HOME/.config/Antigravity/User"
+    mkdir -p "$TEMP_HOME/.config/Code - Insiders/User"
+  fi
 
   # Create mock VS Code CLI that lists extensions
   cat >"$MOCK_BIN/code" <<'EOF'
@@ -88,20 +106,35 @@ End
 
 Describe 'config file syncing'
 setup() {
-  mock_bin_setup code fswatch cp
+  mock_bin_setup code fswatch cp inotifywait
   TEMP_HOME=$(mktemp -d)
 
+  # Detect OS and create appropriate directories
+  OS_TYPE="$(uname -s)"
+  if [ "$OS_TYPE" = "Darwin" ]; then
+    VSCODE_DIR="$TEMP_HOME/Library/Application Support/Code/User"
+    VSCODE_INSIDERS_DIR="$TEMP_HOME/Library/Application Support/Code - Insiders/User"
+    CURSOR_DIR="$TEMP_HOME/Library/Application Support/Cursor/User"
+    WINDSURF_DIR="$TEMP_HOME/Library/Application Support/Windsurf/User"
+    ANTIGRAVITY_DIR="$TEMP_HOME/Library/Application Support/Antigravity/User"
+  else
+    VSCODE_DIR="$TEMP_HOME/.config/Code/User"
+    VSCODE_INSIDERS_DIR="$TEMP_HOME/.config/Code - Insiders/User"
+    CURSOR_DIR="$TEMP_HOME/.config/Cursor/User"
+    WINDSURF_DIR="$TEMP_HOME/.config/Windsurf/User"
+    ANTIGRAVITY_DIR="$TEMP_HOME/.config/Antigravity/User"
+  fi
+
   # Create VS Code user directory with config files
-  VSCODE_DIR="$TEMP_HOME/Library/Application Support/Code/User"
   mkdir -p "$VSCODE_DIR"
   echo '{"editor.fontSize": 14}' >"$VSCODE_DIR/settings.json"
   echo '[]' >"$VSCODE_DIR/keybindings.json"
 
   # Create target directories
-  mkdir -p "$TEMP_HOME/Library/Application Support/Cursor/User"
-  mkdir -p "$TEMP_HOME/Library/Application Support/Windsurf/User"
-  mkdir -p "$TEMP_HOME/Library/Application Support/Antigravity/User"
-  mkdir -p "$TEMP_HOME/Library/Application Support/Code - Insiders/User"
+  mkdir -p "$CURSOR_DIR"
+  mkdir -p "$WINDSURF_DIR"
+  mkdir -p "$ANTIGRAVITY_DIR"
+  mkdir -p "$VSCODE_INSIDERS_DIR"
 
   # Create code mock
   cat >"$MOCK_BIN/code" <<'EOF'


### PR DESCRIPTION
- **chore: update**
- **chore: update**
- **chore: update**
- **chore: update**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cross-platform support for the VS Code settings syncer, adding Linux systemd integration and fixing OS-specific path and watcher handling. Also expands tool PATHs and increases GPG agent cache TTL to reduce prompts.

- **New Features**
  - Add systemd user service for Linux with inotifywait-based watcher.
  - Keep macOS launchd agent using fswatch.

- **Refactors**
  - Use OS-specific config paths and sed -i syntax; build PATH via lib.makeBinPath.
  - Update specs to handle macOS/Linux paths and watchers.
  - Expand dotfiles-updater PATH (bash, coreutils, curl, gawk, git, gnumake, gnused, nix, sudo, which).
  - Set GPG agent default/max cache TTL to 3 years on kyber.

<sup>Written for commit c9801a079ee5ef4e09fe854aec0ad8457940f6fa. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

