### PR TITLE
feat(packages): add Rust native compilation dependencies for Linux

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -94,15 +94,21 @@ with pkgs;
 ++ lib.optionals stdenv.isLinux [
   atop
   below
+  binutils
   blueberry
   claude-code
+  cmake
   codex
   collectd
   docker
   docker-compose
+  gcc
   gemini-cli
   keychain
   opencode
+  openssl
+  openssl.dev
+  pkg-config
   powertop
   tailscale
   trashy


### PR DESCRIPTION
## Changes
- Add `gcc` and `binutils` for C compilation and linking
- Add `pkg-config` for library discovery
- Add `cmake` for tree-sitter grammar builds
- Add `openssl` and `openssl.dev` for HTTPS support

## Technical Details
These packages are required to build Rust crates with native dependencies on Linux, such as:
- tree-sitter grammars (require C compiler)
- rusqlite with bundled SQLite
- self_update crate (requires OpenSSL for HTTPS)

## Testing
- Verified `cargo build --release` succeeds for destructive_command_guard after adding these packages

Generated with Claude Code by claude-opus-4-5-20251101

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Linux-only build tools to home-manager packages to compile Rust crates with native dependencies. This unblocks builds for tree-sitter grammars, rusqlite (bundled), and self_update (OpenSSL).

- **Dependencies**
  - gcc, binutils — C compilation and linking
  - pkg-config — library discovery
  - cmake — tree-sitter grammar builds
  - openssl, openssl.dev — HTTPS/TLS for self_update

<sup>Written for commit 6490402a060772c8c5729bbc11e753f427d573ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

