### PR TITLE
refactor: rename rules submodule to dotagents

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "rules"]
-	path = rules
-	url = https://github.com/shunkakinoki/rules
+[submodule "dotagents"]
+	path = dotagents
+	url = https://github.com/shunkakinoki/dotagents

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 ##@ Variables
 
-# Include rules from submodule but keep the local help target authoritative.
-RULES_SKIP_HELP := 1
--include rules/Makefile
+# Include dotagents from submodule but keep the local help target authoritative.
+DOTAGENTS_SKIP_HELP := 1
+-include dotagents/Makefile
 
 # Detect architecture and OS
 ARCH := $(shell uname -m)


### PR DESCRIPTION
## Summary
- Renamed the `rules` submodule to `dotagents` for better clarity about its purpose
- Updated `.gitmodules` to point to the new submodule name
- Updated `Makefile` references from `rules/Makefile` to `dotagents/Makefile`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the rules submodule to dotagents for clearer naming. Updated .gitmodules and Makefile references; no functional changes.

- **Refactors**
  - Renamed submodule to dotagents and updated path/URL in .gitmodules.
  - Switched Makefile include and flag from rules to dotagents (DOTAGENTS_SKIP_HELP).

- **Migration**
  - Run: git submodule sync --recursive && git submodule update --init --recursive.

<sup>Written for commit 233e4284616ac08c9ef555887422b69526ba3b03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

