### PR TITLE
feat(claude): add worktrunk plugin

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -12,13 +12,20 @@
     "serena@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
     "plan-export@cc-marketplace": true,
-    "safety-net@cc-marketplace": true
+    "safety-net@cc-marketplace": true,
+    "worktrunk@worktrunk": true
   },
   "extraKnownMarketplaces": {
     "cc-marketplace": {
       "source": {
         "source": "github",
         "repo": "kenryu42/cc-marketplace"
+      }
+    },
+    "worktrunk": {
+      "source": {
+        "source": "github",
+        "repo": "max-sixty/worktrunk"
       }
     }
   },


### PR DESCRIPTION
## Changes
- Add worktrunk marketplace from max-sixty/worktrunk
- Enable worktrunk plugin in Claude Code settings

## Technical Details
- Adds `worktrunk` to `extraKnownMarketplaces` pointing to GitHub repo `max-sixty/worktrunk`
- Enables `worktrunk@worktrunk` plugin in `enabledPlugins`

## Testing
- Plugin will be installed on next Claude Code startup

Generated with Claude Code by claude-opus-4-5-20251101

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the Worktrunk plugin in Claude Code by adding the Worktrunk marketplace source from max-sixty/worktrunk. The plugin will auto-install on the next startup.

<sup>Written for commit bbe6dfe28da56c6daa5cc4093521eb4db69f0ddc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

