### PR TITLE
feat: update codex config for web search and apps feature

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -5,11 +5,11 @@ notify = [
   "notify",
 ]
 
+web_search = "cached"
+
 [features]
 undo = false
 shell_tool = true
-web_search = true
-web_search_cached = true
 unified_exec = true
 apply_patch_freeform = true
 exec_policy = true
@@ -22,7 +22,7 @@ child_agents_md = true
 powershell_utf8 = false
 enable_request_compression = false
 collab = true
-connectors = false
+apps = true
 steer = true
 collaboration_modes = true
 responses_websockets = false

--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -8,6 +8,7 @@ notify = [
 web_search = "cached"
 
 [features]
+ghost_commit = false
 undo = false
 shell_tool = true
 unified_exec = true
@@ -23,9 +24,11 @@ powershell_utf8 = false
 enable_request_compression = false
 collab = true
 apps = true
+skills = true
 steer = true
 collaboration_modes = true
 responses_websockets = false
+personality = true
 
 [model_providers.cliproxyapi]
 name = "CLIProxyAPI"


### PR DESCRIPTION
## Changes
- Updated codex config to use `web_search = "cached"` mode
- Migrated `web_search` and `web_search_cached` feature flags to unified configuration
- Changed `connectors` to `apps` feature flag

## Technical Details
- Consolidated web search configuration into single `web_search = "cached"` setting
- Updated feature flags to reflect latest codex API changes

## Testing
- Configuration builds successfully
- All checks pass

Generated with Claude Code by glm-4.7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched codex config to web_search = "cached" and unified web search flags to match the latest API. Replaced "connectors" with "apps", and enabled "skills" and "personality" features.

<sup>Written for commit 993addb07fe62597565fcb76b59437bba2e8194a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

