### PR TITLE
chore: cleanup nix configuration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -196,7 +196,6 @@
           treefmt = {
             projectRootFile = "flake.nix";
             programs = {
-              stylua.enable = true;
               taplo.enable = true;
               yamlfmt.enable = true;
             };

--- a/home-manager/programs/default.nix
+++ b/home-manager/programs/default.nix
@@ -31,7 +31,7 @@ let
   tmux = import ./tmux;
   zig = import ./zig;
   zoxide = import ./zoxide;
-  zsh = import ./zsh { inherit config lib pkgs; };
+  zsh = import ./zsh;
 in
 [
   atuin

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -8,7 +8,7 @@
 {
   programs.zsh = {
     enable = true;
-    dotDir = ".config/zsh"; # XDG-compliant (relative to $HOME)
+    dotDir = "${config.xdg.configHome}/zsh";
     enableCompletion = true;
     autosuggestion.enable = true;
     syntaxHighlighting.enable = true;


### PR DESCRIPTION
## Changes
- Remove `stylua` from treefmt configuration (unused formatter)
- Simplify zsh module import in home-manager programs
- Update zsh `dotDir` to use XDG config path

## Technical Details
- `flake.nix`: Removed `stylua.enable = true` from treefmt programs
- `home-manager/programs/default.nix`: Simplified zsh import to not pass explicit arguments
- `home-manager/programs/zsh/default.nix`: Changed dotDir from hardcoded `.config/zsh` to `${config.xdg.configHome}/zsh`

## Testing
- [ ] Build passes with `make build`
- [ ] Configuration applies correctly with `make switch`

🤖 Generated with Claude Code by claude-opus-4-5-20251101

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up Nix config by removing the unused stylua formatter, simplifying the zsh module import, and switching zsh dotDir to the XDG config path (${config.xdg.configHome}/zsh). This reduces config noise and keeps zsh files under the standard XDG directory.

<sup>Written for commit 1dacc89b1e4f7e28d6b496ee821d30824fdc95fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

