### PR TITLE
feat: add matic host configuration for Framework 13" AMD AI 300

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,8 @@ DETECTED_HOST := $(shell \
 		hostname=$$(hostname 2>/dev/null || echo ""); \
 		if [ "$$hostname" = "kyber" ]; then \
 			echo "kyber"; \
+		elif [ "$$hostname" = "matic" ]; then \
+			echo "matic"; \
 		else \
 			echo ""; \
 		fi; \

--- a/flake.lock
+++ b/flake.lock
@@ -482,6 +482,22 @@
         "type": "github"
       }
     },
+    "nixos-hardware": {
+      "locked": {
+        "lastModified": 1769302137,
+        "narHash": "sha256-QEDtctEkOsbx8nlFh4yqPEOtr4tif6KTqWwJ37IM2ds=",
+        "owner": "NixOS",
+        "repo": "nixos-hardware",
+        "rev": "a351494b0e35fd7c0b7a1aae82f0afddf4907aa8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixos-hardware",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1769527094,
@@ -545,6 +561,7 @@
         "neovim-nightly-overlay": "neovim-nightly-overlay",
         "nix-darwin": "nix-darwin",
         "nix2container": "nix2container",
+        "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs",
         "nur": "nur",
         "treefmt-nix": "treefmt-nix_2"

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,9 @@
       url = "github:nlewo/nix2container";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    nixos-hardware = {
+      url = "github:NixOS/nixos-hardware/master";
+    };
   };
 
   outputs =
@@ -113,6 +116,10 @@
                 inherit inputs;
                 isRunner = true;
                 username = "runner";
+              };
+              matic = import ./named-hosts/matic {
+                inherit inputs;
+                username = "shunkakinoki";
               };
             };
             homeConfigurations = {

--- a/lib/host.nix
+++ b/lib/host.nix
@@ -5,6 +5,9 @@
   # Detect if running on galactica (macOS node)
   isGalactica = builtins.getEnv "HOSTNAME" == "galactica" || builtins.getEnv "HOST" == "galactica";
 
+  # Detect if running on matic (Framework 13" AMD AI 300)
+  isMatic = builtins.getEnv "HOSTNAME" == "matic" || builtins.getEnv "HOST" == "matic";
+
   # Get the node name for OpenClaw remote mode
   # Falls back to "unknown" if no hostname is detected
   nodeName =
@@ -12,6 +15,8 @@
       "kyber"
     else if builtins.getEnv "HOSTNAME" == "galactica" || builtins.getEnv "HOST" == "galactica" then
       "galactica"
+    else if builtins.getEnv "HOSTNAME" == "matic" || builtins.getEnv "HOST" == "matic" then
+      "matic"
     else
       "unknown";
 }

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -1,0 +1,139 @@
+{
+  inputs,
+  username,
+  ...
+}:
+let
+  system = "x86_64-linux";
+  nixpkgsConfig = import ../../lib/nixpkgs-config.nix {
+    nixpkgsLib = inputs.nixpkgs.lib;
+  };
+  overlays = import ../../overlays { inherit inputs; };
+  pkgs = import inputs.nixpkgs {
+    inherit system overlays;
+    config = nixpkgsConfig;
+  };
+in
+inputs.nixpkgs.lib.nixosSystem {
+  inherit system;
+  specialArgs = {
+    inherit inputs username;
+  };
+  modules = [
+    # Framework 13" AMD AI 300 hardware support
+    inputs.nixos-hardware.nixosModules.framework-amd-ai-300-series
+
+    # Hardware configuration
+    ./hardware-configuration.nix
+
+    # Base system configuration
+    (
+      { config, lib, ... }:
+      {
+        # Boot loader (EFI/systemd-boot)
+        boot.loader.systemd-boot.enable = true;
+        boot.loader.systemd-boot.configurationLimit = 10;
+        boot.loader.efi.canTouchEfiVariables = true;
+
+        # Latest kernel for AMD AI 300 support
+        boot.kernelPackages = pkgs.linuxPackages_latest;
+
+        # Networking
+        networking.hostName = "matic";
+        networking.networkmanager.enable = true;
+        networking.networkmanager.wifi.powersave = false;
+
+        # User configuration
+        users.users.${username} = {
+          isNormalUser = true;
+          extraGroups = [
+            "wheel"
+            "networkmanager"
+            "video"
+          ];
+          home = "/home/${username}";
+        };
+
+        security.sudo.wheelNeedsPassword = false;
+
+        # AMD graphics with hardware acceleration
+        hardware.graphics.enable = true;
+        hardware.graphics.extraPackages = with pkgs; [
+          libva
+          libva-vdpau-driver
+          libvdpau-va-gl
+        ];
+
+        # Thunderbolt support
+        services.hardware.bolt.enable = true;
+
+        # Fingerprint authentication
+        services.fprintd.enable = true;
+
+        # Firmware updates
+        services.fwupd.enable = true;
+
+        # Power management
+        services.power-profiles-daemon.enable = true;
+
+        # WiFi MT7925e fix (disable ASPM)
+        boot.extraModprobeConfig = ''
+          options mt7925e disable_aspm=1
+        '';
+
+        # System packages
+        environment.systemPackages = with pkgs; [
+          curl
+          git
+          home-manager
+          vim
+          wget
+          zellij
+        ];
+
+        # Nix settings
+        nix = {
+          settings = {
+            experimental-features = [
+              "nix-command"
+              "flakes"
+            ];
+            substituters = [
+              "https://cache.nixos.org"
+            ];
+            trusted-users = [
+              "root"
+              username
+            ];
+          };
+          package = pkgs.nixVersions.stable;
+        };
+
+        system.stateVersion = "24.11";
+      }
+    )
+
+    # Fonts
+    {
+      nixpkgs.pkgs = pkgs;
+      fonts.packages = with pkgs; [
+        nerd-fonts.jetbrains-mono
+      ];
+    }
+
+    # Home Manager integration
+    inputs.home-manager.nixosModules.home-manager
+    {
+      home-manager.backupFileExtension = "hm-backup";
+      home-manager.extraSpecialArgs = { inherit inputs; };
+      home-manager.useGlobalPkgs = true;
+      home-manager.useUserPackages = true;
+      home-manager.users.${username} = import ../../home-manager {
+        inherit inputs username;
+        lib = inputs.nixpkgs.lib;
+        pkgs = pkgs;
+        config = { };
+      };
+    }
+  ];
+}

--- a/named-hosts/matic/hardware-configuration.nix
+++ b/named-hosts/matic/hardware-configuration.nix
@@ -1,0 +1,42 @@
+# Placeholder hardware configuration for Framework 13" AMD AI 300
+# Regenerate on actual hardware with:
+#   nixos-generate-config --show-hardware-config > named-hosts/matic/hardware-configuration.nix
+{
+  config,
+  lib,
+  pkgs,
+  modulesPath,
+  ...
+}:
+{
+  imports = [
+    (modulesPath + "/installer/scan/not-detected.nix")
+  ];
+
+  # Framework 13" AMD AI 300 kernel modules
+  boot.initrd.availableKernelModules = [
+    "nvme"
+    "xhci_pci"
+    "thunderbolt"
+    "usb_storage"
+    "sd_mod"
+  ];
+  boot.kernelModules = [ "kvm-amd" ];
+
+  # Placeholder filesystem - UPDATE after installation
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixos";
+    fsType = "ext4";
+  };
+  fileSystems."/boot" = {
+    device = "/dev/disk/by-label/boot";
+    fsType = "vfat";
+    options = [
+      "fmask=0077"
+      "dmask=0077"
+    ];
+  };
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+  hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+}


### PR DESCRIPTION
## Changes
- Added NixOS host configuration for "matic" (Framework 13" AMD AI 300)
- Integrated nixos-hardware input for framework-amd-ai-300-series module
- Added hostname detection in lib/host.nix
- Configured AMD graphics, Thunderbolt, fingerprint, and power management
- Set up Home Manager integration for the new host

## Technical Details
- Hardware: Framework 13" AMD AI 300 laptop
- Uses latest Linux kernel for hardware support
- NetworkManager with WiFi powersave disabled for connectivity
- AMD graphics with VA-API and VDPAU acceleration
- WiFi MT7925e ASPM fix via kernel module option
- Placeholder hardware configuration (to be regenerated on actual hardware)

## Testing
- Configuration builds successfully
- Follows existing host configuration patterns
- Compatible with NixOS 24.11

Generated with Claude Code by GLM-4.7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add NixOS host configuration for matic (Framework 13" AMD AI 300) with hardware support and Home Manager integration. Updates the flake to include nixos-hardware and adds hostname detection.

- **New Features**
  - New host profile with latest kernel, AMD VA-API/VDPAU, and graphics enablement.
  - Enables Thunderbolt (bolt), fingerprint (fprintd), fwupd, and power-profiles-daemon.
  - WiFi MT7925e ASPM workaround.
  - Adds nixos-hardware input and matic detection in lib/host.nix.

- **Migration**
  - Regenerate named-hosts/matic/hardware-configuration.nix on the device:
    - nixos-generate-config --show-hardware-config > named-hosts/matic/hardware-configuration.nix
  - Verify / and /boot labels, then rebuild.

<sup>Written for commit e4bfad942d6fbb4b6cf85436d1d43d7dad1b0476. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

