### PR TITLE
feat(ccs): add GLM provider configuration with ZAI API key support

### DIFF
--- a/config/ccs/glm.settings.template.json
+++ b/config/ccs/glm.settings.template.json
@@ -1,0 +1,10 @@
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://api.z.ai/api/anthropic",
+    "ANTHROPIC_AUTH_TOKEN": "__ZAI_API_KEY__",
+    "ANTHROPIC_MODEL": "glm-4.7",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-4.7",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-4.7",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "glm-4.7"
+  }
+}

--- a/config/ccs/hydrate.sh
+++ b/config/ccs/hydrate.sh
@@ -22,6 +22,11 @@ if [ -z "${CLIPROXY_API_KEY:-}" ]; then
   exit 0
 fi
 
+# Optional API keys (warn if not set but continue)
+if [ -z "${ZAI_API_KEY:-}" ]; then
+  echo "Warning: ZAI_API_KEY not set in .env, GLM provider may not work" >&2
+fi
+
 mkdir -p "$CCS_DIR"
 
 # Hydrate config.yaml
@@ -29,6 +34,7 @@ CONFIG_TEMPLATE="${TEMPLATE_DIR}/config.template.yaml"
 if [ -f "$CONFIG_TEMPLATE" ]; then
   @sed@ \
     -e "s|__CLIPROXY_API_KEY__|${CLIPROXY_API_KEY}|g" \
+    -e "s|__ZAI_API_KEY__|${ZAI_API_KEY:-}|g" \
     "$CONFIG_TEMPLATE" >"${CCS_DIR}/config.yaml"
   echo "Hydrated CCS config.yaml" >&2
 fi
@@ -42,9 +48,10 @@ for template in "$TEMPLATE_DIR"/*.settings.template.json; do
   provider="${filename%.settings.template.json}"
   output="${CCS_DIR}/${provider}.settings.json"
 
-  # Substitute placeholder and write output
+  # Substitute placeholders and write output
   @sed@ \
     -e "s|__CLIPROXY_API_KEY__|${CLIPROXY_API_KEY}|g" \
+    -e "s|__ZAI_API_KEY__|${ZAI_API_KEY:-}|g" \
     "$template" >"$output"
 
   echo "Hydrated CCS ${provider}.settings.json" >&2


### PR DESCRIPTION
## Summary
- Add GLM provider configuration template with ZAI API integration
- Update hydration script to support ZAI_API_KEY substitution
- Add warning for optional ZAI_API_KEY environment variable

## Changes
- **glm.settings.template.json**: New template for GLM provider configuration using ZAI API
- **hydrate.sh**: Enhanced to support ZAI_API_KEY substitution with optional handling

## Details
This change enables the GLM (General Language Model) provider to work with the ZAI API service, allowing users to configure their ZAI API key through the standard environment variable system. The hydration script now handles the ZAI_API_KEY substitution across both config.yaml and provider-specific settings files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GLM provider settings template and hydration support for ZAI_API_KEY so GLM can be configured via environment variables without manual edits.

- **New Features**
  - Added glm.settings.template.json using ZAI base URL with glm-4.7 defaults and a __ZAI_API_KEY__ placeholder.
  - Updated hydrate.sh to substitute ZAI_API_KEY in config.yaml and provider settings; warns if the key is not set.

<sup>Written for commit 669a005dfe0e8125010282f8ebadc8aa0e8563c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

