### PR TITLE
Add CLIProxyAPI models and update naming for clarity

### DIFF
--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -26,28 +26,28 @@
 			},
 			"models": {
 				"gemini-3-pro-preview": {
-					"name": "Gemini 3.0 Pro (via CLIProxy)"
+					"name": "Gemini 3.0 Pro (via shunkakinoki's CLIProxy)"
 				},
 				"gpt-5.1": {
-					"name": "GPT-5.1 (via CLIProxy)"
+					"name": "GPT-5.1 (via shunkakinoki's CLIProxy)"
 				},
 				"gpt-5.1-codex": {
-					"name": "GPT-5.1 Codex (via CLIProxy)"
+					"name": "GPT-5.1 Codex (via shunkakinoki's CLIProxy)"
 				},
 				"gpt-5.1-codex-max": {
-					"name": "GPT-5.1 Codex Max (via CLIProxy)"
+					"name": "GPT-5.1 Codex Max (via shunkakinoki's CLIProxy)"
 				},
 				"claude-opus-4-5-20251101": {
-					"name": "Claude Opus 4.5 (via CLIProxy)"
+					"name": "Claude Opus 4.5 (via shunkakinoki's CLIProxy)"
 				},
 				"claude-haiku-4-5-20251001": {
-					"name": "Claude Haiku 4.5 (via CLIProxy)"
+					"name": "Claude Haiku 4.5 (via shunkakinoki's CLIProxy)"
 				},
 				"z-ai/glm-4.6": {
-					"name": "GLM-4.6 (via CLIProxy)"
+					"name": "GLM-4.6 (via shunkakinoki's CLIProxy)"
 				},
 				"z-ai/glm-4.7": {
-					"name": "GLM-4.7 (via CLIProxy)"
+					"name": "GLM-4.7 (via shunkakinoki's CLIProxy)"
 				}
 			}
 		},

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -17,6 +17,40 @@
 		}
 	},
 	"provider": {
+		"shunkakinoki": {
+			"npm": "@ai-sdk/openai-compatible",
+			"name": "CLIProxyAPI (remote)",
+			"options": {
+				"baseURL": "https://cliproxy.shunkakinoki.com/v1",
+				"apiKey": "{env:CLIPROXY_API_KEY}"
+			},
+			"models": {
+				"gemini-3-pro-preview": {
+					"name": "Gemini 3.0 Pro (via CLIProxy)"
+				},
+				"gpt-5.1": {
+					"name": "GPT-5.1 (via CLIProxy)"
+				},
+				"gpt-5.1-codex": {
+					"name": "GPT-5.1 Codex (via CLIProxy)"
+				},
+				"gpt-5.1-codex-max": {
+					"name": "GPT-5.1 Codex Max (via CLIProxy)"
+				},
+				"claude-opus-4-5-20251101": {
+					"name": "Claude Opus 4.5 (via CLIProxy)"
+				},
+				"claude-haiku-4-5-20251001": {
+					"name": "Claude Haiku 4.5 (via CLIProxy)"
+				},
+				"z-ai/glm-4.6": {
+					"name": "GLM-4.6 (via CLIProxy)"
+				},
+				"z-ai/glm-4.7": {
+					"name": "GLM-4.7 (via CLIProxy)"
+				}
+			}
+		},
 		"cliproxyapi": {
 			"npm": "@ai-sdk/openai-compatible",
 			"name": "CLIProxyAPI (local)",


### PR DESCRIPTION
Introduce remote CLIProxyAPI models and configuration for improved functionality. Update model names to include 'shunkakinoki' for better clarity and identification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a remote CLIProxyAPI provider (shunkakinoki) and registers Gemini, GPT-5.1, Claude 4.5, and GLM models. Updates model display names to show they run via shunkakinoki’s CLIProxy.

- New Features
  - New provider "shunkakinoki" at https://cliproxy.shunkakinoki.com/v1 using @ai-sdk/openai-compatible.
  - Enabled: gemini-3-pro-preview; gpt-5.1, gpt-5.1-codex, gpt-5.1-codex-max; claude-opus-4-5-20251101, claude-haiku-4-5-20251001; z-ai/glm-4.6, z-ai/glm-4.7.

- Migration
  - Set CLIPROXY_API_KEY in the environment to use the remote provider.

<sup>Written for commit 454501f54cf7fc19fd1a0fdd3cd447d31aa43cf0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

