### PR TITLE
chore(matic): set boot loader timeout to 3 seconds

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -34,6 +34,7 @@ inputs.nixpkgs.lib.nixosSystem {
         boot.loader.systemd-boot.enable = true;
         boot.loader.systemd-boot.configurationLimit = 10;
         boot.loader.efi.canTouchEfiVariables = true;
+        boot.loader.timeout = 3;
 
         # Latest kernel for AMD AI 300 support
         boot.kernelPackages = pkgs.linuxPackages_latest;


### PR DESCRIPTION
## Changes
- Set systemd-boot timeout to 3 seconds on matic host

## Technical Details
- Modified 
- Added  configuration
- Reduces boot menu wait time

## Testing
- Nix build successful

Generated with opencode by glm-4.7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the systemd-boot timeout to 3 seconds on the matic host to reduce boot menu wait and speed up startup.

<sup>Written for commit 77ee758878c76ef909d8cc6318076b54e455ec60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

