### PR TITLE
chore: enable quiet startup for pi to suppress warnings

### DIFF
--- a/config/pi/settings.json
+++ b/config/pi/settings.json
@@ -1,5 +1,6 @@
 {
   "theme": "dark",
+  "quietStartup": true,
   "defaultProvider": "cli-proxy-api",
   "defaultModel": "glm-4.7",
   "defaultThinkingLevel": "medium",


### PR DESCRIPTION
## Changes Made
- Added `quietStartup: true` to pi settings configuration
- Suppresses startup header and skill collision warnings

## Technical Details
- The pi-coding-agent startup header displays loaded skills, AGENTS.md files, and any warnings
- Setting `quietStartup` to true hides this entire header section
- Configuration is managed via Nix home-manager in `config/pi/settings.json`

## Testing
- Configuration change is syntactically valid JSON
- Will take effect after Nix rebuild: `make switch`
- No breaking changes to existing functionality

🤖 Generated with pi

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable quiet startup for pi by setting quietStartup: true. This hides the startup header and suppresses skill collision warnings for a cleaner boot.

- **Migration**
  - Run make switch to apply the Nix home-manager change.

<sup>Written for commit 9c709deb4a07bc05acba0e4892aacfe83017f9d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

