### PR TITLE
feat(clawdbot): integrate cliproxyapi as model provider

### DIFF
--- a/home-manager/modules/clawdbot/default.nix
+++ b/home-manager/modules/clawdbot/default.nix
@@ -135,6 +135,42 @@ lib.mkIf (!env.isCI) {
             executablePath = "${pkgs.chromium}/bin/chromium";
             noSandbox = true; # SUID sandbox requires root-owned binary with mode 4755
           };
+          # Route through cliproxyapi for access to all model providers
+          # cliproxyapi runs locally on port 8317 with OpenAI-compatible API
+          models = {
+            mode = "merge";
+            providers = {
+              cliproxy = {
+                baseUrl = "http://localhost:8317/v1";
+                apiKeyFile = "${clawdbotDir}/cliproxy-key";
+                api = "openai-completions";
+                models = [
+                  # Anthropic models
+                  { id = "claude-opus-4-5-20251101"; name = "Claude Opus 4.5"; }
+                  { id = "claude-opus-4-5-thinking"; name = "Claude Opus 4.5 Thinking"; }
+                  { id = "claude-sonnet-4-5-20250929"; name = "Claude Sonnet 4.5"; }
+                  { id = "claude-sonnet-4-5-thinking"; name = "Claude Sonnet 4.5 Thinking"; }
+                  { id = "claude-sonnet-4-20250514"; name = "Claude Sonnet 4"; }
+                  { id = "claude-opus-4-20250514"; name = "Claude Opus 4"; }
+                  { id = "claude-haiku-4-5-20251001"; name = "Claude Haiku 4.5"; }
+                  # OpenAI models
+                  { id = "gpt-5.2"; name = "GPT-5.2"; }
+                  { id = "gpt-5.2-codex"; name = "GPT-5.2 Codex"; }
+                  { id = "gpt-5.1"; name = "GPT-5.1"; }
+                  { id = "gpt-5"; name = "GPT-5"; }
+                  { id = "gpt-5-codex"; name = "GPT-5 Codex"; }
+                  # Google Gemini models
+                  { id = "gemini-3-pro-preview"; name = "Gemini 3 Pro"; }
+                  { id = "gemini-3-flash-preview"; name = "Gemini 3 Flash"; }
+                  { id = "gemini-2.5-pro"; name = "Gemini 2.5 Pro"; }
+                  { id = "gemini-2.5-flash"; name = "Gemini 2.5 Flash"; }
+                  # Z-AI GLM models
+                  { id = "glm-4.7"; name = "GLM 4.7"; }
+                  { id = "glm-4.6"; name = "GLM 4.6"; }
+                ];
+              };
+            };
+          };
         }
         # All other hosts (macOS + non-kyber Linux): Remote mode - connect to kyber gateway
         // lib.optionalAttrs (!host.isKyber) {

--- a/home-manager/modules/clawdbot/default.nix
+++ b/home-manager/modules/clawdbot/default.nix
@@ -146,27 +146,81 @@ lib.mkIf (!env.isCI) {
                 api = "openai-completions";
                 models = [
                   # Anthropic models
-                  { id = "claude-opus-4-5-20251101"; name = "Claude Opus 4.5"; }
-                  { id = "claude-opus-4-5-thinking"; name = "Claude Opus 4.5 Thinking"; }
-                  { id = "claude-sonnet-4-5-20250929"; name = "Claude Sonnet 4.5"; }
-                  { id = "claude-sonnet-4-5-thinking"; name = "Claude Sonnet 4.5 Thinking"; }
-                  { id = "claude-sonnet-4-20250514"; name = "Claude Sonnet 4"; }
-                  { id = "claude-opus-4-20250514"; name = "Claude Opus 4"; }
-                  { id = "claude-haiku-4-5-20251001"; name = "Claude Haiku 4.5"; }
+                  {
+                    id = "claude-opus-4-5-20251101";
+                    name = "Claude Opus 4.5";
+                  }
+                  {
+                    id = "claude-opus-4-5-thinking";
+                    name = "Claude Opus 4.5 Thinking";
+                  }
+                  {
+                    id = "claude-sonnet-4-5-20250929";
+                    name = "Claude Sonnet 4.5";
+                  }
+                  {
+                    id = "claude-sonnet-4-5-thinking";
+                    name = "Claude Sonnet 4.5 Thinking";
+                  }
+                  {
+                    id = "claude-sonnet-4-20250514";
+                    name = "Claude Sonnet 4";
+                  }
+                  {
+                    id = "claude-opus-4-20250514";
+                    name = "Claude Opus 4";
+                  }
+                  {
+                    id = "claude-haiku-4-5-20251001";
+                    name = "Claude Haiku 4.5";
+                  }
                   # OpenAI models
-                  { id = "gpt-5.2"; name = "GPT-5.2"; }
-                  { id = "gpt-5.2-codex"; name = "GPT-5.2 Codex"; }
-                  { id = "gpt-5.1"; name = "GPT-5.1"; }
-                  { id = "gpt-5"; name = "GPT-5"; }
-                  { id = "gpt-5-codex"; name = "GPT-5 Codex"; }
+                  {
+                    id = "gpt-5.2";
+                    name = "GPT-5.2";
+                  }
+                  {
+                    id = "gpt-5.2-codex";
+                    name = "GPT-5.2 Codex";
+                  }
+                  {
+                    id = "gpt-5.1";
+                    name = "GPT-5.1";
+                  }
+                  {
+                    id = "gpt-5";
+                    name = "GPT-5";
+                  }
+                  {
+                    id = "gpt-5-codex";
+                    name = "GPT-5 Codex";
+                  }
                   # Google Gemini models
-                  { id = "gemini-3-pro-preview"; name = "Gemini 3 Pro"; }
-                  { id = "gemini-3-flash-preview"; name = "Gemini 3 Flash"; }
-                  { id = "gemini-2.5-pro"; name = "Gemini 2.5 Pro"; }
-                  { id = "gemini-2.5-flash"; name = "Gemini 2.5 Flash"; }
+                  {
+                    id = "gemini-3-pro-preview";
+                    name = "Gemini 3 Pro";
+                  }
+                  {
+                    id = "gemini-3-flash-preview";
+                    name = "Gemini 3 Flash";
+                  }
+                  {
+                    id = "gemini-2.5-pro";
+                    name = "Gemini 2.5 Pro";
+                  }
+                  {
+                    id = "gemini-2.5-flash";
+                    name = "Gemini 2.5 Flash";
+                  }
                   # Z-AI GLM models
-                  { id = "glm-4.7"; name = "GLM 4.7"; }
-                  { id = "glm-4.6"; name = "GLM 4.6"; }
+                  {
+                    id = "glm-4.7";
+                    name = "GLM 4.7";
+                  }
+                  {
+                    id = "glm-4.6";
+                    name = "GLM 4.6";
+                  }
                 ];
               };
             };

--- a/home-manager/modules/clawdbot/extract-secrets.sh
+++ b/home-manager/modules/clawdbot/extract-secrets.sh
@@ -32,5 +32,15 @@ if [[ ! -s "$CLAWDBOT_DIR/anthropic-key" ]] && [[ -f $DOTFILES_ENV ]]; then
   @grep@ -E "^CLAWDBOT_ANTHROPIC_KEY=" "$DOTFILES_ENV" 2>/dev/null | @cut@ -d= -f2- | @tr@ -d '"' >"$CLAWDBOT_DIR/anthropic-key" || true
 fi
 
+# Extract cliproxyapi API key from config.yaml
+CLIPROXY_CONFIG="$HOME/.cli-proxy-api/config.yaml"
+if [[ -f $CLIPROXY_CONFIG ]]; then
+  # Extract first api-key from api-keys list in config.yaml
+  @grep@ -E '^\s*-\s*"[^"]+"\s*$' "$CLIPROXY_CONFIG" 2>/dev/null | @head@ -1 | @tr@ -d '"-' | @tr@ -d ' ' >"$CLAWDBOT_DIR/cliproxy-key" || true
+  if [[ -s "$CLAWDBOT_DIR/cliproxy-key" ]]; then
+    echo "Extracted cliproxyapi key from config" >&2
+  fi
+fi
+
 # Set secure permissions
 chmod 600 "$CLAWDBOT_DIR"/* 2>/dev/null || true


### PR DESCRIPTION
## Summary
Add cliproxyapi as a model provider for Clawdbot, enabling access to all models through a single local proxy.

## Changes
- **clawdbot/default.nix**: Add \`models.providers.cliproxy\` configuration pointing to local cliproxyapi (port 8317)
- **extract-secrets.sh**: Extract clipproxyapi key from \`~/.cli-proxy-api/config.yaml\`

## Available Models (via cliproxy)
| Provider | Models |
|----------|--------|
| Anthropic | claude-opus-4-5, claude-sonnet-4-5, claude-haiku-4-5, etc. |
| OpenAI | gpt-5.2, gpt-5.1, gpt-5, codex variants |
| Google | gemini-3-pro, gemini-3-flash, gemini-2.5-pro/flash |
| Z-AI | glm-4.7, glm-4.6 |

## Usage
After merge, use models like: \`cliproxy/claude-opus-4-5-20251101\` or \`cliproxy/gpt-5.2\`

## Notes
- Only applies to kyber (gateway host) where cliproxyapi runs
- Built-in anthropic provider remains as fallback

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates cliproxyapi as a Clawdbot model provider, routing through a local OpenAI-compatible proxy on port 8317 to unlock Anthropic, OpenAI, Gemini, and GLM models. Active on kyber only; existing Anthropic provider remains as fallback.

- **New Features**
  - Add providers.cliproxy with baseUrl http://localhost:8317/v1 and OpenAI Completions API.
  - Auto-extract cliproxyapi key from ~/.cli-proxy-api/config.yaml into clawdbotDir.
  - Register model IDs across Anthropic, OpenAI, Gemini, and GLM.
  - Enable on kyber gateway; other hosts keep remote mode.

<sup>Written for commit c9a7cb19cd28c101928f6454cb4abb5d52898ceb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

