### PR TITLE
feat(cliproxyapi): enable api-keys authentication on Linux only

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -10,19 +10,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 jobs:
-  shellspec:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run ShellSpec Tests (Dev Shell)
-        run: make shell-test-dev
-  shellcheck:
+  shell-lint:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -34,11 +22,23 @@ jobs:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run ShellCheck (Dev Shell)
         run: make shell-check-dev
+  shell-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run ShellSpec Tests (Dev Shell)
+        run: make shell-test-dev
   shell-check:
     if: always()
     needs:
-      - shellspec
-      - shellcheck
+      - shell-lint
+      - shell-test
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:

--- a/config/cliproxyapi/config.yaml
+++ b/config/cliproxyapi/config.yaml
@@ -15,7 +15,7 @@ remote-management:
 auth-dir: "~/.cli-proxy-api"
 # API keys for client authentication (optional - leave commented for open access)
 # api-keys:
-#   - "your-api-key"
+#   - "__CLIPROXY_API_KEY__"
 
 # Enable debug logging
 debug: true

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -68,6 +68,15 @@ if [ -f "$TEMPLATE" ]; then
     -e "s|__ZAI_API_KEY__|${ZAI_API_KEY:-}|g" \
     -e "s|__AMP_UPSTREAM_API_KEY__|${AMP_UPSTREAM_API_KEY:-}|g" \
     "$TEMPLATE" >"$CONFIG"
+
+  # Linux: uncomment and enable api-keys for client authentication
+  # macOS: leave api-keys commented for open access
+  if [ "$(uname)" = "Linux" ]; then
+    @sed@ -i \
+      -e "s|^# api-keys:|api-keys:|" \
+      -e "s|^#   - \"__CLIPROXY_API_KEY__\"|  - \"${CLIPROXY_API_KEY:-}\"|" \
+      "$CONFIG"
+  fi
   # Also copy to objectstore config location (cliproxyapi uses this for persistence)
   mkdir -p "$CONFIG_DIR/objectstore/config"
   cp "$CONFIG" "$CONFIG_DIR/objectstore/config/config.yaml"


### PR DESCRIPTION
## Changes
- Add platform-specific api-keys configuration in cliproxyapi start.sh
- Linux: Uncomment and enable api-keys section with `CLIPROXY_API_KEY` substitution
- macOS: Keep api-keys commented for open access
- Update config.yaml template to use `__CLIPROXY_API_KEY__` placeholder

## Technical Details
- Added conditional sed processing in start.sh that runs only on Linux (`uname = Linux`)
- The sed command uncomments the `# api-keys:` and `#   - "__CLIPROXY_API_KEY__"` lines
- Substitutes the placeholder with the `CLIPROXY_API_KEY` environment variable

## Testing
- Linux: api-keys section will be active in generated config.yaml
- macOS: api-keys section remains commented (open access)

🤖 Generated with Claude Code by claude-opus-4-5-20250101

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces platform-specific client authentication for CLIProxyAPI.
> 
> - Adds Linux-only `sed` step in `start.sh` to uncomment `api-keys` and substitute `CLIPROXY_API_KEY` into the generated `config.yaml`
> - Updates `config/cliproxyapi/config.yaml` template to include `"__CLIPROXY_API_KEY__"` placeholder under commented `api-keys`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0b61b8403a4f57c7de3422ca7a4334781fdff23. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable API key authentication on Linux by uncommenting the api-keys section and substituting CLIPROXY_API_KEY in the generated config.yaml. On macOS, api-keys remain commented for open access.

- **Migration**
  - On Linux, set CLIPROXY_API_KEY before starting cliproxyapi.

<sup>Written for commit fceb6816612a90d2f7d54ef2fd27e0a7d4c159d8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







