### PR TITLE
chore: upgrade overlays

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,18 +1,18 @@
 { inputs }:
 let
-  # Override clawdbot source to v2026.1.21
+  # Override clawdbot source to v2026.1.22
   clawdbotSourceOverride = {
     owner = "clawdbot";
     repo = "clawdbot";
-    rev = "80c1edc3ff43b3bd3b7b545eed79f303d992f7dc";
-    hash = "sha256-IsTNC79KXKL7ByBh7zUmH6qXx0YFdiQ4a4TI40C53U8=";
+    rev = "c48751a99c1aacea1092927ff85a09ee40ac374d";
+    hash = "sha256-DJZulGqo2E7XvitR3kYKme9vqSfQyYs9I9fsBIpqQdQ=";
     pnpmDepsHash = "sha256-tGzKcCiZNlWlKMNNFmxcFpIvO92G9myhM+OYaGea4hw=";
   };
-  # Override clawdbot-app to v2026.1.21 (fixes broken app package)
+  # Override clawdbot-app to v2026.1.22 (fixes broken app package)
   clawdbotAppOverride = {
-    version = "2026.1.21";
-    url = "https://github.com/clawdbot/clawdbot/releases/download/v2026.1.21/Clawdbot-2026.1.21.zip";
-    hash = "sha256-EhGRakuN0dhEkXvrOd21t79odf4T2jY7oKFRubLqGbI=";
+    version = "2026.1.22";
+    url = "https://github.com/clawdbot/clawdbot/releases/download/v2026.1.22/Clawdbot-2026.1.22.zip";
+    hash = "sha256-IXb+WNrSqH80mYOR62rRK+mJUhReJ+CZVPNFefgkcao=";
   };
 in
 [
@@ -22,7 +22,7 @@ in
   (
     final: prev:
     let
-      clawdbotVersion = "2026.1.21";
+      clawdbotVersion = "2026.1.22";
       basePkgs = import "${inputs.nix-clawdbot}/nix/packages" {
         pkgs = prev;
         sourceInfo = clawdbotSourceOverride;


### PR DESCRIPTION
Automated overlay upgrade

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded clawdbot overlays to v2026.1.22 to fix the broken app package. Updates the source override, app artifact URL and hash, and bumps clawdbotVersion.

<sup>Written for commit 95c49b31e37ea4a6477a51dedfa38a604f56f4e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

