### PR TITLE
feat: add destructive command guard integration

### DIFF
--- a/.local-binaries.txt
+++ b/.local-binaries.txt
@@ -2,9 +2,10 @@
 # Add one binary path per line
 # Lines starting with # are comments
 
-~/ghq/github.com/Dicklesworthstone/ultimate_bug_scanner/ubs
-~/ghq/github.com/Dicklesworthstone/coding_agent_session_search/target/release/cass
 ~/ghq/github.com/Dicklesworthstone/beads_viewer/bv
+~/ghq/github.com/Dicklesworthstone/coding_agent_session_search/target/release/cass
+~/ghq/github.com/Dicklesworthstone/destructive_command_guard/target/release/dcg
+~/ghq/github.com/Dicklesworthstone/ultimate_bug_scanner/ubs
 ~/ghq/github.com/nwiizo/ccswarm/target/release/ccswarm
 ~/ghq/github.com/steveyegge/beads/bd
 ~/ghq/github.com/steveyegge/gastown

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -152,6 +152,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "command -v dcg >/dev/null 2>&1 && dcg",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "$HOME/.claude/security.sh",
             "timeout": 5
           },

--- a/home-manager/modules/local-binaries/sync-local-binaries.sh
+++ b/home-manager/modules/local-binaries/sync-local-binaries.sh
@@ -32,6 +32,9 @@ while IFS= read -r line || [ -n "$line" ]; do
   \#*) continue ;;
   esac
 
+  # Expand ~ to $HOME
+  line="${line/#\~/$HOME}"
+
   # Check if binary exists and is executable
   if [ ! -f "$line" ] || [ ! -x "$line" ]; then
     echo "Skipping (not found or not executable): $line"

--- a/home-manager/programs/neovim/nvim-pack-lock.json
+++ b/home-manager/programs/neovim/nvim-pack-lock.json
@@ -177,6 +177,10 @@
       "rev": "01cb3a8ad7d5e8707041edc775af83dbf33838f4",
       "src": "https://github.com/stevearc/oil.nvim"
     },
+    "opencode.nvim": {
+      "rev": "990c062d4036877a047cb3f5372e2f261a889f0a",
+      "src": "https://github.com/NickvanDyke/opencode.nvim"
+    },
     "other.nvim": {
       "rev": "1d48e090f6d1d53dda9fb5094af3f2006ebbb858",
       "src": "https://github.com/rgroli/other.nvim"
@@ -188,6 +192,10 @@
     "sidekick.nvim": {
       "rev": "c2bdf8cfcd87a6be5f8b84322c1b5052e78e302e",
       "src": "https://github.com/folke/sidekick.nvim"
+    },
+    "snacks.nvim": {
+      "rev": "fe7cfe9800a182274d0f868a74b7263b8c0c020b",
+      "src": "https://github.com/folke/snacks.nvim"
     },
     "telescope-fzf-native.nvim": {
       "rev": "6fea601bd2b694c6f2ae08a6c6fab14930c60e2c",


### PR DESCRIPTION
## Changes
- Added destructive command guard (dcg) binary to local binaries list
- Added Claude settings hook to run dcg before bash commands
- Fixed tilde expansion in local binaries sync script

## Technical Details
- dcg provides protection against destructive commands
- Integrated with Claude's command execution flow
- Sync script now properly handles ~ home directory expansion

## Testing
- Verified dcg binary is executable and accessible
- Confirmed tilde expansion works in sync script
- Tested Claude settings integration

Generated with OpenCode by Claude 3.5 Sonnet

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates destructive command guard (dcg) into the Bash command flow to block unsafe commands. Also fixes tilde expansion in the local binaries sync and updates the local binaries list.

- **New Features**
  - Run dcg as a pre-execution hook for Bash commands in Claude settings (timeout 5s).
  - Add dcg to .local-binaries.txt for local discovery.
  - Update Neovim pack lock with opencode.nvim and snacks.nvim.

- **Bug Fixes**
  - Expand ~ to $HOME in the local-binaries sync script to correctly resolve home paths.

<sup>Written for commit 7abd96572ddec5a26fed7e4476e2a5d4b97a0862. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

