### PR TITLE
fix(clawdbot): add browser executablePath and use configOverrides

### DIFF
--- a/home-manager/modules/clawdbot/default.nix
+++ b/home-manager/modules/clawdbot/default.nix
@@ -69,9 +69,12 @@ lib.mkIf (!env.isCI) {
         browser = {
           enabled = true;
           headless = pkgs.stdenv.isLinux;
+        }
+        // lib.optionalAttrs pkgs.stdenv.isLinux {
           executablePath = "${pkgs.chromium}/bin/chromium";
         };
-      } // lib.optionalAttrs pkgs.stdenv.isLinux {
+      }
+      // lib.optionalAttrs pkgs.stdenv.isLinux {
         gateway = {
           bind = "lan";
         };

--- a/home-manager/modules/clawdbot/default.nix
+++ b/home-manager/modules/clawdbot/default.nix
@@ -64,12 +64,15 @@ lib.mkIf (!env.isCI) {
 
       # Browser configuration (headless on Linux, GUI on macOS)
       # Gateway binds to LAN on Linux for k8s ingress access
-      config = {
+      # NOTE: uses configOverrides because upstream nix-clawdbot doesn't merge `config` into output
+      configOverrides = {
         browser = {
           enabled = true;
           headless = pkgs.stdenv.isLinux;
+          executablePath = "${pkgs.chromium}/bin/chromium";
         };
-        gateway = lib.mkIf pkgs.stdenv.isLinux {
+      } // lib.optionalAttrs pkgs.stdenv.isLinux {
+        gateway = {
           bind = "lan";
         };
       };


### PR DESCRIPTION
## Summary
Fixes browser tool not finding chromium on Linux.

## Changes
- Use \`configOverrides\` instead of \`config\` (upstream nix-clawdbot bug: \`config\` option isn't merged into output JSON)
- Add explicit \`executablePath\` for chromium to fix browser detection
- Enables headless browser on Linux for web search capabilities

## Testing
Built and verified config output includes:
\`\`\`json
"browser": {
  "enabled": true,
  "executablePath": "/nix/store/.../chromium",
  "headless": true
}
\`\`\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Clawdbot’s browser on Linux so Chromium is found and headless browsing works. Restores web search capability.

- **Bug Fixes**
  - Use configOverrides instead of config (upstream nix-clawdbot doesn’t merge config into output).
  - On Linux, set browser.executablePath to the Chromium binary and keep headless=true; do not set executablePath on macOS.
  - Preserve Linux gateway.bind=lan.

<sup>Written for commit 9eef43307c4a72961a0fab42d624ad74b459090d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

