### PR TITLE
feat: add git-submodule-sync to install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ help: ## Show this help message.
 ##@ General
 
 .PHONY: install
-install: setup nix-build nix-switch shell-install ## Set up full environment (setup, flake-update, build, switch, shell-install).
+install: setup git-submodule-sync nix-build nix-switch shell-install ## Set up full environment (setup, flake-update, build, switch, shell-install).
 
 .PHONY: build
 build: nix-build ## Build Nix configuration.


### PR DESCRIPTION
## Changes
- Added `git-submodule-sync` to the install target in Makefile

## Technical Details
The install target now includes `git-submodule-sync` to ensure Git submodules are properly synchronized during full environment setup.

## Testing
- Configuration builds successfully
- Install target runs without errors

Generated with Claude Code by claude-sonnet-4.1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add git-submodule-sync to the Makefile install target to sync Git submodules during full setup. This ensures submodules are up to date before nix-build and nix-switch, reducing setup failures.

<sup>Written for commit 8b96ea87f72141f9b9b08972eb9f352fc669c943. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

