### PR TITLE
feat: add docker-postgres service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -631,7 +631,7 @@ lua-check-hammerspoon-dev: ## Run the Hammerspoon Lua check inside the Nix dev s
 ##@ Launchd Services
 
 .PHONY: launchctl
-launchctl: launchctl-brew-upgrader launchctl-clawdbot launchctl-cliproxyapi launchctl-cliproxyapi-backup launchctl-code-syncer launchctl-dotfiles-updater launchctl-neverssl-keepalive launchctl-ollama ## Restart all launchd agents.
+launchctl: launchctl-brew-upgrader launchctl-clawdbot launchctl-cliproxyapi launchctl-cliproxyapi-backup launchctl-code-syncer launchctl-docker-postgres launchctl-dotfiles-updater launchctl-neverssl-keepalive launchctl-ollama ## Restart all launchd agents.
 
 .PHONY: launchctl-brew-upgrader
 launchctl-brew-upgrader: ## Restart brew-upgrader launchd agent.
@@ -689,6 +689,14 @@ launchctl-neverssl-keepalive: ## Restart neverssl-keepalive launchd agent.
 	@launchctl load ~/Library/LaunchAgents/org.nix-community.home.neverssl-keepalive.plist
 	@echo "✅ neverssl-keepalive restarted"
 
+.PHONY: launchctl-docker-postgres
+launchctl-docker-postgres: ## Restart docker-postgres launchd agent.
+	@echo "🔄 Restarting docker-postgres..."
+	@launchctl unload ~/Library/LaunchAgents/org.nix-community.home.docker-postgres.plist 2>/dev/null || true
+	@sleep 3
+	@launchctl load ~/Library/LaunchAgents/org.nix-community.home.docker-postgres.plist
+	@echo "✅ docker-postgres restarted"
+
 .PHONY: launchctl-ollama
 launchctl-ollama: ## Restart ollama launchd agent.
 	@echo "🔄 Restarting ollama..."
@@ -700,7 +708,7 @@ launchctl-ollama: ## Restart ollama launchd agent.
 ##@ Systemd Services (Linux)
 
 .PHONY: systemctl
-systemctl: systemctl-cliproxyapi systemctl-clawdbot systemctl-code-syncer systemctl-dotfiles-updater systemctl-ollama ## Restart all systemd user services.
+systemctl: systemctl-cliproxyapi systemctl-clawdbot systemctl-code-syncer systemctl-docker-postgres systemctl-dotfiles-updater systemctl-ollama ## Restart all systemd user services.
 
 .PHONY: systemctl-cliproxyapi
 systemctl-cliproxyapi: ## Pull latest image and restart cliproxyapi systemd user service.
@@ -719,6 +727,12 @@ systemctl-code-syncer: ## Restart code-syncer systemd user service.
 	@echo "🔄 Restarting code-syncer..."
 	@systemctl --user restart code-syncer.service || true
 	@echo "✅ code-syncer restarted"
+
+.PHONY: systemctl-docker-postgres
+systemctl-docker-postgres: ## Restart docker-postgres systemd user service.
+	@echo "🔄 Restarting docker-postgres..."
+	@systemctl --user restart docker-postgres.service || true
+	@echo "✅ docker-postgres restarted"
 
 .PHONY: systemctl-dotfiles-updater
 systemctl-dotfiles-updater: ## Restart dotfiles-updater systemd user service.

--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -9,6 +9,7 @@ let
   cliproxyapi = import ./cliproxyapi;
   codeSyncer = import ./code-syncer { inherit pkgs; };
   docker = import ./docker { inherit lib pkgs; };
+  dockerPostgres = import ./docker-postgres { inherit pkgs; };
   dotfilesUpdater = import ./dotfiles-updater { inherit pkgs; };
   makeUpdater = import ./make-updater { inherit pkgs; };
   neversslKeepalive = import ./neverssl-keepalive { inherit pkgs; };
@@ -22,6 +23,7 @@ in
   cliproxyapi
   codeSyncer
   docker
+  dockerPostgres
   dotfilesUpdater
   makeUpdater
   neversslKeepalive

--- a/home-manager/services/docker-postgres/default.nix
+++ b/home-manager/services/docker-postgres/default.nix
@@ -1,0 +1,47 @@
+{ pkgs, ... }:
+let
+  inherit (pkgs) lib;
+in
+{
+  launchd.agents.docker-postgres = lib.mkIf pkgs.stdenv.isDarwin {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "${pkgs.bash}/bin/bash"
+        "${./start-postgres.sh}"
+      ];
+      EnvironmentVariables = {
+        PATH = "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin";
+      };
+      RunAtLoad = true;
+      StandardOutPath = "/tmp/docker-postgres.log";
+      StandardErrorPath = "/tmp/docker-postgres.error.log";
+    };
+  };
+
+  systemd.user.services.docker-postgres = lib.mkIf pkgs.stdenv.isLinux {
+    Unit = {
+      Description = "PostgreSQL Docker container auto-start";
+      After = [
+        "network.target"
+        "docker.service"
+      ];
+      Wants = [ "docker.service" ];
+    };
+    Service = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      Environment = "PATH=${
+        lib.makeBinPath [
+          pkgs.bash
+          pkgs.coreutils
+          pkgs.docker
+        ]
+      }";
+      ExecStart = "${pkgs.bash}/bin/bash ${./start-postgres.sh}";
+    };
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
+}

--- a/home-manager/services/docker-postgres/start-postgres.sh
+++ b/home-manager/services/docker-postgres/start-postgres.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONTAINER_NAME="postgres"
+IMAGE="postgres:18"
+HOST_PORT="5432"
+CONTAINER_PORT="5432"
+MAX_RETRIES=30
+RETRY_INTERVAL=5
+
+log() {
+  echo "$(date '+%Y-%m-%d %H:%M:%S') [docker-postgres] $*"
+}
+
+wait_for_docker() {
+  log "Waiting for Docker daemon..."
+  local attempt=0
+  while [ "$attempt" -lt "$MAX_RETRIES" ]; do
+    if docker info >/dev/null 2>&1; then
+      log "Docker daemon is ready"
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    log "Docker not ready (attempt $attempt/$MAX_RETRIES), retrying in ${RETRY_INTERVAL}s..."
+    sleep "$RETRY_INTERVAL"
+  done
+  log "ERROR: Docker daemon did not become available after $((MAX_RETRIES * RETRY_INTERVAL))s"
+  return 1
+}
+
+ensure_container() {
+  if docker container inspect "$CONTAINER_NAME" >/dev/null 2>&1; then
+    local state
+    state=$(docker container inspect --format '{{.State.Status}}' "$CONTAINER_NAME")
+    if [ "$state" = "running" ]; then
+      log "Container '$CONTAINER_NAME' is already running"
+      return 0
+    fi
+    log "Container '$CONTAINER_NAME' exists but is $state, starting..."
+    docker start "$CONTAINER_NAME"
+    log "Container '$CONTAINER_NAME' started"
+  else
+    log "Container '$CONTAINER_NAME' does not exist, creating..."
+    docker run -d \
+      --name "$CONTAINER_NAME" \
+      --restart=unless-stopped \
+      -p "${HOST_PORT}:${CONTAINER_PORT}" \
+      -e POSTGRES_DB=trails_api \
+      -e POSTGRES_PASSWORD=postgres \
+      "$IMAGE"
+    log "Container '$CONTAINER_NAME' created and started"
+  fi
+}
+
+verify_postgres() {
+  log "Verifying PostgreSQL is accepting connections..."
+  local attempt=0
+  local max_verify=12
+  while [ "$attempt" -lt "$max_verify" ]; do
+    if docker exec "$CONTAINER_NAME" pg_isready -U postgres >/dev/null 2>&1; then
+      log "PostgreSQL is ready and accepting connections"
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    sleep 2
+  done
+  log "WARNING: PostgreSQL container is running but not yet accepting connections"
+  return 0
+}
+
+wait_for_docker
+ensure_container
+verify_postgres
+log "Done"

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -45,6 +45,10 @@ It 'has spec file for home-manager/services/code-syncer/sync.sh'
 The path "spec/code_syncer_spec.sh" should be exist
 End
 
+It 'has spec file for home-manager/services/docker-postgres/start-postgres.sh'
+The path "spec/docker_postgres_spec.sh" should be exist
+End
+
 It 'has spec file for home-manager/services/dotfiles-updater/update.sh'
 The path "spec/dotfiles_updater_spec.sh" should be exist
 End
@@ -136,6 +140,7 @@ home-manager/services/cliproxyapi/scripts/hydrate.sh
 home-manager/services/cliproxyapi/scripts/start.sh
 home-manager/services/cliproxyapi/scripts/wrapper.sh
 home-manager/services/code-syncer/sync.sh
+home-manager/services/docker-postgres/start-postgres.sh
 home-manager/services/dotfiles-updater/update.sh
 home-manager/services/make-updater/update.sh
 home-manager/services/neverssl-keepalive/keepalive.sh

--- a/spec/docker_postgres_spec.sh
+++ b/spec/docker_postgres_spec.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'docker-postgres/start-postgres.sh'
+SCRIPT="$PWD/home-manager/services/docker-postgres/start-postgres.sh"
+
+Describe 'script properties'
+It 'uses strict mode'
+When run bash -c "head -5 '$SCRIPT'"
+The output should include 'set -euo pipefail'
+End
+
+It 'uses bash shebang'
+When run bash -c "head -1 '$SCRIPT'"
+The output should include '#!/usr/bin/env bash'
+End
+End
+
+Describe 'container configuration'
+It 'uses postgres:18 image'
+When run bash -c "cat '$SCRIPT'"
+The output should include 'IMAGE="postgres:18"'
+End
+
+It 'uses container name postgres'
+When run bash -c "cat '$SCRIPT'"
+The output should include 'CONTAINER_NAME="postgres"'
+End
+
+It 'maps port 5432'
+When run bash -c "cat '$SCRIPT'"
+The output should include 'HOST_PORT="5432"'
+End
+
+It 'sets POSTGRES_DB=trails_api'
+When run bash -c "cat '$SCRIPT'"
+The output should include 'POSTGRES_DB=trails_api'
+End
+
+It 'sets POSTGRES_PASSWORD=postgres'
+When run bash -c "cat '$SCRIPT'"
+The output should include 'POSTGRES_PASSWORD=postgres'
+End
+End
+
+Describe 'docker daemon wait logic'
+It 'defines wait_for_docker function'
+When run bash -c "cat '$SCRIPT'"
+The output should include 'wait_for_docker'
+End
+
+It 'checks docker info for readiness'
+When run bash -c "cat '$SCRIPT'"
+The output should include 'docker info'
+End
+
+It 'has configurable retry settings'
+When run bash -c "cat '$SCRIPT'"
+The output should include 'MAX_RETRIES='
+End
+End
+
+Describe 'container management'
+It 'inspects container state before acting'
+When run bash -c "cat '$SCRIPT'"
+The output should include 'docker container inspect'
+End
+
+It 'starts existing stopped containers'
+When run bash -c "cat '$SCRIPT'"
+The output should include 'docker start'
+End
+
+It 'creates new container with docker run'
+When run bash -c "cat '$SCRIPT'"
+The output should include 'docker run -d'
+End
+
+It 'sets restart policy to unless-stopped'
+When run bash -c "cat '$SCRIPT'"
+The output should include '--restart=unless-stopped'
+End
+End
+
+Describe 'health verification'
+It 'verifies postgres with pg_isready'
+When run bash -c "cat '$SCRIPT'"
+The output should include 'pg_isready'
+End
+End
+
+End


### PR DESCRIPTION
## Changes
- Added docker-postgres service with launchctl (macOS) and systemctl (Linux) commands
- Created start-postgres.sh script for service initialization
- Added Makefile targets for managing postgres service
- Added tests for docker-postgres functionality

## Technical Details
- Integrated with home-manager services
- Cross-platform support for macOS and Linux
- Automated PostgreSQL container management

## Testing
- All checks pass

Generated with Claude Code by glm-4.7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new cross-platform user service that auto-starts a PostgreSQL Docker container and exposes `5432` with hard-coded credentials, which can have local security/port-collision implications. Changes are otherwise additive and isolated to devops/service management.
> 
> **Overview**
> Adds a new `docker-postgres` Home Manager service that auto-starts (and verifies) a `postgres:18` Docker container on login/startup for both macOS (`launchd`) and Linux (`systemd --user`).
> 
> Updates the `Makefile` to include `launchctl-docker-postgres`/`systemctl-docker-postgres` in the aggregated service restart targets, and adds ShellSpec coverage (`spec/docker_postgres_spec.sh` + `coverage_spec.sh`) for the new startup script.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e01547299c4ee6241aa8f02289c630117e256ba. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cross-platform service to auto-start a PostgreSQL Docker container and Makefile commands to manage it. This makes local Postgres easy and reliable on macOS and Linux.

- **New Features**
  - Home Manager service definitions for launchd (macOS) and systemd user (Linux).
  - start-postgres.sh waits for Docker, starts or creates the container, and verifies readiness with pg_isready.
  - Makefile targets: launchctl-docker-postgres and systemctl-docker-postgres; included in the aggregate launchctl/systemctl commands.
  - Default settings: postgres:18, port 5432, DB trails_api, password postgres, restart unless-stopped.
  - Tests added for the script and coverage updated.

<sup>Written for commit 5975bd2ac4fc4c68e965c23dd73435f6cbb122b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

