### PR TITLE
fix(cliproxyapi): recover missing auth files from git-tracked dotfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -614,7 +614,9 @@ launchctl-brew-upgrader: ## Restart brew-upgrader launchd agent.
 .PHONY: launchctl-cliproxyapi
 launchctl-cliproxyapi: ## Restart cliproxyapi launchd agent.
 	@echo "🔄 Restarting cliproxyapi..."
-	@timeout 5 launchctl kickstart -k gui/$$(id -u)/org.nix-community.home.cliproxyapi || true
+	@launchctl unload ~/Library/LaunchAgents/org.nix-community.home.cliproxyapi.plist 2>/dev/null || true
+	@sleep 1
+	@launchctl load ~/Library/LaunchAgents/org.nix-community.home.cliproxyapi.plist
 	@echo "✅ cliproxyapi restarted"
 
 .PHONY: launchctl-code-syncer

--- a/home-manager/services/cliproxyapi/README.md
+++ b/home-manager/services/cliproxyapi/README.md
@@ -116,10 +116,20 @@ If auth files are lost locally, they are automatically recovered from:
 
 **Solution:**
 - Removed dotfiles from WatchPaths
-- Dotfiles is now **write-only** (except for bootstrap on service start)
+- Dotfiles is now **write-only** for output, but used as **read-only recovery source**
 - Only `objectstore/auths` and `ccs/auth` trigger sync events
 
-### 5. Object Storage Integration
+### 5. Automatic Recovery from Git
+
+**Problem Solved:** Files could be lost if deleted from R2 (e.g., by cliproxyapi internals or manual deletion).
+
+**Solution:**
+- Both `start.sh` and `backup-auth.sh` merge missing files from dotfiles
+- Uses `rsync --ignore-existing` to never overwrite newer files from R2
+- Git-tracked dotfiles acts as a third backup location that survives R2 deletions
+- Recovery is automatic and logged when files are restored
+
+### 6. Object Storage Integration
 
 When `OBJECTSTORE_ENDPOINT` is configured, cliproxyapi uses object-backed storage:
 - Auth files stored in `objectstore/auths/` subdirectory


### PR DESCRIPTION
## Changes
- Always merge missing auth files from dotfiles using `rsync --ignore-existing`
- Applied to both `start.sh` (on service start) and `backup-auth.sh` (on file changes)
- Documented the new automatic recovery feature in README

## Problem
Auth files could be lost if deleted from R2 (e.g., by cliproxyapi internals or manual deletion). The previous bootstrap logic only restored files when the local objectstore was completely empty, leaving partial losses unrecovered.

## Solution
- Use `rsync --ignore-existing` to merge missing files from git-tracked dotfiles
- Never overwrites newer files from R2 (only fills gaps)
- Git-tracked dotfiles now act as a reliable third backup location

## Testing
- Verified auth files are restored after manual R2 deletion
- Confirmed `cliproxyapi --claude-login` works after recovery

🤖 Generated with [Claude Code](https://claude.ai/code)





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically recover missing auth files from git-tracked dotfiles to prevent data loss after R2 deletions. Recovery runs on service start and during backup sync, and never overwrites newer files.

- **Bug Fixes**
  - Merge missing files from dotfiles with rsync --ignore-existing in start.sh and backup-auth.sh (macOS).
  - Log restored file count; use unload/load for launchctl restart to reload the plist; README documents the recovery flow.

<sup>Written for commit 19aad3618b3b081315f4dd3eefd6c3ec096aae5c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





