### PR TITLE
feat: enhance Nix build and switch commands to support named and auto-detected hosts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,15 @@ nix-build: nix-connect ## Build Nix configuration.
 		elif [ "$(OS)" = "Darwin" ]; then \
 			$(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#$(NIX_CONFIG_TYPE).$(NIX_SYSTEM).system $(NIX_FLAGS) --impure --show-trace; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "nixosConfigurations" ]; then \
-			sudo $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- build --flake .#$(NIX_SYSTEM) --impure; \
+			if [ -n "$(HOST)" ]; then \
+				echo "Building named host: $(HOST)"; \
+				sudo $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- build --flake .#$(HOST) --impure; \
+			elif [ -n "$(DETECTED_HOST)" ]; then \
+				echo "Auto-detected host: $(DETECTED_HOST)"; \
+				sudo $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- build --flake .#$(DETECTED_HOST) --impure; \
+			else \
+				sudo $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- build --flake .#$(NIX_SYSTEM) --impure; \
+			fi; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "homeConfigurations" ]; then \
 			HOST=$(DETECTED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#$(NIX_CONFIG_TYPE)."$(NIX_USERNAME)@$(NIX_SYSTEM)".activationPackage $(NIX_FLAGS) --impure --show-trace; \
 		else \
@@ -372,7 +380,15 @@ nix-switch: ## Activate Nix configuration.
 				sudo HOST=$(NIX_SYSTEM) $(NIX_ALLOW_UNFREE) $(DARWIN_REBUILD) switch --flake .#$(NIX_SYSTEM) --impure; \
 			fi; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "nixosConfigurations" ]; then \
-			sudo $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure nixpkgs#nixos-rebuild -- switch --flake .#$(NIX_SYSTEM); \
+			if [ -n "$(HOST)" ]; then \
+				echo "Switching named host: $(HOST)"; \
+				sudo $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure nixpkgs#nixos-rebuild -- switch --flake .#$(HOST); \
+			elif [ -n "$(DETECTED_HOST)" ]; then \
+				echo "Auto-detected host: $(DETECTED_HOST)"; \
+				sudo $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure nixpkgs#nixos-rebuild -- switch --flake .#$(DETECTED_HOST); \
+			else \
+				sudo $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure nixpkgs#nixos-rebuild -- switch --flake .#$(NIX_SYSTEM); \
+			fi; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "homeConfigurations" ]; then \
 			if [ -n "$(HOST)" ]; then \
 				echo "Switching named home config: $(HOST)"; \


### PR DESCRIPTION
## Changes
- Enhanced `nix-build` and `nix-switch` Makefile targets to support named host configuration via `HOST` variable
- Added auto-detection support using `DETECTED_HOST` variable
- Falls back to `NIX_SYSTEM` when neither `HOST` nor `DETECTED_HOST` is set
- Added informational echo statements to display which host is being built/switched
- Updated dotagents submodule

## Technical Details
The changes improve flexibility in building and switching Nix configurations by:
- Prioritizing explicitly named hosts (`HOST`) for targeted builds
- Supporting auto-detected hosts (`DETECTED_HOST`) for convenience
- Maintaining backward compatibility with existing `NIX_SYSTEM` usage
- Providing clear console output for debugging and transparency

Both `nix-build` and `nix-switch` targets now follow the same host resolution logic, ensuring consistency between build and activation workflows.

## Testing
- Verified host selection logic with `HOST` variable
- Confirmed auto-detection works with `DETECTED_HOST` variable
- Tested fallback to `NIX_SYSTEM` when both variables are unset
- Validated informational output displays correctly for all scenarios

Generated with Claude Code by glm-4.7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add host selection to nix-build and nix-switch using HOST and DETECTED_HOST, with fallback to NIX_SYSTEM and clearer logs. This makes targeted builds/switches easier and keeps behavior consistent.

- **New Features**
  - Host resolution order: HOST → DETECTED_HOST → NIX_SYSTEM.
  - Echo which host is being built/switched.
  - Same host logic for both build and switch targets.

- **Dependencies**
  - Updated dotagents submodule.

<sup>Written for commit bee485f8a0cb22e7bebd24d2ef6478386c077a2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

