### PR TITLE
chore(deps): upgrade clawdbot to v2026.1.20 and add automatic pnpmDepsHash computation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -93,11 +93,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768908528,
-        "narHash": "sha256-kUpVZ2x0mwqTP3Pt8QWuBHNctMg4CqbboeuP9oKW364=",
+        "lastModified": 1768954892,
+        "narHash": "sha256-9MLrJVD51kua4WXMyfImcwZ8WhOLaKwmU6q9eSlYkdQ=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "cba7f773ec009ba7f7076f085bbb51c61d922e8c",
+        "rev": "c6267b9343bbc96c88038765d02e2a2ad2a3b8a0",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768912518,
-        "narHash": "sha256-FJlof1jnbLIT5RbKxef/NV6RzcOj1GoMzXE4FcBFg5Y=",
+        "lastModified": 1768984719,
+        "narHash": "sha256-O6nXCW9FN39qw204e5Nl3qgaxKFcSvdpx0bULqfwyTA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9c5f8aceb6ef620e881f50fe65cb4a2c6b1e8527",
+        "rev": "d6e3935ec6e43c8f54cd0132276c82d951e1453e",
         "type": "github"
       },
       "original": {
@@ -349,11 +349,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768867482,
-        "narHash": "sha256-fwCzB1GWt6gG0hsGH+T06SzkuRogLjcoQqiPMnWFj7c=",
+        "lastModified": 1768953881,
+        "narHash": "sha256-czdbiHZT2Ul3Oh5QfOgxWOb5rcOIX7oD0MznaU64vEI=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "c8181e7b9bbef51276e0985dcb1a7ac2b7f4b373",
+        "rev": "574a0de26b2b36447a32dd9a10653cfd19ecf92b",
         "type": "github"
       },
       "original": {
@@ -365,11 +365,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1768865817,
-        "narHash": "sha256-tvf/Q1/+pYPfOaJmw6j0Bd79yAYzbnnlEBgsjoy5PxE=",
+        "lastModified": 1768952091,
+        "narHash": "sha256-FGZ3rTKc6g2Cvqf1J7Py7/xUQ44M3PhS/cNt4rTEUus=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "64057d266c29edb516d2c7dc2e080a59b7063b14",
+        "rev": "87276db7f9b2671ed9f416b4484dfc613dd3a83e",
         "type": "github"
       },
       "original": {
@@ -428,11 +428,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768905997,
-        "narHash": "sha256-6rWFT2QskskeH7LbJGK3dYwsaPsRYv88wUdFPds22lo=",
+        "lastModified": 1768984365,
+        "narHash": "sha256-1/I4xlqw0BIWNlheznS2Z5d8Hii6ULVHoJuLrZ0Dvts=",
         "owner": "clawdbot",
         "repo": "nix-clawdbot",
-        "rev": "74fa0a28b780c2d5eb4c4526eb10307072e25bab",
+        "rev": "219a7a0d705e8b28a2dfb1398dcf6b0e1bc3eb0c",
         "type": "github"
       },
       "original": {
@@ -559,11 +559,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1768783163,
-        "narHash": "sha256-tLj4KcRDLakrlpvboTJDKsrp6z2XLwyQ4Zmo+w8KsY4=",
+        "lastModified": 1768875095,
+        "narHash": "sha256-dYP3DjiL7oIiiq3H65tGIXXIT1Waiadmv93JS0sS+8A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bde09022887110deb780067364a0818e89258968",
+        "rev": "ed142ab1b3a092c4d149245d0c4126a5d7ea00b0",
         "type": "github"
       },
       "original": {
@@ -581,11 +581,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768912076,
-        "narHash": "sha256-HJscyhI0zg2hzyTcg5ziXrDvGBpQUokVFdICxDLyet4=",
+        "lastModified": 1768994775,
+        "narHash": "sha256-EggtqMRatDQ0RWcHDYjRmnHf5DwXe1TF5l8Q3exzj/0=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2af475ba9207b9edd8ce12cb20892d656120bf5c",
+        "rev": "fb6cdd5a5ef393434471dc782cca31e8ab363b75",
         "type": "github"
       },
       "original": {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,18 +1,18 @@
 { inputs }:
 let
-  # Override clawdbot source to v2026.1.16-2
+  # Override clawdbot source to v2026.1.20
   clawdbotSourceOverride = {
     owner = "clawdbot";
     repo = "clawdbot";
-    rev = "be37b39782e0799ba5b9533561de6d128d50c863";
-    hash = "sha256-y1ToqEcfl0yVAJkVld0k5AX5tztiE7yJt/F7Rhg+dAc=";
-    pnpmDepsHash = "sha256-NPQrkhhvAoIYzR1gopqsErps1K/HkfxmrPXpyMlN0Bc=";
+    rev = "9a14267dfa5238188a30636bd60eed08f05a7255";
+    hash = "sha256-T44joLbbbEFmsdOA9Q6W5Fpq1+1BtRJOHAy7/p3CXls=";
+    pnpmDepsHash = "sha256-tGzKcCiZNlWlKMNNFmxcFpIvO92G9myhM+OYaGea4hw=";
   };
-  # Override clawdbot-app to v2026.1.16-2 (fixes broken app package)
+  # Override clawdbot-app to v2026.1.20 (fixes broken app package)
   clawdbotAppOverride = {
-    version = "2026.1.16-2";
-    url = "https://github.com/clawdbot/clawdbot/releases/download/v2026.1.16-2/Clawdbot-2026.1.16-2.zip";
-    hash = "sha256-CQDGFA+/2McVxIw7WXtJZgr6LmtWTy0Dks++pjdU4rU=";
+    version = "2026.1.20";
+    url = "https://github.com/clawdbot/clawdbot/releases/download/v2026.1.20/Clawdbot-2026.1.20.zip";
+    hash = "sha256-BQuZqiTgcshT/YUnEq4OS6RxvjeTFgpPhd2jrGmcZXk=";
   };
 in
 [
@@ -22,7 +22,7 @@ in
   (
     final: prev:
     let
-      clawdbotVersion = "2026.1.16-2";
+      clawdbotVersion = "2026.1.20";
       basePkgs = import "${inputs.nix-clawdbot}/nix/packages" {
         pkgs = prev;
         sourceInfo = clawdbotSourceOverride;

--- a/spec/upgrade_overlays_spec.sh
+++ b/spec/upgrade_overlays_spec.sh
@@ -17,7 +17,7 @@ End
 It 'shows usage with --help flag'
 When run bash "$SCRIPT" --help
 The output should include 'Usage:'
-The output should include 'Available overlays:'
+The output should include 'Available commands:'
 The status should be success
 End
 
@@ -42,8 +42,8 @@ After 'cleanup'
 
 It 'fails for unknown overlay'
 When run bash "$SCRIPT" unknown-overlay
-The output should include 'Unknown overlay: unknown-overlay'
-The output should include 'Available overlays'
+The output should include 'Unknown command: unknown-overlay'
+The output should include 'Available commands'
 The status should be failure
 End
 End


### PR DESCRIPTION
## Changes
- Upgraded clawdbot overlay from v2026.1.16-2 to v2026.1.20
- Updated all related hashes (source hash, pnpmDepsHash, app hash)
- Added automatic pnpmDepsHash computation function to upgrade-overlays.sh
- Added pnpm-hash command to update only pnpmDepsHash when needed
- Improved upgrade script to automatically compute correct pnpmDepsHash

## Technical Details
- The new compute_pnpm_deps_hash() function runs a build attempt with a fake hash
- Extracts the correct hash from the nix build error output
- Automatically updates overlays/default.nix with the computed hash
- Allows manual hash updates via ./scripts/upgrade-overlays.sh pnpm-hash

## Testing
- Manual testing of pnpmDepsHash computation function
- Verified hash extraction from build error output
- Tested new pnpm-hash command

Generated with opencode by claude-3.5-sonnet

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades the clawdbot overlay to v2026.1.20 and automates pnpmDepsHash updates to prevent manual fixes after Nix build failures.

- **Dependencies**
  - Updated clawdbot source and app to v2026.1.20 with new hashes.
  - Refreshed flake.lock (nix-clawdbot, nixpkgs, home-manager, etc.).

- **New Features**
  - Added compute_pnpm_deps_hash() to auto-derive pnpmDepsHash from a build error.
  - Introduced pnpm-hash command to update only pnpmDepsHash.
  - upgrade-overlays.sh now auto-updates pnpmDepsHash during clawdbot upgrades.

<sup>Written for commit 0c4b0eb9b20e31f306a35a0141dd7faceac1ebb5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

