### PR TITLE
feat: add development container configuration with VSCode setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "Dotfiles Development",
+  "image": "ghcr.io/shunkakinoki/dotfiles:latest",
+  "remoteUser": "runner",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "jnoortheen.nix-ide",
+        "mkhl.direnv",
+        "bmalehorn.shell-syntax",
+        "sumneko.lua",
+        "ms-azuretools.vscode-docker",
+        "tamasfe.even-better-toml"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "fish"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.devcontainer/devcontainer.json` for containerized development environment
- Configure VSCode with Nix, Direnv, Shell, Lua, Docker, and TOML extensions
- Set Fish as the default terminal profile for Linux containers
- Use the official dotfiles Docker image as base environment

This enables developers to quickly spin up a consistent development environment with all necessary tools and extensions pre-configured.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a VS Code Dev Container to make setup instant and consistent for all developers. Uses the dotfiles image, preinstalls key extensions, and sets fish as the default shell.

- **New Features**
  - Adds .devcontainer/devcontainer.json using ghcr.io/shunkakinoki/dotfiles:latest and remoteUser runner.
  - Preinstalls VS Code extensions: nix-ide, direnv, shell syntax, Lua, Docker, TOML.
  - Sets terminal.integrated.defaultProfile.linux to fish.

<sup>Written for commit d6cdfd7d6fa10266af45052367429814506d498d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

