### PR TITLE
fix: pass CI env vars through sudo in macOS nix-switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,7 +315,7 @@ nix-switch: ## Activate Nix configuration.
 	@echo "🔧 Activating Nix configuration for $(NIX_CONFIG_TYPE) on $(OS) $(ARCH) for USER=$(NIX_USERNAME)"
 	@if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \
 		if [ "$(OS)" = "Darwin" ]; then \
-			sudo $(NIX_ALLOW_UNFREE) $(DARWIN_REBUILD) switch --flake .#runner --impure --no-update-lock-file; \
+			sudo env CI="$$CI" IN_DOCKER="$$IN_DOCKER" $(NIX_ALLOW_UNFREE) $(DARWIN_REBUILD) switch --flake .#runner --impure --no-update-lock-file; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "nixosConfigurations" ]; then \
 			echo "⏭️ NixOS switch skipped in CI as the runner is not a NixOS system"; \
 			sudo $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure nixpkgs#nixos-rebuild -- switch --flake .#runner --no-update-lock-file || exit 0; \


### PR DESCRIPTION
## Changes
- Modified Makefile line 318 to explicitly pass `CI` and `IN_DOCKER` environment variables through sudo

## Technical Details
The E2E macOS test was failing at the `clawdbotSecrets` activation step because:
- The `sudo` command doesn't pass environment variables by default
- This caused `builtins.getEnv "CI"` in the clawdbot module to return empty
- The `lib.mkIf (!env.isCI)` condition evaluated to true, causing the activation script to run in CI
- The activation script failed because required files (.env, cliproxyapi auth) don't exist in CI

The fix uses `sudo env CI="$$CI" IN_DOCKER="$$IN_DOCKER"` to explicitly pass these variables through sudo, ensuring proper CI environment detection during nix-darwin builds.

## Testing
- E2E macOS workflow should now pass
- The clawdbot module will be properly disabled in CI environments
- Local (non-CI) builds remain unaffected

Generated with Claude Code by Claude Sonnet 4.5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass CI and IN_DOCKER environment variables through sudo in the macOS nix-switch step to restore correct CI detection in nix-darwin builds. This prevents the clawdbot secrets activation from running in CI and fixes the E2E macOS workflow.

<sup>Written for commit 8545785d9063e614a721b870ad6580e4ae5d68b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

