### PR TITLE
feat: enhance cliproxyapi with AMP API keys, GLM-4.7 support, and S3 config backup

### DIFF
--- a/config/cliproxyapi/config.yaml
+++ b/config/cliproxyapi/config.yaml
@@ -77,12 +77,14 @@ openai-compatibility:
       - "__OPENROUTER_API_KEY__"
     models:
       - name: "z-ai/glm-4.6"
+      - name: "z-ai/glm-4.7"
   - name: "z-ai"
     base-url: "https://api.z.ai/api/coding/paas/v4"
     api-keys:
       - "__ZAI_API_KEY__"
     models:
       - name: "glm-4.6"
+      - name: "glm-4.7"
 
 # payload: # Optional payload configuration
 #   default: # Default rules only set parameters when they are missing in the payload.

--- a/config/cliproxyapi/config.yaml
+++ b/config/cliproxyapi/config.yaml
@@ -13,9 +13,9 @@ remote-management:
   disable-control-panel: false
 # Authentication directory (supports ~ for home directory). If you use Windows, please set the directory like this: `C:/cli-proxy-api/`
 auth-dir: "~/.cli-proxy-api"
-# API keys for client authentication (e.g., Amp CLI)
-api-keys:
-  - "__AMP_API_KEY__"
+# API keys for client authentication (optional - leave commented for open access)
+# api-keys:
+#   - "your-api-key"
 
 # Enable debug logging
 debug: true

--- a/config/cliproxyapi/config.yaml
+++ b/config/cliproxyapi/config.yaml
@@ -38,7 +38,6 @@ ampcode:
   upstream-url: "https://ampcode.com"
   upstream-api-key: "__AMP_UPSTREAM_API_KEY__"
   restrict-management-to-localhost: false
-
 # Gemini API keys (preferred)
 # gemini-api-key:
 #   - api-key: "AIzaSy...01"

--- a/config/cliproxyapi/config.yaml
+++ b/config/cliproxyapi/config.yaml
@@ -13,10 +13,9 @@ remote-management:
   disable-control-panel: false
 # Authentication directory (supports ~ for home directory). If you use Windows, please set the directory like this: `C:/cli-proxy-api/`
 auth-dir: "~/.cli-proxy-api"
-# API keys for authentication
-# api-keys:
-#   - "your-api-key-1"
-#   - "your-api-key-2"
+# API keys for client authentication (e.g., Amp CLI)
+api-keys:
+  - "__AMP_API_KEY__"
 
 # Enable debug logging
 debug: true
@@ -34,11 +33,11 @@ quota-exceeded:
   switch-preview-model: true # Whether to automatically switch to a preview model when a quota is exceeded
 # When true, enable authentication for the WebSocket API (/v1/ws).
 ws-auth: false
-# AMP
+# AMP integration
 ampcode:
   upstream-url: "https://ampcode.com"
-  restrict-management-to-localhost: true
-# amp-upstream-api-key: "" # Optional - use AMP_API_KEY env var or ~/.local/share/amp/secrets.json
+  upstream-api-key: "__AMP_UPSTREAM_API_KEY__"
+  restrict-management-to-localhost: false
 
 # Gemini API keys (preferred)
 # gemini-api-key:

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -197,6 +197,9 @@
 			"models": {
 				"glm-4.6": {
 					"name": "GLM-4.6 (via Z-AI)",
+				},
+				"zai-coding-plan/glm-4.7": {
+					"name": "GLM-4.7 Coding Plan (via Z-AI)"
 				}
 			},
 			"options": {

--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -17,6 +17,7 @@ in
           lib.makeBinPath [
             pkgs.gnused
             pkgs.coreutils
+            pkgs.awscli2
           ]
         }:/opt/homebrew/bin:/usr/local/bin:/usr/bin";
       };
@@ -38,6 +39,8 @@ in
         lib.makeBinPath [
           pkgs.gnused
           pkgs.bash
+          pkgs.coreutils
+          pkgs.awscli2
         ]
       }";
       ExecStart = "${pkgs.bash}/bin/bash ${./scripts/start.sh}";

--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -1,6 +1,12 @@
 { pkgs, ... }:
 let
   inherit (pkgs) lib;
+
+  # Create start script with paths substituted at build time
+  startScript = pkgs.replaceVars ./scripts/start.sh {
+    aws = "${pkgs.awscli2}/bin/aws";
+    sed = "${pkgs.gnused}/bin/sed";
+  };
 in
 {
   # Main cliproxyapi service
@@ -9,7 +15,7 @@ in
     config = {
       ProgramArguments = [
         "${pkgs.bash}/bin/bash"
-        "${./scripts/start.sh}"
+        "${startScript}"
       ];
       Environment = {
         HOME = "/Users/shunkakinoki";
@@ -43,7 +49,7 @@ in
           pkgs.awscli2
         ]
       }";
-      ExecStart = "${pkgs.bash}/bin/bash ${./scripts/start.sh}";
+      ExecStart = "${pkgs.bash}/bin/bash ${startScript}";
       Restart = "always";
       RestartSec = 3;
     };

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 CONFIG_DIR="$HOME/.cli-proxy-api"
 TEMPLATE="$CONFIG_DIR/config.template.yaml"
 CONFIG="$CONFIG_DIR/config.yaml"
-ENV_FILE="$HOME/dotfiles/.env"
+# Use explicit path since $HOME may not be set correctly in launchd context
+ENV_FILE="${HOME:-/Users/shunkakinoki}/dotfiles/.env"
 
 # Source .env file to get API keys
 if [ -f "$ENV_FILE" ]; then

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -31,6 +31,8 @@ if [ -f "$TEMPLATE" ]; then
     -e "s|__OPENROUTER_API_KEY__|${OPENROUTER_API_KEY:-}|g" \
     -e "s|__CLIPROXY_MANAGEMENT_PASSWORD__|${CLIPROXY_MANAGEMENT_PASSWORD:-}|g" \
     -e "s|__ZAI_API_KEY__|${ZAI_API_KEY:-}|g" \
+    -e "s|__AMP_API_KEY__|${AMP_API_KEY:-}|g" \
+    -e "s|__AMP_UPSTREAM_API_KEY__|${AMP_UPSTREAM_API_KEY:-}|g" \
     "$TEMPLATE" >"$CONFIG"
   # Also copy to objectstore config location (cliproxyapi uses this for persistence)
   mkdir -p "$CONFIG_DIR/objectstore/config"

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -31,7 +31,6 @@ if [ -f "$TEMPLATE" ]; then
     -e "s|__OPENROUTER_API_KEY__|${OPENROUTER_API_KEY:-}|g" \
     -e "s|__CLIPROXY_MANAGEMENT_PASSWORD__|${CLIPROXY_MANAGEMENT_PASSWORD:-}|g" \
     -e "s|__ZAI_API_KEY__|${ZAI_API_KEY:-}|g" \
-    -e "s|__AMP_API_KEY__|${AMP_API_KEY:-}|g" \
     -e "s|__AMP_UPSTREAM_API_KEY__|${AMP_UPSTREAM_API_KEY:-}|g" \
     "$TEMPLATE" >"$CONFIG"
   # Also copy to objectstore config location (cliproxyapi uses this for persistence)


### PR DESCRIPTION
## Summary

- Enhance cliproxyapi service reliability with S3 config backup and proper launchd path handling to prevent configuration corruption across service restarts
- Add AMP API key authentication support and GLM-4.7 model support for improved AI capabilities





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AMP API key auth, enables GLM-4.7 models, and hardens cliproxyapi with S3-backed config and launchd-safe startup. Improves reliability across restarts and expands model options.

- **New Features**
  - S3 backup of the generated config on startup to prevent corrupted state.
  - AMP integration: client API keys and upstream API key support; remote management enabled by default.
  - GLM-4.7 support for OpenRouter (z-ai) and Z-AI providers; added GLM-4.7 Coding Plan in opencode config.

- **Bug Fixes**
  - Reliable launchd startup by resolving HOME for .env and using Nix-injected paths for aws/sed.

<sup>Written for commit 6fc5a7011dfd074d1fcb9bbeed1537c39ac00a6b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





