### PR TITLE
feat(ccs): add CCS configuration with dynamic secret hydration

### DIFF
--- a/config/ccs/accounts.json
+++ b/config/ccs/accounts.json
@@ -9,7 +9,7 @@
           "nickname": "shunkakinoki",
           "tokenFile": "antigravity-shunkakinoki_gmail_com.json",
           "createdAt": "2026-01-17T00:00:00.000Z",
-          "lastUsedAt": "2026-01-17T19:28:18.251Z",
+          "lastUsedAt": "2026-01-17T20:19:49.880Z",
           "tier": "paid"
         }
       }

--- a/config/ccs/agy.settings.template.json
+++ b/config/ccs/agy.settings.template.json
@@ -2,9 +2,9 @@
   "env": {
     "ANTHROPIC_BASE_URL": "http://127.0.0.1:8317/api/provider/agy",
     "ANTHROPIC_AUTH_TOKEN": "__CLIPROXY_API_KEY__",
-    "ANTHROPIC_MODEL": "claude-opus-4-5-thinking",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-5-thinking",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-opus-4-5-thinking",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-4-5"
+    "ANTHROPIC_MODEL": "gemini-claude-opus-4-5-thinking",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "gemini-claude-opus-4-5-thinking",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "gemini-claude-opus-4-5-thinking",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gemini-claude-sonnet-4-5"
   }
 }

--- a/config/ccs/agy.settings.template.json
+++ b/config/ccs/agy.settings.template.json
@@ -2,9 +2,9 @@
   "env": {
     "ANTHROPIC_BASE_URL": "http://127.0.0.1:8317/api/provider/agy",
     "ANTHROPIC_AUTH_TOKEN": "__CLIPROXY_API_KEY__",
-    "ANTHROPIC_MODEL": "gemini-claude-opus-4-5-thinking",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "gemini-claude-opus-4-5-thinking",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "gemini-claude-opus-4-5-thinking",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gemini-claude-sonnet-4-5"
+    "ANTHROPIC_MODEL": "claude-opus-4-5-thinking",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-5-thinking",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-opus-4-5-thinking",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-4-5"
   }
 }

--- a/config/cliproxyapi/config.yaml
+++ b/config/cliproxyapi/config.yaml
@@ -39,9 +39,14 @@ ampcode:
   upstream-url: "https://ampcode.com"
   upstream-api-key: "__AMP_UPSTREAM_API_KEY__"
   restrict-management-to-localhost: false
-  # model-mappings:
-  #   - from: "requested-model-name"
-  #     to: "local-model-name"
+  # Map non-prefixed model names to antigravity provider's gemini-prefixed models
+  model-mappings:
+    - from: "claude-opus-4-5-thinking"
+      to: "gemini-claude-opus-4-5-thinking"
+    - from: "claude-sonnet-4-5"
+      to: "gemini-claude-sonnet-4-5"
+    - from: "claude-sonnet-4-5-thinking"
+      to: "gemini-claude-sonnet-4-5-thinking"
 # Gemini API keys (preferred)
 # gemini-api-key:
 #   - api-key: "AIzaSy...01"

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -92,6 +92,10 @@ if [ -f "$TEMPLATE" ]; then
       -e "s|^  upstream-url:|#   upstream-url:|" \
       -e "s|^  upstream-api-key:|#   upstream-api-key:|" \
       -e "s|^  restrict-management-to-localhost:|#   restrict-management-to-localhost:|" \
+      -e "s|^  # Map non-prefixed|#   # Map non-prefixed|" \
+      -e "s|^  model-mappings:|#   model-mappings:|" \
+      -e "s|^    - from:|#     - from:|" \
+      -e "s|^      to:|#       to:|" \
       "$CONFIG"
   fi
 fi


### PR DESCRIPTION
## Summary
- Add CCS accounts registry configuration for cliproxy providers (agy, gemini, codex)
- Add template-based settings hydration with `CLIPROXY_API_KEY` substitution
- Add model-mappings for antigravity provider to work on both Linux and macOS
- Fix cliproxyapi auth-dir to avoid duplicate scanning
- Add cliproxyapi to `make switch` restart targets

## Changes
- `config/ccs/accounts.json` - CCS account registry for OAuth providers
- `config/ccs/config.template.yaml` - CCS config with auth_token placeholder
- `config/ccs/*.settings.template.json` - Provider settings templates (agy, codex, gemini)
- `config/ccs/hydrate.sh` - Script to substitute secrets from `.env`
- `config/cliproxyapi/config.yaml` - Add model-mappings for antigravity provider
- `home-manager/services/cliproxyapi/scripts/start.sh` - Disable AMP on Linux, comment model-mappings

## How it works
- On `make switch`, hydration script runs during home-manager activation
- Reads `CLIPROXY_API_KEY` from `~/dotfiles/.env`
- Generates `~/.ccs/config.yaml` and `~/.ccs/*.settings.json` with actual API key
- On Linux: AMP disabled, non-prefixed model names work directly
- On macOS: AMP enabled with model-mappings to route to antigravity provider

## Test plan
- [x] `make shell-check` passes
- [x] `make shell-test` passes (359 examples, 0 failures)
- [x] `make build` succeeds
- [x] `make switch` hydrates settings correctly
- [x] `ccs agy -p "say hi"` works on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CCS config with dynamic secret hydration and an accounts registry for cliproxy providers (agy, gemini, codex). Fix auth directory scanning and model routing, and make switch now hydrates settings and restarts cliproxyapi for reliable ccs commands on Linux and macOS.

- **New Features**
  - Hydrates ~/.ccs/config.yaml and provider settings from templates using CLIPROXY_API_KEY.
  - Symlinks CCS accounts registry to ~/.ccs/cliproxy/accounts.json.
  - Adds systemctl-cliproxyapi to pull latest image and restart; included in systemctl.

- **Bug Fixes**
  - Sets cliproxyapi auth-dir to ~/.cli-proxy-api/objectstore/auths to avoid duplicate scans.
  - Linux: disables AMP to prevent antigravity routing issues.
  - macOS: adds model-mappings to route non-prefixed models to gemini-prefixed equivalents.

<sup>Written for commit d276723b8f3567b1c60651c6aca69eebd884ec9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

