### PR TITLE
chore(config): update Claude and OpenCode plugin configurations

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -11,6 +11,7 @@
     "ralph-loop@claude-plugins-official": true,
     "serena@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
+    "plan-export@cc-marketplace": true,
     "safety-net@cc-marketplace": true
   },
   "extraKnownMarketplaces": {

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -8,10 +8,18 @@
     "frontend-design@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,
     "code-simplifier@claude-plugins-official": true,
-    "ralph-wiggum@claude-plugins-official": true,
+    "ralph-loop@claude-plugins-official": true,
     "serena@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
     "safety-net@cc-marketplace": true
+  },
+  "extraKnownMarketplaces": {
+    "acme-tools": {
+      "source": {
+        "source": "github",
+        "repo": "kenryu42/cc-marketplace"
+      }
+    }
   },
   "permissions": {
     "allow": [

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -15,7 +15,7 @@
     "safety-net@cc-marketplace": true
   },
   "extraKnownMarketplaces": {
-    "acme-tools": {
+    "cc-marketplace": {
       "source": {
         "source": "github",
         "repo": "kenryu42/cc-marketplace"

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -196,7 +196,7 @@
 				"apiKey": "{env:OPENROUTER_API_KEY}"
 			},
 			"models": {
-				"glm-4-6": {
+				"glm-4-7": {
 					"id": "@preset/glm-4-7",
 					"name": "Preset GLM-4.7 (via OpenRouter)"
 				}
@@ -288,6 +288,9 @@
 			}
 		}
 	},
+	"plugin": [
+		"cc-safety-net"
+	],
 	"tui": {
 		"scroll_speed": 3
 	}


### PR DESCRIPTION
## Summary
- Update Claude settings: replace ralph-wiggum plugin with ralph-loop
- Add acme-tools marketplace configuration for Claude plugins
- Update OpenCode GLM model reference to glm-4-7
- Add cc-safety-net plugin to OpenCode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Claude and OpenCode configs: swapped ralph-wiggum→ralph-loop, added cc-marketplace, enabled plan-export and cc-safety-net, and bumped the OpenCode GLM preset to glm-4-7.

<sup>Written for commit acf401de642b8842743cdd6221ecd68ef40a8e65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

