### PR TITLE
fix(clawdbot): force overwrite clawdbot.json on home-manager switch

### DIFF
--- a/home-manager/modules/clawdbot/default.nix
+++ b/home-manager/modules/clawdbot/default.nix
@@ -22,6 +22,10 @@ let
 in
 # Disable clawdbot entirely in CI builds
 lib.mkIf (!env.isCI) {
+  # Force overwrite clawdbot.json to prevent home-manager switch failures
+  # when the file already exists (e.g., modified by clawdbot at runtime)
+  home.file.".clawdbot/clawdbot.json".force = true;
+
   # Extract secrets from cliproxyapi auth and .env on home-manager activation
   home.activation.clawdbotSecrets = lib.mkIf (lib ? hm && lib.hm ? dag) (
     lib.hm.dag.entryAfter [ "writeBoundary" ] ''


### PR DESCRIPTION
## Summary
- Add `force = true` to the clawdbot.json home.file configuration
- Prevents home-manager switch from failing when the file already exists
- This is a more robust solution than the backup approach in #543

## Context
Clawdbot can modify its own config at runtime (e.g., when asked to change settings via Telegram). When home-manager tries to switch, it fails because it can't replace the existing file with a symlink.

Using `force = true` ensures the declarative Nix config always wins, which is the expected behavior for a Nix-managed file.

## Test plan
- [ ] Run `make switch` with an existing `~/.clawdbot/clawdbot.json`
- [ ] Verify the switch completes successfully
- [ ] Verify the file is now a symlink to the Nix store

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force overwrite of ~/.clawdbot/clawdbot.json during home-manager switch to prevent failures when the file already exists. Sets home.file.".clawdbot/clawdbot.json".force = true so the Nix-managed symlink always replaces any runtime-modified file.

<sup>Written for commit 830d7b47a41448dd708c6a600695b47c85a2a46a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

