### PR TITLE
fix(dotfiles-updater): export HOST for impure Nix builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,10 @@ services: ## Restart platform-specific services (launchd on macOS, systemd on Li
 		$(MAKE) systemctl; \
 	fi
 
+.PHONY: sync
+sync: ## Sync dotagents (commands, skills, MCP configuration).
+	@$(MAKE) -C dotagents sync
+
 .PHONY: test
 test: neovim-test shell-test ## Run all tests (neovim + shell).
 

--- a/home-manager/services/dotfiles-updater/update.sh
+++ b/home-manager/services/dotfiles-updater/update.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+# Export HOST for Nix impure builds (used by lib/host.nix to detect kyber/galactica)
+# This is needed because systemd doesn't inherit the shell environment
+export HOST="${HOST:-$(/usr/bin/hostname 2>/dev/null || hostname 2>/dev/null || echo '')}"
+
 cd ~/dotfiles
 
 # Skip if the current branch is not main


### PR DESCRIPTION
## Summary
- Export HOST environment variable in update.sh before running install/switch to fix impure Nix build host detection
- Add missing `sync` target to Makefile (was added as dependency in commit 6470c33 but the actual target was missing)

## Problem
When `dotfiles-updater` runs via systemd, the `HOST` environment variable is not set. This causes `lib/host.nix` to evaluate `isKyber` as `false`, which disabled the `clawdbot-gateway` systemd service in the latest home-manager generation.

## Test plan
- [x] Verified `HOST` is correctly exported when running the update.sh script
- [x] Verified `make switch` completes without "No rule to make target 'sync'" error
- [x] Verified clawdbot-gateway service is now running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes host detection for impure Nix builds by exporting HOST in dotfiles-updater when run via systemd, restoring the clawdbot-gateway service. Adds the missing Makefile sync target for dotagents to prevent build failures.

- **Bug Fixes**
  - Export HOST in update.sh using hostname fallback so lib/host.nix correctly detects the host and enables clawdbot-gateway.
  - Add .PHONY sync target that calls dotagents sync to resolve "No rule to make target 'sync'" during make switch.

<sup>Written for commit bea13c53ed83957bf3ab2aa4f376c8b64311ebcc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

