### PR TITLE
feat: add logging to neverssl keepalive script

### DIFF
--- a/home-manager/services/neverssl-keepalive/keepalive.sh
+++ b/home-manager/services/neverssl-keepalive/keepalive.sh
@@ -5,7 +5,11 @@
 set -euo pipefail
 
 # Silently ping neverssl.com - ignore failures (network may be unavailable)
-curl -fsS --max-time 10 http://neverssl.com >/dev/null 2>&1 || true
+if curl -fsS --max-time 10 http://neverssl.com >/dev/null 2>&1; then
+  echo "$(date): OK"
+else
+  echo "$(date): FAIL" >&2
+fi
 
 # macOS-specific: Open captive portal for Starbucks WiFi if connectivity is lost
 if [[ $OSTYPE == "darwin"* ]]; then

--- a/spec/keepalive_spec.sh
+++ b/spec/keepalive_spec.sh
@@ -62,11 +62,13 @@ After 'cleanup'
 It 'exits 0 even when curl fails'
 When run bash "$SCRIPT"
 The status should be success
+The stderr should include 'FAIL'
 End
 
-It 'silently ignores curl failures'
+It 'logs failure to stderr when curl fails'
 When run bash "$SCRIPT"
 The output should eq ''
+The stderr should include 'FAIL'
 The status should be success
 End
 End


### PR DESCRIPTION
## Changes
- Added success/failure logging to neverssl keepalive script
- Logs timestamped 'OK' on successful curl requests
- Logs timestamped 'FAIL' to stderr on failures
- Updated tests to verify stderr includes 'FAIL' messages

## Technical Details
Modified Fri Jan 30 11:09:53 JST 2026: OK to replace silent failure handling with explicit logging. The script now writes timestamped status messages to help diagnose captive portal connectivity issues.

## Testing
- Updated spec/keepalive_spec.sh to verify stderr contains 'FAIL' on curl failures
- Script still exits with 0 status to prevent service crashes

Generated with Claude Code by glm-4.7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add timestamped success/failure logging to the neverssl keepalive script to make captive portal connectivity issues easier to diagnose. Logs "OK" on successful curl requests and "FAIL" to stderr on failures while continuing to exit 0.

<sup>Written for commit dc632d4f5b0a988d1f8ec0f4af4bcfac6f3928fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

