### PR TITLE
feat(fish): simplify AI CLI functions to run in foreground

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -60,8 +60,13 @@
 
       # Function-based abbreviations
       clxe = "_clxe_function";
+      clxeh = "_clxeh_function";
       coxe = "_coxe_function";
+      coxeh = "_coxeh_function";
       coxel = "_coxel_function";
+      coxelh = "_coxelh_function";
+      ocxe = "_ocxe_function";
+      ocxeh = "_ocxeh_function";
       gco = "_gco_function";
       grco = "_grco_function";
       grcr = "_grcr_function";
@@ -127,8 +132,13 @@
       })
       [
         "_clxe_function"
+        "_clxeh_function"
         "_coxe_function"
+        "_coxeh_function"
         "_coxel_function"
+        "_coxelh_function"
+        "_ocxe_function"
+        "_ocxeh_function"
         "_fish_shortcuts"
         "_fzf_cmd_history"
         "_fzf_directory_picker"

--- a/home-manager/programs/fish/functions/_clxeh_function.fish
+++ b/home-manager/programs/fish/functions/_clxeh_function.fish
@@ -1,0 +1,12 @@
+function _clxeh_function --description "Run Claude Code headlessly with a prompted input"
+  # Prompt for input and run Claude Code
+  # Usage: clxeh
+
+  read -P "Prompt: " prompt
+  if test -z "$prompt"
+    echo "No prompt provided, aborting."
+    return 1
+  end
+
+  claude --dangerously-skip-permissions --print -- "$prompt"
+end

--- a/home-manager/programs/fish/functions/_clxeh_function.fish
+++ b/home-manager/programs/fish/functions/_clxeh_function.fish
@@ -4,7 +4,7 @@ function _clxeh_function --description "Run Claude Code headlessly with a prompt
 
   read -P "Prompt: " prompt
   if test -z "$prompt"
-    echo "No prompt provided, aborting."
+    echo "No prompt provided, aborting." >&2
     return 1
   end
 

--- a/home-manager/programs/fish/functions/_coxeh_function.fish
+++ b/home-manager/programs/fish/functions/_coxeh_function.fish
@@ -4,7 +4,7 @@ function _coxeh_function --description "Run Codex headlessly with a prompted inp
 
   read -P "Prompt: " prompt
   if test -z "$prompt"
-    echo "No prompt provided, aborting."
+    echo "No prompt provided, aborting." >&2
     return 1
   end
 

--- a/home-manager/programs/fish/functions/_coxeh_function.fish
+++ b/home-manager/programs/fish/functions/_coxeh_function.fish
@@ -1,0 +1,12 @@
+function _coxeh_function --description "Run Codex headlessly with a prompted input"
+  # Prompt for input and run Codex
+  # Usage: coxeh
+
+  read -P "Prompt: " prompt
+  if test -z "$prompt"
+    echo "No prompt provided, aborting."
+    return 1
+  end
+
+  codex --model 'gpt-5-codex' --full-auto -c model_reasoning_summary_format=experimental -- "$prompt"
+end

--- a/home-manager/programs/fish/functions/_coxelh_function.fish
+++ b/home-manager/programs/fish/functions/_coxelh_function.fish
@@ -4,7 +4,7 @@ function _coxelh_function --description "Run Codex headlessly with local gpt-oss
 
   read -P "Prompt: " prompt
   if test -z "$prompt"
-    echo "No prompt provided, aborting."
+    echo "No prompt provided, aborting." >&2
     return 1
   end
 

--- a/home-manager/programs/fish/functions/_coxelh_function.fish
+++ b/home-manager/programs/fish/functions/_coxelh_function.fish
@@ -1,0 +1,12 @@
+function _coxelh_function --description "Run Codex headlessly with local gpt-oss:120b model"
+  # Prompt for input and run Codex with local model
+  # Usage: coxelh
+
+  read -P "Prompt: " prompt
+  if test -z "$prompt"
+    echo "No prompt provided, aborting."
+    return 1
+  end
+
+  codex --profile 'gpt-oss-120b' --full-auto -c model_reasoning_summary_format=experimental -- "$prompt"
+end

--- a/home-manager/programs/fish/functions/_ocxe_function.fish
+++ b/home-manager/programs/fish/functions/_ocxe_function.fish
@@ -1,0 +1,11 @@
+function _ocxe_function --description "Run OpenCode with GLM-4.7 via OpenRouter"
+  # Run OpenCode with a free-form prompt (spaces allowed) using GLM-4.7
+  # Usage: ocxe [<prompt words...>]
+
+  if test (count $argv) -eq 0
+    opencode -m 'openrouter-preset/glm-4-7'
+  else
+    set -l prompt (string join " " -- $argv)
+    opencode run "$prompt" -m 'openrouter-preset/glm-4-7'
+  end
+end

--- a/home-manager/programs/fish/functions/_ocxeh_function.fish
+++ b/home-manager/programs/fish/functions/_ocxeh_function.fish
@@ -4,7 +4,7 @@ function _ocxeh_function --description "Run OpenCode headlessly with GLM-4.7"
 
   read -P "Prompt: " prompt
   if test -z "$prompt"
-    echo "No prompt provided, aborting."
+    echo "No prompt provided, aborting." >&2
     return 1
   end
 

--- a/home-manager/programs/fish/functions/_ocxeh_function.fish
+++ b/home-manager/programs/fish/functions/_ocxeh_function.fish
@@ -1,0 +1,12 @@
+function _ocxeh_function --description "Run OpenCode headlessly with GLM-4.7"
+  # Prompt for input and run OpenCode
+  # Usage: ocxeh
+
+  read -P "Prompt: " prompt
+  if test -z "$prompt"
+    echo "No prompt provided, aborting."
+    return 1
+  end
+
+  opencode run "$prompt" -m 'openrouter-preset/glm-4-7'
+end


### PR DESCRIPTION
## Summary

- Simplified AI CLI helper functions to run in foreground instead of background
- Added new shell abbreviations for Claude Code, Codex, and OpenCode tools
- Improved function descriptions and removed unnecessary background execution logic

## Changes

- **Removed** background execution (`nohup`, `disown`) from headless functions
- **Added** 5 new shell functions with corresponding abbreviations:
  - `clxeh` - Claude Code headless with prompted input
  - `coxeh` - Codex headless with prompted input
  - `coxelh` - Codex headless with local gpt-oss:120b model
  - `ocxe` - OpenCode with GLM-4.7 via OpenRouter
  - `ocxeh` - OpenCode headless with GLM-4.7
- **Updated** OpenCode function to use new `opencode run` command syntax
- **Improved** function descriptions for better clarity

## Files Modified

- `home-manager/programs/fish/default.nix` - Added abbreviations and function definitions
- `home-manager/programs/fish/functions/_clxeh_function.fish`
- `home-manager/programs/fish/functions/_coxeh_function.fish`
- `home-manager/programs/fish/functions/_coxelh_function.fish`
- `home-manager/programs/fish/functions/_ocxe_function.fish`
- `home-manager/programs/fish/functions/_ocxeh_function.fish`

## Testing

Run `make format` to verify code formatting standards.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified fish CLI helpers to run in the foreground for clearer output. Added new shortcuts for Claude Code, Codex, and OpenCode, and updated OpenCode to use the run command.

- **New Features**
  - Added functions/abbreviations: clxeh, coxeh, coxelh, ocxe, ocxeh.
  - Models: ocxe/ocxeh use GLM-4.7 via OpenRouter; coxeh uses gpt-5-codex; coxelh uses local gpt-oss:120b.

- **Bug Fixes**
  - Prompt validation now writes errors to stderr.

<sup>Written for commit 194feb9d8495f3329964679ba71c4e5d03f732f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

