### PR TITLE
feat(shell): add OpenSSL env vars for cargo builds on Linux

### DIFF
--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -35,6 +35,12 @@
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
       if [ "$(uname)" = "Linux" ]; then
           export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+
+          # OpenSSL for cargo builds (rust crates like openssl-sys)
+          export PKG_CONFIG_PATH="${pkgs.openssl.dev}/lib/pkgconfig''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+          export OPENSSL_DIR="${pkgs.openssl.dev}"
+          export OPENSSL_LIB_DIR="${pkgs.openssl.out}/lib"
+          export OPENSSL_INCLUDE_DIR="${pkgs.openssl.dev}/include"
       fi
 
       # Go configuration

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -11,6 +11,12 @@
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
       if test (uname) = "Linux"
           set -gx XDG_RUNTIME_DIR /run/user/(id -u)
+
+          # OpenSSL for cargo builds (rust crates like openssl-sys)
+          set -gx PKG_CONFIG_PATH "${pkgs.openssl.dev}/lib/pkgconfig" $PKG_CONFIG_PATH
+          set -gx OPENSSL_DIR "${pkgs.openssl.dev}"
+          set -gx OPENSSL_LIB_DIR "${pkgs.openssl.out}/lib"
+          set -gx OPENSSL_INCLUDE_DIR "${pkgs.openssl.dev}/include"
       end
 
       # Go configuration


### PR DESCRIPTION
## Summary
Set OpenSSL environment variables in bash and fish shells on Linux so cargo can find OpenSSL without needing `nix-shell -p gcc pkg-config openssl`.

**Environment variables added:**
- `PKG_CONFIG_PATH` - points to openssl.dev pkgconfig
- `OPENSSL_DIR` - openssl dev directory
- `OPENSSL_LIB_DIR` - openssl library directory
- `OPENSSL_INCLUDE_DIR` - openssl headers

## Problem
Cargo builds for crates depending on `openssl-sys` fail with:
```
The system library `openssl` required by crate `openssl-sys` was not found.
```

## Test plan
- [x] `make build` passes
- [x] `cargo build --release` works for projects with openssl-sys dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set OpenSSL env vars in bash and fish on Linux so cargo can find OpenSSL during builds. Fixes openssl-sys build failures and removes the need to enter nix-shell.

- **Bug Fixes**
  - Exports PKG_CONFIG_PATH, OPENSSL_DIR, OPENSSL_LIB_DIR, and OPENSSL_INCLUDE_DIR from pkgs.openssl.
  - Applies to both bash and fish; cargo builds now work without nix-shell.

<sup>Written for commit 94ed1ecd330cbc03d431e718a47700789994d2b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

