### PR TITLE
feat: add flameshot to homebrew casks

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -80,6 +80,7 @@
       "dropbox"
       "figma"
       "firefox"
+      "flameshot"
       "font-hack-nerd-font"
       "font-jetbrains-mono"
       "font-jetbrains-mono-nerd-font"


### PR DESCRIPTION
## Changes
- Added flameshot to homebrew casks for screenshot capabilities

## Testing
- Configuration builds successfully

Generated with opencode by glm-4.7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds a single Homebrew cask entry, affecting installed apps but not core logic or security-sensitive behavior.
> 
> **Overview**
> Adds `flameshot` to the `homebrew.casks` list in `nix-darwin/config/homebrew.nix` so it will be installed/managed via Homebrew on activation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2b08484450abfdbbdce95ff7dc77ec0784d1f59. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Flameshot to the nix-darwin Homebrew casks so new macOS setups install a screenshot and annotation tool by default. This enables quick captures without extra manual installs.

<sup>Written for commit e2b08484450abfdbbdce95ff7dc77ec0784d1f59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

