### PR TITLE
fix: guard cliproxyapi auth on restart

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -101,7 +101,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v6
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -93,6 +93,7 @@ jobs:
       - nix-flake
       - nix-format
       - nix-linux
+      - nix-nixos
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:

--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -13,6 +13,7 @@ let
 
   startScript = pkgs.replaceVars ./scripts/start.sh {
     sed = "${pkgs.gnused}/bin/sed";
+    aws = "${pkgs.awscli2}/bin/aws";
   };
 
   dockerStartScript = pkgs.writeShellScript "cliproxyapi-docker-start" ''

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -6,6 +6,7 @@ CONFIG_DIR="${HOME}/.cli-proxy-api"
 TEMPLATE="$CONFIG_DIR/config.template.yaml"
 CONFIG="$CONFIG_DIR/config.yaml"
 ENV_FILE="${HOME}/dotfiles/.env"
+AUTH_DIR="${CONFIG_DIR}/objectstore/auths"
 
 if [ -f "$ENV_FILE" ]; then
   set -a
@@ -25,6 +26,47 @@ OBJECTSTORE_ACCESS_KEY="$(strip_quotes "${OBJECTSTORE_ACCESS_KEY:-}")"
 OBJECTSTORE_SECRET_KEY="$(strip_quotes "${OBJECTSTORE_SECRET_KEY:-}")"
 MANAGEMENT_PASSWORD="${CLIPROXY_MANAGEMENT_PASSWORD:-}"
 export OBJECTSTORE_ENDPOINT OBJECTSTORE_BUCKET OBJECTSTORE_ACCESS_KEY OBJECTSTORE_SECRET_KEY MANAGEMENT_PASSWORD
+
+if [ -n "$OBJECTSTORE_ENDPOINT" ] && [ -n "$OBJECTSTORE_ACCESS_KEY" ] && [ -n "$OBJECTSTORE_SECRET_KEY" ]; then
+  mkdir -p "$AUTH_DIR"
+
+  if [ -z "$(ls -A "$AUTH_DIR" 2>/dev/null)" ]; then
+    echo "⚠️  Local auth cache empty; hydrating from S3" >&2
+    AWS_ACCESS_KEY_ID="$OBJECTSTORE_ACCESS_KEY" \
+      AWS_SECRET_ACCESS_KEY="$OBJECTSTORE_SECRET_KEY" \
+      @aws@ s3 sync \
+      --endpoint-url="$OBJECTSTORE_ENDPOINT" \
+      --no-progress \
+      "s3://${OBJECTSTORE_BUCKET}/auths/" \
+      "$AUTH_DIR/" || true
+
+    AWS_ACCESS_KEY_ID="$OBJECTSTORE_ACCESS_KEY" \
+      AWS_SECRET_ACCESS_KEY="$OBJECTSTORE_SECRET_KEY" \
+      @aws@ s3 sync \
+      --endpoint-url="$OBJECTSTORE_ENDPOINT" \
+      --no-progress \
+      "s3://${OBJECTSTORE_BUCKET}/backup/auths/" \
+      "$AUTH_DIR/" || true
+  fi
+
+  if [ -n "$(ls -A "$AUTH_DIR" 2>/dev/null)" ]; then
+    AWS_ACCESS_KEY_ID="$OBJECTSTORE_ACCESS_KEY" \
+      AWS_SECRET_ACCESS_KEY="$OBJECTSTORE_SECRET_KEY" \
+      @aws@ s3 sync \
+      --endpoint-url="$OBJECTSTORE_ENDPOINT" \
+      --no-progress \
+      "$AUTH_DIR/" \
+      "s3://${OBJECTSTORE_BUCKET}/auths/" || true
+
+    AWS_ACCESS_KEY_ID="$OBJECTSTORE_ACCESS_KEY" \
+      AWS_SECRET_ACCESS_KEY="$OBJECTSTORE_SECRET_KEY" \
+      @aws@ s3 sync \
+      --endpoint-url="$OBJECTSTORE_ENDPOINT" \
+      --no-progress \
+      "$AUTH_DIR/" \
+      "s3://${OBJECTSTORE_BUCKET}/backup/auths/" || true
+  fi
+fi
 
 # Generate config from template
 if [ -f "$TEMPLATE" ]; then


### PR DESCRIPTION
## Changes
- Add a pre-start S3 hydrate + re-sync guard for cliproxyapi auth cache (temporary until router-for-me/CLIProxyAPI#859 merges)
- Wire aws into the start script replacement
- CI tweaks: pin download-artifact to v6 and add nix-nixos to the matrix

## Technical Details
- If S3 creds exist and the local auth cache is empty, hydrate from `s3://$OBJECTSTORE_BUCKET/auths` and `backup/auths`, then re-sync back to S3 to avoid deletions on restart
- Pass awscli into the Nix start script so the guard can run

## Testing
- shellspec spec/cliproxyapi_spec.sh spec/cliproxyapi_backup_spec.sh

🤖 Generated with Codex CLI by GPT-5


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Protect CLIProxyAPI auth cache on restart by hydrating from S3 when the local cache is empty, then re-syncing to avoid deletions. Also wires awscli into the start script and makes small CI tweaks.

- **Bug Fixes**
  - Add pre-start S3 hydrate + re-sync guard in start.sh for auths when OBJECTSTORE_* env vars are set.

- **Dependencies**
  - Pass awscli2 into the Nix start script.
  - Pin actions/download-artifact to v6 and add nix-nixos to the CI matrix.

<sup>Written for commit fe4a9da1a5f5bcfbf04d6fd7032d6024993b0e62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

