### PR TITLE
fix(cliproxyapi): enhance auth file sync with atomic staging

### DIFF
--- a/home-manager/services/cliproxyapi/README.md
+++ b/home-manager/services/cliproxyapi/README.md
@@ -46,7 +46,7 @@ R2 Storage (Cloudflare):
 2. Pull from R2 `backup/auths/` → staged temp dir (merge)
 3. Merge CCS auth dir (if present) → staged temp dir (union/overwrite newer)
 4. On macOS, merge `dotfiles/objectstore/auths/` (ignore-existing) → staged temp dir
-5. **Atomic swap:** replace `objectstore/auths/` with the staged dir to avoid partial reads
+5. **Atomic swap (non-empty only):** replace `objectstore/auths/` with the staged dir to avoid partial reads; if the staged dir is empty, keep the existing cache.
 6. If objectstore ends up empty, copy from `dotfiles/objectstore/auths/` (bootstrapping)
 
 cliproxyapi then reads directly from `objectstore/auths/` (no additional sync needed).

--- a/home-manager/services/cliproxyapi/README.md
+++ b/home-manager/services/cliproxyapi/README.md
@@ -44,9 +44,9 @@ R2 Storage (Cloudflare):
 
 1. Pull auth files from R2 `auths/` → staged temp dir
 2. Pull from R2 `backup/auths/` → staged temp dir (merge)
-3. Merge CCS auth dir (if present) → staged temp dir (union/overwrite newer)
-4. On macOS, merge `dotfiles/objectstore/auths/` (ignore-existing) → staged temp dir
-5. **Atomic swap (non-empty only):** replace `objectstore/auths/` with the staged dir to avoid partial reads; if the staged dir is empty, keep the existing cache.
+3. On macOS, merge `dotfiles/objectstore/auths/` (ignore-existing) → staged temp dir
+4. Merge CCS auth dir (if present) → staged temp dir (CCS takes precedence)
+5. **Atomic swap (two-phase, non-empty only):** replace `objectstore/auths/` with the staged dir using a safe two-phase swap to avoid partial reads; if the staged dir is empty, keep the existing cache.
 6. If objectstore ends up empty, copy from `dotfiles/objectstore/auths/` (bootstrapping)
 
 cliproxyapi then reads directly from `objectstore/auths/` (no additional sync needed).

--- a/home-manager/services/cliproxyapi/README.md
+++ b/home-manager/services/cliproxyapi/README.md
@@ -42,9 +42,12 @@ R2 Storage (Cloudflare):
 
 ### On Service Start (`start.sh`)
 
-1. Pull auth files from R2 `auths/` → `objectstore/auths/`
-2. Pull from R2 `backup/auths/` → `objectstore/auths/` (merge)
-3. **Bootstrap:** If objectstore is empty, copy from `dotfiles/objectstore/auths/`
+1. Pull auth files from R2 `auths/` → staged temp dir
+2. Pull from R2 `backup/auths/` → staged temp dir (merge)
+3. Merge CCS auth dir (if present) → staged temp dir (union/overwrite newer)
+4. On macOS, merge `dotfiles/objectstore/auths/` (ignore-existing) → staged temp dir
+5. **Atomic swap:** replace `objectstore/auths/` with the staged dir to avoid partial reads
+6. If objectstore ends up empty, copy from `dotfiles/objectstore/auths/` (bootstrapping)
 
 cliproxyapi then reads directly from `objectstore/auths/` (no additional sync needed).
 


### PR DESCRIPTION
## Summary
- Improves auth file synchronization process by using atomic staging to prevent partial reads
- Enhances merge logic to properly handle multiple auth sources (R2, CCS, dotfiles backup)
- Preserves existing auth cache when temporary directory is empty to avoid wiping auth tokens

## Changes
- Added temporary staging directory for auth file merging
- Implemented atomic swap operation to prevent race conditions
- Enhanced merge order: R2 → backup → CCS → dotfiles backup
- Added protection against empty auth cache scenarios
- Updated documentation to reflect new sync process

## Files Changed
- `home-manager/services/cliproxyapi/scripts/start.sh`: Enhanced sync logic
- `home-manager/services/cliproxyapi/README.md`: Updated documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make auth file sync atomic and safe. We stage merges from R2, backup, macOS dotfiles, then CCS, and use a two-phase swap only when the staged dir has files to prevent partial reads and token wipes; if the cache ends empty, we bootstrap from dotfiles.

- **Bug Fixes**
  - Clean temp dir before use and log warnings on R2 sync errors.

<sup>Written for commit cc8efb708a0fd03e6aee818c7baffb6dabf5f94b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

