### PR TITLE
feat(security): add git force push restrictions for main/master

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -106,7 +106,13 @@
       "Bash(rm -rf ~/*:*)",
       "Bash(chmod -R 777:*)",
       "Bash(mkfs:*)",
-      "Bash(dd if=:*)"
+      "Bash(dd if=:*)",
+      "Bash(git push --force origin main:*)",
+      "Bash(git push --force origin master:*)",
+      "Bash(git push -f origin main:*)",
+      "Bash(git push -f origin master:*)",
+      "Bash(git push --force-with-lease origin main:*)",
+      "Bash(git push --force-with-lease origin master:*)"
     ],
     "read": {
       "deny": [


### PR DESCRIPTION
## Changes
- Added security restrictions to prevent force pushes to main/master branches
- Blocks dangerous git commands: `--force`, `-f`, and `--force-with-lease` on main/master
- Protects repository from accidental branch overwrites

## Technical Details
- Updated Claude Code settings.json deny list
- Covers multiple force push syntax variations
- Applies to both `main` and `master` branch naming conventions

## Testing
- Configuration validates correctly
- Security restrictions are properly formatted

Generated with Claude Code by glm-4.7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block force pushes to main/master by adding deny-list rules in config/claude/settings.json for git push --force, -f, and --force-with-lease, preventing accidental branch overwrites.

<sup>Written for commit 72539a18f2dc74f8b0079573caf61f191b2593ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

