### PR TITLE
feat(fish): add global dev command for nix devshell

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -65,6 +65,7 @@
       coxeh = "_coxeh_function";
       coxel = "_coxel_function";
       coxelh = "_coxelh_function";
+      dev = "_dev_function";
       ocxe = "_ocxe_function";
       ocxeh = "_ocxeh_function";
       gco = "_gco_function";
@@ -137,6 +138,7 @@
         "_coxeh_function"
         "_coxel_function"
         "_coxelh_function"
+        "_dev_function"
         "_ocxe_function"
         "_ocxeh_function"
         "_fish_shortcuts"

--- a/home-manager/programs/fish/functions/_dev_function.fish
+++ b/home-manager/programs/fish/functions/_dev_function.fish
@@ -1,0 +1,23 @@
+function _dev_function --description "Enter Nix development shell"
+    # Find the nearest directory with flake.nix, or use dotfiles
+    set -l target_dir ""
+
+    # Check if current directory or any parent has flake.nix
+    set -l check_dir (pwd)
+    while test "$check_dir" != "/"
+        if test -f "$check_dir/flake.nix"
+            set target_dir $check_dir
+            break
+        end
+        set check_dir (dirname $check_dir)
+    end
+
+    # Fallback to dotfiles if no flake found
+    if test -z "$target_dir"
+        set target_dir "$HOME/dotfiles"
+    end
+
+    # Enter the devshell
+    echo "Entering devshell in $target_dir"
+    DEVENV_ROOT=$target_dir nix develop $target_dir $argv
+end


### PR DESCRIPTION
## Changes
- Add `dev` fish abbreviation for entering Nix devshells from anywhere
- Creates `_dev_function.fish` that searches for nearest `flake.nix` in parent directories
- Falls back to `~/dotfiles` devshell if no local flake found

## Technical Details
- Function walks up directory tree looking for `flake.nix`
- Sets `DEVENV_ROOT` properly for devenv integration
- Passes through any additional arguments to `nix develop`

## Testing
- `make switch` completes successfully
- `dev` from dotfiles directory enters devshell
- `dev` from random directory falls back to dotfiles devshell

Generated with Claude Code by claude-opus-4-5-20251101

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a global dev command in fish to enter a Nix devshell from any directory. It finds the closest flake.nix or falls back to ~/dotfiles.

- **New Features**
  - Added a dev abbreviation mapped to _dev_function.
  - Searches parent directories for flake.nix; otherwise uses ~/dotfiles.
  - Sets DEVENV_ROOT and forwards args to nix develop.

<sup>Written for commit 880efe7fc4ba40ef704cc2de88d120c6ae4c6a6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

