### PR TITLE
Increase timeout for ShellSpec tests to 30 minutes

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -24,7 +24,7 @@ jobs:
         run: make shell-test-dev
   shellcheck:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase the GitHub Actions timeout for the shellcheck job from 10 to 30 minutes to avoid premature failures for long-running ShellSpec tests. This reduces flakiness on slower runners.

<sup>Written for commit 0afa81b985372df39800e19dc43328e8d291a2a8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

