### PR TITLE
feat(shell): replace kybers with dedicated kyberd/kyberm and zdo/zmo functions

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -145,7 +145,6 @@
         "_kyber_function"
         "_kyberd_function"
         "_kyberm_function"
-        "_kybers_function"
         "_zdo_function"
         "_zmo_function"
         "_ssh_add_github"

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -66,7 +66,10 @@
       grco = "_grco_function";
       grcr = "_grcr_function";
       kyber = "_kyber_function";
-      kybers = "_kybers_function";
+      kyberd = "_kyberd_function";
+      kyberm = "_kyberm_function";
+      zdo = "_zdo_function";
+      zmo = "_zmo_function";
       fch = "_fzf_cmd_history --allow-execute";
       fdp = "_fzf_directory_picker --allow-cd --prompt-name Projects ~/";
       ffp = "_fzf_file_picker --allow-open-in-editor --prompt-name Files";
@@ -140,7 +143,11 @@
         "_grcr_function"
         "_hm_load_env_file"
         "_kyber_function"
+        "_kyberd_function"
+        "_kyberm_function"
         "_kybers_function"
+        "_zdo_function"
+        "_zmo_function"
         "_ssh_add_github"
         "fish_user_key_bindings"
       ]

--- a/home-manager/programs/fish/functions/_kyberd_function.fish
+++ b/home-manager/programs/fish/functions/_kyberd_function.fish
@@ -1,0 +1,3 @@
+function _kyberd_function --description "SSH to Kyber with zellij desktop session"
+  ssh -t ubuntu@(tailscale ip -4 kyber) "zellij attach desktop -c"
+end

--- a/home-manager/programs/fish/functions/_kyberm_function.fish
+++ b/home-manager/programs/fish/functions/_kyberm_function.fish
@@ -1,0 +1,3 @@
+function _kyberm_function --description "SSH to Kyber with zellij mobile session"
+  ssh -t ubuntu@(tailscale ip -4 kyber) "zellij attach mobile -c"
+end

--- a/home-manager/programs/fish/functions/_kybers_function.fish
+++ b/home-manager/programs/fish/functions/_kybers_function.fish
@@ -1,3 +1,0 @@
-function _kybers_function --description "SSH to Kyber server via Tailscale with zellij"
-  ssh -t ubuntu@(tailscale ip -4 kyber) "zellij attach main -c"
-end

--- a/home-manager/programs/fish/functions/_zdo_function.fish
+++ b/home-manager/programs/fish/functions/_zdo_function.fish
@@ -1,0 +1,3 @@
+function _zdo_function --description "Attach to zellij desktop session"
+  zellij attach desktop -c
+end

--- a/home-manager/programs/fish/functions/_zmo_function.fish
+++ b/home-manager/programs/fish/functions/_zmo_function.fish
@@ -1,0 +1,3 @@
+function _zmo_function --description "Attach to zellij mobile session"
+  zellij attach mobile -c
+end


### PR DESCRIPTION
## Summary
- Replace single `kybers` function with dedicated `kyberd` and `kyberm` functions for desktop and mobile zellij sessions
- Add `zdo` and `zmo` functions for local zellij session management
- Remove deprecated `kybers_function.fish`

## Changes
- `kyberd`: SSH to Kyber server and attach to desktop zellij session
- `kyberm`: SSH to Kyber server and attach to mobile zellij session  
- `zdo`: Attach to local desktop zellij session
- `zmo`: Attach to local mobile zellij session

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the single kybers function with dedicated kyberd/kyberm for desktop and mobile sessions, and added zdo/zmo for local zellij session management. This makes session attachment clearer and faster.

- **New Features**
  - kyberd: SSH to Kyber and attach to desktop zellij
  - kyberm: SSH to Kyber and attach to mobile zellij
  - zdo: Attach to local desktop zellij
  - zmo: Attach to local mobile zellij

- **Migration**
  - Use kyberd or kyberm instead of kybers
  - Use zdo or zmo for local sessions
  - Removed kybers_function.fish

<sup>Written for commit 37f6a3ecb46ae12a1a21296e0a5a9b4e28dab333. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

