### PR TITLE
feat(matic): add comprehensive font configuration

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -122,9 +122,25 @@ inputs.nixpkgs.lib.nixosSystem {
     # Fonts
     {
       nixpkgs.pkgs = pkgs;
+      nixpkgs.config.joypixels.acceptLicense = true;
+
+      fonts.fontconfig.enable = true;
       fonts.packages = with pkgs; [
+        inter
+        ipaexfont
+        ipafont
+        joypixels
         nerd-fonts.jetbrains-mono
+        noto-fonts-cjk-sans
+        noto-fonts-cjk-serif
+        noto-fonts-color-emoji
       ];
+      fonts.fontconfig.defaultFonts = {
+        serif = [ "Noto Serif CJK JP" "DejaVu Serif" ];
+        sansSerif = [ "Inter" "Noto Sans CJK JP" "DejaVu Sans" ];
+        monospace = [ "JetBrainsMono Nerd Font" "Noto Sans Mono CJK JP" ];
+        emoji = [ "JoyPixels" "Noto Color Emoji" ];
+      };
     }
 
     # Home Manager integration

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -136,10 +136,23 @@ inputs.nixpkgs.lib.nixosSystem {
         noto-fonts-color-emoji
       ];
       fonts.fontconfig.defaultFonts = {
-        serif = [ "Noto Serif CJK JP" "DejaVu Serif" ];
-        sansSerif = [ "Inter" "Noto Sans CJK JP" "DejaVu Sans" ];
-        monospace = [ "JetBrainsMono Nerd Font" "Noto Sans Mono CJK JP" ];
-        emoji = [ "JoyPixels" "Noto Color Emoji" ];
+        serif = [
+          "Noto Serif CJK JP"
+          "DejaVu Serif"
+        ];
+        sansSerif = [
+          "Inter"
+          "Noto Sans CJK JP"
+          "DejaVu Sans"
+        ];
+        monospace = [
+          "JetBrainsMono Nerd Font"
+          "Noto Sans Mono CJK JP"
+        ];
+        emoji = [
+          "JoyPixels"
+          "Noto Color Emoji"
+        ];
       };
     }
 


### PR DESCRIPTION
## Changes
- Added Joypixels license acceptance
- Enabled fontconfig for matic host
- Added font packages: Inter, IPA fonts, JoyPixels, JetBrains Mono Nerd Font, Noto CJK fonts, Noto Color Emoji
- Configured default fonts for serif, sansSerif, monospace, and emoji

## Technical Details
Configured comprehensive font stack including:
- Sans-serif: Inter + Noto Sans CJK JP for mixed Japanese/English display
- Serif: Noto Serif CJK JP + DejaVu Serif
- Monospace: JetBrainsMono Nerd Font + Noto Sans Mono CJK JP
- Emoji: JoyPixels + Noto Color Emoji fallback

## Testing
Configuration builds successfully

Generated with opencode by GLM-4.7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a complete font stack on the matic host. Improves Japanese/English text and emoji rendering and sets sensible default font families.

- **New Features**
  - Enabled fontconfig and set defaults for serif, sans, monospace, and emoji.
  - Installed fonts: Inter, IPA (ipaexfont/ipafont), JetBrains Mono Nerd Font, Noto CJK (sans/serif), Noto Color Emoji, JoyPixels (license accepted).

<sup>Written for commit ef856f3e7796a9bc483ad39db3cbb978392ef0b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

