### PR TITLE
fix: skip docker pull when docker is not accessible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -676,8 +676,12 @@ systemctl: systemctl-cliproxyapi systemctl-clawdbot systemctl-code-syncer system
 
 .PHONY: systemctl-cliproxyapi
 systemctl-cliproxyapi: ## Pull latest image and restart cliproxyapi systemd user service.
-	@echo "🔄 Pulling latest cliproxyapi image..."
-	@docker pull eceasy/cli-proxy-api:latest || true
+	@if docker info >/dev/null 2>&1; then \
+		echo "🔄 Pulling latest cliproxyapi image..."; \
+		docker pull eceasy/cli-proxy-api:latest || true; \
+	else \
+		echo "⏭️ Skipping docker pull (docker not accessible)"; \
+	fi
 	@echo "🔄 Restarting cliproxyapi..."
 	@systemctl --user restart cliproxyapi.service || true
 	@echo "✅ cliproxyapi restarted"


### PR DESCRIPTION
Check if docker daemon is accessible before attempting to pull images.

This prevents permission errors on systems where the user doesn't have docker socket access.

**Changes:**
- Added \`docker info\` check before running \`docker pull\`
- Shows skip message when docker is not accessible
- Still restarts the systemd service regardless

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Check Docker access before pulling the cliproxyapi image to prevent permission errors when the user lacks socket access. The systemd user service still restarts even if the pull is skipped.

<sup>Written for commit ff53b28b1e02f30e3d7196fc9b25d9b88c8c9377. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

