### PR TITLE
feat(clawdbot): update telegram provider config

### DIFF
--- a/home-manager/modules/clawdbot/default.nix
+++ b/home-manager/modules/clawdbot/default.nix
@@ -79,10 +79,13 @@ lib.mkIf (!env.isCI) {
       providers.telegram = {
         enable = pkgs.stdenv.isLinux;
         botTokenFile = "${clawdbotDir}/telegram-token";
-        allowFrom = [ 983653361 ];
+        allowFrom = [
+          983653361
+          2104262990
+        ];
         groups = {
           "*" = {
-            requireMention = true;
+            requireMention = false;
           };
         };
       };


### PR DESCRIPTION
## Changes
- Add additional user ID (2104262990) to telegram allowFrom list
- Disable requireMention for group messages

## Technical Details
- Updates `home-manager/modules/clawdbot/default.nix`
- Telegram provider now accepts messages from two users
- Group messages no longer require bot mention

## Testing
- Build passes: `make build` succeeds

Generated with Claude Code by claude-opus-4-5-20251101

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Clawdbot’s Telegram config to add user 2104262990 to allowFrom and disable requireMention for all groups. This allows two users to message the bot and enables group messages without tagging the bot.

<sup>Written for commit deab83a1d1eadffe543a239d02adf90b80e32b9f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

