### PR TITLE
fix(dotfiles-updater): add --no-confirm flag for automated Nix installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,7 @@ fi
 if ! command -v nix >/dev/null 2>&1; then
   echo "Installing Nix..."
   if [ "$OS" = "macos" ]; then
-    curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+    curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm
     # For macOS, source the Nix profile immediately to update PATH in CI.
     # shellcheck source=/dev/null
     . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh


### PR DESCRIPTION
## Changes
- Add `--no-confirm` flag to Nix installation command in `install.sh`
- Allows dotfiles-updater service to run automatically without interactive prompts

## Technical Details
The launchd service runs every 3 hours to pull and apply dotfiles updates. When Nix installation was required, it would fail with "Unable to run interactively" error because launchd cannot accept user input.

## Testing
- Service pulls changes successfully (verified in logs)
- With this fix, service should also apply changes without hanging

Generated with Claude Code by glm-4.7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use --no-confirm with the Determinate Systems Nix installer in install.sh so dotfiles-updater can install Nix non-interactively under launchd. Fixes the "Unable to run interactively" error and lets scheduled updates apply without hanging.

<sup>Written for commit 710d555b9194a43fa71e6336ace771d4e3de60a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

