### PR TITLE
feat: add Docker support for cliproxyapi service on Linux

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,11 +92,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1766843567,
-        "narHash": "sha256-062oL6KZCH7ePf4BBG61OdFJUh5ovw6zTpd/lVwy/xk=",
+        "lastModified": 1766676776,
+        "narHash": "sha256-2bmlDZ7eFr1gO4lMKE9aw1RRUoR+9MDMAHbuVugIoi4=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "d0f2c8545f09e5aba9d321079a284b550371879d",
+        "rev": "85b34019389c192e10e3508745c15b98060216f5",
         "type": "github"
       },
       "original": {
@@ -257,11 +257,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1766881808,
-        "narHash": "sha256-JR7A2xS3EBPWFeONzhqez5vp7nKEsp7eLj2Ks210Srk=",
+        "lastModified": 1766682973,
+        "narHash": "sha256-GKO35onS711ThCxwWcfuvbIBKXwriahGqs+WZuJ3v9E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d2e0458d6531885600b346e161c38790dc356fa8",
+        "rev": "91cdb0e2d574c64fae80d221f4bf09d5592e9ec2",
         "type": "github"
       },
       "original": {
@@ -294,11 +294,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1766880341,
-        "narHash": "sha256-yYh/TNwR9GsJUT8d73nsK39lZ/j240jDwNr6807lx60=",
+        "lastModified": 1766793883,
+        "narHash": "sha256-k5pLDiwKWQfsSSwKs6UbIWiKWZo6xKNsTNPnuzHPeNo=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "7e6bb31ced1de2c6360122173f63c44113223622",
+        "rev": "6c63748c49be61297332a11c984973194638d4fb",
         "type": "github"
       },
       "original": {
@@ -310,11 +310,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1766877615,
-        "narHash": "sha256-iojFwrzLMqEaOLkXVjIVLWFW5DU1Vhh40Xndx3fR/Xs=",
+        "lastModified": 1766742707,
+        "narHash": "sha256-vWRPyUDlSiFucT3dwRuYm8AdZ75kzvQg+ymsiLapMwk=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "ab5a92bff67d654c543d89b4803a64b2e648253a",
+        "rev": "899ec829be85b52202f0ce32c455ae4f4d60b85b",
         "type": "github"
       },
       "original": {
@@ -405,11 +405,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1766840161,
-        "narHash": "sha256-Ss/LHpJJsng8vz1Pe33RSGIWUOcqM1fjrehjUkdrWio=",
+        "lastModified": 1766747458,
+        "narHash": "sha256-m63jjuo/ygo8ztkCziYh5OOIbTSXUDkKbqw3Vuqu4a4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3edc4a30ed3903fdf6f90c837f961fa6b49582d1",
+        "rev": "c633f572eded8c4f3c75b8010129854ed404a6ce",
         "type": "github"
       },
       "original": {
@@ -442,11 +442,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1766886304,
-        "narHash": "sha256-+I9MvwsgeYCueF1a4BoZ4UwGDJyaEaVi5UgEBCYl8zE=",
+        "lastModified": 1766832543,
+        "narHash": "sha256-997o+QF5S4+5EpEmn1dYBQtnJd2ZeM85NtGMtjZec+A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "7c3ffbcc59a9f6d980565a8160340ee63c587b15",
+        "rev": "e4faf24297c2d89705d150336f5dccd2ad2c8afe",
         "type": "github"
       },
       "original": {

--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -56,7 +56,10 @@ in
   systemd.user.services.cliproxyapi = lib.mkIf pkgs.stdenv.isLinux {
     Unit = {
       Description = "CLI Proxy API server";
-      After = [ "network.target" "docker.service" ];
+      After = [
+        "network.target"
+        "docker.service"
+      ];
       Wants = [ "docker.service" ];
     };
     Service = {

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 CONFIG_DIR="$HOME/.cli-proxy-api"
 TEMPLATE="$CONFIG_DIR/config.template.yaml"
 CONFIG="$CONFIG_DIR/config.yaml"
+AUTH_DIR="$CONFIG_DIR/auths"
 # Use explicit path since $HOME may not be set correctly in launchd context
 ENV_FILE="${HOME:-/Users/shunkakinoki}/dotfiles/.env"
 
@@ -27,11 +28,9 @@ export OBJECTSTORE_SECRET_KEY="${OBJECTSTORE_SECRET_KEY:-${AWS_SECRET_ACCESS_KEY
 
 # CRITICAL: Pull auth files from R2 before starting cliproxyapi
 # This ensures all auth files (including codex-*) are available when the service starts
-# CLIProxyAPI expects auth files in {auth-dir}/auths/ so we sync directly there
-CLIPROXY_AUTH_DIR="$CONFIG_DIR/auths"
 if [ -n "${OBJECTSTORE_ENDPOINT:-}" ] && [ -n "${OBJECTSTORE_ACCESS_KEY:-}" ]; then
   echo "Syncing auth files from R2..." >&2
-  mkdir -p "$CLIPROXY_AUTH_DIR"
+  mkdir -p "$AUTH_DIR"
 
   # Pull from both active and backup locations to ensure we have all files
   AWS_ACCESS_KEY_ID="${OBJECTSTORE_ACCESS_KEY}" \
@@ -40,7 +39,7 @@ if [ -n "${OBJECTSTORE_ENDPOINT:-}" ] && [ -n "${OBJECTSTORE_ACCESS_KEY:-}" ]; t
     --endpoint-url="${OBJECTSTORE_ENDPOINT}" \
     --no-progress \
     "s3://cliproxyapi/auths/" \
-    "$CLIPROXY_AUTH_DIR/" 2>/dev/null && echo "✅ Pulled from R2 auths/" >&2 || true
+    "$AUTH_DIR/" 2>/dev/null && echo "✅ Pulled from R2 auths/" >&2 || true
 
   AWS_ACCESS_KEY_ID="${OBJECTSTORE_ACCESS_KEY}" \
     AWS_SECRET_ACCESS_KEY="${OBJECTSTORE_SECRET_KEY}" \
@@ -48,12 +47,12 @@ if [ -n "${OBJECTSTORE_ENDPOINT:-}" ] && [ -n "${OBJECTSTORE_ACCESS_KEY:-}" ]; t
     --endpoint-url="${OBJECTSTORE_ENDPOINT}" \
     --no-progress \
     "s3://cliproxyapi/backup/auths/" \
-    "$CLIPROXY_AUTH_DIR/" 2>/dev/null && echo "✅ Pulled from R2 backup/auths/" >&2 || true
+    "$AUTH_DIR/" 2>/dev/null && echo "✅ Pulled from R2 backup/auths/" >&2 || true
 
-  # Bootstrap from git-tracked dotfiles if empty
-  if [ ! -d "$CLIPROXY_AUTH_DIR" ] || [ -z "$(ls -A "$CLIPROXY_AUTH_DIR" 2>/dev/null)" ]; then
+  # Bootstrap from git-tracked dotfiles if objectstore is empty
+  if [ ! -d "$AUTH_DIR" ] || [ -z "$(ls -A "$AUTH_DIR" 2>/dev/null)" ]; then
     if [ -d "$HOME/dotfiles/objectstore/auths" ] && [ -n "$(ls -A "$HOME/dotfiles/objectstore/auths" 2>/dev/null)" ]; then
-      @rsync@ -a "$HOME/dotfiles/objectstore/auths/" "$CLIPROXY_AUTH_DIR/"
+      @rsync@ -a "$HOME/dotfiles/objectstore/auths/" "$AUTH_DIR/"
       echo "✅ Bootstrapped from dotfiles (objectstore was empty)" >&2
     fi
   fi

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 CONFIG_DIR="$HOME/.cli-proxy-api"
 TEMPLATE="$CONFIG_DIR/config.template.yaml"
 CONFIG="$CONFIG_DIR/config.yaml"
-AUTH_DIR="$CONFIG_DIR/auths"
+AUTH_DIR="$CONFIG_DIR/objectstore/auths"
 # Use explicit path since $HOME may not be set correctly in launchd context
 ENV_FILE="${HOME:-/Users/shunkakinoki}/dotfiles/.env"
 

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -5,7 +5,6 @@ set -euo pipefail
 CONFIG_DIR="$HOME/.cli-proxy-api"
 TEMPLATE="$CONFIG_DIR/config.template.yaml"
 CONFIG="$CONFIG_DIR/config.yaml"
-AUTH_DIR="$CONFIG_DIR/objectstore/auths"
 # Use explicit path since $HOME may not be set correctly in launchd context
 ENV_FILE="${HOME:-/Users/shunkakinoki}/dotfiles/.env"
 
@@ -58,10 +57,6 @@ if [ -n "${OBJECTSTORE_ENDPOINT:-}" ] && [ -n "${OBJECTSTORE_ACCESS_KEY:-}" ]; t
       echo "✅ Bootstrapped from dotfiles (objectstore was empty)" >&2
     fi
   fi
-
-  # Also keep objectstore/auths/ in sync for legacy compatibility
-  mkdir -p "$AUTH_DIR"
-  @rsync@ -a "$CLIPROXY_AUTH_DIR/" "$AUTH_DIR/"
 else
   echo "⚠️  Skipping auth sync: OBJECTSTORE credentials not set" >&2
 fi

--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -8,6 +8,7 @@ let
   brewUpgrader = import ./brew-upgrader { inherit pkgs; };
   cliproxyapi = import ./cliproxyapi { inherit pkgs; };
   codeSyncer = import ./code-syncer { inherit pkgs; };
+  docker = import ./docker { inherit config pkgs; };
   dotfilesUpdater = import ./dotfiles-updater { inherit pkgs; };
   neversslKeepalive = import ./neverssl-keepalive { inherit pkgs; };
   ollama = import ./ollama { inherit pkgs; };
@@ -19,6 +20,7 @@ in
   brewUpgrader
   cliproxyapi
   codeSyncer
+  docker
   dotfilesUpdater
   neversslKeepalive
   ollama

--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -8,7 +8,7 @@ let
   brewUpgrader = import ./brew-upgrader { inherit pkgs; };
   cliproxyapi = import ./cliproxyapi { inherit pkgs; };
   codeSyncer = import ./code-syncer { inherit pkgs; };
-  docker = import ./docker { inherit config pkgs; };
+  docker = import ./docker { inherit lib pkgs; };
   dotfilesUpdater = import ./dotfiles-updater { inherit pkgs; };
   neversslKeepalive = import ./neverssl-keepalive { inherit pkgs; };
   ollama = import ./ollama { inherit pkgs; };

--- a/home-manager/services/docker/default.nix
+++ b/home-manager/services/docker/default.nix
@@ -1,7 +1,5 @@
-{ config, pkgs, ... }:
+{ pkgs, lib, ... }:
 let
-  inherit (pkgs) lib;
-
   # Systemd service file for Docker daemon
   dockerServiceFile = pkgs.writeText "docker.service" ''
     [Unit]
@@ -63,18 +61,4 @@ in
       exec ${setupDockerScript}
     '')
   ];
-
-  # Check docker availability on activation
-  home.activation.checkDocker = lib.mkIf pkgs.stdenv.isLinux (
-    config.lib.dag.entryAfter [ "writeBoundary" ] ''
-      if ! ${pkgs.systemd}/bin/systemctl is-active --quiet docker 2>/dev/null; then
-        if [ -t 0 ]; then
-          echo ""
-          echo "⚠️  Docker daemon is not running."
-          echo "   Run 'docker-setup' to configure system Docker."
-          echo ""
-        fi
-      fi
-    ''
-  );
 }

--- a/home-manager/services/docker/default.nix
+++ b/home-manager/services/docker/default.nix
@@ -1,0 +1,69 @@
+{ config, pkgs, ... }:
+let
+  inherit (pkgs) lib;
+
+  # Script to ensure user is in docker group and system docker is running
+  setupDockerScript = pkgs.writeShellScript "setup-docker" ''
+    set -euo pipefail
+
+    # Check if docker group exists and user is in it
+    if ! groups | grep -q docker; then
+      echo "Adding user to docker group..."
+      sudo usermod -aG docker $USER
+      echo "✅ Added to docker group. Please log out and back in, or run: newgrp docker"
+    fi
+
+    # Check if system docker service exists and is running
+    if ! systemctl is-active --quiet docker 2>/dev/null; then
+      echo "Starting Docker daemon..."
+      if [ ! -f /etc/systemd/system/docker.service ]; then
+        echo "Installing Docker systemd service..."
+        sudo tee /etc/systemd/system/docker.service > /dev/null << 'EOF'
+[Unit]
+Description=Docker Application Container Engine
+Documentation=https://docs.docker.com
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=notify
+ExecStart=${pkgs.docker}/bin/dockerd
+ExecReload=/bin/kill -s HUP $MAINPID
+Restart=always
+RestartSec=10s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+        sudo systemctl daemon-reload
+        sudo systemctl enable docker
+      fi
+      sudo systemctl start docker
+      echo "✅ Docker daemon started"
+    else
+      echo "✅ Docker daemon is already running"
+    fi
+  '';
+in
+{
+  # Provide setup script for system Docker
+  home.packages = lib.mkIf pkgs.stdenv.isLinux [
+    (pkgs.writeShellScriptBin "docker-setup" ''
+      exec ${setupDockerScript}
+    '')
+  ];
+
+  # Check docker availability on activation
+  home.activation.checkDocker = lib.mkIf pkgs.stdenv.isLinux (
+    config.lib.dag.entryAfter [ "writeBoundary" ] ''
+      if ! systemctl is-active --quiet docker 2>/dev/null; then
+        if [ -t 0 ]; then
+          echo ""
+          echo "⚠️  Docker daemon is not running."
+          echo "   Run 'docker-setup' to configure system Docker."
+          echo ""
+        fi
+      fi
+    ''
+  );
+}

--- a/home-manager/services/docker/default.nix
+++ b/home-manager/services/docker/default.nix
@@ -2,43 +2,54 @@
 let
   inherit (pkgs) lib;
 
+  # Systemd service file for Docker daemon
+  dockerServiceFile = pkgs.writeText "docker.service" ''
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+
+    [Service]
+    Type=notify
+    ExecStart=${pkgs.docker}/bin/dockerd
+    ExecReload=${pkgs.coreutils}/bin/kill -s HUP $MAINPID
+    Restart=always
+    RestartSec=10s
+
+    [Install]
+    WantedBy=multi-user.target
+  '';
+
   # Script to ensure user is in docker group and system docker is running
   setupDockerScript = pkgs.writeShellScript "setup-docker" ''
     set -euo pipefail
 
+    # Define paths
+    GROUPS=${pkgs.shadow}/bin/groups
+    GREP=${pkgs.gnugrep}/bin/grep
+    USERMOD=${pkgs.shadow}/bin/usermod
+    SYSTEMCTL=${pkgs.systemd}/bin/systemctl
+    TEE=${pkgs.coreutils}/bin/tee
+    DOCKER_SERVICE_FILE=${dockerServiceFile}
+
     # Check if docker group exists and user is in it
-    if ! groups | grep -q docker; then
+    if ! $GROUPS | $GREP -q docker; then
       echo "Adding user to docker group..."
-      sudo usermod -aG docker $USER
+      sudo $USERMOD -aG docker $USER
       echo "✅ Added to docker group. Please log out and back in, or run: newgrp docker"
     fi
 
     # Check if system docker service exists and is running
-    if ! systemctl is-active --quiet docker 2>/dev/null; then
+    if ! $SYSTEMCTL is-active --quiet docker 2>/dev/null; then
       echo "Starting Docker daemon..."
       if [ ! -f /etc/systemd/system/docker.service ]; then
         echo "Installing Docker systemd service..."
-        sudo tee /etc/systemd/system/docker.service > /dev/null << 'EOF'
-[Unit]
-Description=Docker Application Container Engine
-Documentation=https://docs.docker.com
-After=network-online.target
-Wants=network-online.target
-
-[Service]
-Type=notify
-ExecStart=${pkgs.docker}/bin/dockerd
-ExecReload=/bin/kill -s HUP $MAINPID
-Restart=always
-RestartSec=10s
-
-[Install]
-WantedBy=multi-user.target
-EOF
-        sudo systemctl daemon-reload
-        sudo systemctl enable docker
+        sudo $TEE /etc/systemd/system/docker.service > /dev/null < "$DOCKER_SERVICE_FILE"
+        sudo $SYSTEMCTL daemon-reload
+        sudo $SYSTEMCTL enable docker
       fi
-      sudo systemctl start docker
+      sudo $SYSTEMCTL start docker
       echo "✅ Docker daemon started"
     else
       echo "✅ Docker daemon is already running"
@@ -56,7 +67,7 @@ in
   # Check docker availability on activation
   home.activation.checkDocker = lib.mkIf pkgs.stdenv.isLinux (
     config.lib.dag.entryAfter [ "writeBoundary" ] ''
-      if ! systemctl is-active --quiet docker 2>/dev/null; then
+      if ! ${pkgs.systemd}/bin/systemctl is-active --quiet docker 2>/dev/null; then
         if [ -t 0 ]; then
           echo ""
           echo "⚠️  Docker daemon is not running."

--- a/spec/cliproxyapi_spec.sh
+++ b/spec/cliproxyapi_spec.sh
@@ -90,8 +90,8 @@ The output should include '/usr/local/bin/cliproxyapi'
 End
 
 It 'shows error message when binary not found'
-When run bash -c "grep 'cliproxyapi binary not found' '$SCRIPT'"
-The output should include 'cliproxyapi binary not found'
+When run bash -c "grep 'cliproxyapi not found' '$SCRIPT'"
+The output should include 'cliproxyapi not found'
 End
 
 It 'suggests installation command in error message'


### PR DESCRIPTION
## Summary

- Adds Docker container support for running cliproxyapi on Linux systems
- Enables easier upgrades via Docker image updates
- Maintains Homebrew binary support for macOS
- Creates docker service module with setup utilities and daemon checks

## Changes

### cliproxyapi Service
- Modified start script to use Docker container on Linux (`eceasy/cli-proxy-api:latest`)
- Updated systemd service to depend on `docker.service` with proper ordering
- Added docker group permission wrapper for service execution
- Configured container with host networking and proper volume mounts

### Docker Module
- New `home-manager/services/docker/default.nix` module
- Provides `docker-setup` command for user group and daemon configuration
- Includes home activation check for Docker daemon status
- Auto-generates systemd service if needed

### Configuration Updates
- Updated `flake.lock` with latest NUR commits
- Added docker module to services imports

## Implementation Details

The Docker implementation uses:
- Host network mode for optimal performance
- Volume mounts for config (`/CLIProxyAPI/config.yaml`), state (`~/.cli-proxy-api`), and logs
- Proper ulimit configuration for file descriptors (65536)
- Container auto-removal and restart on failure via systemd

## Test Plan

- [ ] Verify Docker daemon setup script works correctly
- [ ] Test cliproxyapi service starts successfully with Docker on Linux
- [ ] Confirm config and logs are properly persisted
- [ ] Verify macOS compatibility with Homebrew binary (no regression)
- [ ] Check systemd service dependencies and ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces Docker-based runtime for `cliproxyapi` on Linux and a helper module to ensure Docker availability.
> 
> - cliproxyapi: Linux `start.sh` now `docker run`'s `eceasy/cli-proxy-api:latest` with host networking, ulimit, and config/state/logs mounts; systemd adds `After`/`Wants` on `docker.service`, PATH includes `docker`, and `ExecStart` uses an `sg docker` wrapper
> - New `home-manager/services/docker`: provides `docker-setup` to add user to `docker` group, bootstrap/enable `docker.service` if missing, and a Home Manager activation check warning when the daemon isn’t running
> - Wiring: includes new `docker` module in services list
> - Misc: bumps NUR in `flake.lock`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24f1aff1d103c379a39d030b6cbce1a3b9a4c678. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->















<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run cliproxyapi via Docker on Linux to simplify upgrades and avoid manual binary installs. Also fixes auth sync to ~/.cli-proxy-api/auths; macOS still uses the Homebrew binary.

- **New Features**
  - Linux: start.sh runs eceasy/cli-proxy-api:latest with host networking, config/state/log mounts, and nofile ulimit 65536.
  - Systemd user service now After/Wants docker.service and runs via a docker group wrapper.
  - New Docker module: docker-setup command adds the user to the docker group, installs/enables the Docker systemd unit if missing, and starts the daemon.
  - Keeps macOS path: uses the Homebrew cliproxyapi binary.

- **Migration**
  - Linux: run docker-setup, log out/in (or run newgrp docker), then restart the cliproxyapi service.
  - Ensure config.yaml exists; logs are under ~/.cli-proxy-api/logs.

<sup>Written for commit 4137f8081ca5593f49c0dc2f562743ac5775b075. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->















