### PR TITLE
fix: disable fastfetch brightnessSupport on arm64

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -31,4 +31,10 @@
       '';
     });
   })
+  (final: prev: {
+    # Disable brightnessSupport on aarch64-linux to avoid ddcutil build failure
+    fastfetch = prev.fastfetch.override {
+      brightnessSupport = !prev.stdenv.hostPlatform.isAarch64;
+    };
+  })
 ]


### PR DESCRIPTION
## Problem

`ddcutil 2.2.4` fails to compile on `aarch64-linux`, which causes the Docker arm64 build to fail:

```
make[1]: Leaving directory '/tmp/nix-build-ddcutil-2.2.4.drv-0/ddcutil-2.2.4'
make: *** [Makefile:433: all] Error 2
error: 1 dependencies of derivation 'fastfetch-2.58.0.drv' failed to build
```

## Solution

Disable `brightnessSupport` (which pulls in `ddcutil`) only on arm64 platforms via an overlay. This keeps full functionality on x86_64 while allowing arm64 builds to succeed.

## Changes

- Added overlay to disable `fastfetch` brightness detection on aarch64
- No functional impact on x86_64 builds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled fastfetch brightnessSupport on arm64 to work around ddcutil 2.2.4 failing to compile on aarch64 and unblock arm64 Docker builds. x86_64 builds keep full brightness functionality.

<sup>Written for commit 93758167a2c7eacd6a5b7a610f25e37191ca98c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

