### PR TITLE
fix: resolve degraded systemd user services

### DIFF
--- a/.local-binaries.txt
+++ b/.local-binaries.txt
@@ -6,7 +6,6 @@
 ~/ghq/github.com/Dicklesworthstone/coding_agent_session_search/target/release/cass
 ~/ghq/github.com/Dicklesworthstone/destructive_command_guard/target/release/dcg
 ~/ghq/github.com/Dicklesworthstone/ultimate_bug_scanner/ubs
-~/ghq/github.com/dlorenc/multiclaude/multiclaude
 ~/ghq/github.com/nwiizo/ccswarm/target/release/ccswarm
 ~/ghq/github.com/steveyegge/beads/bd
 ~/ghq/github.com/steveyegge/gastown/gt

--- a/home-manager/services/make-updater/default.nix
+++ b/home-manager/services/make-updater/default.nix
@@ -36,12 +36,14 @@ in
         "PATH=${
           lib.makeBinPath [
             pkgs.bash
+            pkgs.cargo
             pkgs.coreutils
             pkgs.curl
             pkgs.gawk
             pkgs.git
             pkgs.gnumake
             pkgs.gnused
+            pkgs.go
             pkgs.nix
             pkgs.sudo
             pkgs.which


### PR DESCRIPTION
## Changes
- **docker-postgres**: Fix `permission denied` on Docker socket in systemd user service by wrapping ExecStart with `/usr/bin/sg docker` (the Nix-packaged `sg` lacks the SUID bit required for group switching). Add `Restart=on-failure` with 30s delay so the service auto-retries when Docker daemon starts slowly at boot.
- **make-updater**: Add `pkgs.go` and `pkgs.cargo` to the systemd service PATH so Go and Rust projects can build successfully.
- **local-binaries**: Remove `multiclaude` entry (directory does not exist).

## Technical Details
- The systemd user manager doesn't inherit the `docker` supplementary group (GID 30001) even though the user is in the group — the user session was started before group membership was applied.
- `/usr/bin/sg` (SUID) is used instead of `${pkgs.shadow}/bin/sg` (no SUID) because `newgrp`/`sg` requires the setuid bit to switch groups.
- `SupplementaryGroups=` directive doesn't work in user-level systemd units (exit code 216).

## Test plan
- [x] `make build` passes
- [x] `make format` passes
- [x] `docker-postgres.service` starts successfully and Postgres accepts connections
- [x] System reports `running` with zero failed units

Generated with [Claude Code](https://claude.com/code) by Claude Opus 4.5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix degraded systemd user services by running docker-postgres with the docker group and adding retry on failure. make-updater now builds Go and Rust projects; removed a stale local binary entry.

- **Bug Fixes**
  - docker-postgres: use /usr/bin/sg docker to fix permission denied, and add Restart=on-failure with a 30s delay.
  - make-updater: add go and cargo to PATH so Go/Rust builds succeed.
  - Remove nonexistent multiclaude path from .local-binaries.txt.

<sup>Written for commit 42577b8794352831a79c7237555f40c6c2645cb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

