### PR TITLE
fix: detect sudo path for NixOS compatibility

### DIFF
--- a/config/k3s/default.nix
+++ b/config/k3s/default.nix
@@ -15,8 +15,22 @@
   home.activation.k3s-config = lib.mkIf pkgs.stdenv.isLinux (
     config.lib.dag.entryAfter [ "writeBoundary" ] ''
       if [ -f "$HOME/.config/k3s/config.yaml" ]; then
-        $DRY_RUN_CMD /usr/bin/sudo mkdir -p /etc/rancher/k3s
-        $DRY_RUN_CMD /usr/bin/sudo cp "$HOME/.config/k3s/config.yaml" /etc/rancher/k3s/config.yaml
+        # Find sudo (NixOS uses /run/wrappers/bin/sudo)
+        SUDO_CMD=""
+        if command -v sudo >/dev/null 2>&1; then
+          SUDO_CMD="sudo"
+        elif [ -x /run/wrappers/bin/sudo ]; then
+          SUDO_CMD="/run/wrappers/bin/sudo"
+        elif [ -x /usr/bin/sudo ]; then
+          SUDO_CMD="/usr/bin/sudo"
+        fi
+
+        if [ -n "$SUDO_CMD" ]; then
+          $DRY_RUN_CMD $SUDO_CMD mkdir -p /etc/rancher/k3s
+          $DRY_RUN_CMD $SUDO_CMD cp "$HOME/.config/k3s/config.yaml" /etc/rancher/k3s/config.yaml
+        else
+          echo "Warning: sudo not found, skipping k3s config installation" >&2
+        fi
       fi
     ''
   );

--- a/home-manager/modules/tailscale/default.nix
+++ b/home-manager/modules/tailscale/default.nix
@@ -226,6 +226,9 @@ in
                 SUDO_CMD=""
                 if command -v sudo >/dev/null 2>&1; then
                   SUDO_CMD="sudo"
+                elif [ -x /run/wrappers/bin/sudo ]; then
+                  # NixOS puts sudo in /run/wrappers/bin
+                  SUDO_CMD="/run/wrappers/bin/sudo"
                 elif [ -x /usr/bin/sudo ]; then
                   SUDO_CMD="/usr/bin/sudo"
                 elif command -v doas >/dev/null 2>&1; then


### PR DESCRIPTION
## Changes
- Add sudo path detection to support NixOS where sudo is located in `/run/wrappers/bin/sudo`
- Update Makefile to use `$(SUDO)` variable across all targets
- Update k3s config installation to dynamically find sudo
- Update Tailscale module to detect NixOS sudo path
- Add `make clean` target for garbage collection

## Technical Details
NixOS uses a different path for sudo (`/run/wrappers/bin/sudo`) compared to traditional Linux systems (`/usr/bin/sudo`). This change adds intelligent path detection that checks multiple possible sudo locations and uses the first one found.

## Testing
- Verified on NixOS systems with `/run/wrappers/bin/sudo`
- Verified on macOS systems with standard `/usr/bin/sudo`
- `make clean` target tested successfully

Generated with Claude Code by GLM-4.7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects the correct sudo path at runtime so Makefile targets and activation scripts work on NixOS, Linux, and macOS. Adds a make clean target for garbage collection.

- **Bug Fixes**
  - Use a $(SUDO) variable in the Makefile (checks command -v sudo, /run/wrappers/bin/sudo, then /usr/bin/sudo) and apply it across build/switch/service commands.
  - k3s config install script now finds sudo dynamically before writing to /etc/rancher/k3s.
  - Tailscale module detects the NixOS sudo path.

- **New Features**
  - make clean to run nix-collect-garbage -d.

<sup>Written for commit a4b4a7af6cad2cc60f288acc1f597fb572dd0117. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

