### PR TITLE
fix(clawdbot): enable noSandbox for browser on Linux

### DIFF
--- a/home-manager/modules/clawdbot/default.nix
+++ b/home-manager/modules/clawdbot/default.nix
@@ -72,6 +72,7 @@ lib.mkIf (!env.isCI) {
         }
         // lib.optionalAttrs pkgs.stdenv.isLinux {
           executablePath = "${pkgs.chromium}/bin/chromium";
+          noSandbox = true; # SUID sandbox requires root-owned binary with mode 4755
         };
       }
       // lib.optionalAttrs pkgs.stdenv.isLinux {


### PR DESCRIPTION
## Summary

Enable \`noSandbox = true\` for the Chromium browser on Linux to fix browser startup failures.

## Problem

Chromium's SUID sandbox requires the sandbox binary to be owned by root with mode 4755:
\`\`\`
The SUID sandbox helper binary was found, but is not configured correctly.
/nix/store/.../chromium-sandbox/bin/__chromium-suid-sandbox needs to be owned by root with mode 4755
\`\`\`

This isn't the case with Nix-installed Chromium.

## Solution

Add \`noSandbox = true\` to the browser config on Linux. This disables the SUID sandbox and allows headless browsing to work.

## Trade-off

Running without the SUID sandbox is slightly less secure, but acceptable for a headless browser used for web searches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable noSandbox=true for Chromium on Linux to bypass the SUID sandbox requirement in Nix and fix headless browser startup failures. Restores Clawdbot’s headless browsing on Linux, with the trade-off of disabling the SUID sandbox.

<sup>Written for commit 86b067f8f8cc960d3c92d3030235a0ac575ada30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

