### PR TITLE
refactor: reorganize Rust development environment

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -41,6 +41,7 @@ with pkgs;
   gh
   google-cloud-sdk
   git
+  glance
   glow
   gnumake
   gping
@@ -67,7 +68,6 @@ with pkgs;
   procs
   # qwen-code  # FIXME: npmDepsHash is stale in nixpkgs, uncomment when fixed
   ripgrep
-  rustup
   sccache
   sd
   shellcheck

--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -43,6 +43,7 @@
       # Add additional bin paths
       export PATH="$PATH:$GOPATH/bin"
       export PATH="$HOME/.bun/bin:$PATH"
+      export PATH="$HOME/.cargo/bin:$PATH"
       export PATH="$HOME/.foundry/bin:$PATH"
       export PATH="$HOME/.local/bin:$PATH"
       export PATH="$HOME/.nix-profile/bin:$PATH"

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -12,14 +12,20 @@
       if test (uname) = "Linux"
           set -gx XDG_RUNTIME_DIR /run/user/(id -u)
       end
+
+      # Go configuration
+      set -gx GOPATH $HOME/go
+
       direnv hook fish | source
     '';
     loginShellInit = ''
       fish_add_path -p ~/.local/bin
       fish_add_path -p ~/.bun/bin
-      fish_add_path -p ~/.nix-profile/bin
-      fish_add_path -p /nix/var/nix/profiles/default/bin
+      fish_add_path -p ~/.cargo/bin
       fish_add_path -p ~/.foundry/bin
+      fish_add_path -p ~/.nix-profile/bin
+      fish_add_path -p ~/go/bin
+      fish_add_path -p /nix/var/nix/profiles/default/bin
       fish_add_path -p /opt/homebrew/bin
       fish_add_path -p /opt/homebrew/opt/postgresql@18/bin
       fish_add_path -p /etc/profiles/per-user/${config.home.username}/bin
@@ -31,9 +37,11 @@
       set fish_theme dracula
       fish_add_path -p ~/.local/bin
       fish_add_path -p ~/.bun/bin
-      fish_add_path -p ~/.nix-profile/bin
-      fish_add_path -p /nix/var/nix/profiles/default/bin
+      fish_add_path -p ~/.cargo/bin
       fish_add_path -p ~/.foundry/bin
+      fish_add_path -p ~/.nix-profile/bin
+      fish_add_path -p ~/go/bin
+      fish_add_path -p /nix/var/nix/profiles/default/bin
       fish_add_path -p /opt/homebrew/bin
       fish_add_path -p /opt/homebrew/opt/postgresql@18/bin
       fish_add_path -p /etc/profiles/per-user/${config.home.username}/bin
@@ -54,7 +62,6 @@
       j = "jj";
       lzd = "lazydocker";
       lzg = "lazygit";
-      sag = "_ssh_add_github";
       ta = "tmux new -A -s default";
       v = "nvim";
 
@@ -66,16 +73,6 @@
       coxel = "_coxel_function";
       coxelh = "_coxelh_function";
       dev = "_dev_function";
-      ocxe = "_ocxe_function";
-      ocxeh = "_ocxeh_function";
-      gco = "_gco_function";
-      grco = "_grco_function";
-      grcr = "_grcr_function";
-      kyber = "_kyber_function";
-      kyberd = "_kyberd_function";
-      kyberm = "_kyberm_function";
-      zdo = "_zdo_function";
-      zmo = "_zmo_function";
       fch = "_fzf_cmd_history --allow-execute";
       fdp = "_fzf_directory_picker --allow-cd --prompt-name Projects ~/";
       ffp = "_fzf_file_picker --allow-open-in-editor --prompt-name Files";
@@ -83,7 +80,18 @@
       fgb = "_fzf_git_branch";
       fgw = "_fzf_git_worktree";
       fhq = "_fzf_ghq_picker";
+      gco = "_gco_function";
+      grco = "_grco_function";
+      grcr = "_grcr_function";
+      kyber = "_kyber_function";
+      kyberd = "_kyberd_function";
+      kyberm = "_kyberm_function";
+      ocxe = "_ocxe_function";
+      ocxeh = "_ocxeh_function";
+      sag = "_ssh_add_github";
       shortcuts = "_fish_shortcuts";
+      zdo = "_zdo_function";
+      zmo = "_zmo_function";
     };
     plugins = [
       {

--- a/home-manager/programs/lazydocker/default.nix
+++ b/home-manager/programs/lazydocker/default.nix
@@ -1,4 +1,4 @@
 { pkgs, ... }:
 {
-  home.packages = [ pkgs.lazydocker ];
+  home.packages = with pkgs; [ pkgs.lazydocker ];
 }

--- a/home-manager/programs/rust/default.nix
+++ b/home-manager/programs/rust/default.nix
@@ -1,5 +1,6 @@
+{ pkgs, ... }:
 {
-  programs.fish.interactiveShellInit = ''
-    fish_add_path -p ~/.cargo/bin/
-  '';
+  home.packages = with pkgs; [
+    rustup
+  ];
 }

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -35,6 +35,7 @@
       # Additional bin paths
       export PATH="$PATH:$GOPATH/bin"
       export PATH="$HOME/.bun/bin:$PATH"
+      export PATH="$HOME/.cargo/bin:$PATH"
       export PATH="$HOME/.foundry/bin:$PATH"
       export PATH="$HOME/.local/bin:$PATH"
       export PATH="$HOME/.nix-profile/bin:$PATH"


### PR DESCRIPTION
## Summary
- Move rustup from main packages to Rust-specific module for better organization
- Add glance package for improved system monitoring capabilities  
- Improve Cargo PATH management consistency across bash, fish, and zsh shells
- Clean up shell PATH configuration and reorder for better organization

## Changes
- **Rust module**: Moved rustup to dedicated Rust configuration module
- **Shell environments**: Enhanced Cargo PATH support in bash, fish, and zsh
- **System monitoring**: Added glance package to the base package list
- **Code organization**: Improved module architecture for better maintainability

## Files Modified
- `home-manager/packages/default.nix`: Added glance, removed rustup
- `home-manager/programs/rust/default.nix`: Added rustup package management
- `home-manager/programs/bash/default.nix`: Added Cargo PATH
- `home-manager/programs/fish/default.nix`: Improved PATH organization + Cargo support  
- `home-manager/programs/zsh/default.nix`: Added Cargo PATH
- `home-manager/programs/lazydocker/default.nix`: Fixed package syntax

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorganized the Rust dev environment by moving rustup to a dedicated module and standardizing Cargo PATH across bash, fish, and zsh. Added glance for system monitoring and cleaned up PATH order for consistency.

- **Refactors**
  - Moved rustup into the Rust module (home-manager/programs/rust).
  - Unified Cargo PATH setup in bash, fish, and zsh; set GOPATH and added ~/go/bin in fish; reordered PATH entries for clarity.
  - Fixed lazydocker package declaration.

- **New Features**
  - Added glance to the base packages for system monitoring.

<sup>Written for commit 6484cb26d2cdd0b1ac5ddc39a83ab4785f21eb5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

