### PR TITLE
feat(cliproxyapi): add auth backup recovery from dotfiles

### DIFF
--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -8,6 +8,7 @@ let
   startScript = pkgs.replaceVars ./scripts/start.sh {
     aws = "${pkgs.awscli2}/bin/aws";
     sed = "${pkgs.gnused}/bin/sed";
+    rsync = "${pkgs.rsync}/bin/rsync";
   };
 
   # Wrapper script that runs start.sh with docker group permissions

--- a/home-manager/services/cliproxyapi/scripts/backup-auth.sh
+++ b/home-manager/services/cliproxyapi/scripts/backup-auth.sh
@@ -9,6 +9,7 @@ BACKUP_DIR="s3://cliproxyapi/backup/auths/"
 MAIN_DIR="s3://cliproxyapi/auths/"
 AUTH_DIR="$CONFIG_DIR/objectstore/auths"
 CCS_AUTH_DIR="$HOME/.ccs/cliproxy/auth"
+DOTFILES_AUTH_DIR="$HOME/dotfiles/objectstore/auths"
 
 # STEP 1: Pull from R2 to local (captures files created by cliproxyapi directly in R2)
 mkdir -p "$AUTH_DIR"
@@ -35,6 +36,12 @@ fi
 if [ -d "$CCS_AUTH_DIR" ] && [ -n "$(ls -A "$CCS_AUTH_DIR" 2>/dev/null)" ]; then
   @rsync@ -a "$CCS_AUTH_DIR/" "$AUTH_DIR/"
   echo "✅ Synced from ccs auth dir to local cache" >&2
+fi
+
+# STEP 3: Recover missing files from git-tracked dotfiles backup (macOS only; Linux relies on R2)
+if [ "$(uname)" = "Darwin" ] && [ -d "$DOTFILES_AUTH_DIR" ] && [ -n "$(ls -A "$DOTFILES_AUTH_DIR" 2>/dev/null)" ]; then
+  @rsync@ -a --ignore-existing "$DOTFILES_AUTH_DIR/" "$AUTH_DIR/"
+  echo "✅ Recovered missing auths from dotfiles backup (macOS)" >&2
 fi
 
 # Check if auth directory has files


### PR DESCRIPTION
## Summary
- Add rsync dependency to cliproxyapi service for file recovery operations
- Implement automatic recovery of missing authentication files from git-tracked dotfiles backup
- Recovery only runs on macOS since Linux Docker containers rely on R2 storage
- Uses `--ignore-existing` flag to avoid overwriting newer files from other sources
- Helps prevent authentication issues after system resets or clean setups

## Changes
- **cliproxyapi service**: Added rsync to available binaries
- **backup-auth.sh**: Added recovery step from dotfiles backup after R2 and CCS sync
- **start.sh**: Added bootstrap recovery during service initialization

## Technical Details
The recovery mechanism checks for missing auth files in the git-tracked dotfiles directory (`~/dotfiles/objectstore/auths`) and restores them using rsync with `--ignore-existing` to preserve any newer files from R2 or CCS directories. This provides an additional layer of resilience for authentication file management.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add automatic recovery of missing auth files from a git-tracked dotfiles backup on macOS to prevent auth errors after resets. Includes rsync in the cliproxyapi service and bootstraps recovery in start.sh and backup-auth.sh using --ignore-existing to avoid overwriting newer files.

<sup>Written for commit 37c985112b6dfb32a0269e629554ae86e30395bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

