### PR TITLE
fix(cliproxyapi): improve legacy service configuration and documentation

### DIFF
--- a/config/cliproxyapi/config.yaml
+++ b/config/cliproxyapi/config.yaml
@@ -38,6 +38,9 @@ ampcode:
   upstream-url: "https://ampcode.com"
   upstream-api-key: "__AMP_UPSTREAM_API_KEY__"
   restrict-management-to-localhost: false
+  # model-mappings:
+  #   - from: "requested-model-name"
+  #     to: "local-model-name"
 # Gemini API keys (preferred)
 # gemini-api-key:
 #   - api-key: "AIzaSy...01"
@@ -71,14 +74,14 @@ ampcode:
 openai-compatibility:
   - name: "openrouter"
     base-url: "https://openrouter.ai/api/v1"
-    api-keys:
-      - "__OPENROUTER_API_KEY__"
+    api-key-entries:
+      - api-key: "__OPENROUTER_API_KEY__"
     models:
       - name: "z-ai/glm-4.6"
   - name: "z-ai"
     base-url: "https://api.z.ai/api/coding/paas/v4"
-    api-keys:
-      - "__ZAI_API_KEY__"
+    api-key-entries:
+      - api-key: "__ZAI_API_KEY__"
     models:
       - name: "glm-4.6"
       - name: "glm-4.7"

--- a/home-manager/services/cliproxyapi/README.md
+++ b/home-manager/services/cliproxyapi/README.md
@@ -1,0 +1,264 @@
+# CLIProxyAPI Service Configuration
+
+This directory contains the Nix-based configuration for the cliproxyapi service, including automatic auth file backup/recovery and OAuth token management.
+
+## Overview
+
+The cliproxyapi service provides a unified proxy for multiple AI providers (Claude, Codex, Gemini, OpenRouter, etc.) with automatic authentication management and cloud backup.
+
+## Architecture
+
+### Services
+
+1. **cliproxyapi** - Main proxy server running on port 8317
+2. **cliproxyapi-backup** - File watcher that syncs auth files to R2 storage
+
+### Directory Structure
+
+```
+~/.cli-proxy-api/
+├── config.yaml                    # Generated config (from template)
+├── config.template.yaml           # Template with placeholders
+├── auths/                         # OAuth tokens (what cliproxyapi reads)
+│   ├── claude-*.json
+│   ├── codex-*.json
+│   └── antigravity-*.json
+└── objectstore/
+    ├── config/
+    │   └── config.yaml            # Cloud-synced config
+    └── auths/                     # Primary auth storage (watched)
+        ├── claude-*.json
+        ├── codex-*.json
+        └── antigravity-*.json
+
+~/dotfiles/objectstore/auths/      # Git-tracked backup (write-only)
+~/.ccs/cliproxy/auth/              # CCS auth directory (two-way sync)
+
+R2 Storage (Cloudflare):
+├── s3://cliproxyapi/auths/        # Primary cloud storage
+├── s3://cliproxyapi/backup/auths/ # Redundant backup
+└── s3://cliproxyapi/config/       # Config backup
+```
+
+## Auth File Management
+
+### On Service Start (`start.sh`)
+
+1. Pull auth files from R2 `auths/` → `objectstore/auths/`
+2. Pull from R2 `backup/auths/` → `objectstore/auths/` (merge)
+3. **Bootstrap:** If objectstore is empty, copy from `dotfiles/objectstore/auths/`
+4. **OAuth Support:** Sync `objectstore/auths/` → `auths/` (root directory)
+
+### On File Changes (`backup-auth.sh`)
+
+Triggered by launchd WatchPaths when files change in:
+- `~/.cli-proxy-api/objectstore/auths/`
+- `~/.ccs/cliproxy/auth/`
+
+**Flow:**
+1. Pull from R2 `auths/` → `objectstore/auths/`
+2. Pull from R2 `backup/auths/` → `objectstore/auths/`
+3. Sync CCS auth files → `objectstore/auths/` (if exists)
+4. Push `objectstore/auths/` → R2 `auths/`
+5. Push `objectstore/auths/` → R2 `backup/auths/`
+6. **OAuth Support:** Sync `objectstore/auths/` → `auths/`
+7. Sync `objectstore/auths/` → CCS auth dir
+8. Sync `objectstore/auths/` → dotfiles (git tracking)
+
+### Data Flow
+
+```
+┌──────────────────┐
+│   R2 Storage     │
+│  ┌────────────┐  │      ┌──────────────────────────────┐
+│  │ auths/     │◄─┼──────┤                              │
+│  └────────────┘  │      │   objectstore/auths/         │
+│  ┌────────────┐  │      │   (Primary Source of Truth)  │
+│  │ backup/    │◄─┼──────┤                              │
+│  └────────────┘  │      └──────────────────────────────┘
+└──────────────────┘                   │
+                                       ├─────► auths/ (OAuth tokens)
+                                       ├─────► ccs/auth/
+                                       └─────► dotfiles/ (git backup)
+                                                   │
+                                                   └─► Bootstrap only
+```
+
+## Key Features
+
+### 1. OAuth Token Support
+
+Auth files in `~/.cli-proxy-api/auths/` are automatically used for OAuth-based API calls. This enables:
+- `cliproxyapi --claude-login` for web-based authentication
+- OAuth tokens work with Claude API requests
+- No need for manual API keys
+
+### 2. Multi-Location Backup
+
+Auth files are backed up to:
+- **R2 Primary:** `s3://cliproxyapi/auths/`
+- **R2 Backup:** `s3://cliproxyapi/backup/auths/`
+- **Git:** `~/dotfiles/objectstore/auths/` (version controlled)
+- **CCS:** `~/.ccs/cliproxy/auth/` (for CCS compatibility)
+
+### 3. Automatic Recovery
+
+If auth files are lost locally, they are automatically recovered from:
+1. R2 primary storage
+2. R2 backup storage (if primary is missing files)
+3. Git-tracked dotfiles (on fresh install)
+
+### 4. No Circular Loops
+
+**Problem Solved:** Previously, `dotfiles/objectstore/auths` was both watched and written to, creating infinite sync loops.
+
+**Solution:**
+- Removed dotfiles from WatchPaths
+- Dotfiles is now **write-only** (except for bootstrap)
+- Only `objectstore/auths` and `ccs/auth` trigger sync events
+
+## Environment Variables
+
+Required in `~/dotfiles/.env`:
+
+```bash
+# Object Storage (Cloudflare R2)
+OBJECTSTORE_ENDPOINT="https://....r2.cloudflarestorage.com"
+OBJECTSTORE_BUCKET="cliproxyapi"
+OBJECTSTORE_ACCESS_KEY="..."
+OBJECTSTORE_SECRET_KEY="..."
+
+# Management Password
+CLIPROXY_MANAGEMENT_PASSWORD="..."
+
+# API Keys (injected into config)
+OPENROUTER_API_KEY="sk-or-v1-..."
+ZAI_API_KEY="..."
+AMP_UPSTREAM_API_KEY="sgamp_user_..."
+```
+
+## Usage
+
+### Initial Setup
+
+```bash
+# Build and activate configuration
+make build && make switch
+
+# The service starts automatically
+# Check status
+launchctl list | grep cliproxyapi
+
+# View logs
+tail -f /tmp/cliproxyapi.log
+tail -f /tmp/cliproxyapi.error.log
+tail -f /tmp/cliproxyapi-backup.log
+```
+
+### OAuth Login
+
+```bash
+# Authenticate with Claude
+cliproxyapi --claude-login
+
+# This will:
+# 1. Open browser for OAuth
+# 2. Save token to objectstore/auths/
+# 3. Trigger backup to R2 and dotfiles
+# 4. Sync to auths/ for immediate use
+```
+
+### Testing
+
+```bash
+# Test Claude API with OAuth
+curl -X POST http://localhost:8317/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{"model":"claude-opus-4-5-20251101","messages":[{"role":"user","content":"test"}],"max_tokens":10}'
+```
+
+### Troubleshooting
+
+```bash
+# Restart service
+make restart-cliproxyapi
+
+# Check auth files
+ls -la ~/.cli-proxy-api/auths/
+ls -la ~/.cli-proxy-api/objectstore/auths/
+
+# Verify R2 sync
+aws s3 ls --endpoint-url="$OBJECTSTORE_ENDPOINT" s3://cliproxyapi/auths/
+
+# Force backup
+launchctl start org.nix-community.home.cliproxyapi-backup
+```
+
+## Recovery Scenarios
+
+### Scenario 1: Fresh Machine Setup
+
+1. Clone dotfiles: `git clone ... ~/dotfiles`
+2. Run: `make install`
+3. Service starts and bootstraps from `dotfiles/objectstore/auths/`
+4. Auth files uploaded to R2 for cloud backup
+
+### Scenario 2: Auth File Accidentally Deleted from R2
+
+1. Backup location still has the file
+2. Next sync pulls from `backup/auths/`
+3. File automatically restored to `auths/` and `backup/auths/`
+
+### Scenario 3: Local Machine Crash
+
+1. New machine or service restart
+2. `start.sh` pulls from R2 on startup
+3. All auth files recovered automatically
+
+### Scenario 4: Need to Roll Back Auth
+
+1. Check git history: `git log -- objectstore/auths/`
+2. Restore old version from git
+3. Remove `~/.cli-proxy-api/auths/` and `objectstore/auths/`
+4. Restart service to bootstrap from dotfiles
+
+## Configuration Files
+
+### `default.nix`
+- Defines launchd agents (macOS) or systemd services (Linux)
+- Sets up WatchPaths for file monitoring
+- Configures environment variables
+
+### `scripts/start.sh`
+- Runs on service start
+- Pulls auth files from R2
+- Bootstraps from dotfiles if needed
+- Syncs to OAuth directory
+- Starts cliproxyapi binary
+
+### `scripts/backup-auth.sh`
+- Runs on file changes (WatchPaths)
+- Pulls from R2 first (merge remote changes)
+- Syncs from CCS if available
+- Pushes to R2 (both locations)
+- Syncs to all local locations
+
+### `scripts/backup-and-recover.sh`
+- Wrapper script that sources `.env`
+- Calls `backup-auth.sh`
+- Used by launchd agent
+
+## Notes
+
+- **Auth file naming:** Must match pattern `*-shunkakinoki@gmail.com.json` or `*-shunkakinoki_gmail_com.json`
+- **OAuth tokens:** Start with `sk-ant-oat01-` (different from API keys which start with `sk-ant-api03-`)
+- **File watchers:** Changes in watched directories trigger within ~1 second
+- **Sync is idempotent:** Running multiple times is safe
+- **Bootstrap runs once:** Only when objectstore is empty
+
+## References
+
+- [CLIProxyAPI Documentation](https://help.router-for.me/)
+- [Object Storage Config](https://help.router-for.me/configuration/storage/s3)
+- [Anthropic OAuth](https://docs.anthropic.com/en/api/oauth)

--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -8,6 +8,7 @@ let
   startScript = pkgs.replaceVars ./scripts/start.sh {
     aws = "${pkgs.awscli2}/bin/aws";
     sed = "${pkgs.gnused}/bin/sed";
+    rsync = "${pkgs.rsync}/bin/rsync";
   };
 
   # Create backup scripts with paths substituted at build time

--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -90,9 +90,9 @@ in
         }:/opt/homebrew/bin:/usr/local/bin:/usr/bin";
       };
       # Watch auth directories for changes - triggers sync immediately
+      # NOTE: dotfiles is excluded to prevent circular sync loops
       WatchPaths = [
         "${homeDir}/.cli-proxy-api/objectstore/auths"
-        "${homeDir}/dotfiles/objectstore/auths"
         "${homeDir}/.ccs/cliproxy/auth"
       ];
       RunAtLoad = true;

--- a/home-manager/services/cliproxyapi/scripts/backup-auth.sh
+++ b/home-manager/services/cliproxyapi/scripts/backup-auth.sh
@@ -8,7 +8,6 @@ CONFIG_DIR="$HOME/.cli-proxy-api"
 BACKUP_DIR="s3://cliproxyapi/backup/auths/"
 MAIN_DIR="s3://cliproxyapi/auths/"
 AUTH_DIR="$CONFIG_DIR/objectstore/auths"
-AUTH_DIR_ROOT="$CONFIG_DIR/auths"
 DOTFILES_AUTH_DIR="$HOME/dotfiles/objectstore/auths"
 CCS_AUTH_DIR="$HOME/.ccs/cliproxy/auth"
 
@@ -71,11 +70,6 @@ if [ -d "$AUTH_DIR" ] && [ -n "$(ls -A "$AUTH_DIR" 2>/dev/null)" ]; then
       "$AUTH_DIR/" \
       "$BACKUP_DIR" && echo "✅ Synced to backup/auths/" >&2 || echo "⚠️  Backup sync failed" >&2
   fi
-
-  # CRITICAL: Sync to root auths/ directory for cliproxyapi OAuth token usage
-  mkdir -p "$AUTH_DIR_ROOT"
-  @rsync@ -a "$AUTH_DIR/" "$AUTH_DIR_ROOT/"
-  echo "✅ Synced to root auths dir (for OAuth)" >&2
 
   # Sync to ccs auth dir (so ccs can find the tokens)
   mkdir -p "$CCS_AUTH_DIR"

--- a/home-manager/services/cliproxyapi/scripts/backup-auth.sh
+++ b/home-manager/services/cliproxyapi/scripts/backup-auth.sh
@@ -33,11 +33,12 @@ if [ -n "${OBJECTSTORE_ENDPOINT:-}" ]; then
     "$AUTH_DIR/" 2>/dev/null && echo "✅ Pulled from R2 backup/auths/" >&2 || true
 fi
 
-# STEP 2: Sync from dotfiles repo to local cache (picks up new auth files from ccs auth)
-if [ -d "$DOTFILES_AUTH_DIR" ] && [ -n "$(ls -A "$DOTFILES_AUTH_DIR" 2>/dev/null)" ]; then
-  @rsync@ -a "$DOTFILES_AUTH_DIR/" "$AUTH_DIR/"
-  echo "✅ Synced from dotfiles repo to local cache" >&2
-fi
+# STEP 2: Sync from dotfiles repo to local cache ONLY on initial bootstrap
+# (This step is commented out to prevent circular sync loops - dotfiles is write-only)
+# if [ -d "$DOTFILES_AUTH_DIR" ] && [ -n "$(ls -A "$DOTFILES_AUTH_DIR" 2>/dev/null)" ]; then
+#   @rsync@ -a "$DOTFILES_AUTH_DIR/" "$AUTH_DIR/"
+#   echo "✅ Synced from dotfiles repo to local cache" >&2
+# fi
 
 # STEP 2b: Sync from ccs auth dir (picks up files created by ccs's internal cliproxy)
 if [ -d "$CCS_AUTH_DIR" ] && [ -n "$(ls -A "$CCS_AUTH_DIR" 2>/dev/null)" ]; then

--- a/home-manager/services/cliproxyapi/scripts/backup-auth.sh
+++ b/home-manager/services/cliproxyapi/scripts/backup-auth.sh
@@ -8,6 +8,7 @@ CONFIG_DIR="$HOME/.cli-proxy-api"
 BACKUP_DIR="s3://cliproxyapi/backup/auths/"
 MAIN_DIR="s3://cliproxyapi/auths/"
 AUTH_DIR="$CONFIG_DIR/objectstore/auths"
+AUTH_DIR_ROOT="$CONFIG_DIR/auths"
 DOTFILES_AUTH_DIR="$HOME/dotfiles/objectstore/auths"
 CCS_AUTH_DIR="$HOME/.ccs/cliproxy/auth"
 
@@ -69,6 +70,11 @@ if [ -d "$AUTH_DIR" ] && [ -n "$(ls -A "$AUTH_DIR" 2>/dev/null)" ]; then
       "$AUTH_DIR/" \
       "$BACKUP_DIR" && echo "✅ Synced to backup/auths/" >&2 || echo "⚠️  Backup sync failed" >&2
   fi
+
+  # CRITICAL: Sync to root auths/ directory for cliproxyapi OAuth token usage
+  mkdir -p "$AUTH_DIR_ROOT"
+  @rsync@ -a "$AUTH_DIR/" "$AUTH_DIR_ROOT/"
+  echo "✅ Synced to root auths dir (for OAuth)" >&2
 
   # Sync to ccs auth dir (so ccs can find the tokens)
   mkdir -p "$CCS_AUTH_DIR"

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -31,7 +31,6 @@ export OBJECTSTORE_SECRET_KEY="${OBJECTSTORE_SECRET_KEY:-${AWS_SECRET_ACCESS_KEY
 if [ -n "${OBJECTSTORE_ENDPOINT:-}" ] && [ -n "${OBJECTSTORE_ACCESS_KEY:-}" ]; then
   echo "Syncing auth files from R2..." >&2
   mkdir -p "$AUTH_DIR"
-  mkdir -p "$CONFIG_DIR/auths"
 
   # Pull from both active and backup locations to ensure we have all files
   AWS_ACCESS_KEY_ID="${OBJECTSTORE_ACCESS_KEY}" \
@@ -57,10 +56,6 @@ if [ -n "${OBJECTSTORE_ENDPOINT:-}" ] && [ -n "${OBJECTSTORE_ACCESS_KEY:-}" ]; t
       echo "✅ Bootstrapped from dotfiles (objectstore was empty)" >&2
     fi
   fi
-
-  # CRITICAL: Copy to root auths/ directory for OAuth token usage
-  @rsync@ -a "$AUTH_DIR/" "$CONFIG_DIR/auths/"
-  echo "✅ Synced to root auths dir (for OAuth)" >&2
 else
   echo "⚠️  Skipping auth sync: OBJECTSTORE credentials not set" >&2
 fi

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -31,6 +31,7 @@ export OBJECTSTORE_SECRET_KEY="${OBJECTSTORE_SECRET_KEY:-${AWS_SECRET_ACCESS_KEY
 if [ -n "${OBJECTSTORE_ENDPOINT:-}" ] && [ -n "${OBJECTSTORE_ACCESS_KEY:-}" ]; then
   echo "Syncing auth files from R2..." >&2
   mkdir -p "$AUTH_DIR"
+  mkdir -p "$CONFIG_DIR/auths"
 
   # Pull from both active and backup locations to ensure we have all files
   AWS_ACCESS_KEY_ID="${OBJECTSTORE_ACCESS_KEY}" \
@@ -48,6 +49,10 @@ if [ -n "${OBJECTSTORE_ENDPOINT:-}" ] && [ -n "${OBJECTSTORE_ACCESS_KEY:-}" ]; t
     --no-progress \
     "s3://cliproxyapi/backup/auths/" \
     "$AUTH_DIR/" 2>/dev/null && echo "✅ Pulled from R2 backup/auths/" >&2 || true
+
+  # CRITICAL: Copy to root auths/ directory for OAuth token usage
+  @rsync@ -a "$AUTH_DIR/" "$CONFIG_DIR/auths/"
+  echo "✅ Synced to root auths dir (for OAuth)" >&2
 else
   echo "⚠️  Skipping auth sync: OBJECTSTORE credentials not set" >&2
 fi

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -50,6 +50,14 @@ if [ -n "${OBJECTSTORE_ENDPOINT:-}" ] && [ -n "${OBJECTSTORE_ACCESS_KEY:-}" ]; t
     "s3://cliproxyapi/backup/auths/" \
     "$AUTH_DIR/" 2>/dev/null && echo "✅ Pulled from R2 backup/auths/" >&2 || true
 
+  # Bootstrap from git-tracked dotfiles if objectstore is empty
+  if [ ! -d "$AUTH_DIR" ] || [ -z "$(ls -A "$AUTH_DIR" 2>/dev/null)" ]; then
+    if [ -d "$HOME/dotfiles/objectstore/auths" ] && [ -n "$(ls -A "$HOME/dotfiles/objectstore/auths" 2>/dev/null)" ]; then
+      @rsync@ -a "$HOME/dotfiles/objectstore/auths/" "$AUTH_DIR/"
+      echo "✅ Bootstrapped from dotfiles (objectstore was empty)" >&2
+    fi
+  fi
+
   # CRITICAL: Copy to root auths/ directory for OAuth token usage
   @rsync@ -a "$AUTH_DIR/" "$CONFIG_DIR/auths/"
   echo "✅ Synced to root auths dir (for OAuth)" >&2

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 CONFIG_DIR="$HOME/.cli-proxy-api"
 TEMPLATE="$CONFIG_DIR/config.template.yaml"
 CONFIG="$CONFIG_DIR/config.yaml"
+AUTH_DIR="$CONFIG_DIR/objectstore/auths"
 # Use explicit path since $HOME may not be set correctly in launchd context
 ENV_FILE="${HOME:-/Users/shunkakinoki}/dotfiles/.env"
 
@@ -24,6 +25,32 @@ export OBJECTSTORE_ENDPOINT="${OBJECTSTORE_ENDPOINT:-${AWS_S3_ENDPOINT:-}}"
 export OBJECTSTORE_BUCKET="${OBJECTSTORE_BUCKET:-${AWS_S3_BUCKET:-}}"
 export OBJECTSTORE_ACCESS_KEY="${OBJECTSTORE_ACCESS_KEY:-${AWS_ACCESS_KEY_ID:-}}"
 export OBJECTSTORE_SECRET_KEY="${OBJECTSTORE_SECRET_KEY:-${AWS_SECRET_ACCESS_KEY:-}}"
+
+# CRITICAL: Pull auth files from R2 before starting cliproxyapi
+# This ensures all auth files (including codex-*) are available when the service starts
+if [ -n "${OBJECTSTORE_ENDPOINT:-}" ] && [ -n "${OBJECTSTORE_ACCESS_KEY:-}" ]; then
+  echo "Syncing auth files from R2..." >&2
+  mkdir -p "$AUTH_DIR"
+
+  # Pull from both active and backup locations to ensure we have all files
+  AWS_ACCESS_KEY_ID="${OBJECTSTORE_ACCESS_KEY}" \
+    AWS_SECRET_ACCESS_KEY="${OBJECTSTORE_SECRET_KEY}" \
+    @aws@ s3 sync \
+    --endpoint-url="${OBJECTSTORE_ENDPOINT}" \
+    --no-progress \
+    "s3://cliproxyapi/auths/" \
+    "$AUTH_DIR/" 2>/dev/null && echo "✅ Pulled from R2 auths/" >&2 || true
+
+  AWS_ACCESS_KEY_ID="${OBJECTSTORE_ACCESS_KEY}" \
+    AWS_SECRET_ACCESS_KEY="${OBJECTSTORE_SECRET_KEY}" \
+    @aws@ s3 sync \
+    --endpoint-url="${OBJECTSTORE_ENDPOINT}" \
+    --no-progress \
+    "s3://cliproxyapi/backup/auths/" \
+    "$AUTH_DIR/" 2>/dev/null && echo "✅ Pulled from R2 backup/auths/" >&2 || true
+else
+  echo "⚠️  Skipping auth sync: OBJECTSTORE credentials not set" >&2
+fi
 
 # Generate config from template with secrets injected
 if [ -f "$TEMPLATE" ]; then


### PR DESCRIPTION
## Summary

This PR enhances the cliproxyapi service with comprehensive documentation and improves the start script with proper rsync path variable substitution. It refactors the authentication file syncing to remove unnecessary root directory sync while preserving OAuth token functionality.

## Changes

- **Documentation**: Add comprehensive README for cliproxyapi service configuration and management
- **Start Script**: Add rsync path to variable substitution in start.sh for proper environment variable handling
- **Auth Syncing**: Remove root auths directory sync to eliminate redundant OAuth token syncing
- **Config Updates**: Refactor API key structure and add model mappings to config.yaml
- **Backup Script**: Enhance backup script with improved auth file syncing from R2 storage

## Files Modified

- `config/cliproxyapi/config.yaml` - Enhanced API configuration
- `home-manager/services/cliproxyapi/README.md` - New comprehensive documentation
- `home-manager/services/cliproxyapi/default.nix` - Updated module configuration
- `home-manager/services/cliproxyapi/scripts/backup-auth.sh` - Enhanced backup logic
- `home-manager/services/cliproxyapi/scripts/start.sh` - Added rsync path substitution

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Configuration refinement

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens cliproxyapi’s auth handling and docs with objectstore-centric workflows and safer sync.
> 
> - **Auth sync overhaul:** `start.sh` now pulls auths from R2 (`auths/` + `backup/auths/`) before launch and bootstraps from `dotfiles` only if empty; backup script stops reading from dotfiles to avoid loops and still merges CCS tokens
> - **File watching:** Removes `dotfiles` from launchd `WatchPaths`, preventing circular sync; watchers now monitor only `objectstore/auths` and `~/.ccs/cliproxy/auth`
> - **Config:** Switches provider keys to `api-key-entries` in `config.yaml`; adds commented `ampcode.model-mappings` example
> - **Nix module:** Injects `rsync` path for scripts; updates PATHs accordingly
> - **Docs:** Adds comprehensive `README.md` describing architecture, flows, and recovery
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe285e8a7843e9d57669413a987edf7a48be7a1e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves cliproxyapi reliability and docs. Startup now pulls auth files from R2, removes circular sync loops, and keeps OAuth tokens working.

- Bug Fixes
  - Sync auth files from R2 (auths and backup/auths) before start; bootstrap from dotfiles only if empty.
  - Read auth only from objectstore/auths when object storage is enabled; remove root auths sync.
  - Exclude dotfiles from WatchPaths and disable dotfiles→cache sync to prevent infinite loops.
  - Add rsync path substitution in start.sh for correct env path handling.

- New Features
  - Add comprehensive README covering setup, OAuth, backups, and recovery.
  - Update config: switch api-keys to api-key-entries and add optional model-mappings example.

<sup>Written for commit fe285e8a7843e9d57669413a987edf7a48be7a1e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

