### PR TITLE
feat: configure postgresql linking in homebrew

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -40,7 +40,14 @@
       "pinentry-mac"
       "pnpm"
       "postgresql"
-      "postgresql@18"
+      {
+        name = "postgresql";
+        link = false;
+      }
+      {
+        name = "postgresql@18";
+        link = true;
+      }
       "protobuf"
       "pulumi"
       "qwen-code"


### PR DESCRIPTION
## Changes
- Configured postgresql link settings in homebrew
- Set postgresql link to false
- Set postgresql@18 link to true

## Technical Details
- Modified nix-darwin/config/homebrew.nix to specify link attribute for postgresql packages
- Ensures correct postgresql version is linked

## Testing
- Configuration builds successfully

Generated with OpenCode by Claude 3.5 Sonnet

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configure Homebrew linking to make postgresql@18 the active version and keep the generic postgresql unlinked. This ensures v18 is on PATH by default and avoids version conflicts.

<sup>Written for commit e262383d46a6cac7b399af23b2bfb2e3b71aadb5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

