### PR TITLE
feat(homebrew): add repobar cask to homebrew configuration

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -84,6 +84,7 @@
       "ollama-app"
       "opencode-desktop"
       "raycast"
+      "repobar"
       "rescuetime"
       "screen-studio"
       "sf-symbols"


### PR DESCRIPTION
## Summary
- Add repobar cask to the homebrew configuration in nix-darwin/config/homebrew.nix
- This adds the repobar application to the managed Homebrew casks list

## Changes
- Added "repobar" to the casks list in homebrew.nix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the repobar cask to the nix-darwin Homebrew configuration so Repobar is installed and kept up to date on managed macOS machines.

This adds "repobar" to the casks list in nix-darwin/config/homebrew.nix.

<sup>Written for commit 4f82db38430bbb2e7df63bc580be376fb6cda553. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

