### PR TITLE
feat: add node program configuration

### DIFF
--- a/home-manager/programs/default.nix
+++ b/home-manager/programs/default.nix
@@ -23,6 +23,7 @@ let
   lazygit = import ./lazygit;
   lsd = import ./lsd;
   neovim = import ./neovim;
+  node = import ./node;
   python = import ./python;
   rust = import ./rust;
   ssh = import ./ssh;

--- a/home-manager/programs/node/default.nix
+++ b/home-manager/programs/node/default.nix
@@ -1,0 +1,6 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [
+    node
+  ];
+}


### PR DESCRIPTION
## Changes
- Added node program configuration to home-manager
- Created new module at home-manager/programs/node/default.nix

## Technical Details
- Node.js package added to home.packages
- Module imported in home-manager/programs/default.nix

## Testing
- Configuration builds successfully with `make build`

Generated with Claude Code by claude-opencode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Home Manager configuration change that only adds a new `node` module to install Node.js. Main risk is misconfiguration (the module is imported but not included in the exported module list, so it may not take effect).
> 
> **Overview**
> Adds a new `home-manager/programs/node` module that installs the `node` package via `home.packages`.
> 
> Updates `home-manager/programs/default.nix` to import the new `node` module (note: it is imported but not added to the returned module list).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96e627dc0ae0c02bb7e3dc9c8c438a2cd27d7168. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Node.js program module to Home Manager so Node is installed via home.packages. The new module lives at home-manager/programs/node/default.nix and is imported in home-manager/programs/default.nix.

<sup>Written for commit 96e627dc0ae0c02bb7e3dc9c8c438a2cd27d7168. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

