### PR TITLE
feat(claude): add safety-net plugin from cc-marketplace

### DIFF
--- a/config/claude/default.nix
+++ b/config/claude/default.nix
@@ -24,7 +24,6 @@
     executable = true;
   };
 
-  # Custom plugin marketplaces (Claude Code will merge with built-in ones)
   home.file.".claude/plugins/known_marketplaces.json" = {
     source = ./known_marketplaces.json;
   };

--- a/config/claude/default.nix
+++ b/config/claude/default.nix
@@ -23,4 +23,9 @@
     source = ./statusline-git.sh;
     executable = true;
   };
+
+  # Custom plugin marketplaces (Claude Code will merge with built-in ones)
+  home.file.".claude/plugins/known_marketplaces.json" = {
+    source = ./known_marketplaces.json;
+  };
 }

--- a/config/claude/known_marketplaces.json
+++ b/config/claude/known_marketplaces.json
@@ -1,0 +1,26 @@
+{
+  "claude-code-plugins": {
+    "source": {
+      "source": "git",
+      "url": "https://github.com/anthropics/claude-code.git"
+    }
+  },
+  "claude-plugins-official": {
+    "source": {
+      "source": "github",
+      "repo": "anthropics/claude-plugins-official"
+    }
+  },
+  "anthropic-agent-skills": {
+    "source": {
+      "source": "github",
+      "repo": "anthropics/skills"
+    }
+  },
+  "cc-marketplace": {
+    "source": {
+      "source": "git",
+      "url": "https://github.com/kenryu42/cc-marketplace.git"
+    }
+  }
+}

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -9,7 +9,8 @@
     "pr-review-toolkit@claude-plugins-official": true,
     "ralph-wiggum@claude-plugins-official": true,
     "serena@claude-plugins-official": true,
-    "typescript-lsp@claude-plugins-official": true
+    "typescript-lsp@claude-plugins-official": true,
+    "safety-net@cc-marketplace": true
   },
   "permissions": {
     "allow": [


### PR DESCRIPTION
## Summary
- Add `safety-net@cc-marketplace` plugin to Claude Code configuration
- Add `known_marketplaces.json` to manage custom marketplace registry via Nix
- The safety-net plugin prevents destructive git and filesystem commands during development

## Test plan
- [ ] Run `make switch` to apply configuration
- [ ] Restart Claude Code to load the plugin
- [ ] Verify safety-net plugin is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the safety-net plugin in Claude Code to block destructive git and filesystem actions during development. Adds a Nix-managed custom marketplace registry to source the plugin from cc-marketplace.

- **New Features**
  - Enable safety-net@cc-marketplace in settings.json.
  - Add known_marketplaces.json and link it via default.nix to merge custom registries.

- **Migration**
  - Run make switch to apply changes.
  - Restart Claude Code to load the plugin.

<sup>Written for commit 2d5da2441373cdce8f16a64e588b5e46c8f2c125. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

