### PR TITLE
feat(launchd): add cliproxyapi-backup to launchctl target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -603,7 +603,7 @@ lua-check-hammerspoon-dev: ## Run the Hammerspoon Lua check inside the Nix dev s
 ##@ Launchd Services
 
 .PHONY: launchctl
-launchctl: launchctl-brew-upgrader launchctl-cliproxyapi launchctl-code-syncer launchctl-dotfiles-updater launchctl-neverssl-keepalive launchctl-ollama ## Restart all launchd agents.
+launchctl: launchctl-brew-upgrader launchctl-cliproxyapi launchctl-cliproxyapi-backup launchctl-code-syncer launchctl-dotfiles-updater launchctl-neverssl-keepalive launchctl-ollama ## Restart all launchd agents.
 
 .PHONY: launchctl-brew-upgrader
 launchctl-brew-upgrader: ## Restart brew-upgrader launchd agent.
@@ -620,6 +620,14 @@ launchctl-cliproxyapi: ## Restart cliproxyapi launchd agent.
 	@sleep 3
 	@launchctl load ~/Library/LaunchAgents/org.nix-community.home.cliproxyapi.plist
 	@echo "✅ cliproxyapi restarted"
+
+.PHONY: launchctl-cliproxyapi-backup
+launchctl-cliproxyapi-backup: ## Restart cliproxyapi backup launchd agent.
+	@echo "🔄 Restarting cliproxyapi-backup..."
+	@launchctl unload ~/Library/LaunchAgents/org.nix-community.home.cliproxyapi-backup.plist 2>/dev/null || true
+	@sleep 3
+	@launchctl load ~/Library/LaunchAgents/org.nix-community.home.cliproxyapi-backup.plist
+	@echo "✅ cliproxyapi-backup restarted"
 
 .PHONY: launchctl-code-syncer
 launchctl-code-syncer: ## Restart code-syncer launchd agent.


### PR DESCRIPTION
## Summary
- Add launchctl-cliproxyapi-backup target to Makefile
- Include cliproxyapi-backup in main launchctl target  
- Enables restarting cliproxyapi backup service alongside other agents

## Changes
- Added new `launchctl-cliproxyapi-backup` target to restart the cliproxyapi backup launchd agent
- Updated main `launchctl` target to include cliproxyapi-backup service
- Follows same pattern as other launchctl targets with proper error handling

## Testing
- Verified the new target properly unloads and loads the cliproxyapi-backup plist
- Confirmed the service restarts successfully alongside other agents

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new launchctl target for the cliproxyapi backup service and includes it in the main launchctl task, so it restarts alongside other agents.

- **New Features**
  - Added launchctl-cliproxyapi-backup target to unload/load the backup plist with safe error handling.
  - Included cliproxyapi-backup in the main launchctl target.

<sup>Written for commit 4026ce2848d70667be7bd35f527df5c350a4c29e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

