### PR TITLE
fix(shell): set XDG_RUNTIME_DIR on Linux for consistent socket paths

### DIFF
--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -47,6 +47,11 @@
     '';
 
     profileExtra = ''
+      # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
+      if [ "$(uname)" = "Linux" ]; then
+          export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+      fi
+
       # Nix
       if [ -e ~/.nix-profile/etc/profile.d/nix.sh ]; then
         . ~/.nix-profile/etc/profile.d/nix.sh

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -11,6 +11,10 @@
       direnv hook fish | source
     '';
     loginShellInit = ''
+      # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
+      if test (uname) = "Linux"
+          set -gx XDG_RUNTIME_DIR /run/user/(id -u)
+      end
       fish_add_path -p ~/.local/bin
       fish_add_path -p ~/.bun/bin
       fish_add_path -p ~/.nix-profile/bin

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -18,6 +18,11 @@
     };
 
     initContent = ''
+      # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
+      if [ "$(uname)" = "Linux" ]; then
+          export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+      fi
+
       # Go configuration
       export GOPATH="$HOME/go"
 


### PR DESCRIPTION
## Summary
- Sets `XDG_RUNTIME_DIR` to `/run/user/<uid>/` on Linux for fish, bash, and zsh
- Ensures zellij and other socket-based applications always use the same socket directory
- Prevents duplicate server instances when connecting via different methods (e.g., Tailscale SSH vs regular SSH)

## Test plan
- [ ] Verify `echo $XDG_RUNTIME_DIR` returns `/run/user/1000` on Linux
- [ ] Verify zellij uses consistent socket path across sessions
- [ ] Verify no impact on macOS (variable should not be set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set XDG_RUNTIME_DIR to /run/user/<uid> on Linux in bash, zsh, and fish. This gives socket-based apps (like zellij) a stable path and prevents duplicate servers across different SSH/session types.

- **Migration**
  - Restart your shell or log out/in to load the variable.
  - Verify on Linux: echo $XDG_RUNTIME_DIR → /run/user/<uid>.
  - No changes on macOS.

<sup>Written for commit 6f63bfc2f8bc33f3f9de37e75a3d0bab67a88c64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

