### PR TITLE
feat: add primary layout configuration for zellij

### DIFF
--- a/config/pi/models.json
+++ b/config/pi/models.json
@@ -142,8 +142,8 @@
           "maxTokens": 8192
         },
         {
-          "id": "z-ai/glm-4-7",
-          "name": "glm-4-7 (Z-AI)",
+          "id": "glm-4.7",
+          "name": "glm-4.7 (Z-AI)",
           "reasoning": false,
           "input": [
             "text"

--- a/config/pi/settings.json
+++ b/config/pi/settings.json
@@ -1,7 +1,7 @@
 {
   "theme": "dark",
   "defaultProvider": "cli-proxy-api",
-  "defaultModel": "gpt-5.2-codex",
+  "defaultModel": "glm-4.7",
   "defaultThinkingLevel": "medium",
   "enabledModels": [
     "cli-proxy-api/*",

--- a/config/zellij/config.kdl
+++ b/config/zellij/config.kdl
@@ -305,7 +305,7 @@ web_client {
 // The name of the default layout to load on startup
 // Default: "default"
 // 
-// default_layout "compact"
+default_layout "primary"
  
 // The folder in which Zellij will look for layouts
 // (Requires restart)

--- a/config/zellij/default.nix
+++ b/config/zellij/default.nix
@@ -3,4 +3,7 @@
   xdg.configFile."zellij/config.kdl" = {
     source = config.lib.file.mkOutOfStoreSymlink ./config.kdl;
   };
+  xdg.configFile."zellij/layouts/primary.kdl" = {
+    source = config.lib.file.mkOutOfStoreSymlink ./layouts/primary.kdl;
+  };
 }

--- a/config/zellij/layouts/primary.kdl
+++ b/config/zellij/layouts/primary.kdl
@@ -1,0 +1,22 @@
+layout {
+    default_tab_template {
+        pane size=1 borderless=true {
+            plugin location="tab-bar"
+        }
+        children
+        pane size=1 borderless=true {
+            plugin location="status-bar"
+        }
+    }
+    tab name="btop" {
+        pane command="btop"
+    }
+    tab name="fastfetch" {
+        pane command="fastfetch"
+        pane
+    }
+    tab name="fastfetch-2" {
+        pane command="fastfetch"
+        pane
+    }
+}

--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -56,6 +56,9 @@
       export PATH="/nix/var/nix/profiles/default/bin:$PATH"
       export PATH="/opt/homebrew/bin:$PATH"
       export PATH="/opt/homebrew/opt/postgresql@18/bin:$PATH"
+
+      # Worktrunk shell init
+      eval "$(wt config shell init bash)"
     '';
 
     profileExtra = ''

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -23,6 +23,9 @@
       set -gx GOPATH $HOME/go
 
       direnv hook fish | source
+
+      # Worktrunk shell init
+      wt config shell init fish | source
     '';
     loginShellInit = ''
       if test -f /opt/homebrew/bin/brew

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -65,6 +65,9 @@
       export FNM_LOGLEVEL="info"
       export FNM_NODE_DIST_MIRROR="https://nodejs.org/dist"
       export FNM_VERSION_FILE_STRATEGY="local"
+
+      # Worktrunk shell init
+      eval "$(wt config shell init zsh)"
     '';
   };
 }


### PR DESCRIPTION
## Changes
- Added primary.kdl layout configuration for zellij
- Updated config.kdl to include the new primary layout
- Updated default.nix to add the new layout file

## Technical Details
The primary layout provides a structured layout configuration for zellij sessions with proper pane arrangement.

## Testing
- Configuration builds successfully with `make build`
- Layout file follows zellij KDL syntax

Generated with OpenCode by glm-4.7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new “primary” Zellij layout as the default, with a clean tab/status bar and ready-to-use tabs. The layout is wired into Nix so it’s installed with the config, and Worktrunk is initialized for bash, fish, and zsh.

- **New Features**
  - Added layouts/primary.kdl with tab-bar, status-bar, and tabs for btop and fastfetch.
  - Set default_layout to "primary" and wired the layout via Nix symlink; added Worktrunk shell init for bash, fish, and zsh.

- **Bug Fixes**
  - Normalized model id/name in config/pi/models.json to glm-4.7, and set defaultModel in config/pi/settings.json to glm-4.7.

<sup>Written for commit ef41a73a41364d1d9041ec694db95700c3585969. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

