### PR TITLE
config: switch AI model to GLM-4.7 Flash

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -33,6 +33,6 @@ model_provider = "ollama"
 model = "openai/gpt-oss-120b"
 model_provider = "lmstudio"
 
-[profiles.qwen3-coder-30b]
-model = "qwen/qwen3-coder-30b"
+[profiles.glm-4.7-flash]
+model = "zai-org/glm-4.7-flash"
 model_provider = "lmstudio"

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -103,8 +103,8 @@
 				"openai/gpt-oss-120b": {
 					"name": "OpenAI: gpt-oss-120b"
 				},
-				"qwen/qwen3-coder-30b": {
-					"name": "Qwen: Qwen3 Coder 30B A3B Instruct"
+				"zai-org/glm-4.7-flash": {
+					"name": "GLM-4.7 Flash (via LM Studio)"
 				}
 			}
 		},

--- a/home-manager/programs/fish/functions/_coxel_function.fish
+++ b/home-manager/programs/fish/functions/_coxel_function.fish
@@ -1,11 +1,11 @@
-function _coxel_function --description "Run Codex with a free-form prompt using the local gpt-oss:120b model"
-  # Run Codex with a free-form prompt (spaces allowed) using the local gpt-oss:120b model
+function _coxel_function --description "Run Codex with a free-form prompt using the local glm-4.7-flash model"
+  # Run Codex with a free-form prompt (spaces allowed) using the local glm-4.7-flash model
   # Usage: cxel [<prompt words...>]
 
   if test (count $argv) -eq 0
-    codex --profile 'gpt-oss-120b' --full-auto -c model_reasoning_summary_format=experimental
+    codex --profile 'glm-4.7-flash' --full-auto -c model_reasoning_summary_format=experimental
   else
     set -l prompt (string join " " -- $argv)
-    codex --profile 'gpt-oss-120b' --full-auto -c model_reasoning_summary_format=experimental -- "$prompt"
+    codex --profile 'glm-4.7-flash' --full-auto -c model_reasoning_summary_format=experimental -- "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_coxelh_function.fish
+++ b/home-manager/programs/fish/functions/_coxelh_function.fish
@@ -1,4 +1,4 @@
-function _coxelh_function --description "Run Codex headlessly with local gpt-oss:120b model"
+function _coxelh_function --description "Run Codex headlessly with local glm-4.7-flash model"
   # Prompt for input and run Codex with local model
   # Usage: coxelh
 
@@ -8,5 +8,5 @@ function _coxelh_function --description "Run Codex headlessly with local gpt-oss
     return 1
   end
 
-  codex --profile 'gpt-oss-120b' --full-auto -c model_reasoning_summary_format=experimental -- "$prompt"
+  codex --profile 'glm-4.7-flash' --full-auto -c model_reasoning_summary_format=experimental -- "$prompt"
 end


### PR DESCRIPTION
## Changes
- Switched AI model from Qwen3 Coder 30B to GLM-4.7 Flash in Codex and OpenCode configurations
- Updated model references in Fish functions for coxel and coxelh
- Updated dotagents submodule

## Technical Details
- Changed model ID from `qwen/qwen3-coder-30b` to `zai-org/glm-4.7-flash`
- Updated LM Studio provider configuration across multiple config files

## Testing
- Configuration builds successfully

Generated with opencode by claude-3.5-sonnet

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches local model to GLM-4.7 Flash via LM Studio and updates Codex/OpenCode configs and fish helpers to use the new profile. Replaces the previous Qwen3 Coder 30B and gpt-oss:120b usage to standardize local runs.

- **Refactors**
  - Configs: replaced qwen/qwen3-coder-30b with zai-org/glm-4.7-flash in Codex and OpenCode; provider remains LM Studio.
  - Fish helpers: coxel and coxelh now call codex with --profile 'glm-4.7-flash'.
  - Submodule: bumped dotagents.

<sup>Written for commit e0663df60f956ac3b76b8e3d9641e2240acd7050. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

