### PR TITLE
fix(dotfiles-updater): skip nix-daemon restart in automated updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,10 +173,13 @@ nix-connect: ## Ensure Nix daemon is running.
 		sudo launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist 2>/dev/null || true; \
 		sudo launchctl load -w /Library/LaunchDaemons/org.nixos.nix-daemon.plist; \
 	elif [ "$(OS)" = "Linux" ]; then \
-		if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \
-			echo "🏃‍♂️ Nix daemon management (e.g., systemctl) is skipped in CI/Docker environments."; \
+		if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ] || [ "$$AUTOMATED_UPDATE" = "true" ]; then \
+			echo "🏃‍♂️ Nix daemon management (e.g., systemctl) is skipped in CI/Docker/automated environments."; \
 			if [ "$$IN_DOCKER" = "true" ]; then \
 				echo "ℹ️ Docker environment is using a single-user Nix installation (no separate daemon)."; \
+			fi; \
+			if [ "$$AUTOMATED_UPDATE" = "true" ]; then \
+				echo "ℹ️ Running in automated update mode - assuming nix-daemon is already running."; \
 			fi; \
 		else \
 			if [ -d /run/systemd/system ] && [ -S /run/systemd/private ]; then \

--- a/home-manager/services/dotfiles-updater/default.nix
+++ b/home-manager/services/dotfiles-updater/default.nix
@@ -36,20 +36,23 @@ in
     };
     Service = {
       Type = "oneshot";
-      Environment = "PATH=${
-        lib.makeBinPath [
-          pkgs.bash
-          pkgs.coreutils
-          pkgs.curl
-          pkgs.gawk
-          pkgs.git
-          pkgs.gnumake
-          pkgs.gnused
-          pkgs.nix
-          pkgs.sudo
-          pkgs.which
-        ]
-      }";
+      Environment = [
+        "PATH=${
+          lib.makeBinPath [
+            pkgs.bash
+            pkgs.coreutils
+            pkgs.curl
+            pkgs.gawk
+            pkgs.git
+            pkgs.gnumake
+            pkgs.gnused
+            pkgs.nix
+            pkgs.sudo
+            pkgs.which
+          ]
+        }"
+        "AUTOMATED_UPDATE=true"
+      ];
       ExecStart = "${./update.sh}";
     };
   };


### PR DESCRIPTION
## Summary

Fixes the dotfiles-updater service failing due to attempting to restart nix-daemon with sudo during automated updates.

## Problem

The dotfiles-updater systemd service was failing with exit code 2 because:
1. The service runs `make install` during automated updates
2. `make install` includes `make nix-connect`
3. `nix-connect` tries to run `sudo systemctl restart nix-daemon.service`
4. The systemd user service doesn't have passwordless sudo access

## Solution

- Add `AUTOMATED_UPDATE=true` environment variable to the dotfiles-updater service
- Modified Makefile to skip nix-daemon restart when `AUTOMATED_UPDATE` is set
- This follows the same pattern as existing CI and Docker environment handling
- The nix-daemon should already be running during automated updates, so restarting it is unnecessary

## Test Plan

- [x] Verify the fix resolves the sudo permission error
- [ ] Merge and deploy to verify automated updates work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip nix-daemon restarts during automated updates to prevent dotfiles-updater failures. Adds an AUTOMATED_UPDATE env flag and treats automated runs like CI/Docker.

- **Bug Fixes**
  - Set AUTOMATED_UPDATE=true in the dotfiles-updater systemd service.
  - Update Makefile nix-connect to skip nix-daemon management when AUTOMATED_UPDATE is set.
  - Avoids sudo/systemctl calls so the service no longer exits with code 2.

<sup>Written for commit dd87c85d473eaf9bcc42b4511707b6bc7556eafb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

