### PR TITLE
fix(npm-globals): auto-extract bd tarball after bun postinstall failure

### DIFF
--- a/home-manager/modules/npm-globals/default.nix
+++ b/home-manager/modules/npm-globals/default.nix
@@ -7,6 +7,21 @@
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash ${./install-npm-globals.sh}
   '';
 
+  # Fix bun postinstall failures (e.g., @beads/bd tarball not extracted)
+  # Runs after npm globals to extract any tarballs that failed during postinstall
+  home.activation.fixBunPostinstall = config.lib.dag.entryAfter [ "installNpmGlobals" ] ''
+    BD_BIN_DIR="$HOME/.bun/install/global/node_modules/@beads/bd/bin"
+    if [ -d "$BD_BIN_DIR" ]; then
+      # Check if tarball exists but binary doesn't
+      TARBALL=$(find "$BD_BIN_DIR" -name "beads_*.tar.gz" 2>/dev/null | head -1)
+      if [ -n "$TARBALL" ] && [ ! -f "$BD_BIN_DIR/bd" ]; then
+        echo "Extracting bd binary from tarball..."
+        ${pkgs.gnutar}/bin/tar -xzf "$TARBALL" -C "$BD_BIN_DIR"
+        chmod +x "$BD_BIN_DIR/bd" 2>/dev/null || true
+      fi
+    fi
+  '';
+
   # Add local and bun bins to PATH
   home.sessionPath = [
     "$HOME/.local/bin"

--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -35,6 +35,12 @@
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
       if [ "$(uname)" = "Linux" ]; then
           export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+
+          # OpenSSL for cargo builds (rust crates like openssl-sys)
+          export PKG_CONFIG_PATH="${pkgs.openssl.dev}/lib/pkgconfig''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+          export OPENSSL_DIR="${pkgs.openssl.dev}"
+          export OPENSSL_LIB_DIR="${pkgs.openssl.out}/lib"
+          export OPENSSL_INCLUDE_DIR="${pkgs.openssl.dev}/include"
       fi
 
       # Go configuration

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -11,6 +11,12 @@
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
       if test (uname) = "Linux"
           set -gx XDG_RUNTIME_DIR /run/user/(id -u)
+
+          # OpenSSL for cargo builds (rust crates like openssl-sys)
+          set -gx PKG_CONFIG_PATH "${pkgs.openssl.dev}/lib/pkgconfig" $PKG_CONFIG_PATH
+          set -gx OPENSSL_DIR "${pkgs.openssl.dev}"
+          set -gx OPENSSL_LIB_DIR "${pkgs.openssl.out}/lib"
+          set -gx OPENSSL_INCLUDE_DIR "${pkgs.openssl.dev}/include"
       end
 
       # Go configuration


### PR DESCRIPTION
## Summary
- Added `fixBunPostinstall` activation script that runs after `installNpmGlobals`
- Detects if `@beads/bd` tarball exists but binary wasn't extracted
- Automatically extracts using Nix's gnutar (guaranteed to be in PATH)

## Problem
Bun postinstall scripts can fail silently when `tar` isn't in PATH (common in Nix environments). The `@beads/bd` package downloads a tarball but fails to extract it.

## Test plan
- [x] `make build` passes
- [ ] `make switch` extracts bd tarball if present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically extracts the @beads/bd binary when Bun’s postinstall fails in Nix environments, and sets OpenSSL env vars on Linux so cargo can build openssl-sys.

- **Bug Fixes**
  - Added a fixBunPostinstall activation step that runs after installNpmGlobals.
  - Extracts the beads tarball with Nix’s gnutar and restores bd executable permissions.

- **New Features**
  - Sets PKG_CONFIG_PATH, OPENSSL_DIR, OPENSSL_LIB_DIR, OPENSSL_INCLUDE_DIR in bash and fish on Linux so cargo can find OpenSSL.

<sup>Written for commit e21e6401afc8f41fbfc987d704e7ed6e59b2c053. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

