### PR TITLE
fix: restart clawdbot only on explicit make switch

### DIFF
--- a/home-manager/modules/clawdbot/default.nix
+++ b/home-manager/modules/clawdbot/default.nix
@@ -26,6 +26,12 @@ lib.mkIf (!env.isCI) {
   # when the file already exists (e.g., modified by clawdbot at runtime)
   home.file.".clawdbot/clawdbot.json".force = true;
 
+  # Prevent home-manager from auto-restarting clawdbot during activation
+  # Restart only happens via explicit `make switch` (which runs systemctl-clawdbot)
+  systemd.user.services.clawdbot-gateway = lib.mkIf pkgs.stdenv.isLinux {
+    Unit.X-RestartIfChanged = "false";
+  };
+
   # Extract secrets from cliproxyapi auth and .env on home-manager activation
   home.activation.clawdbotSecrets = lib.mkIf (lib ? hm && lib.hm ? dag) (
     lib.hm.dag.entryAfter [ "writeBoundary" ] ''


### PR DESCRIPTION
## Problem
Clawdbot restarts on every \`home-manager switch\`, even during automated updates.

## Solution
Add \`X-RestartIfChanged=false\` to clawdbot service unit.

## Behavior

| Command | Clawdbot Restart |
|---------|------------------|
| \`make install\` (automated updates) | ❌ No |
| \`make switch\` (manual) | ✅ Yes |
| System reboot | ✅ Yes |

The \`make switch\` target runs \`systemctl-clawdbot\` which explicitly restarts the service.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop home-manager from auto-restarting clawdbot. Restarts now happen only on make switch or system reboot, so automated updates don’t interrupt the bot.

- **Bug Fixes**
  - Set Unit.X-RestartIfChanged=false on the clawdbot-gateway user service.
  - make install no longer restarts; make switch explicitly restarts via systemctl-clawdbot; reboot still restarts.

<sup>Written for commit 9fd39af035897a8f979b90f4048a50e2d86b2955. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

