### PR TITLE
fix(clawdbot): bind gateway to LAN on Linux for k8s ingress

### DIFF
--- a/home-manager/modules/clawdbot/default.nix
+++ b/home-manager/modules/clawdbot/default.nix
@@ -59,10 +59,14 @@ lib.mkIf (!env.isCI) {
       systemd.enable = pkgs.stdenv.isLinux;
 
       # Browser configuration (headless on Linux, GUI on macOS)
+      # Gateway binds to LAN on Linux for k8s ingress access
       config = {
         browser = {
           enabled = true;
           headless = pkgs.stdenv.isLinux;
+        };
+        gateway = lib.mkIf pkgs.stdenv.isLinux {
+          bind = "lan";
         };
       };
 


### PR DESCRIPTION
## Problem

Clawdbot gateway binds to \`127.0.0.1\` (loopback) by default, which makes it inaccessible from within the Kubernetes cluster. This causes 503 errors when accessing https://clawdbot.shunkakinoki.com/.

## Solution

Set \`gateway.bind = "lan"\` on Linux to bind to \`0.0.0.0\`, making the gateway accessible from k8s pods via the Service/Endpoints.

## Changes

\`\`\`nix
config = {
  # ...
  gateway = lib.mkIf pkgs.stdenv.isLinux {
    bind = "lan";
  };
};
\`\`\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind Clawdbot gateway to LAN (0.0.0.0) on Linux so Kubernetes ingress can reach it, fixing 503s at https://clawdbot.shunkakinoki.com/.

- **Bug Fixes**
  - On Linux, set gateway.bind = "lan" via lib.mkIf so the gateway listens on 0.0.0.0 and is reachable from k8s Services/Endpoints.

<sup>Written for commit 39654a01df1ba9a822168ce79e1f595b810847d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

