### PR TITLE
fix(kybers_function): remove unnecessary -t flag from tailscale ssh command

### DIFF
--- a/home-manager/programs/fish/functions/_kybers_function.fish
+++ b/home-manager/programs/fish/functions/_kybers_function.fish
@@ -1,3 +1,3 @@
 function _kybers_function --description "SSH to Kyber server via Tailscale with zellij"
-  tailscale ssh -t ubuntu@kyber zellij attach -c
+  tailscale ssh ubuntu@kyber zellij attach -c
 end

--- a/home-manager/programs/fish/functions/_kybers_function.fish
+++ b/home-manager/programs/fish/functions/_kybers_function.fish
@@ -1,3 +1,3 @@
 function _kybers_function --description "SSH to Kyber server via Tailscale with zellij"
-  tailscale ssh ubuntu@kyber zellij attach -c
+  ssh -t ubuntu@(tailscale ip -4 kyber) "zellij attach main -c"
 end


### PR DESCRIPTION
## Summary
- Remove the unnecessary `-t` flag from the tailscale SSH command in the kybers function
- Update the SSH command to use `ssh -t` with the Tailscale IP address for proper terminal allocation
- This fixes the SSH connection to properly attach to the zellij session with correct terminal handling

## Changes
- Modified `home-manager/programs/fish/functions/_kybers_function.fish` to use standard SSH with Tailscale IP instead of tailscale SSH command



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace tailscale ssh with standard ssh -t to the dynamic Tailscale IPv4 address and attach to the zellij main session. This fixes terminal handling and restores a reliable SSH connection to Kyber.

<sup>Written for commit 97c90b538cd3fa18b1fbca10ba149f42b8bde445. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



