### PR TITLE
feat(matic): change username to skakinoki

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -119,7 +119,7 @@
               };
               matic = import ./named-hosts/matic {
                 inherit inputs;
-                username = "shunkakinoki";
+                username = "skakinoki";
               };
             };
             homeConfigurations = {


### PR DESCRIPTION
## Changes
- Update username for matic NixOS host from `shunkakinoki` to `skakinoki`

## Technical Details
- Modified `flake.nix` to set `username = "skakinoki"` for the matic host configuration
- Only affects the matic NixOS host, no other hosts are changed

## Testing
- Requires manual user migration on the matic host before `nixos-rebuild switch`

Generated with [Claude Code](https://claude.ai/code) by Claude

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changed the matic NixOS host username from "shunkakinoki" to "skakinoki" in flake.nix. Only the matic host is affected.

- **Migration**
  - Create or rename the user to "skakinoki" on matic and set correct groups.
  - Move/rename the home directory to /home/skakinoki and fix ownership.
  - Update any references (SSH keys, sudoers, services) to the new username.
  - Then run nixos-rebuild switch.

<sup>Written for commit 43cc27eab44594722d803cc8c99175d4a67a3f32. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

