### PR TITLE
feat(cliproxyapi): ensure required auth files exist to prevent bootstrap failures

### DIFF
--- a/home-manager/services/cliproxyapi/scripts/backup-auth.sh
+++ b/home-manager/services/cliproxyapi/scripts/backup-auth.sh
@@ -10,7 +10,6 @@ MAIN_DIR="s3://cliproxyapi/auths/"
 AUTH_DIR="$CONFIG_DIR/objectstore/auths"
 CCS_AUTH_DIR="$HOME/.ccs/cliproxy/auth"
 DOTFILES_AUTH_DIR="$HOME/dotfiles/objectstore/auths"
-REQUIRED_FILES=("shunkakinoki@gmail.com-shunkakinoki.json")
 
 # STEP 1: Pull from R2 to local (captures files created by cliproxyapi directly in R2)
 mkdir -p "$AUTH_DIR"
@@ -44,22 +43,6 @@ if [ "$(uname)" = "Darwin" ] && [ -d "$DOTFILES_AUTH_DIR" ] && [ -n "$(ls -A "$D
   @rsync@ -a --ignore-existing "$DOTFILES_AUTH_DIR/" "$AUTH_DIR/"
   echo "✅ Recovered missing auths from dotfiles backup (macOS)" >&2
 fi
-
-# STEP 4: Ensure required auth files exist to avoid bootstrap failures
-for fname in "${REQUIRED_FILES[@]}"; do
-  target="$AUTH_DIR/$fname"
-  if [ ! -f "$target" ]; then
-    # Prefer dotfiles copy if present
-    if [ -f "$DOTFILES_AUTH_DIR/$fname" ]; then
-      @rsync@ -a "$DOTFILES_AUTH_DIR/$fname" "$target"
-      echo "✅ Restored missing $fname from dotfiles backup" >&2
-    else
-      echo "{}" >"$target"
-      chmod 600 "$target"
-      echo "⚠️  Created empty placeholder for $fname (no backup found)" >&2
-    fi
-  fi
-done
 
 # Check if auth directory has files
 if [ -d "$AUTH_DIR" ] && [ -n "$(ls -A "$AUTH_DIR" 2>/dev/null)" ]; then

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -7,6 +7,7 @@ TEMPLATE="$CONFIG_DIR/config.template.yaml"
 CONFIG="$CONFIG_DIR/config.yaml"
 AUTH_DIR="$CONFIG_DIR/objectstore/auths"
 DOTFILES_AUTH_DIR="$HOME/dotfiles/objectstore/auths"
+CCS_AUTH_DIR="$HOME/.ccs/cliproxy/auth"
 # Use explicit path since $HOME may not be set correctly in launchd context
 ENV_FILE="${HOME:-/Users/shunkakinoki}/dotfiles/.env"
 
@@ -54,6 +55,12 @@ if [ -n "${OBJECTSTORE_ENDPOINT:-}" ] && [ -n "${OBJECTSTORE_ACCESS_KEY:-}" ]; t
   if [ "$(uname)" = "Darwin" ] && [ -d "$DOTFILES_AUTH_DIR" ] && [ -n "$(ls -A "$DOTFILES_AUTH_DIR" 2>/dev/null)" ]; then
     @rsync@ -a --ignore-existing "$DOTFILES_AUTH_DIR/" "$AUTH_DIR/"
     echo "✅ Bootstrapped auth files from dotfiles backup (macOS)" >&2
+  fi
+
+  # Pull from CCS auth dir (if present) to pick up locally-created tokens
+  if [ -d "$CCS_AUTH_DIR" ] && [ -n "$(ls -A "$CCS_AUTH_DIR" 2>/dev/null)" ]; then
+    @rsync@ -a "$CCS_AUTH_DIR/" "$AUTH_DIR/"
+    echo "✅ Synced auths from CCS directory" >&2
   fi
 
   # CRITICAL: Always sync local auth files back to R2 after pulling


### PR DESCRIPTION
## Summary
- Add step to backup-auth.sh that ensures required auth files are present
- Restore missing files from dotfiles backup if available  
- Create empty placeholders when no backup exists to prevent bootstrap failures
- Prevents cliproxyapi service failures due to missing authentication files

## Changes
- Added REQUIRED_FILES array with default auth file
- Added Step 4 to check and restore missing required auth files
- Improved error handling and logging for missing file scenarios

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CCS auth directory sync on startup to include locally-created tokens and prevent bootstrap failures. Removes the required-files check from auth backup to simplify bootstrapping.

<sup>Written for commit ed3f7d589767e0e20119a81bc561779ab878ab38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

