### PR TITLE
feat(clawdbot): add Telegram group -1003612372477 to allowlist

### DIFF
--- a/home-manager/modules/clawdbot/default.nix
+++ b/home-manager/modules/clawdbot/default.nix
@@ -173,6 +173,10 @@ lib.mkIf (!env.isCI) {
           "*" = {
             requireMention = false;
           };
+          "-1003612372477" = {
+            enabled = true;
+            requireMention = false;
+          };
         };
       };
 


### PR DESCRIPTION
Add Telegram group ID -1003612372477 to the allowlist so Clawdbot can respond in that group chat.

Config change applied to \`providers.telegram.groups\` in the nix module.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enabled Clawdbot in Telegram group -1003612372477 by adding it to the providers.telegram.groups allowlist. The group is enabled and replies do not require a mention.

<sup>Written for commit 84b4bcb0b2cb33abbc774e84407105e0d1482870. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

