### PR TITLE
feat: add aichat configuration

### DIFF
--- a/config/aichat/config.yaml
+++ b/config/aichat/config.yaml
@@ -1,0 +1,9 @@
+# see https://github.com/sigoden/aichat/blob/main/config.example.yaml
+
+model: cliproxy:glm-4.7
+clients:
+- type: openai-compatible
+  name: cliproxy
+  api_base: http://localhost:8317/v1
+  models:
+  - name: glm-4.7

--- a/config/aichat/config.yaml
+++ b/config/aichat/config.yaml
@@ -1,9 +1,8 @@
 # see https://github.com/sigoden/aichat/blob/main/config.example.yaml
-
 model: cliproxy:glm-4.7
 clients:
-- type: openai-compatible
-  name: cliproxy
-  api_base: http://localhost:8317/v1
-  models:
-  - name: glm-4.7
+  - type: openai-compatible
+    name: cliproxy
+    api_base: http://localhost:8317/v1
+    models:
+      - name: glm-4.7

--- a/config/aichat/default.nix
+++ b/config/aichat/default.nix
@@ -1,0 +1,7 @@
+{ config, ... }:
+{
+  home.file.".config/aichat/config.yaml" = {
+    source = ./config.yaml;
+    force = true;
+  };
+}

--- a/config/default.nix
+++ b/config/default.nix
@@ -1,4 +1,5 @@
 [
+  ./aichat
   ./amp
   ./ccs
   ./cliproxyapi


### PR DESCRIPTION
## Changes
- Added aichat configuration module with default.nix and config.yaml

## Technical Details
- Integrated aichat into home-manager configuration
- Configured OpenAI model settings

## Testing
- Configuration builds successfully

Generated with Claude Code by glm-4.7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new Home Manager config file and wires it into the existing config list; no security-sensitive logic or runtime code changes beyond writing a config file.
> 
> **Overview**
> Adds a new `config/aichat` module that installs `~/.config/aichat/config.yaml` via Home Manager (with `force = true`).
> 
> The new `config.yaml` configures `aichat` to use an OpenAI-compatible client named `cliproxy` pointing at `http://localhost:8317/v1` with default model `cliproxy:glm-4.7`, and `config/default.nix` is updated to include `./aichat`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecf10da9818cd33305a8f56a730878be1d6fa0cd. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds aichat to home-manager and configures it to use the cliproxy client with the glm-4.7 model. This lets the aichat CLI work out of the box with a local proxy.

- New Features
  - Installs ~/.config/aichat/config.yaml via home-manager (forced overwrite).
  - Sets an openai-compatible client named cliproxy at http://localhost:8317/v1 with model glm-4.7.
  - Registers the aichat module in config/default.nix.

- Migration
  - Ensure cliproxy is running on http://localhost:8317 before using aichat.

<sup>Written for commit aca0658ce517bad64a2d31276e1994dd720a4625. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

