### PR TITLE
feat: add CI testing for named hosts

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -98,6 +98,44 @@ jobs:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Nix Tests
         run: make nix-test
+  nix-named-hosts:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - host: galactica
+            runner: macos-latest
+            config_target: ""
+          - host: matic
+            runner: ubuntu-latest
+            config_target: nixos
+          - host: kyber
+            runner: ubuntu-latest
+            config_target: home
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 300
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Free Disk Space (Ubuntu)
+        if: runner.os == 'Linux'
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Prepare System Files
+        if: runner.os == 'macOS'
+        run: |
+          sudo mv /etc/nix/nix.conf /etc/nix/nix.conf.before-nix-darwin || true
+          sudo mv /etc/shells /etc/shells.before-nix-darwin || true
+      - name: Build ${{ matrix.host }}
+        env:
+          NIX_CONFIG_TARGET: ${{ matrix.config_target }}
+          HOST: ${{ matrix.host }}
+        run: make build
   nix-check:
     if: always()
     needs:
@@ -107,6 +145,7 @@ jobs:
       - nix-linux
       - nix-nixos
       - nix-test
+      - nix-named-hosts
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -26,6 +26,10 @@ jobs:
           sudo mv /etc/shells /etc/shells.before-nix-darwin || true
       - name: Run Nix Darwin
         run: make build
+      - name: Build Host `galactica`
+        env:
+          HOST: galactica
+        run: make build
   nix-flake:
     runs-on: ubuntu-latest
     timeout-minutes: 300
@@ -68,6 +72,11 @@ jobs:
         env:
           NIX_CONFIG_TARGET: home
         run: make build
+      - name: Build Host `kyber`
+        env:
+          NIX_CONFIG_TARGET: home
+          HOST: kyber
+        run: make build
   nix-nixos:
     runs-on: ubuntu-latest
     timeout-minutes: 300
@@ -86,6 +95,11 @@ jobs:
         env:
           NIX_CONFIG_TARGET: nixos
         run: make build
+      - name: Build Host `matic`
+        env:
+          NIX_CONFIG_TARGET: nixos
+          HOST: matic
+        run: make build
   nix-test:
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -98,44 +112,6 @@ jobs:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Nix Tests
         run: make nix-test
-  nix-named-hosts:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - host: galactica
-            runner: macos-latest
-            config_target: ""
-          - host: matic
-            runner: ubuntu-latest
-            config_target: nixos
-          - host: kyber
-            runner: ubuntu-latest
-            config_target: home
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 300
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Free Disk Space (Ubuntu)
-        if: runner.os == 'Linux'
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: false
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Prepare System Files
-        if: runner.os == 'macOS'
-        run: |
-          sudo mv /etc/nix/nix.conf /etc/nix/nix.conf.before-nix-darwin || true
-          sudo mv /etc/shells /etc/shells.before-nix-darwin || true
-      - name: Build ${{ matrix.host }}
-        env:
-          NIX_CONFIG_TARGET: ${{ matrix.config_target }}
-          HOST: ${{ matrix.host }}
-        run: make build
   nix-check:
     if: always()
     needs:
@@ -145,7 +121,6 @@ jobs:
       - nix-linux
       - nix-nixos
       - nix-test
-      - nix-named-hosts
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -79,8 +79,8 @@ inputs.nixpkgs.lib.nixosSystem {
 
         # Desktop environment (GNOME)
         services.xserver.enable = true;
-        services.xserver.displayManager.gdm.enable = true;
-        services.xserver.desktopManager.gnome.enable = true;
+        services.displayManager.gdm.enable = true;
+        services.desktopManager.gnome.enable = true;
 
         # WiFi MT7925e fix (disable ASPM)
         boot.extraModprobeConfig = ''

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -66,6 +66,13 @@ let
           isRunner = true;
           username = "runner";
         }).config.system.build.toplevel;
+
+    eval-nixos-matic =
+      mkEvalCheck "nixos-matic"
+        (import ../named-hosts/matic {
+          inherit inputs;
+          username = "shunkakinoki";
+        }).config.system.build.toplevel;
   };
 
   # --- Home-manager configurations (filtered by matching system) ---


### PR DESCRIPTION
## Changes
- Added nix-named-hosts CI job with matrix strategy for galactica, matic, and kyber hosts
- Fixed matic GNOME/GDM service configuration paths (removed obsolete services.xserver prefix)
- Added NixOS evaluation test for matic host configuration

## Technical Details
- Matrix job runs on appropriate runners (macOS for galactica, Ubuntu for matic/kyber)
- Properly sets NIX_CONFIG_TARGET and HOST environment variables
- Added matic to nix-check job dependencies for complete test coverage

## Testing
- CI tests will automatically validate named host configurations
- All three named hosts included in build matrix

Generated with Claude Code by claude-4.7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CI builds for named hosts (galactica, matic, kyber) across existing jobs. Fix matic GNOME/GDM config and add a NixOS evaluation to improve coverage.

- **New Features**
  - Build galactica on macOS with HOST=galactica.
  - Build kyber with NIX_CONFIG_TARGET=home and HOST=kyber.
  - Build matic with NIX_CONFIG_TARGET=nixos and HOST=matic.
  - Add matic NixOS eval in tests.

- **Bug Fixes**
  - Update matic GNOME/GDM service paths to services.displayManager and services.desktopManager (remove xserver prefix).

<sup>Written for commit 8b4fa0c204bdd4267463039d4fe33485bfef072b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

