### PR TITLE
feat(matic): add GNOME desktop environment

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -76,6 +76,11 @@ inputs.nixpkgs.lib.nixosSystem {
         # Power management
         services.power-profiles-daemon.enable = true;
 
+        # Desktop environment (GNOME)
+        services.xserver.enable = true;
+        services.xserver.displayManager.gdm.enable = true;
+        services.xserver.desktopManager.gnome.enable = true;
+
         # WiFi MT7925e fix (disable ASPM)
         boot.extraModprobeConfig = ''
           options mt7925e disable_aspm=1


### PR DESCRIPTION
## Changes
- Added GNOME desktop environment to matic host
- Enabled X11 server with GDM display manager

## Technical Details
- Enables services.xserver for graphical environment
- Configures GDM as display manager
- Installs GNOME desktop manager

## Testing
- Configuration builds successfully with `make build`

Generated with opencode by glm-4.7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the GNOME desktop environment to the matic NixOS host to provide a full graphical session. Enables X11, GDM for login, and the GNOME desktop manager.

<sup>Written for commit 060ec3045f9929bcb5ac121511de53f001165b6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

