### PR TITLE
feat: add usage statistics persistence for cliproxyapi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -704,12 +704,6 @@ systemctl: systemctl-cliproxyapi systemctl-clawdbot systemctl-code-syncer system
 
 .PHONY: systemctl-cliproxyapi
 systemctl-cliproxyapi: ## Pull latest image and restart cliproxyapi systemd user service.
-	@if docker info >/dev/null 2>&1; then \
-		echo "🔄 Pulling latest cliproxyapi image..."; \
-		docker pull eceasy/cli-proxy-api:latest || true; \
-	else \
-		echo "⏭️ Skipping docker pull (docker not accessible)"; \
-	fi
 	@echo "🔄 Restarting cliproxyapi..."
 	@systemctl --user restart cliproxyapi.service || true
 	@echo "✅ cliproxyapi restarted"

--- a/home-manager/services/cliproxyapi/README.md
+++ b/home-manager/services/cliproxyapi/README.md
@@ -15,7 +15,7 @@ This directory contains the Nix-based configuration for the cliproxyapi service 
 |--------|---------|
 | `hydrate.sh` | Pull S3 → local → CCS (runs at activation) |
 | `backup.sh` | Push local → S3 → CCS (triggered by WatchPaths) |
-| `start.sh` | Load .env, hydrate auth cache if needed, generate config, start binary |
+| `start.sh` | Load .env, hydrate auth cache if needed, generate config, start service |
 | `wrapper.sh` | Load .env, sync auth cache, exec binary (for CLI usage) |
 
 ### Directory Structure
@@ -134,6 +134,8 @@ tail -f /tmp/cliproxyapi-backup.log
 
 # OAuth login
 cliproxyapi --claude-login
+
+# Usage statistics backup/restore happens automatically on start/exit
 ```
 
 ## Dependencies

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -7,6 +7,8 @@ TEMPLATE="$CONFIG_DIR/config.template.yaml"
 CONFIG="$CONFIG_DIR/config.yaml"
 ENV_FILE="${HOME}/dotfiles/.env"
 AUTH_DIR="${CONFIG_DIR}/objectstore/auths"
+USAGE_EXPORT_FILE="${CONFIG_DIR}/usage-export.json"
+MANAGEMENT_URL="${CLIPROXY_MANAGEMENT_URL:-http://127.0.0.1:8317/v0/management}"
 
 if [ -f "$ENV_FILE" ]; then
   set -a
@@ -26,6 +28,7 @@ OBJECTSTORE_ACCESS_KEY="$(strip_quotes "${OBJECTSTORE_ACCESS_KEY:-}")"
 OBJECTSTORE_SECRET_KEY="$(strip_quotes "${OBJECTSTORE_SECRET_KEY:-}")"
 OBJECTSTORE_LOCAL_PATH="$CONFIG_DIR"
 MANAGEMENT_PASSWORD="${CLIPROXY_MANAGEMENT_PASSWORD:-}"
+MANAGEMENT_KEY="${CLIPROXY_MANAGEMENT_PASSWORD:-${CLIPROXY_MANAGEMENT_KEY:-}}"
 export OBJECTSTORE_ENDPOINT OBJECTSTORE_BUCKET OBJECTSTORE_ACCESS_KEY OBJECTSTORE_SECRET_KEY OBJECTSTORE_LOCAL_PATH MANAGEMENT_PASSWORD
 
 if [ -n "$OBJECTSTORE_ENDPOINT" ] && [ -n "$OBJECTSTORE_ACCESS_KEY" ] && [ -n "$OBJECTSTORE_SECRET_KEY" ]; then
@@ -132,10 +135,62 @@ fi
 cd "$CONFIG_DIR"
 
 # Linux: Docker
+usage_import() {
+  if [ -z "$MANAGEMENT_KEY" ] || [ ! -f "$USAGE_EXPORT_FILE" ]; then
+    return 0
+  fi
+  curl -sS \
+    -H "Authorization: Bearer ${MANAGEMENT_KEY}" \
+    -H "Content-Type: application/json" \
+    -X POST \
+    --data-binary @"$USAGE_EXPORT_FILE" \
+    "${MANAGEMENT_URL}/usage/import" >/dev/null || true
+}
+
+usage_export() {
+  if [ -z "$MANAGEMENT_KEY" ]; then
+    return 0
+  fi
+  mkdir -p "$(dirname "$USAGE_EXPORT_FILE")"
+  curl -sS \
+    -H "Authorization: Bearer ${MANAGEMENT_KEY}" \
+    "${MANAGEMENT_URL}/usage/export" \
+    -o "$USAGE_EXPORT_FILE" || true
+}
+
+wait_for_management() {
+  if [ -z "$MANAGEMENT_KEY" ]; then
+    return 0
+  fi
+  local attempts=60
+  local i
+  for i in $(seq 1 "$attempts"); do
+    if curl -sS \
+      -H "Authorization: Bearer ${MANAGEMENT_KEY}" \
+      "${MANAGEMENT_URL}/usage/export" \
+      -o /dev/null; then
+      return 0
+    fi
+    sleep 3
+  done
+  return 1
+}
+
+child_pid=""
+trap 'usage_export' EXIT
+trap 'usage_export; if [ -n "$child_pid" ]; then kill -TERM "$child_pid" 2>/dev/null || true; wait "$child_pid" 2>/dev/null || true; fi' TERM INT
+
 if [ "$(uname)" = "Linux" ] && command -v docker >/dev/null 2>&1; then
+  if docker info >/dev/null 2>&1; then
+    echo "🔄 Pulling latest cliproxyapi image..."
+    docker pull eceasy/cli-proxy-api:latest || true
+  else
+    echo "⏭️ Skipping docker pull (docker not accessible)"
+  fi
+
   docker rm -f cliproxyapi 2>/dev/null || true
   mkdir -p "$CONFIG_DIR/logs"
-  exec docker run --rm \
+  docker run --rm \
     --name cliproxyapi \
     --network host \
     --ulimit nofile=65536:65536 \
@@ -143,14 +198,29 @@ if [ "$(uname)" = "Linux" ] && command -v docker >/dev/null 2>&1; then
     -v "$CONFIG_DIR:/root/.cli-proxy-api" \
     -v "$CONFIG_DIR/logs:/CLIProxyAPI/logs" \
     -e MANAGEMENT_PASSWORD="${MANAGEMENT_PASSWORD:-}" \
-    eceasy/cli-proxy-api:latest
+    eceasy/cli-proxy-api:latest &
+  child_pid=$!
+  wait_for_management || true
+  usage_import
+  wait "$child_pid"
+  exit $?
 fi
 
 # macOS: Homebrew binary
 if [ -x /opt/homebrew/bin/cliproxyapi ]; then
-  exec /opt/homebrew/bin/cliproxyapi -config "$CONFIG" "$@"
+  /opt/homebrew/bin/cliproxyapi -config "$CONFIG" "$@" &
+  child_pid=$!
+  wait_for_management || true
+  usage_import
+  wait "$child_pid"
+  exit $?
 elif [ -x /usr/local/bin/cliproxyapi ]; then
-  exec /usr/local/bin/cliproxyapi -config "$CONFIG" "$@"
+  /usr/local/bin/cliproxyapi -config "$CONFIG" "$@" &
+  child_pid=$!
+  wait_for_management || true
+  usage_import
+  wait "$child_pid"
+  exit $?
 else
   echo "cliproxyapi not found" >&2
   exit 1

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -147,6 +147,7 @@ usage_import() {
     "${MANAGEMENT_URL}/usage/import" >/dev/null || true
 }
 
+# shellcheck disable=SC2329 # Invoked via trap
 usage_export() {
   if [ -z "$MANAGEMENT_KEY" ]; then
     return 0
@@ -163,8 +164,7 @@ wait_for_management() {
     return 0
   fi
   local attempts=60
-  local i
-  for i in $(seq 1 "$attempts"); do
+  for _ in $(seq 1 "$attempts"); do
     if curl -sS \
       -H "Authorization: Bearer ${MANAGEMENT_KEY}" \
       "${MANAGEMENT_URL}/usage/export" \


### PR DESCRIPTION
## Changes
- Added automatic usage statistics backup on service exit
- Added automatic usage statistics restore on service start
- Moved Docker pull logic to start.sh from Makefile
- Added trap handlers for graceful shutdown with usage export

## Technical Details
- Implemented usage_export() function to save usage stats to JSON file
- Implemented usage_import() function to restore usage stats from JSON file
- Added wait_for_management() to ensure management API is ready before import
- Set up EXIT and TERM/INT traps to export usage on service termination

## Testing
- Manual testing on Linux with Docker
- Manual testing on macOS with Homebrew binary

Generated with opencode by glm-4.7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist cliproxyapi usage statistics across restarts by auto-exporting on shutdown and restoring on startup. Moved Docker image pull into start.sh and added graceful shutdown traps.

- **New Features**
  - Auto export usage to JSON on exit; auto restore on start via the management API.
  - Waits for the management API to be ready before importing.
  - Works for Docker and macOS binaries; uses MANAGEMENT_KEY for auth.

- **Refactors**
  - Moved Docker pull logic from the Makefile to start.sh.
  - Updated README to note automatic usage backup/restore.

<sup>Written for commit 00d610e074dd6556385113750a45a81ab906ccc2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

