### PR TITLE
feat(packages): add copybara package

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -21,6 +21,7 @@ with pkgs;
   bun
   clipse
   cloudflared
+  copybara
   curl
   curlie
   cursor-cli


### PR DESCRIPTION
## Changes
- Add copybara package to home-manager packages
- Update dotagents submodule

## Technical Details
Copybara is Google's tool for transforming and moving code between repositories.

## Testing
- Build configuration passes locally

Generated with Claude Code by claude-opus-4-5-20251101

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Copybara to Home Manager packages to support moving code between repositories. Also updates the dotagents submodule.

- **New Features**
  - Add copybara to home-manager/packages/default.nix

- **Dependencies**
  - Update dotagents submodule to the latest revision

<sup>Written for commit 2613e2f889d49774c874954a4c79213680902b0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

