### PR TITLE
fix(matic): correct TUF directory permissions for Kolide

### DIFF
--- a/named-hosts/matic/kolide.nix
+++ b/named-hosts/matic/kolide.nix
@@ -67,8 +67,8 @@ in
     # Create Kolide directories
     "d /etc/kolide-k2 0755 root root -"
     "d /opt/kolide-k2 0755 root root -"
-    "d /var/kolide-k2 0770 root root -"
-    "d /var/kolide-k2/tuf 0770 root root -"
+    "d /var/kolide-k2 0750 root root -"
+    "d /var/kolide-k2/tuf 0750 root root -"
   ];
 
   # Kolide Launcher service


### PR DESCRIPTION
## Changes
- Fix TUF directory permissions from 0770 to 0750

## Technical Details
- Kolide requires max permissions of 0750 (rwxr-x---)
- Previous 0770 caused validation error

## Testing
- Rebuild on matic and verify Kolide service starts

Generated with [Claude Code](https://claude.ai/code) by Claude

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected Kolide directory permissions on matic to 0750 to meet Kolide’s requirements and fix validation errors so the launcher starts.

- **Bug Fixes**
  - Set /var/kolide-k2 and /var/kolide-k2/tuf to 0750 (rwxr-x---).
  - Prevents Kolide permission validation failure on matic.

<sup>Written for commit 1855e6050ffa4b3c376882091786a82db15c23c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

