### PR TITLE
chore(settings): configure Claude Code plugins

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -1,5 +1,13 @@
 {
   "cleanupPeriodDays": 99999,
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true,
+    "serena@claude-plugins-official": true,
+    "context7@claude-plugins-official": true,
+    "commit-commands@claude-plugins-official": true,
+    "feature-dev@claude-plugins-official": true,
+    "ralph-wiggum@claude-plugins-official": true
+  },
   "permissions": {
     "allow": [
       "Bash(bun:*)",

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -227,6 +227,5 @@
     "type": "command",
     "command": "$HOME/.claude/statusline-git.sh"
   },
-  "model": "default",
   "defaultMode": "bypassPermissions"
 }

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -1,12 +1,15 @@
 {
   "cleanupPeriodDays": 99999,
   "enabledPlugins": {
-    "frontend-design@claude-plugins-official": true,
-    "serena@claude-plugins-official": true,
-    "context7@claude-plugins-official": true,
     "commit-commands@claude-plugins-official": true,
+    "context7@claude-plugins-official": true,
+    "code-review@claude-plugins-official": true,
     "feature-dev@claude-plugins-official": true,
-    "ralph-wiggum@claude-plugins-official": true
+    "frontend-design@claude-plugins-official": true,
+    "pr-review-toolkit@claude-plugins-official": true,
+    "ralph-wiggum@claude-plugins-official": true,
+    "serena@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true
   },
   "permissions": {
     "allow": [


### PR DESCRIPTION
## Summary
- Add enabledPlugins configuration to Claude Code settings
- Enable 9 official plugins: commit-commands, context7, code-review, feature-dev, frontend-design, pr-review-toolkit, ralph-wiggum, serena, typescript-lsp
- Remove unused model configuration
- Reorder settings for better organization

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enabled nine official Claude Code plugins and cleaned up settings.json to simplify configuration and improve developer tooling.

- **New Features**
  - Added enabledPlugins and turned on: commit-commands, context7, code-review, feature-dev, frontend-design, pr-review-toolkit, ralph-wiggum, serena, typescript-lsp.

- **Refactors**
  - Removed the unused model config and reordered settings for better organization.

<sup>Written for commit e7db330c006e93fa0587831c3fea492f2f5ef432. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

