### PR TITLE
fix(makefile): use unload/load for all launchctl restarts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -608,39 +608,49 @@ launchctl: launchctl-brew-upgrader launchctl-cliproxyapi launchctl-code-syncer l
 .PHONY: launchctl-brew-upgrader
 launchctl-brew-upgrader: ## Restart brew-upgrader launchd agent.
 	@echo "🔄 Restarting brew-upgrader..."
-	@timeout 5 launchctl kickstart -k gui/$$(id -u)/org.nix-community.home.brew-upgrader || true
+	@launchctl unload ~/Library/LaunchAgents/org.nix-community.home.brew-upgrader.plist 2>/dev/null || true
+	@sleep 3
+	@launchctl load ~/Library/LaunchAgents/org.nix-community.home.brew-upgrader.plist
 	@echo "✅ brew-upgrader restarted"
 
 .PHONY: launchctl-cliproxyapi
 launchctl-cliproxyapi: ## Restart cliproxyapi launchd agent.
 	@echo "🔄 Restarting cliproxyapi..."
 	@launchctl unload ~/Library/LaunchAgents/org.nix-community.home.cliproxyapi.plist 2>/dev/null || true
-	@sleep 1
+	@sleep 3
 	@launchctl load ~/Library/LaunchAgents/org.nix-community.home.cliproxyapi.plist
 	@echo "✅ cliproxyapi restarted"
 
 .PHONY: launchctl-code-syncer
 launchctl-code-syncer: ## Restart code-syncer launchd agent.
 	@echo "🔄 Restarting code-syncer..."
-	@timeout 5 launchctl kickstart -k gui/$$(id -u)/org.nix-community.home.code-syncer || true
+	@launchctl unload ~/Library/LaunchAgents/org.nix-community.home.code-syncer.plist 2>/dev/null || true
+	@sleep 3
+	@launchctl load ~/Library/LaunchAgents/org.nix-community.home.code-syncer.plist
 	@echo "✅ code-syncer restarted"
 
 .PHONY: launchctl-dotfiles-updater
 launchctl-dotfiles-updater: ## Restart dotfiles-updater launchd agent.
 	@echo "🔄 Restarting dotfiles-updater..."
-	@timeout 5 launchctl kickstart -k gui/$$(id -u)/org.nix-community.home.dotfiles-updater || true
+	@launchctl unload ~/Library/LaunchAgents/org.nix-community.home.dotfiles-updater.plist 2>/dev/null || true
+	@sleep 3
+	@launchctl load ~/Library/LaunchAgents/org.nix-community.home.dotfiles-updater.plist
 	@echo "✅ dotfiles-updater restarted"
 
 .PHONY: launchctl-neverssl-keepalive
 launchctl-neverssl-keepalive: ## Restart neverssl-keepalive launchd agent.
 	@echo "🔄 Restarting neverssl-keepalive..."
-	@timeout 5 launchctl kickstart -k gui/$$(id -u)/org.nix-community.home.neverssl-keepalive || true
+	@launchctl unload ~/Library/LaunchAgents/org.nix-community.home.neverssl-keepalive.plist 2>/dev/null || true
+	@sleep 3
+	@launchctl load ~/Library/LaunchAgents/org.nix-community.home.neverssl-keepalive.plist
 	@echo "✅ neverssl-keepalive restarted"
 
 .PHONY: launchctl-ollama
 launchctl-ollama: ## Restart ollama launchd agent.
 	@echo "🔄 Restarting ollama..."
-	@timeout 5 launchctl kickstart -k gui/$$(id -u)/org.nix-community.home.ollama || true
+	@launchctl unload ~/Library/LaunchAgents/org.nix-community.home.ollama.plist 2>/dev/null || true
+	@sleep 3
+	@launchctl load ~/Library/LaunchAgents/org.nix-community.home.ollama.plist
 	@echo "✅ ollama restarted"
 
 ##@ Systemd Services (Linux)


### PR DESCRIPTION
## Changes
- Replace `launchctl kickstart -k` with `launchctl unload` + `launchctl load` for all 6 launchd agents
- Add 3 second sleep between unload and load for clean transition

## Problem
`kickstart -k` only restarts the running process but doesn't reload the plist file. After `make switch`, the plist file points to a new nix store path, but kickstart continues running the old script.

## Solution
Use `unload` followed by `load` to fully reload the plist file, ensuring services pick up new script paths after nix configuration changes.

## Affected Services
- brew-upgrader
- cliproxyapi  
- code-syncer
- dotfiles-updater
- neverssl-keepalive
- ollama

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Properly restarts all launchd agents by unloading and reloading their plists so services pick up new Nix store paths after make switch. Adds a 3-second pause between unload and load for a clean transition.

- **Bug Fixes**
  - Replace kickstart -k with unload + load in Makefile targets.
  - Applies to: brew-upgrader, cliproxyapi, code-syncer, dotfiles-updater, neverssl-keepalive, ollama.

<sup>Written for commit 57f71e0f18304daea9c4bf706cba6286344d665a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

