### PR TITLE
fix(shell): add OpenSSL env vars to bash profile and zsh env

### DIFF
--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -68,6 +68,20 @@
       if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
         . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
       fi
+
+      # OpenSSL for cargo builds on Linux (available in login shells)
+      if [ "$(uname)" = "Linux" ]; then
+          export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+          export PKG_CONFIG_PATH="${pkgs.openssl.dev}/lib/pkgconfig''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+          export OPENSSL_DIR="${pkgs.openssl.dev}"
+          export OPENSSL_LIB_DIR="${pkgs.openssl.out}/lib"
+          export OPENSSL_INCLUDE_DIR="${pkgs.openssl.dev}/include"
+      fi
+
+      # Source .bashrc for login shells to get PATH and other settings
+      if [ -f ~/.bashrc ]; then
+        . ~/.bashrc
+      fi
     '';
   };
 }

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -23,7 +23,7 @@
       extended = true;
     };
 
-    # envExtra goes to .zshenv (always sourced, even for scripts)
+    # envExtra goes to .zshenv (always sourced)
     envExtra = ''
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
       if [ "$(uname)" = "Linux" ]; then

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -23,12 +23,21 @@
       extended = true;
     };
 
-    initContent = ''
+    # envExtra goes to .zshenv (always sourced, even for scripts)
+    envExtra = ''
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
       if [ "$(uname)" = "Linux" ]; then
           export XDG_RUNTIME_DIR="/run/user/$(id -u)"
-      fi
 
+          # OpenSSL for cargo builds (rust crates like openssl-sys)
+          export PKG_CONFIG_PATH="${pkgs.openssl.dev}/lib/pkgconfig''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+          export OPENSSL_DIR="${pkgs.openssl.dev}"
+          export OPENSSL_LIB_DIR="${pkgs.openssl.out}/lib"
+          export OPENSSL_INCLUDE_DIR="${pkgs.openssl.dev}/include"
+      fi
+    '';
+
+    initContent = ''
       # Go configuration
       export GOPATH="$HOME/go"
 


### PR DESCRIPTION
## Changes
- Add OpenSSL environment variables to bash `profileExtra` for login shells
- Move zsh Linux-specific environment variables from `initContent` to `envExtra` (`.zshenv`)
- Source `.bashrc` from `.bash_profile` for consistent PATH setup

## Technical Details
- `profileExtra` in bash maps to `.bash_profile` which is sourced by login shells
- `envExtra` in zsh maps to `.zshenv` which is sourced by all zsh instances including non-interactive scripts
- This ensures cargo/rust builds can find OpenSSL in more shell contexts

## Testing
- Configuration builds successfully with `make build`
- OpenSSL env vars available in login shells and zsh scripts on Linux

Generated with Claude Code by claude-opus-4-5-20251101

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure OpenSSL env vars are loaded in bash login shells and all zsh contexts so cargo builds find OpenSSL reliably. Also source .bashrc from .bash_profile for consistent PATH.

- **Bug Fixes**
  - Set OPENSSL_* and PKG_CONFIG_PATH in bash profileExtra on Linux.
  - Move Linux env vars (OpenSSL and XDG_RUNTIME_DIR) to zsh envExtra (.zshenv) so non-interactive zsh scripts inherit them.
  - Source .bashrc from .bash_profile to keep PATH consistent in login shells.

<sup>Written for commit 657c3165dcbf955acc389875055c131f60f0bb4b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

