### PR TITLE
fix(matic): use system default shell in ghostty

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -8,7 +8,6 @@ background-opacity = 0.8
 confirm-close-surface = true
 macos-option-as-alt = true
 macos-titlebar-style = "tabs"
-command = /etc/profiles/per-user/shunkakinoki/bin/fish
 shell-integration = fish
 cursor-style = bar
 cursor-style-blink = true

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -48,6 +48,9 @@ inputs.nixpkgs.lib.nixosSystem {
         networking.networkmanager.enable = true;
         networking.networkmanager.wifi.powersave = false;
 
+        # Enable fish shell
+        programs.fish.enable = true;
+
         # User configuration
         users.users.${username} = {
           isNormalUser = true;
@@ -57,6 +60,7 @@ inputs.nixpkgs.lib.nixosSystem {
             "video"
           ];
           home = "/home/${username}";
+          shell = pkgs.fish;
         };
 
         security.sudo.wheelNeedsPassword = false;


### PR DESCRIPTION
## Changes
- Remove hardcoded shell path from ghostty config
- Set fish as default shell for matic user via NixOS config

## Technical Details
- Removed `command = /etc/profiles/per-user/shunkakinoki/bin/fish` from ghostty config
- Added `programs.fish.enable = true` and `shell = pkgs.fish` to matic host config
- Ghostty will now use the system default shell instead of a hardcoded path

## Testing
- Rebuild on matic and verify Ghostty opens with fish shell

Generated with [Claude Code](https://claude.ai/code) by Claude

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ghostty now launches using the system default shell instead of a hardcoded path. Fish is enabled and set as the matic user’s login shell via NixOS so Ghostty opens with fish reliably.

<sup>Written for commit 7bc543e800f2ef30b6f38b8be980ea52b3177100. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

