### PR TITLE
fix(matic): enable nix-ld for dynamically linked binaries

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -61,7 +61,7 @@ inputs.nixpkgs.lib.nixosSystem {
           ];
           home = "/home/${username}";
           shell = pkgs.fish;
-          initialPassword = "changemeow";  # Change this after first login with: passwd
+          initialPassword = "changemeow"; # Change this after first login with: passwd
         };
 
         security.sudo.wheelNeedsPassword = false;
@@ -104,6 +104,18 @@ inputs.nixpkgs.lib.nixosSystem {
           vim
           wget
           zellij
+        ];
+
+        # Enable nix-ld for running dynamically linked binaries (CrowdStrike, Kolide, etc.)
+        programs.nix-ld.enable = true;
+        programs.nix-ld.libraries = with pkgs; [
+          # Common libraries needed by security tools
+          glibc
+          zlib
+          openssl
+          curl
+          libnl
+          libgcc
         ];
 
         # Nix settings


### PR DESCRIPTION
## Changes
- Enable `programs.nix-ld` on matic host to allow running dynamically linked binaries

## Technical Details
- NixOS cannot run dynamically linked executables by default
- CrowdStrike Falcon and Kolide require standard library paths
- `nix-ld` provides a shim that makes these binaries work
- Added common libraries: glibc, zlib, openssl, curl, libnl, libgcc

## Testing
- Rebuild on matic and verify CrowdStrike/Kolide services start

Generated with [Claude Code](https://claude.ai/code) by Claude

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enabled nix-ld on the matic NixOS host to run dynamically linked binaries required by CrowdStrike and Kolide. Added common runtime libraries (glibc, zlib, openssl, curl, libnl, libgcc) so these services start correctly.

<sup>Written for commit b10676459a08e49f45b29cec2ee210c82b3c7a84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

