### PR TITLE
chore(config): update opencode configuration

### DIFF
--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -197,8 +197,8 @@
 			},
 			"models": {
 				"glm-4-6": {
-					"id": "@preset/glm-4-6",
-					"name": "Preset GLM-4.6 (via OpenRouter)"
+					"id": "@preset/glm-4-7",
+					"name": "Preset GLM-4.7 (via OpenRouter)"
 				}
 			}
 		},


### PR DESCRIPTION
## Summary
- Updated GLM model from 4.6 to 4.7 in opencode configuration
- Changed model ID from @preset/glm-4-6 to @preset/glm-4-7
- Updated display name to reflect the new version

## Changes
- Modified config/opencode/opencode.jsonc to use the latest GLM model version

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates opencode configuration to use Preset GLM-4.7 instead of 4.6 via OpenRouter. Keeps the default model current; only the model ID and display name were changed.

<sup>Written for commit 8f1a973f917b46622dd76f792443a09cb43b4ab3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

