### PR TITLE
feat(matic): add initial password for user

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -57,6 +57,7 @@ inputs.nixpkgs.lib.nixosSystem {
             "video"
           ];
           home = "/home/${username}";
+          initialPassword = "changemeow";  # Change this after first login with: passwd
         };
 
         security.sudo.wheelNeedsPassword = false;


### PR DESCRIPTION
## Changes
- Add `initialPassword` for the matic NixOS host user

## Technical Details
- Sets initial password to `changemeow` for first login
- User should change password immediately after login with `passwd`

## Testing
- Rebuild on matic host and verify login works

Generated with [Claude Code](https://claude.ai/code) by Claude

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets an initial password for the matic host user to enable first login. The default is "changemeow"; change it immediately with "passwd".

- **Migration**
  - Rebuild the matic host and verify login works with the new password.

<sup>Written for commit ebb632d0d15691a565812f5692ed4cea1e743d57. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

