### PR TITLE
feat(dotfiles-updater): skip build/switch when no changes detected

### DIFF
--- a/home-manager/services/dotfiles-updater/update.sh
+++ b/home-manager/services/dotfiles-updater/update.sh
@@ -10,8 +10,24 @@ if [ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]; then
   exit 0
 fi
 
-# Fetch and pull latest changes
+# Store current commit hash before fetching
+CURRENT_COMMIT=$(git rev-parse HEAD)
+
+# Fetch latest changes
 git fetch origin main
+
+# Get the latest remote commit
+REMOTE_COMMIT=$(git rev-parse origin/main)
+
+# Check if there are any changes
+if [ "$CURRENT_COMMIT" = "$REMOTE_COMMIT" ]; then
+  echo "No changes detected (current: ${CURRENT_COMMIT:0:8}). Skipping build and switch."
+  exit 0
+fi
+
+echo "Changes detected: ${CURRENT_COMMIT:0:8} -> ${REMOTE_COMMIT:0:8}"
+
+# Reset to latest
 git reset --hard origin/main
 
 # Run the install script

--- a/spec/dotfiles_updater_spec.sh
+++ b/spec/dotfiles_updater_spec.sh
@@ -50,6 +50,34 @@ The output should include 'git reset --hard origin/main'
 End
 End
 
+Describe 'change detection'
+It 'stores current commit before fetching'
+When run bash -c "grep 'CURRENT_COMMIT=\$(git rev-parse HEAD)' '$SCRIPT'"
+The output should include 'CURRENT_COMMIT=$(git rev-parse HEAD)'
+End
+
+It 'gets remote commit after fetching'
+When run bash -c "grep 'REMOTE_COMMIT=\$(git rev-parse origin/main)' '$SCRIPT'"
+The output should include 'REMOTE_COMMIT=$(git rev-parse origin/main)'
+End
+
+It 'compares commits to detect changes'
+When run bash -c "grep 'CURRENT_COMMIT.*=.*REMOTE_COMMIT' '$SCRIPT'"
+The output should include 'CURRENT_COMMIT'
+The output should include 'REMOTE_COMMIT'
+End
+
+It 'skips build when no changes detected'
+When run bash -c "grep 'No changes detected' '$SCRIPT'"
+The output should include 'No changes detected'
+End
+
+It 'logs when changes are detected'
+When run bash -c "grep 'Changes detected' '$SCRIPT'"
+The output should include 'Changes detected'
+End
+End
+
 Describe 'installation'
 It 'runs install.sh after update'
 When run bash -c "grep './install.sh' '$SCRIPT'"

--- a/spec/dotfiles_updater_spec.sh
+++ b/spec/dotfiles_updater_spec.sh
@@ -53,11 +53,13 @@ End
 Describe 'change detection'
 It 'stores current commit before fetching'
 When run bash -c "grep 'CURRENT_COMMIT=\$(git rev-parse HEAD)' '$SCRIPT'"
+# shellcheck disable=SC2016
 The output should include 'CURRENT_COMMIT=$(git rev-parse HEAD)'
 End
 
 It 'gets remote commit after fetching'
 When run bash -c "grep 'REMOTE_COMMIT=\$(git rev-parse origin/main)' '$SCRIPT'"
+# shellcheck disable=SC2016
 The output should include 'REMOTE_COMMIT=$(git rev-parse origin/main)'
 End
 


### PR DESCRIPTION
## Summary

Skip the \`make build && make switch\` step when the periodic 3hr dotfiles-updater runs and there are no new changes in git.

## Changes

- Store the current commit hash before fetching
- Compare with \`origin/main\` after fetch
- Only run \`install.sh\` if commits differ
- Log which commits changed for debugging

## Why

Saves CPU/time when there are no dotfiles changes to apply. The 3hr update cycle will now be a quick no-op check instead of a full rebuild.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dotfiles updater now fetches origin/main, compares HEAD to it, and exits early if identical—skipping install.sh (make build && make switch). This makes the 3‑hour update a fast no‑op when there are no changes and saves CPU.

<sup>Written for commit b4dd1d8b1b8585e0a153db207c92a577f8ff89a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

