### PR TITLE
fix: quote profile name in codex config.toml

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -33,6 +33,6 @@ model_provider = "ollama"
 model = "openai/gpt-oss-120b"
 model_provider = "lmstudio"
 
-[profiles.glm-4.7-flash]
+[profiles."glm-4.7-flash"]
 model = "zai-org/glm-4.7-flash"
 model_provider = "lmstudio"

--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -30,6 +30,6 @@ model_provider = "ollama"
 model = "openai/gpt-oss-120b"
 model_provider = "lmstudio"
 
-[profiles."glm-4.7-flash"]
+[profiles.glm-4.7-flash]
 model = "zai-org/glm-4.7-flash"
 model_provider = "lmstudio"

--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -5,9 +5,6 @@ notify = [
   "notify",
 ]
 
-[features]
-web_search_request = true
-
 [model_providers.cliproxyapi]
 name = "CLIProxyAPI"
 base_url = "http://localhost:8317/v1"


### PR DESCRIPTION
## Summary
- Fixed TOML section header to properly handle hyphenated profile names
- Changed `[profiles.glm-4.7-flash]` to `[profiles."glm-4.7-flash"]`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quoted the hyphenated profile name in config/codex/config.toml so TOML parses the glm-4.7-flash profile correctly. Removed the unused web_search_request feature block.

Changed [profiles.glm-4.7-flash] to [profiles."glm-4.7-flash"].

<sup>Written for commit ee274c812403a9c758694e80dfae646ef6c65cc1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

