### PR TITLE
fix(fish): cd to target directory before running nix develop

### DIFF
--- a/home-manager/programs/fish/functions/_dev_function.fish
+++ b/home-manager/programs/fish/functions/_dev_function.fish
@@ -17,7 +17,7 @@ function _dev_function --description "Enter Nix development shell"
         set target_dir "$HOME/dotfiles"
     end
 
-    # Enter the devshell
+    # Enter the devshell (cd first since nix develop needs to run from the directory)
     echo "Entering devshell in $target_dir"
-    DEVENV_ROOT=$target_dir nix develop $target_dir $argv
+    cd $target_dir && DEVENV_ROOT=$target_dir nix develop $argv
 end


### PR DESCRIPTION
## Changes
- Fixed the `_dev_function` to change directory to the target directory before running `nix develop`
- The previous implementation passed the path as an argument to `nix develop`, but `nix develop` needs to run from within the directory containing the flake

## Technical Details
- Changed from `DEVENV_ROOT=$target_dir nix develop $target_dir $argv` to `cd $target_dir && DEVENV_ROOT=$target_dir nix develop $argv`
- This ensures the shell is in the correct working directory when the devshell starts

## Testing
- Run `dev` from any directory to enter the dotfiles devshell
- Run `dev` from a directory containing a `flake.nix` to enter that project's devshell

Generated with [Claude Code](https://claude.ai/code) by claude-opus-4-5-20251101

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix _dev_function to cd into the target directory before running nix develop, so devshells start from the correct flake directory. Running dev now works from any location and enters the right devshell (dotfiles or project flake).

<sup>Written for commit f441edcf0b940cd0c10ba51a62d76220a98798bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

