### PR TITLE
feat(fish): add alias for 'jj' to shell aliases

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -8,6 +8,7 @@
   ./factory
   ./ghostty
   ./hammerspoon
+  ./jj
   ./k3s
   ./karabiner
   ./opencode

--- a/config/jj/config.toml
+++ b/config/jj/config.toml
@@ -1,0 +1,5 @@
+#:schema https://docs.jj-vcs.dev/latest/config-schema.json
+
+[user]
+name = "Shun Kakinoki"
+email = "shunkakinoki@gmail.com"

--- a/config/jj/default.nix
+++ b/config/jj/default.nix
@@ -1,0 +1,6 @@
+{ config, ... }:
+{
+  xdg.configFile."jj/config.toml" = {
+    source = config.lib.file.mkOutOfStoreSymlink ./config.toml;
+  };
+}

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -47,6 +47,7 @@
       cat = "bat";
       e = "nvim";
       g = "git";
+      j = "jj";
       lzd = "lazydocker";
       lzg = "lazygit";
       sag = "_ssh_add_github";

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -30,6 +30,7 @@
       "gnupg"
       "graphviz"
       "helm"
+      "jjui"
       "kurtosis-cli"
       "mas"
       "opencode"


### PR DESCRIPTION
## Summary
- Add 'j' alias for 'jj' (Jujutsu) command in Fish shell configuration
- Provides convenient short alias for the Jujutsu version control system



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 'j' alias for Jujutsu in Fish, configure jj (name/email), and install jjui to streamline version control.

<sup>Written for commit cafaafe4cfc1c59160086a6883fd1f5b562792ec. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



