### PR TITLE
feat(clawdbot): enable headless browser on Linux

### DIFF
--- a/home-manager/modules/clawdbot/default.nix
+++ b/home-manager/modules/clawdbot/default.nix
@@ -58,6 +58,14 @@ lib.mkIf (!env.isCI) {
       launchd.enable = pkgs.stdenv.isDarwin;
       systemd.enable = pkgs.stdenv.isLinux;
 
+      # Browser configuration - Linux only (headless Chromium)
+      config = lib.mkIf pkgs.stdenv.isLinux {
+        browser = {
+          enabled = true;
+          headless = true;
+        };
+      };
+
       # Anthropic API provider (reads from ~/.config/clawdbot/anthropic-key)
       providers.anthropic = {
         apiKeyFile = "${clawdbotDir}/anthropic-key";

--- a/home-manager/modules/clawdbot/default.nix
+++ b/home-manager/modules/clawdbot/default.nix
@@ -58,11 +58,11 @@ lib.mkIf (!env.isCI) {
       launchd.enable = pkgs.stdenv.isDarwin;
       systemd.enable = pkgs.stdenv.isLinux;
 
-      # Browser configuration - Linux only (headless Chromium)
-      config = lib.mkIf pkgs.stdenv.isLinux {
+      # Browser configuration (headless on Linux, GUI on macOS)
+      config = {
         browser = {
           enabled = true;
-          headless = true;
+          headless = pkgs.stdenv.isLinux;
         };
       };
 


### PR DESCRIPTION
Enable headless Chromium browser support for Clawdbot on Linux.

## Changes
- Add browser configuration to clawdbot instance (Linux only)
- \`enabled: true\` - enables browser tool
- \`headless: true\` - runs without GUI

## Depends on
- Chromium package being installed (separate PR)

## References
- https://github.com/clawdbot/nix-clawdbot
- https://github.com/clawdbot/clawdinators

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the Clawdbot browser tool on Linux and macOS. Headless with Chromium on Linux; GUI on macOS.

- **Dependencies**
  - Chromium must be installed on Linux hosts (handled in a separate PR).

<sup>Written for commit f23ec206ecdbde804539bf52ad9393eb9d965d21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

