### PR TITLE
fix(matic): add TUF directory for Kolide launcher

### DIFF
--- a/named-hosts/matic/kolide.nix
+++ b/named-hosts/matic/kolide.nix
@@ -67,7 +67,8 @@ in
     # Create Kolide directories
     "d /etc/kolide-k2 0755 root root -"
     "d /opt/kolide-k2 0755 root root -"
-    "d /var/kolide-k2 0755 root root -"
+    "d /var/kolide-k2 0770 root root -"
+    "d /var/kolide-k2/tuf 0770 root root -"
   ];
 
   # Kolide Launcher service


### PR DESCRIPTION
## Changes
- Add TUF directory creation for Kolide launcher
- Fix directory permissions (0770 for write access)

## Technical Details
- Kolide needs a writable TUF directory at `/var/kolide-k2/tuf`
- Changed `/var/kolide-k2` permissions from 0755 to 0770

## Testing
- Rebuild on matic and verify Kolide service starts without TUF errors

Generated with [Claude Code](https://claude.ai/code) by Claude

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures Kolide Launcher on matic can initialize TUF by creating /var/kolide-k2/tuf and making both it and /var/kolide-k2 writable (0770). Prevents startup errors caused by a missing or non-writable TUF directory.

<sup>Written for commit 3fa338c4ef0d8053fed1bb7e5345d74808438184. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

