### PR TITLE
refactor(cliproxyapi): remove gitignored dotfiles auth sync logic

### DIFF
--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -49,29 +49,7 @@ if [ -n "${OBJECTSTORE_ENDPOINT:-}" ] && [ -n "${OBJECTSTORE_ACCESS_KEY:-}" ]; t
     "s3://cliproxyapi/backup/auths/" \
     "$AUTH_DIR/" 2>/dev/null && echo "✅ Pulled from R2 backup/auths/" >&2 || true
 
-  # macOS only: Always merge missing files from git-tracked dotfiles
-  # Uses --ignore-existing to never overwrite newer files from R2
-  # This ensures files deleted from R2 are recovered from git backup
-  # (Skipped on Linux to avoid redundant auth file copies)
-  if [ "$(uname)" = "Darwin" ]; then
-    DOTFILES_AUTH_DIR="$HOME/dotfiles/objectstore/auths"
-    if [ -d "$DOTFILES_AUTH_DIR" ] && [ -n "$(ls -A "$DOTFILES_AUTH_DIR" 2>/dev/null)" ]; then
-      # Count files before merge
-      before_count=$(find "$AUTH_DIR" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
-
-      # Merge missing files from dotfiles (never overwrite existing)
-      @rsync@ -a --ignore-existing "$DOTFILES_AUTH_DIR/" "$AUTH_DIR/"
-
-      # Count files after merge
-      after_count=$(find "$AUTH_DIR" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
-
-      if [ "$after_count" -gt "$before_count" ]; then
-        echo "✅ Restored $((after_count - before_count)) missing auth file(s) from dotfiles" >&2
-      fi
-    fi
-  fi
-
-  # CRITICAL: Always sync local auth files to R2 after merge
+  # CRITICAL: Always sync local auth files back to R2 after pulling
   # This ensures any files that exist locally but not in R2 get uploaded,
   # preventing "key does not exist" errors when cliproxyapi reads from object storage
   if [ -d "$AUTH_DIR" ] && [ -n "$(ls -A "$AUTH_DIR" 2>/dev/null)" ]; then


### PR DESCRIPTION
## Summary  
- Removed defunct dotfiles recovery/sync logic from `start.sh` and `backup-auth.sh`
- Simplified codebase by removing 48 lines of dead code
- objectstore/auths is gitignored, making git-based recovery impossible

## Background
PR #472 added bidirectional R2 sync to fix "key does not exist" errors. However, it also included dotfiles recovery logic that attempts to sync auth files to/from `~/dotfiles/objectstore/auths/`.

This directory is gitignored, so the recovery mechanism cannot work:
- Files in objectstore/auths won't persist in git
- Fresh clones won't have these files
- The sync is redundant since R2 backup is the source of truth

## Changes
- **start.sh**: Removed macOS-specific dotfiles merge logic (lines 52-72)
- **backup-auth.sh**: Removed dotfiles recovery and sync-back logic  
- **Result**: Cleaner, simpler code that relies solely on R2 for backup/recovery

## Why This is Safe
1. R2 backup already serves as the source of truth (pulled in STEP 1)
2. start.sh now syncs local -> R2 after pulling (added in #472)
3. Removing gitignored directory sync has no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed dotfiles-based auth recovery/sync from cliproxyapi scripts and now rely solely on R2 for backup and restore. This removes dead code and avoids a non-working path since objectstore/auths is gitignored.

- **Refactors**
  - start.sh: removed macOS dotfiles merge; still pulls from R2 and syncs local -> R2.
  - backup-auth.sh: removed dotfiles recovery and sync-back; kept ccs auth dir sync.
  - Reason: dotfiles/objectstore/auths is gitignored, so git recovery cannot persist.

<sup>Written for commit 28a0e42ad570e77dd2dcdf84a52b940386fd963d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

