### PR TITLE
refactor: manage foundry via nix instead of manual installation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -218,6 +218,42 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "foundry": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769497704,
+        "narHash": "sha256-McmVZ/3yWd1ifYyhyPG+GIiG5LjOukwu0l3S5mob96g=",
+        "owner": "shazow",
+        "repo": "foundry.nix",
+        "rev": "55d3c56b759b03bc15c2a4ebf7d47c41beec886b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shazow",
+        "repo": "foundry.nix",
+        "type": "github"
+      }
+    },
     "git-hooks": {
       "inputs": {
         "flake-compat": [
@@ -503,6 +539,7 @@
         "agenix": "agenix",
         "devenv": "devenv",
         "flake-parts": "flake-parts_2",
+        "foundry": "foundry",
         "home-manager": "home-manager",
         "mk-shell-bin": "mk-shell-bin",
         "neovim-nightly-overlay": "neovim-nightly-overlay",

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,10 @@
       url = "github:cachix/devenv";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    foundry = {
+      url = "github:shazow/foundry.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     mk-shell-bin = {
       url = "github:rrbutani/nix-mk-shell-bin";
     };

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -36,6 +36,7 @@ with pkgs;
   eza
   fastfetch
   fd
+  foundry-bin
   fswatch
   fzf-make
   gh

--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -50,7 +50,6 @@
       export PATH="$PATH:$GOPATH/bin"
       export PATH="$HOME/.bun/bin:$PATH"
       export PATH="$HOME/.cargo/bin:$PATH"
-      export PATH="$HOME/.foundry/bin:$PATH"
       export PATH="$HOME/.local/bin:$PATH"
       export PATH="$HOME/.nix-profile/bin:$PATH"
       export PATH="/nix/var/nix/profiles/default/bin:$PATH"

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -35,7 +35,6 @@
       fish_add_path -p ~/.local/bin
       fish_add_path -p ~/.bun/bin
       fish_add_path -p ~/.cargo/bin
-      fish_add_path -p ~/.foundry/bin
       fish_add_path -p ~/.nix-profile/bin
       fish_add_path -p ~/go/bin
       fish_add_path -p /nix/var/nix/profiles/default/bin
@@ -56,7 +55,6 @@
       fish_add_path -p ~/.local/bin
       fish_add_path -p ~/.bun/bin
       fish_add_path -p ~/.cargo/bin
-      fish_add_path -p ~/.foundry/bin
       fish_add_path -p ~/.nix-profile/bin
       fish_add_path -p ~/go/bin
       fish_add_path -p /nix/var/nix/profiles/default/bin

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -50,7 +50,6 @@
       export PATH="$PATH:$GOPATH/bin"
       export PATH="$HOME/.bun/bin:$PATH"
       export PATH="$HOME/.cargo/bin:$PATH"
-      export PATH="$HOME/.foundry/bin:$PATH"
       export PATH="$HOME/.local/bin:$PATH"
       export PATH="$HOME/.nix-profile/bin:$PATH"
       export PATH="/nix/var/nix/profiles/default/bin:$PATH"

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -2,6 +2,7 @@
 [
   inputs.nur.overlays.default
   inputs.neovim-nightly-overlay.overlays.default
+  inputs.foundry.overlay
   (final: prev: {
     # Ensure neovim-unwrapped exposes a lua attribute for wrapper consumers (e.g., home-manager)
     neovim-unwrapped =


### PR DESCRIPTION
## Changes
- Added foundry input to flake.nix from shazow/foundry.nix
- Added foundry.overlay to overlays/default.nix
- Added foundry-bin to home-manager packages
- Removed manual .foundry/bin PATH references from bash, fish, and zsh configs

## Technical Details
Foundry is now managed through Nix instead of manual installation, improving reproducibility and version management across systems.

## Testing
- All configuration files build successfully
- Foundry tools now available through Nix-managed packages

Generated with opencode by glm-4.7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Foundry tooling to Nix (via shazow/foundry.nix), replacing manual installs. Improves reproducibility and version pinning, and removes custom PATH hacks.

- **Refactors**
  - Add foundry input to flake.nix and enable overlay.
  - Add foundry-bin to home-manager packages.
  - Remove ~/.foundry/bin PATH entries from bash, fish, and zsh.

- **Dependencies**
  - Add foundry.nix and flake-utils inputs; update flake.lock.

<sup>Written for commit 40111acae9112eb854aa26caec1ebb3ed5edefb7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

