### PR TITLE
feat(claude): add skill installer script

### DIFF
--- a/config/claude/default.nix
+++ b/config/claude/default.nix
@@ -23,4 +23,9 @@
     source = ./statusline-git.sh;
     executable = true;
   };
+
+  home.file.".claude/install-skills.sh" = {
+    source = ./install-skills.sh;
+    executable = true;
+  };
 }

--- a/config/claude/install-skills.sh
+++ b/config/claude/install-skills.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Install agent skills from external repositories
+# Usage: ./install-skills.sh
+# Docs: https://agentskills.io
+
+set -euo pipefail
+
+echo "Installing agent skills..."
+
+# Install Vercel agent-skills (React best practices + Web design guidelines)
+# https://github.com/vercel-labs/agent-skills
+npx add-skill vercel-labs/agent-skills \
+  --agent claude-code \
+  --skill vercel-react-best-practices \
+  --skill web-design-guidelines \
+  --yes
+
+echo "Done! Skills installed to ~/.claude/skills/"

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -21,6 +21,10 @@ It 'has spec file for config/claude/statusline-git.sh'
 The path "spec/statusline_git_spec.sh" should be exist
 End
 
+It 'has spec file for config/claude/install-skills.sh'
+The path "spec/install_skills_spec.sh" should be exist
+End
+
 It 'has spec file for home-manager/programs/neovim/run_tests.sh'
 The path "spec/neovim_tests_spec.sh" should be exist
 End
@@ -93,7 +97,8 @@ Describe 'no shell scripts are missing from coverage list'
 It 'covers all non-spec shell scripts in the repository'
 # List of all shell scripts that should have tests
 # Update this list when adding new shell scripts
-covered_scripts="config/claude/notify.sh
+covered_scripts="config/claude/install-skills.sh
+config/claude/notify.sh
 config/claude/pushover.sh
 config/claude/security.sh
 config/claude/statusline-git.sh

--- a/spec/install_skills_spec.sh
+++ b/spec/install_skills_spec.sh
@@ -2,69 +2,69 @@
 # shellcheck disable=SC2329,SC2016
 
 Describe 'install-skills.sh'
-  SCRIPT="$PWD/config/claude/install-skills.sh"
+SCRIPT="$PWD/config/claude/install-skills.sh"
 
-  Describe 'script structure'
-    It 'has valid bash syntax'
-      When run bash -n "$SCRIPT"
-      The status should be success
-    End
+Describe 'script structure'
+It 'has valid bash syntax'
+When run bash -n "$SCRIPT"
+The status should be success
+End
 
-    It 'uses strict mode'
-      When run grep -q 'set -euo pipefail' "$SCRIPT"
-      The status should be success
-    End
+It 'uses strict mode'
+When run grep -q 'set -euo pipefail' "$SCRIPT"
+The status should be success
+End
 
-    It 'has executable permission'
-      When run test -x "$SCRIPT"
-      The status should be success
-    End
-  End
+It 'has executable permission'
+When run test -x "$SCRIPT"
+The status should be success
+End
+End
 
-  Describe 'npx add-skill invocation'
-    setup() {
-      mock_bin_setup npx
-    }
-    cleanup() {
-      mock_bin_cleanup
-    }
-    Before 'setup'
-    After 'cleanup'
+Describe 'npx add-skill invocation'
+setup() {
+  mock_bin_setup npx
+}
+cleanup() {
+  mock_bin_cleanup
+}
+Before 'setup'
+After 'cleanup'
 
-    It 'calls npx add-skill with correct arguments'
-      When run bash "$SCRIPT"
-      The status should be success
-      The output should include 'Installing agent skills'
-    End
+It 'calls npx add-skill with correct arguments'
+When run bash "$SCRIPT"
+The status should be success
+The output should include 'Installing agent skills'
+End
 
-    It 'passes vercel-labs/agent-skills as source'
-      When run bash -c 'bash '"$SCRIPT"'; cat "$MOCK_LOG"'
-      The status should be success
-      The output should include 'vercel-labs/agent-skills'
-    End
+It 'passes vercel-labs/agent-skills as source'
+When run bash -c 'bash '"$SCRIPT"'; cat "$MOCK_LOG"'
+The status should be success
+The output should include 'vercel-labs/agent-skills'
+End
 
-    It 'specifies claude-code as target agent'
-      When run bash -c 'bash '"$SCRIPT"'; cat "$MOCK_LOG"'
-      The status should be success
-      The output should include '--agent claude-code'
-    End
+It 'specifies claude-code as target agent'
+When run bash -c 'bash '"$SCRIPT"'; cat "$MOCK_LOG"'
+The status should be success
+The output should include '--agent claude-code'
+End
 
-    It 'includes vercel-react-best-practices skill'
-      When run bash -c 'bash '"$SCRIPT"'; cat "$MOCK_LOG"'
-      The status should be success
-      The output should include 'vercel-react-best-practices'
-    End
+It 'includes vercel-react-best-practices skill'
+When run bash -c 'bash '"$SCRIPT"'; cat "$MOCK_LOG"'
+The status should be success
+The output should include 'vercel-react-best-practices'
+End
 
-    It 'includes web-design-guidelines skill'
-      When run bash -c 'bash '"$SCRIPT"'; cat "$MOCK_LOG"'
-      The status should be success
-      The output should include 'web-design-guidelines'
-    End
+It 'includes web-design-guidelines skill'
+When run bash -c 'bash '"$SCRIPT"'; cat "$MOCK_LOG"'
+The status should be success
+The output should include 'web-design-guidelines'
+End
 
-    It 'uses --yes flag for non-interactive mode'
-      When run bash -c 'bash '"$SCRIPT"'; cat "$MOCK_LOG"'
-      The status should be success
-      The output should include '--yes'
-    End
-  End
+It 'uses --yes flag for non-interactive mode'
+When run bash -c 'bash '"$SCRIPT"'; cat "$MOCK_LOG"'
+The status should be success
+The output should include '--yes'
+End
+End
 End

--- a/spec/install_skills_spec.sh
+++ b/spec/install_skills_spec.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329,SC2016
+
+Describe 'install-skills.sh'
+  SCRIPT="$PWD/config/claude/install-skills.sh"
+
+  Describe 'script structure'
+    It 'has valid bash syntax'
+      When run bash -n "$SCRIPT"
+      The status should be success
+    End
+
+    It 'uses strict mode'
+      When run grep -q 'set -euo pipefail' "$SCRIPT"
+      The status should be success
+    End
+
+    It 'has executable permission'
+      When run test -x "$SCRIPT"
+      The status should be success
+    End
+  End
+
+  Describe 'npx add-skill invocation'
+    setup() {
+      mock_bin_setup npx
+    }
+    cleanup() {
+      mock_bin_cleanup
+    }
+    Before 'setup'
+    After 'cleanup'
+
+    It 'calls npx add-skill with correct arguments'
+      When run bash "$SCRIPT"
+      The status should be success
+      The output should include 'Installing agent skills'
+    End
+
+    It 'passes vercel-labs/agent-skills as source'
+      When run bash -c 'bash '"$SCRIPT"'; cat "$MOCK_LOG"'
+      The status should be success
+      The output should include 'vercel-labs/agent-skills'
+    End
+
+    It 'specifies claude-code as target agent'
+      When run bash -c 'bash '"$SCRIPT"'; cat "$MOCK_LOG"'
+      The status should be success
+      The output should include '--agent claude-code'
+    End
+
+    It 'includes vercel-react-best-practices skill'
+      When run bash -c 'bash '"$SCRIPT"'; cat "$MOCK_LOG"'
+      The status should be success
+      The output should include 'vercel-react-best-practices'
+    End
+
+    It 'includes web-design-guidelines skill'
+      When run bash -c 'bash '"$SCRIPT"'; cat "$MOCK_LOG"'
+      The status should be success
+      The output should include 'web-design-guidelines'
+    End
+
+    It 'uses --yes flag for non-interactive mode'
+      When run bash -c 'bash '"$SCRIPT"'; cat "$MOCK_LOG"'
+      The status should be success
+      The output should include '--yes'
+    End
+  End
+End


### PR DESCRIPTION
Add \`install-skills.sh\` to install agent skills from external repositories using [\`add-skill\` CLI](https://agentskills.io).

## Usage

\`\`\`bash
./config/claude/install-skills.sh
\`\`\`

## Skills installed

From [vercel-labs/agent-skills](https://github.com/vercel-labs/agent-skills):
- **vercel-react-best-practices**: 40+ React/Next.js performance optimization rules
- **web-design-guidelines**: 100+ UI/UX best practices

Skills are installed to \`~/.claude/skills/\` and automatically available to Claude Code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a script to install Claude Code agent skills from external repositories using the add-skill CLI. Installs React best practices and web design guidelines to ~/.claude/skills and makes them available in Claude Code.

- **New Features**
  - Script added at config/claude/install-skills.sh; also installed to ~/.claude/install-skills.sh via Nix
  - Run with: ./config/claude/install-skills.sh or ~/.claude/install-skills.sh

<sup>Written for commit d82e7bd01420d7cf8a8f8519e5155dcab7405762. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

