### PR TITLE
fix(linux): backup clawdbot.json before home-manager switch

### DIFF
--- a/hosts/linux/default.nix
+++ b/hosts/linux/default.nix
@@ -44,6 +44,12 @@ home-manager.lib.homeManagerConfiguration {
               fi
             done
 
+            # Backup existing clawdbot configuration
+            if [ -f "$HOME/.clawdbot/clawdbot.json" ] && [ ! -L "$HOME/.clawdbot/clawdbot.json" ]; then
+              echo "Backing up existing .clawdbot/clawdbot.json to .clawdbot/clawdbot.json.hm-backup"
+              mv "$HOME/.clawdbot/clawdbot.json" "$HOME/.clawdbot/clawdbot.json.hm-backup"
+            fi
+
             # Clean up old backups in .codex
             find ~/.codex -name "*.hm-backup*" -delete 2>/dev/null || true
           '';


### PR DESCRIPTION
## Summary
- Add clawdbot.json to the activation backup script for Linux standalone home-manager
- Prevents `home-manager switch` from failing when the file already exists and needs to be replaced by a symlink

## Test plan
- [ ] Run `make switch` on a Linux host with existing `~/.clawdbot/clawdbot.json`
- [ ] Verify the file is backed up to `~/.clawdbot/clawdbot.json.hm-backup`
- [ ] Verify the switch completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backs up ~/.clawdbot/clawdbot.json before running home-manager switch on Linux, preventing failures when replacing the file with a symlink.

<sup>Written for commit 7824973ac930cc0d906115fdd638713ce80f7d99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

