### PR TITLE
Remove redundant joypixels license acceptance from default.nix

### DIFF
--- a/lib/nixpkgs-config.nix
+++ b/lib/nixpkgs-config.nix
@@ -8,4 +8,5 @@
       "qwen-code"
       "crush"
     ];
+  joypixels.acceptLicense = true;
 }

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -122,7 +122,6 @@ inputs.nixpkgs.lib.nixosSystem {
     # Fonts
     {
       nixpkgs.pkgs = pkgs;
-      nixpkgs.config.joypixels.acceptLicense = true;
 
       fonts.fontconfig.enable = true;
       fonts.packages = with pkgs; [


### PR DESCRIPTION
Eliminate unnecessary joypixels license acceptance from the configuration to streamline the setup process.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved JoyPixels license acceptance to the global nixpkgs config to avoid per-host duplication and keep font setup consistent. Simplifies the matic host configuration.

- **Refactors**
  - Set joypixels.acceptLicense = true in lib/nixpkgs-config.nix.
  - Removed duplicate setting from named-hosts/matic/default.nix.

<sup>Written for commit 71373e05573bb442bb4946a080323195f17cc5a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

