### PR TITLE
feat(claude): add Trail of Bits skills repository

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -13,7 +13,24 @@
     "typescript-lsp@claude-plugins-official": true,
     "plan-export@cc-marketplace": true,
     "safety-net@cc-marketplace": true,
-    "worktrunk@worktrunk": true
+    "worktrunk@worktrunk": true,
+    "building-secure-contracts@trailofbits": true,
+    "entry-point-analyzer@trailofbits": true,
+    "audit-context-building@trailofbits": true,
+    "burpsuite-project-parser@trailofbits": true,
+    "differential-review@trailofbits": true,
+    "semgrep-rule-creator@trailofbits": true,
+    "sharp-edges@trailofbits": true,
+    "static-analysis@trailofbits": true,
+    "testing-handbook-skills@trailofbits": true,
+    "variant-analysis@trailofbits": true,
+    "constant-time-analysis@trailofbits": true,
+    "property-based-testing@trailofbits": true,
+    "spec-to-code-compliance@trailofbits": true,
+    "fix-review@trailofbits": true,
+    "dwarf-expert@trailofbits": true,
+    "ask-questions-if-underspecified@trailofbits": true,
+    "culture-index@trailofbits": true
   },
   "extraKnownMarketplaces": {
     "cc-marketplace": {
@@ -26,6 +43,12 @@
       "source": {
         "source": "github",
         "repo": "max-sixty/worktrunk"
+      }
+    },
+    "trailofbits": {
+      "source": {
+        "source": "github",
+        "repo": "trailofbits/skills"
       }
     }
   },


### PR DESCRIPTION
Add trailofbits/skills as a custom marketplace with 17 security-focused skills enabled. Includes smart contract auditing, code analysis, static analysis, property-based testing, and vulnerability detection tools for enhanced security analysis capabilities.

🛡️ Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the Trail of Bits skills repository as a custom marketplace and enabled 17 security-focused skills to strengthen code and smart contract analysis in Claude. Improves static analysis, property-based testing, and vulnerability detection coverage.

- **New Features**
  - Added “trailofbits” marketplace pointing to trailofbits/skills.
  - Enabled skills spanning static analysis, smart contract auditing, property-based testing, constant-time checks, variant analysis, spec-to-code compliance, differential review, BurpSuite project parsing, DWARF analysis, and audit context helpers.

<sup>Written for commit 0664482dba2ed494a82cc85161d4ecd614ff04cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

