### PR TITLE
fix(cargo-globals): add gcc and openssl for native crate compilation

### DIFF
--- a/home-manager/modules/cargo-globals/default.nix
+++ b/home-manager/modules/cargo-globals/default.nix
@@ -2,8 +2,12 @@
 {
   # Install cargo global packages from Cargo.toml using home-manager activation
   home.activation.installCargoGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
-    export PATH=${pkgs.rustup}/bin:${pkgs.cargo}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:$PATH
+    export PATH=${pkgs.rustup}/bin:${pkgs.cargo}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:$PATH
     export CARGO_HOME="$HOME/.cargo"
+    export PKG_CONFIG_PATH="${pkgs.openssl.dev}/lib/pkgconfig"
+    export OPENSSL_DIR="${pkgs.openssl.dev}"
+    export OPENSSL_LIB_DIR="${pkgs.openssl.out}/lib"
+    export OPENSSL_INCLUDE_DIR="${pkgs.openssl.dev}/include"
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash ${./install-cargo-globals.sh}
   '';
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,7 @@
 name = "dotfiles"
 version = "0.1.0"
 requires-python = ">=3.14"
-dependencies = [
-    "ruff>=0.14.13",
-]
+dependencies = ["ruff>=0.14.13"]
 
 [tool.uv]
 dev-dependencies = []


### PR DESCRIPTION
## Summary
- Add `gcc` and `pkg-config` to PATH in cargo-globals activation script
- Set OpenSSL environment variables for crates with SSL dependencies
- Fixes "linker 'cc' not found" error when installing crates like `worktrunk`

## Test plan
- [x] Verified `nix-shell -p gcc pkg-config openssl` allows `cargo install worktrunk` to succeed
- [x] Build passes with `make build`
- [x] Switch completes with `make switch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add gcc and pkg-config to PATH and set OpenSSL env vars in the cargo-globals activation script so native Rust crates compile. Fixes cargo install failures like “linker 'cc' not found” and missing OpenSSL during builds (e.g., worktrunk).

- **Bug Fixes**
  - Add gcc and pkg-config to PATH during activation.
  - Export PKG_CONFIG_PATH, OPENSSL_DIR, OPENSSL_LIB_DIR, and OPENSSL_INCLUDE_DIR for OpenSSL-dependent crates.

<sup>Written for commit b5bf8ede716b7f55d483a96269e07c69e56347db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

