### PR TITLE
fix(dotfiles-updater): skip flake update during automated updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,8 +285,8 @@ nix-flake-check: ## Check Nix flake configuration.
 .PHONY: nix-flake-update
 nix-flake-update: nix-connect ## Update flake.lock file.
 	@echo "♻️ Refreshing flake.lock file..."
-	@if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \
-		echo "Bypassing flake update in CI/Docker"; \
+	@if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ] || [ "$$AUTOMATED_UPDATE" = "true" ]; then \
+		echo "Bypassing flake update in CI/Docker/automated update"; \
 	else \
 		$(NIX_EXEC) flake update $(NIX_FLAGS); \
 	fi


### PR DESCRIPTION
## Summary
- Skip `nix flake update` when `AUTOMATED_UPDATE=true` is set
- Prevents `flake.lock` from being modified during automated dotfiles-updater runs
- Keeps git status clean after automated updates

## Test plan
- [ ] Verify dotfiles-updater service still runs successfully
- [ ] Confirm flake.lock is not modified after automated update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip nix flake update when AUTOMATED_UPDATE=true to avoid modifying flake.lock during automated dotfiles-updater runs. The Makefile now bypasses flake updates in CI, Docker, and automated updates, keeping git status clean.

<sup>Written for commit 9dc4f2bc19a27647a23dbf6e4b4e7005f00b1843. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

