### PR TITLE
fix(stream): disable streaming for GLM models in opencode configuration

### DIFF
--- a/config/cliproxyapi/config.yaml
+++ b/config/cliproxyapi/config.yaml
@@ -78,6 +78,7 @@ openai-compatibility:
       - api-key: "__OPENROUTER_API_KEY__"
     models:
       - name: "z-ai/glm-4.6"
+        alias: "glm-4.6"
   - name: "z-ai"
     base-url: "https://api.z.ai/api/coding/paas/v4"
     api-key-entries:

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -157,7 +157,7 @@
 		"openrouter": {
 			"models": {
 				"@preset/glm-4-6": {
-					"name": "GLM-4.6 (via OpenRouter)"
+					"name": "Preset GLM-4.6 (via OpenRouter)"
 				},
 				"deepseek/deepseek-chat-v3.1:free": {
 					"name": "DeepSeek Chat V3.1 (via OpenRouter)",

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -43,10 +43,16 @@
 					"name": "Claude Haiku 4.5 (via CLIProxyAPI)"
 				},
 				"z-ai/glm-4.6": {
-					"name": "GLM-4.6 (via OpenRouter and Z.AI Coding Plan)"
+					"name": "GLM-4.6 (via CLIProxyAPI)",
+					"options": {
+						"stream": false
+					}
 				},
 				"z-ai/glm-4.7": {
-					"name": "GLM-4.7 (via OpenRouter and Z.AI Coding Plan)"
+					"name": "GLM-4.7 (via CLIProxyAPI)",
+					"options": {
+						"stream": false
+					}
 				}
 			}
 		},

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -154,11 +154,22 @@
 				}
 			}
 		},
+		"openrouter-preset": {
+			"npm": "@ai-sdk/openai-compatible",
+			"name": "OpenRouter Presets",
+			"options": {
+				"baseURL": "https://openrouter.ai/api/v1",
+				"apiKey": "{env:OPENROUTER_API_KEY}"
+			},
+			"models": {
+				"glm-4-6": {
+					"id": "@preset/glm-4-6",
+					"name": "Preset GLM-4.6 (via OpenRouter)"
+				}
+			}
+		},
 		"openrouter": {
 			"models": {
-				"@preset/glm-4-6": {
-					"name": "Preset GLM-4.6 (via OpenRouter)"
-				},
 				"deepseek/deepseek-chat-v3.1:free": {
 					"name": "DeepSeek Chat V3.1 (via OpenRouter)",
 					"options": {

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -156,7 +156,11 @@
 		},
 		"openrouter": {
 			"models": {
+				"@preset/glm-4-6": {
+					"name": "GLM-4.6 (via OpenRouter)"
+				},
 				"deepseek/deepseek-chat-v3.1:free": {
+					"name": "DeepSeek Chat V3.1 (via OpenRouter)",
 					"options": {
 						"provider": {
 							"order": [
@@ -167,6 +171,7 @@
 					}
 				},
 				"moonshotai/kimi-k2": {
+					"name": "Kimi K2 (via OpenRouter)",
 					"options": {
 						"provider": {
 							"order": [
@@ -177,6 +182,7 @@
 					}
 				},
 				"moonshotai/kimi-k2:free": {
+					"name": "Kimi K2 Free (via OpenRouter)",
 					"options": {
 						"provider": {
 							"order": [
@@ -187,6 +193,7 @@
 					}
 				},
 				"openai/gpt-oss-120b:free": {
+					"name": "GPT-OSS 120B Free (via OpenRouter)",
 					"options": {
 						"provider": {
 							"order": [
@@ -197,6 +204,7 @@
 					}
 				},
 				"qwen/qwen3-coder:free": {
+					"name": "Qwen3 Coder Free (via OpenRouter)",
 					"options": {
 						"provider": {
 							"order": [

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -163,6 +163,9 @@
 					"name": "DeepSeek Chat V3.1 (via OpenRouter)",
 					"options": {
 						"provider": {
+							"order": [
+								"open-inference"
+							],
 							"allow_fallbacks": false
 						}
 					}

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -163,9 +163,6 @@
 					"name": "DeepSeek Chat V3.1 (via OpenRouter)",
 					"options": {
 						"provider": {
-							"order": [
-								"baseten"
-							],
 							"allow_fallbacks": false
 						}
 					}
@@ -175,7 +172,7 @@
 					"options": {
 						"provider": {
 							"order": [
-								"baseten"
+								"open-inference"
 							],
 							"allow_fallbacks": false
 						}
@@ -186,7 +183,7 @@
 					"options": {
 						"provider": {
 							"order": [
-								"baseten"
+								"open-inference"
 							],
 							"allow_fallbacks": false
 						}
@@ -197,7 +194,7 @@
 					"options": {
 						"provider": {
 							"order": [
-								"baseten"
+								"open-inference"
 							],
 							"allow_fallbacks": false
 						}
@@ -208,7 +205,7 @@
 					"options": {
 						"provider": {
 							"order": [
-								"baseten"
+								"open-inference"
 							],
 							"allow_fallbacks": false
 						}


### PR DESCRIPTION
## Summary

- **Add alias for glm-4.6 model** in cliproxyapi configuration for better identification
- **Disable streaming** for GLM-4.6 and GLM-4.7 models in opencode configuration to prevent parsing issues
- **Update model names** to reflect direct CLIProxyAPI usage instead of OpenRouter

This fixes streaming issues with GLM models that were causing parsing problems in the OpenCode AI assistant.

## Files Changed

- `config/cliproxyapi/config.yaml`: Added alias for glm-4.6 model
- `config/opencode/opencode.jsonc`: Disabled streaming for GLM models and updated naming



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable streaming for GLM-4.6 and GLM-4.7 to stop parsing errors in OpenCode. Also update model naming to use CLIProxyAPI, add a glm-4.6 alias, and add OpenRouter presets with provider updates.

- **Bug Fixes**
  - Disable stream: false for z-ai/glm-4.6 and z-ai/glm-4.7 in opencode.jsonc to prevent parsing issues.

- **Refactors**
  - Rename models to "via CLIProxyAPI" in OpenCode config.
  - Add alias "glm-4.6" in cliproxyapi config.
  - Add OpenRouter preset for GLM-4.6 and set provider order to "open-inference" across OpenRouter models.

<sup>Written for commit 434e36fcf6ecaf9267bbeb0f9d599cb1fa1362fc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



