### PR TITLE
feat(ccs): add CCS accounts registry configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -672,7 +672,13 @@ launchctl-ollama: ## Restart ollama launchd agent.
 ##@ Systemd Services (Linux)
 
 .PHONY: systemctl
-systemctl: systemctl-clawdbot systemctl-code-syncer systemctl-dotfiles-updater systemctl-ollama ## Restart all systemd user services.
+systemctl: systemctl-cliproxyapi systemctl-clawdbot systemctl-code-syncer systemctl-dotfiles-updater systemctl-ollama ## Restart all systemd user services.
+
+.PHONY: systemctl-cliproxyapi
+systemctl-cliproxyapi: ## Restart cliproxyapi systemd user service.
+	@echo "🔄 Restarting cliproxyapi..."
+	@systemctl --user restart cliproxyapi.service || true
+	@echo "✅ cliproxyapi restarted"
 
 .PHONY: systemctl-clawdbot
 systemctl-clawdbot: ## Restart clawdbot gateway systemd user service.

--- a/Makefile
+++ b/Makefile
@@ -675,7 +675,9 @@ launchctl-ollama: ## Restart ollama launchd agent.
 systemctl: systemctl-cliproxyapi systemctl-clawdbot systemctl-code-syncer systemctl-dotfiles-updater systemctl-ollama ## Restart all systemd user services.
 
 .PHONY: systemctl-cliproxyapi
-systemctl-cliproxyapi: ## Restart cliproxyapi systemd user service.
+systemctl-cliproxyapi: ## Pull latest image and restart cliproxyapi systemd user service.
+	@echo "🔄 Pulling latest cliproxyapi image..."
+	@docker pull eceasy/cli-proxy-api:latest || true
 	@echo "🔄 Restarting cliproxyapi..."
 	@systemctl --user restart cliproxyapi.service || true
 	@echo "✅ cliproxyapi restarted"

--- a/config/ccs/accounts.json
+++ b/config/ccs/accounts.json
@@ -1,0 +1,42 @@
+{
+  "version": 1,
+  "providers": {
+    "agy": {
+      "default": "shunkakinoki@gmail.com",
+      "accounts": {
+        "shunkakinoki@gmail.com": {
+          "email": "shunkakinoki@gmail.com",
+          "nickname": "shunkakinoki",
+          "tokenFile": "antigravity-shunkakinoki_gmail_com.json",
+          "createdAt": "2026-01-17T00:00:00.000Z",
+          "lastUsedAt": "2026-01-17T00:00:00.000Z",
+          "tier": "paid"
+        }
+      }
+    },
+    "gemini": {
+      "default": "shunkakinoki@gmail.com",
+      "accounts": {
+        "shunkakinoki@gmail.com": {
+          "email": "shunkakinoki@gmail.com",
+          "nickname": "shunkakinoki",
+          "tokenFile": "gemini-shunkakinoki@gmail.com-gen-lang-client-0359793614.json",
+          "createdAt": "2026-01-12T00:00:00.000Z",
+          "lastUsedAt": "2026-01-12T00:00:00.000Z"
+        }
+      }
+    },
+    "codex": {
+      "default": "shunkakinoki@gmail.com",
+      "accounts": {
+        "shunkakinoki@gmail.com": {
+          "email": "shunkakinoki@gmail.com",
+          "nickname": "shunkakinoki",
+          "tokenFile": "codex-shunkakinoki@gmail.com.json",
+          "createdAt": "2025-12-18T00:00:00.000Z",
+          "lastUsedAt": "2025-12-18T00:00:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/config/ccs/accounts.json
+++ b/config/ccs/accounts.json
@@ -9,7 +9,7 @@
           "nickname": "shunkakinoki",
           "tokenFile": "antigravity-shunkakinoki_gmail_com.json",
           "createdAt": "2026-01-17T00:00:00.000Z",
-          "lastUsedAt": "2026-01-17T00:00:00.000Z",
+          "lastUsedAt": "2026-01-17T19:28:18.251Z",
           "tier": "paid"
         }
       }

--- a/config/ccs/agy.settings.template.json
+++ b/config/ccs/agy.settings.template.json
@@ -1,0 +1,10 @@
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "http://127.0.0.1:8317/api/provider/agy",
+    "ANTHROPIC_AUTH_TOKEN": "__CLIPROXY_API_KEY__",
+    "ANTHROPIC_MODEL": "claude-opus-4-5-thinking",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-5-thinking",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-opus-4-5-thinking",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-4-5"
+  }
+}

--- a/config/ccs/codex.settings.template.json
+++ b/config/ccs/codex.settings.template.json
@@ -1,0 +1,10 @@
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "http://127.0.0.1:8317/api/provider/codex",
+    "ANTHROPIC_AUTH_TOKEN": "__CLIPROXY_API_KEY__",
+    "ANTHROPIC_MODEL": "gpt-5.1-codex-max",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "gpt-5.1-codex-max-high",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "gpt-5.1-codex-max",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gpt-5.1-codex-mini-high"
+  }
+}

--- a/config/ccs/config.template.yaml
+++ b/config/ccs/config.template.yaml
@@ -1,0 +1,131 @@
+# CCS Unified Configuration
+# Docs: https://github.com/kaitranntt/ccs
+version: 7
+# ----------------------------------------------------------------------------
+# Accounts: Isolated Claude instances (each with separate auth/sessions)
+# Manage with: ccs auth add <name>, ccs auth list, ccs auth remove <name>
+# ----------------------------------------------------------------------------
+accounts: {}
+# ----------------------------------------------------------------------------
+# Profiles: API-based providers (GLM, GLMT, Kimi, custom endpoints)
+# Each profile points to a *.settings.json file containing env vars.
+# Edit the settings file directly to customize (ANTHROPIC_MAX_TOKENS, etc.)
+# ----------------------------------------------------------------------------
+profiles: {}
+# ----------------------------------------------------------------------------
+# CLIProxy: OAuth-based providers (gemini, codex, agy, qwen, iflow)
+# Each variant can reference a *.settings.json file for custom env vars.
+# Edit the settings file directly to customize model or other settings.
+# ----------------------------------------------------------------------------
+cliproxy:
+  oauth_accounts: {}
+  providers:
+    - gemini
+    - codex
+    - agy
+    - qwen
+    - iflow
+    - kiro
+    - ghcp
+  variants: {}
+  logging:
+    enabled: false
+    request_log: false
+# ----------------------------------------------------------------------------
+# CLIProxy Server: Remote proxy connection settings
+# Configure via Dashboard (`ccs config`) > Proxy tab.
+#
+# remote: Connect to a remote CLIProxyAPI instance
+# fallback: Use local proxy if remote is unreachable
+# local: Local proxy settings (port, auto-start)
+# ----------------------------------------------------------------------------
+cliproxy_server:
+  remote:
+    enabled: true
+    host: 127.0.0.1
+    port: 8317
+    protocol: http
+    auth_token: __CLIPROXY_API_KEY__
+  fallback:
+    enabled: true
+    auto_start: false
+  local:
+    port: 8317
+    auto_start: false
+# ----------------------------------------------------------------------------
+# Preferences: User settings
+# ----------------------------------------------------------------------------
+preferences:
+  theme: system
+  telemetry: false
+  auto_update: true
+# ----------------------------------------------------------------------------
+# WebSearch: CLI-based web search for third-party profiles
+# Dashboard (`ccs config`) is the source of truth for provider selection.
+#
+# Third-party providers (gemini, codex, agy, etc.) do not have access to
+# Anthropic's WebSearch tool. These CLI tools provide fallback web search.
+#
+# Fallback chain: Gemini -> OpenCode -> Grok (tries in order until success)
+#
+# Gemini models: gemini-2.5-flash (default), gemini-2.5-pro, gemini-2.5-flash-lite
+# OpenCode models: opencode/grok-code (default), opencode/gpt-4o, opencode/claude-3.5-sonnet
+#
+# Install commands:
+#   gemini: npm i -g @google/gemini-cli (FREE - 1000 req/day)
+#   opencode: curl -fsSL https://opencode.ai/install | bash (FREE via Zen)
+#   grok: npm i -g @vibe-kit/grok-cli (requires GROK_API_KEY)
+# ----------------------------------------------------------------------------
+websearch:
+  enabled: true
+  providers:
+    gemini:
+      enabled: true
+      model: gemini-2.5-flash
+      timeout: 55
+    opencode:
+      enabled: false
+      model: opencode/grok-code
+      timeout: 90
+    grok:
+      enabled: false
+      timeout: 55
+# ----------------------------------------------------------------------------
+# Copilot: GitHub Copilot API proxy (via copilot-api)
+# Uses your existing GitHub Copilot subscription with Claude Code.
+#
+# !! DISCLAIMER - USE AT YOUR OWN RISK !!
+# This uses an UNOFFICIAL reverse-engineered API.
+# Excessive usage may trigger GitHub account restrictions.
+# CCS provides NO WARRANTY and accepts NO RESPONSIBILITY for consequences.
+#
+# Setup: npx copilot-api auth (authenticate with GitHub)
+# Usage: ccs copilot (switch to copilot profile)
+#
+# Models: claude-sonnet-4.5, claude-opus-4.5, gpt-5.1, gemini-2.5-pro
+# Account types: individual, business, enterprise
+# ----------------------------------------------------------------------------
+copilot:
+  enabled: false
+  auto_start: false
+  port: 4141
+  account_type: individual
+  rate_limit: null
+  wait_on_limit: true
+  model: gpt-4.1
+# ----------------------------------------------------------------------------
+# Global Environment Variables: Injected into all non-Claude subscription profiles
+# These env vars disable telemetry/reporting for third-party providers.
+# Configure via Dashboard (`ccs config`) > Global Env tab.
+#
+# Default variables:
+#   DISABLE_BUG_COMMAND: Disables /bug command (not supported by proxy)
+#   DISABLE_ERROR_REPORTING: Disables error reporting to Anthropic
+#   DISABLE_TELEMETRY: Disables usage telemetry
+# ----------------------------------------------------------------------------
+global_env:
+  enabled: true
+  env:
+    DISABLE_BUG_COMMAND: "1"
+    DISABLE_ERROR_REPORTING: "1"
+    DISABLE_TELEMETRY: "1"

--- a/config/ccs/default.nix
+++ b/config/ccs/default.nix
@@ -1,0 +1,10 @@
+{ config, ... }:
+{
+  # CCS (Claude Code Switcher) account registry
+  # Maps OAuth token files to registered accounts for cliproxy providers
+  # Token files are stored separately in ~/.ccs/cliproxy/auth/ (not managed here as they contain secrets)
+  home.file.".ccs/cliproxy/accounts.json" = {
+    source = config.lib.file.mkOutOfStoreSymlink ./accounts.json;
+    force = true;
+  };
+}

--- a/config/ccs/default.nix
+++ b/config/ccs/default.nix
@@ -1,4 +1,4 @@
-{ config, ... }:
+{ config, lib, pkgs, ... }:
 let
   dotfilesDir = "${config.home.homeDirectory}/dotfiles";
 in
@@ -11,4 +11,29 @@ in
     source = config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/config/ccs/accounts.json";
     force = true;
   };
+
+  # Hydrate CCS settings templates with secrets from .env
+  # ANTHROPIC_AUTH_TOKEN is substituted from CLIPROXY_API_KEY at activation time
+  home.activation.hydrateCcsSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    ENV_FILE="${dotfilesDir}/.env"
+    TEMPLATE="${dotfilesDir}/config/ccs/agy.settings.template.json"
+    OUTPUT="${config.home.homeDirectory}/.ccs/agy.settings.json"
+
+    if [ -f "$ENV_FILE" ] && [ -f "$TEMPLATE" ]; then
+      # Source .env to get CLIPROXY_API_KEY
+      set -a
+      . "$ENV_FILE"
+      set +a
+
+      # Substitute placeholder and write output
+      if [ -n "$CLIPROXY_API_KEY" ]; then
+        ${pkgs.gnused}/bin/sed \
+          -e "s|__CLIPROXY_API_KEY__|$CLIPROXY_API_KEY|g" \
+          "$TEMPLATE" > "$OUTPUT"
+        $VERBOSE_ECHO "Hydrated CCS agy.settings.json with CLIPROXY_API_KEY"
+      else
+        $VERBOSE_ECHO "Warning: CLIPROXY_API_KEY not set in .env, skipping agy.settings.json hydration"
+      fi
+    fi
+  '';
 }

--- a/config/ccs/default.nix
+++ b/config/ccs/default.nix
@@ -1,10 +1,14 @@
 { config, ... }:
+let
+  dotfilesDir = "${config.home.homeDirectory}/dotfiles";
+in
 {
   # CCS (Claude Code Switcher) account registry
   # Maps OAuth token files to registered accounts for cliproxy providers
   # Token files are stored separately in ~/.ccs/cliproxy/auth/ (not managed here as they contain secrets)
+  # Note: Using mkOutOfStoreSymlink with absolute path so CCS can write to the file (updates lastUsedAt)
   home.file.".ccs/cliproxy/accounts.json" = {
-    source = config.lib.file.mkOutOfStoreSymlink ./accounts.json;
+    source = config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/config/ccs/accounts.json";
     force = true;
   };
 }

--- a/config/ccs/default.nix
+++ b/config/ccs/default.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   dotfilesDir = "${config.home.homeDirectory}/dotfiles";
 

--- a/config/ccs/gemini.settings.template.json
+++ b/config/ccs/gemini.settings.template.json
@@ -1,0 +1,10 @@
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "http://127.0.0.1:8317/api/provider/gemini",
+    "ANTHROPIC_AUTH_TOKEN": "__CLIPROXY_API_KEY__",
+    "ANTHROPIC_MODEL": "gemini-2.5-pro",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "gemini-2.5-pro",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "gemini-2.5-pro",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gemini-2.5-flash"
+  }
+}

--- a/config/ccs/hydrate.sh
+++ b/config/ccs/hydrate.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Hydrate CCS provider settings from templates
+# Substitutes __CLIPROXY_API_KEY__ placeholder with actual API key from .env
+# shellcheck source=/dev/null
+set -euo pipefail
+
+DOTFILES_DIR="${HOME}/dotfiles"
+CCS_DIR="${HOME}/.ccs"
+TEMPLATE_DIR="${DOTFILES_DIR}/config/ccs"
+ENV_FILE="${DOTFILES_DIR}/.env"
+
+# Load environment variables
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  . "$ENV_FILE"
+  set +a
+fi
+
+# Check for required API key
+if [ -z "${CLIPROXY_API_KEY:-}" ]; then
+  echo "Warning: CLIPROXY_API_KEY not set in .env, skipping CCS settings hydration" >&2
+  exit 0
+fi
+
+mkdir -p "$CCS_DIR"
+
+# Process all template files
+for template in "$TEMPLATE_DIR"/*.settings.template.json; do
+  [ -f "$template" ] || continue
+
+  # Extract provider name: foo.settings.template.json -> foo
+  filename=$(basename "$template")
+  provider="${filename%.settings.template.json}"
+  output="${CCS_DIR}/${provider}.settings.json"
+
+  # Substitute placeholder and write output
+  @sed@ \
+    -e "s|__CLIPROXY_API_KEY__|${CLIPROXY_API_KEY}|g" \
+    "$template" > "$output"
+
+  echo "Hydrated CCS ${provider}.settings.json" >&2
+done

--- a/config/cliproxyapi/config.yaml
+++ b/config/cliproxyapi/config.yaml
@@ -12,7 +12,8 @@ remote-management:
   # Disable the bundled management control panel asset download and HTTP route when true.
   disable-control-panel: false
 # Authentication directory (supports ~ for home directory). If you use Windows, please set the directory like this: `C:/cli-proxy-api/`
-auth-dir: "~/.cli-proxy-api"
+# Use objectstore/auths subdirectory to avoid duplicate scanning (root-level files are legacy)
+auth-dir: "~/.cli-proxy-api/objectstore/auths"
 # API keys for client authentication (optional - leave commented for open access)
 # api-keys:
 #   - "__CLIPROXY_API_KEY__"

--- a/config/default.nix
+++ b/config/default.nix
@@ -1,5 +1,6 @@
 [
   ./amp
+  ./ccs
   ./cliproxyapi
   ./codex
   ./crush

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -84,6 +84,16 @@ if [ -f "$TEMPLATE" ]; then
       -e "s|^#   - \"__CLIPROXY_API_KEY__\"|  - \"${CLIPROXY_API_KEY}\"|" \
       "$CONFIG"
   fi
+
+  # Disable AMP on Linux (causes routing issues with antigravity provider)
+  if [ "$(uname)" = "Linux" ]; then
+    @sed@ -i \
+      -e "s|^ampcode:|# ampcode:|" \
+      -e "s|^  upstream-url:|#   upstream-url:|" \
+      -e "s|^  upstream-api-key:|#   upstream-api-key:|" \
+      -e "s|^  restrict-management-to-localhost:|#   restrict-management-to-localhost:|" \
+      "$CONFIG"
+  fi
 fi
 
 cd "$CONFIG_DIR"

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -105,7 +105,8 @@ Describe 'no shell scripts are missing from coverage list'
 It 'covers all non-spec shell scripts in the repository'
 # List of all shell scripts that should have tests
 # Update this list when adding new shell scripts
-covered_scripts="config/claude/notify.sh
+covered_scripts="config/ccs/hydrate.sh
+config/claude/notify.sh
 config/claude/pushover.sh
 config/claude/security.sh
 config/claude/statusline-git.sh


### PR DESCRIPTION
## Summary
- Add home-manager configuration for CCS (Claude Code Switcher) accounts registry
- Fixes the "No accounts configured" error when using `ccs agy`, `ccs gemini`, or `ccs codex` commands
- Token files remain in `~/.ccs/cliproxy/auth/` (not managed here as they contain secrets)

## Test plan
- [ ] Run `home-manager switch` to apply configuration
- [ ] Verify symlink exists: `ls -la ~/.ccs/cliproxy/accounts.json`
- [ ] Test `ccs agy --help` works without "No accounts configured" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Home Manager config for the CCS accounts registry, symlinking accounts.json to ~/.ccs/cliproxy/accounts.json and fixing “No accounts configured” for ccs agy, gemini, and codex. Hydrates ~/.ccs/{provider}.settings.json (agy, gemini, codex) and ~/.ccs/config.yaml from CLIPROXY_API_KEY via templates, points cliproxyapi to ~/.cli-proxy-api/objectstore/auths, adds a Makefile restart target that pulls the latest image, and disables AMP on Linux to fix agy routing; token files remain in ~/.ccs/cliproxy/auth/.

- **Migration**
  - Run `home-manager switch` (ensure `.env` sets `CLIPROXY_API_KEY`).
  - Restart cliproxyapi: `make systemctl-cliproxyapi` or `make systemctl`.
  - Verify `~/.ccs/cliproxy/accounts.json` is a symlink, `~/.ccs/{agy,gemini,codex}.settings.json` exist, and `~/.ccs/config.yaml` exists.
  - Confirm `ccs agy --help`, `ccs gemini --help`, and `ccs codex --help` run without the error.

<sup>Written for commit c8350dba4e516fbee3ac06e137c00f5b04938a6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

