### PR TITLE
fix(claude-config): revert model to default in settings.json and remove rsync from start script variables

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -227,6 +227,6 @@
     "type": "command",
     "command": "$HOME/.claude/statusline-git.sh"
   },
-  "model": "sonnet",
+  "model": "default",
   "defaultMode": "bypassPermissions"
 }

--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -8,7 +8,6 @@ let
   startScript = pkgs.replaceVars ./scripts/start.sh {
     aws = "${pkgs.awscli2}/bin/aws";
     sed = "${pkgs.gnused}/bin/sed";
-    rsync = "${pkgs.rsync}/bin/rsync";
   };
 
   # Wrapper script that runs start.sh with docker group permissions


### PR DESCRIPTION
## Summary
- Revert Claude model setting from "sonnet" back to "default" in settings.json
- Remove unused rsync variable from cliproxyapi start script template

## Changes
- Updated `config/claude/settings.json` to use default model instead of hardcoded sonnet
- Removed rsync path variable from `home-manager/services/cliproxyapi/default.nix` start script

These changes simplify the configuration and remove unnecessary dependencies.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the Claude model in config/claude/settings.json from "sonnet" back to "default" and remove the unused rsync variable from the cliproxyapi start script template. This standardizes model selection and drops an unnecessary dependency.

<sup>Written for commit ebc678fa8694b3cffb41c44ff6a3014eb843a5c4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

