### PR TITLE
feat(models): add GLM-4.7 model support via OpenRouter

### DIFF
--- a/config/pi/models.json
+++ b/config/pi/models.json
@@ -193,6 +193,7 @@
             "cacheRead": 0,
             "cacheWrite": 0
           },
+          "contextWindow": 131072,
           "maxTokens": 16384
         }
       ]

--- a/config/pi/models.json
+++ b/config/pi/models.json
@@ -178,7 +178,7 @@
     "openrouter-preset": {
       "baseUrl": "https://openrouter.ai/api/v1",
       "apiKeyEnvVar": "OPENROUTER_API_KEY",
-      "api": "openai",
+      "api": "openai-responses",
       "models": [
         {
           "id": "@preset/glm-4-7",

--- a/config/pi/models.json
+++ b/config/pi/models.json
@@ -177,8 +177,8 @@
     },
     "openrouter-preset": {
       "baseUrl": "https://openrouter.ai/api/v1",
-      "apiKeyEnvVar": "OPENROUTER_API_KEY",
-      "api": "openai-responses",
+      "apiKey": "OPENROUTER_API_KEY",
+      "api": "openai-completions",
       "models": [
         {
           "id": "@preset/glm-4-7",

--- a/config/pi/models.json
+++ b/config/pi/models.json
@@ -142,8 +142,8 @@
           "maxTokens": 8192
         },
         {
-          "id": "z-ai/glm-4.7",
-          "name": "GLM-4.7 (Z-AI)",
+          "id": "z-ai/glm-4-7",
+          "name": "glm-4-7 (Z-AI)",
           "reasoning": false,
           "input": [
             "text"
@@ -171,6 +171,28 @@
             "cacheWrite": 0
           },
           "contextWindow": 131072,
+          "maxTokens": 16384
+        }
+      ]
+    },
+    "openrouter-preset": {
+      "baseUrl": "https://openrouter.ai/api/v1",
+      "apiKeyEnvVar": "OPENROUTER_API_KEY",
+      "api": "openai",
+      "models": [
+        {
+          "id": "@preset/glm-4-7",
+          "name": "GLM-4.7 (Z-AI)",
+          "reasoning": false,
+          "input": [
+            "text"
+          ],
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          },
           "maxTokens": 16384
         }
       ]

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -88,6 +88,8 @@
       kyberm = "_kyberm_function";
       ocxe = "_ocxe_function";
       ocxeh = "_ocxeh_function";
+      pixe = "_pixe_function";
+      pixeh = "_pixeh_function";
       sag = "_ssh_add_github";
       shortcuts = "_fish_shortcuts";
       zdo = "_zdo_function";
@@ -149,6 +151,10 @@
         "_dev_function"
         "_ocxe_function"
         "_ocxeh_function"
+        "_pilxe_function"
+        "_pilxeh_function"
+        "_pixe_function"
+        "_pixeh_function"
         "_fish_shortcuts"
         "_fzf_cmd_history"
         "_fzf_directory_picker"

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -151,8 +151,6 @@
         "_dev_function"
         "_ocxe_function"
         "_ocxeh_function"
-        "_pilxe_function"
-        "_pilxeh_function"
         "_pixe_function"
         "_pixeh_function"
         "_fish_shortcuts"

--- a/home-manager/programs/fish/functions/_pixe_function.fish
+++ b/home-manager/programs/fish/functions/_pixe_function.fish
@@ -1,0 +1,11 @@
+function _pixe_function --description "Run Pi agent with GLM-4.7 via OpenRouter"
+  # Run Pi agent with a free-form prompt (spaces allowed) using GLM-4.7
+  # Usage: pixe [<prompt words...>]
+
+  if test (count $argv) -eq 0
+    pi-agent -m 'openrouter-preset/@preset/glm-4-7'
+  else
+    set -l prompt (string join " " -- $argv)
+    pi-agent "$prompt" -m 'openrouter-preset/@preset/glm-4-7'
+  end
+end

--- a/home-manager/programs/fish/functions/_pixeh_function.fish
+++ b/home-manager/programs/fish/functions/_pixeh_function.fish
@@ -1,0 +1,12 @@
+function _pixeh_function --description "Run Pi agent headlessly with GLM-4.7"
+  # Prompt for input and run Pi agent
+  # Usage: pixeh
+
+  read -P "Prompt: " prompt
+  if test -z "$prompt"
+    echo "No prompt provided, aborting." >&2
+    return 1
+  end
+
+  pi-agent "$prompt" -m 'openrouter-preset/@preset/glm-4-7'
+end


### PR DESCRIPTION
## Changes
- Added GLM-4.7 model configuration via OpenRouter preset
- Updated model ID from `z-ai/glm-4.7` to `z-ai/glm-4-7`
- Set API endpoint to `openai-completions`
- Increased context window to 131,072 tokens
- Added `pixe` and `pixeh` fish shortcuts for quick GLM-4.7 access

## Technical Details
- Uses OpenRouter's preset system for model routing
- Free API usage for the preset model
- Convenience functions for running Pi agent with GLM-4.7

## Testing
- Configuration builds successfully
- Fish functions registered properly

Generated with Claude Code by Claude 3.5 Sonnet

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add GLM-4.7 support via an OpenRouter preset and new fish shortcuts to run Pi agent with this model. Uses the openai-completions endpoint and increases the context window for longer prompts.

- **New Features**
  - OpenRouter preset for GLM-4.7: @preset/glm-4-7 with a 131,072-token context window.
  - pixe and pixeh fish functions to run Pi agent with the preset (pixeh prompts headlessly).

- **Refactors**
  - Updated model ID to z-ai/glm-4-7.
  - Set API to openai-completions.

<sup>Written for commit be5391e0d0dab4d8105bad8d9844250f47a31e26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

