### PR TITLE
fix(deps): pin nixpkgs and neovim-nightly-overlay to working versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765835352,
-        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
+        "lastModified": 1765495779,
+        "narHash": "sha256-MhA7wmo/7uogLxiewwRRmIax70g6q1U/YemqTGoFHlM=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
+        "rev": "5635c32d666a59ec9a55cab87e898889869f7b71",
         "type": "github"
       },
       "original": {
@@ -294,11 +294,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765843481,
-        "narHash": "sha256-gph2g2MNqvk3Db/PMWib7IIV2EiVk6SQQi+Sry8HsvY=",
+        "lastModified": 1765757048,
+        "narHash": "sha256-Epzt11vJAU1mQqADX3ldstxrVjpmlula4+9y7EhtJxk=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "fbd64d42f0fa18898a17a8fa1cef638433dbfc48",
+        "rev": "fddb9312cf4818b8e39533b931cb4a7039e1471b",
         "type": "github"
       },
       "original": {
@@ -310,11 +310,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1765842602,
-        "narHash": "sha256-S+yCgY7y8Z/q1YeNYWggsfIdrTtO6Wpl/FghfTFqWp8=",
+        "lastModified": 1765753837,
+        "narHash": "sha256-7RvnNJCRzggqoBxRC1jxG6iXS0Sc5gGi2omRHbxC7Oo=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "7a866e6b2008472cceef49d05533d2988c838bff",
+        "rev": "115785732ad78e38eb66246f9841e95e88665fe8",
         "type": "github"
       },
       "original": {
@@ -405,11 +405,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765772535,
-        "narHash": "sha256-aq+dQoaPONOSjtFIBnAXseDm9TUhIbe215TPmkfMYww=",
+        "lastModified": 1765644376,
+        "narHash": "sha256-yqHBL2wYGwjGL2GUF2w3tofWl8qO9tZEuI4wSqbCrtE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "09b8fda8959d761445f12b55f380d90375a1d6bb",
+        "rev": "23735a82a828372c4ef92c660864e82fbe2f5fbe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- Pin nixpkgs to commit `23735a82` (2025-12-13)
- Pin neovim-nightly-overlay to commit `fddb9312` (2025-12-15)
- Resolves tree-sitter buildRustPackage incompatibility that was causing dotfiles-updater.service failures

## Problem

The latest nixpkgs introduced a breaking change in `buildRustPackage` that conflicts with neovim-nightly-overlay's tree-sitter configuration. The overlay expects `buildRustPackage` to receive a set but now receives a function, causing evaluation errors:

```
error: expected a set but found a function: «lambda @ .../tree-sitter/default.nix:104:32»
```

This caused the dotfiles-updater service to fail on every automated run.

## Solution

Temporarily pin both inputs to their last known working versions:
- nixpkgs: 23735a82a828372c4ef92c660864e82fbe2f5fbe
- neovim-nightly-overlay: fddb9312cf4818b8e39533b931cb4a7039e1471b

This is a temporary fix until neovim-nightly-overlay is updated to support the new buildRustPackage API.

## Testing

- ✅ Local build succeeds with pinned versions
- ✅ Configuration activates successfully
- 🔄 Waiting for dotfiles-updater service to verify automated updates work

## Test plan

- [ ] Verify CI builds pass
- [ ] Merge to main
- [ ] Monitor dotfiles-updater service on next automated run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned nixpkgs and neovim-nightly-overlay to working versions to fix a tree-sitter build error from recent nixpkgs changes. This restores successful runs of the dotfiles-updater service.

- **Bug Fixes**
  - Resolved tree-sitter buildRustPackage evaluation error (expected a set, got a function).
  - dotfiles-updater.service no longer fails.

- **Dependencies**
  - Pinned nixpkgs and neovim-nightly-overlay to last known good versions.
  - Temporary until the overlay supports the new buildRustPackage API.

<sup>Written for commit 22e973ab51571145de69d6df9c157e93a6cf813b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

