### PR TITLE
fix(shell): move XDG_RUNTIME_DIR to shellInit for non-login shell support

### DIFF
--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -33,7 +33,6 @@
 
     bashrcExtra = ''
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
-      # Must be in bashrcExtra (not just profileExtra) so it runs for non-login shells too
       if [ "$(uname)" = "Linux" ]; then
           export XDG_RUNTIME_DIR="/run/user/$(id -u)"
       fi

--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -32,6 +32,12 @@
     };
 
     bashrcExtra = ''
+      # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
+      # Must be in bashrcExtra (not just profileExtra) so it runs for non-login shells too
+      if [ "$(uname)" = "Linux" ]; then
+          export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+      fi
+
       # Go configuration
       export GOPATH="$HOME/go"
 
@@ -47,11 +53,6 @@
     '';
 
     profileExtra = ''
-      # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
-      if [ "$(uname)" = "Linux" ]; then
-          export XDG_RUNTIME_DIR="/run/user/$(id -u)"
-      fi
-
       # Nix
       if [ -e ~/.nix-profile/etc/profile.d/nix.sh ]; then
         . ~/.nix-profile/etc/profile.d/nix.sh

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -9,7 +9,6 @@
     enable = true;
     shellInit = ''
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
-      # Must be in shellInit (not loginShellInit) so it runs for `fish -c` commands too
       if test (uname) = "Linux"
           set -gx XDG_RUNTIME_DIR /run/user/(id -u)
       end

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -8,13 +8,14 @@
   programs.fish = {
     enable = true;
     shellInit = ''
-      direnv hook fish | source
-    '';
-    loginShellInit = ''
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
+      # Must be in shellInit (not loginShellInit) so it runs for `fish -c` commands too
       if test (uname) = "Linux"
           set -gx XDG_RUNTIME_DIR /run/user/(id -u)
       end
+      direnv hook fish | source
+    '';
+    loginShellInit = ''
       fish_add_path -p ~/.local/bin
       fish_add_path -p ~/.bun/bin
       fish_add_path -p ~/.nix-profile/bin


### PR DESCRIPTION
## Summary
- Move `XDG_RUNTIME_DIR` from `loginShellInit` to `shellInit` in fish config
- Move `XDG_RUNTIME_DIR` from `profileExtra` to `bashrcExtra` in bash config
- Zsh already had it in `initContent` which covers all cases

## Problem
When using `kybers` to SSH with zellij, duplicate "main" sessions were created because:
1. `kybers` runs `fish -c "zellij attach main -c"` which is a **non-login shell**
2. `loginShellInit` only runs for login shells, so `XDG_RUNTIME_DIR` wasn't set
3. Zellij fell back to `/tmp/zellij-1000/` instead of `/run/user/1000/zellij/`
4. This caused a second zellij server to spawn with a duplicate "main" session

## Fix
Move `XDG_RUNTIME_DIR` to `shellInit`/`bashrcExtra` which runs for **all** shell invocations including `fish -c "..."` commands.

## Test plan
- [x] Verified `fish -c 'echo $XDG_RUNTIME_DIR'` now returns `/run/user/1000`
- [x] Verified only one "main" zellij session exists after fix
- [ ] Test `kybers` from remote machine attaches to existing session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set XDG_RUNTIME_DIR in non-login shell init for fish and bash. This ensures zellij uses the correct runtime dir and prevents duplicate "main" sessions when attaching via kybers.

- **Bug Fixes**
  - Move XDG_RUNTIME_DIR export to fish shellInit and bash bashrcExtra so non-login shells inherit it.
  - Ensure zellij uses /run/user/$UID/zellij instead of /tmp/zellij-$UID in non-login shells.

<sup>Written for commit 10521896b644de24570dbe908ab67e1f15c3601c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

