### PR TITLE
fix: prevent clawdbot auto-restart on home-manager switch

### DIFF
--- a/home-manager/modules/clawdbot/default.nix
+++ b/home-manager/modules/clawdbot/default.nix
@@ -26,6 +26,12 @@ lib.mkIf (!env.isCI) {
   # when the file already exists (e.g., modified by clawdbot at runtime)
   home.file.".clawdbot/clawdbot.json".force = true;
 
+  # Prevent clawdbot from auto-restarting on home-manager switch
+  # Service will only restart on reboot or explicit `systemctl restart`
+  systemd.user.services.clawdbot-gateway = lib.mkIf pkgs.stdenv.isLinux {
+    Unit.X-RestartIfChanged = "false";
+  };
+
   # Extract secrets from cliproxyapi auth and .env on home-manager activation
   home.activation.clawdbotSecrets = lib.mkIf (lib ? hm && lib.hm ? dag) (
     lib.hm.dag.entryAfter [ "writeBoundary" ] ''

--- a/home-manager/services/dotfiles-updater/update.sh
+++ b/home-manager/services/dotfiles-updater/update.sh
@@ -27,8 +27,22 @@ fi
 
 echo "Changes detected: ${CURRENT_COMMIT:0:8} -> ${REMOTE_COMMIT:0:8}"
 
+# Check if clawdbot-related files changed (flake.lock or clawdbot module)
+CLAWDBOT_CHANGED=false
+CHANGED_FILES=$(git diff --name-only "$CURRENT_COMMIT" "$REMOTE_COMMIT")
+if echo "$CHANGED_FILES" | grep -qE "(flake\.lock|clawdbot)"; then
+  CLAWDBOT_CHANGED=true
+  echo "Clawdbot-related files changed, will restart after switch"
+fi
+
 # Reset to latest
 git reset --hard origin/main
 
 # Run the install script
 ./install.sh
+
+# Restart clawdbot only if clawdbot-related files changed
+if [ "$CLAWDBOT_CHANGED" = "true" ]; then
+  echo "Restarting clawdbot due to config/flake changes..."
+  systemctl --user restart clawdbot-gateway.service || true
+fi


### PR DESCRIPTION
## Problem
Clawdbot restarts on every dotfiles change, even unrelated ones.

## Solution
Two-part fix:

1. **\`X-RestartIfChanged=false\`** in clawdbot service unit
   - Prevents home-manager from auto-restarting during activation

2. **Smart restart in update.sh**
   - Checks if \`flake.lock\` or \`clawdbot\` files changed
   - Only restarts clawdbot when relevant files change

## Result
| Change Type | Clawdbot Restart |
|-------------|------------------|
| Unrelated dotfiles | ❌ No |
| \`flake.lock\` update | ✅ Yes |
| Clawdbot config change | ✅ Yes |
| System reboot | ✅ Yes |
| Manual \`systemctl restart\` | ✅ Yes |