### PR TITLE
fix(ccs): hydrate accounts.json from template to avoid git conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # AI
 .claude
 
+# CCS runtime state (lastUsedAt timestamps change frequently)
+config/ccs/accounts.json
+
 # Local binaries list (machine-specific)
 .devenv.nix
 objectstore

--- a/config/ccs/accounts.template.json
+++ b/config/ccs/accounts.template.json
@@ -9,7 +9,6 @@
           "nickname": "shunkakinoki",
           "tokenFile": "antigravity-shunkakinoki_gmail_com.json",
           "createdAt": "2026-01-17T00:00:00.000Z",
-          "lastUsedAt": "2026-01-17T20:19:49.880Z",
           "tier": "paid"
         }
       }
@@ -21,8 +20,7 @@
           "email": "shunkakinoki@gmail.com",
           "nickname": "shunkakinoki",
           "tokenFile": "gemini-shunkakinoki@gmail.com-gen-lang-client-0359793614.json",
-          "createdAt": "2026-01-12T00:00:00.000Z",
-          "lastUsedAt": "2026-01-12T00:00:00.000Z"
+          "createdAt": "2026-01-12T00:00:00.000Z"
         }
       }
     },
@@ -33,8 +31,7 @@
           "email": "shunkakinoki@gmail.com",
           "nickname": "shunkakinoki",
           "tokenFile": "codex-shunkakinoki@gmail.com.json",
-          "createdAt": "2025-12-18T00:00:00.000Z",
-          "lastUsedAt": "2025-12-18T00:00:00.000Z"
+          "createdAt": "2025-12-18T00:00:00.000Z"
         }
       }
     }

--- a/config/ccs/default.nix
+++ b/config/ccs/default.nix
@@ -16,11 +16,7 @@ in
   # CCS (Claude Code Switcher) account registry
   # Maps OAuth token files to registered accounts for cliproxy providers
   # Token files are stored separately in ~/.ccs/cliproxy/auth/ (not managed here as they contain secrets)
-  # Note: Using mkOutOfStoreSymlink with absolute path so CCS can write to the file (updates lastUsedAt)
-  home.file.".ccs/cliproxy/accounts.json" = {
-    source = config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/config/ccs/accounts.json";
-    force = true;
-  };
+  # Note: accounts.json is hydrated from template only if missing (preserves runtime state like lastUsedAt)
 
   # Hydrate CCS settings templates with secrets from .env
   # ANTHROPIC_AUTH_TOKEN is substituted from CLIPROXY_API_KEY at activation time

--- a/config/ccs/hydrate.sh
+++ b/config/ccs/hydrate.sh
@@ -49,3 +49,12 @@ for template in "$TEMPLATE_DIR"/*.settings.template.json; do
 
   echo "Hydrated CCS ${provider}.settings.json" >&2
 done
+
+# Hydrate accounts.json only if it doesn't exist (preserves runtime state like lastUsedAt)
+ACCOUNTS_TEMPLATE="${TEMPLATE_DIR}/accounts.template.json"
+ACCOUNTS_OUTPUT="${CCS_DIR}/cliproxy/accounts.json"
+if [ -f "$ACCOUNTS_TEMPLATE" ] && [ ! -f "$ACCOUNTS_OUTPUT" ]; then
+  mkdir -p "${CCS_DIR}/cliproxy"
+  cp "$ACCOUNTS_TEMPLATE" "$ACCOUNTS_OUTPUT"
+  echo "Hydrated CCS accounts.json (initial)" >&2
+fi


### PR DESCRIPTION
## Summary
- Created `accounts.template.json` without runtime fields (lastUsedAt)
- Hydrate to `~/.ccs/cliproxy/accounts.json` only if file doesn't exist
- Added `config/ccs/accounts.json` to `.gitignore`
- Removed symlink in favor of hydration approach

This prevents constant git conflicts from `lastUsedAt` timestamp changes.

## Test plan
- [x] `make build` passes
- [ ] `make switch` creates accounts.json from template on fresh system
- [ ] Existing accounts.json is preserved (runtime state intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hydrates CCS accounts.json from a template on first run to stop committing runtime state. This removes frequent git conflicts from lastUsedAt updates and preserves existing local data.

- **Bug Fixes**
  - Added accounts.template.json without lastUsedAt.
  - Hydrates ~/.ccs/cliproxy/accounts.json only if missing (via hydrate.sh).
  - Ignored config/ccs/accounts.json in .gitignore.
  - Removed mkOutOfStoreSymlink setup in default.nix.

<sup>Written for commit 94f1fcbc34e18e08e6a9530be2c73932d573f1ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

