### PR TITLE
fix(matic): disable Kolide autoupdate for NixOS compatibility

### DIFF
--- a/named-hosts/matic/kolide.nix
+++ b/named-hosts/matic/kolide.nix
@@ -101,7 +101,7 @@ in
           exit 1
         fi
       '';
-      ExecStart = "${kolideFhs}/bin/kolide-launcher-fhs --enroll_secret_path=/etc/kolide-k2/secret --root_directory=/var/kolide-k2";
+      ExecStart = "${kolideFhs}/bin/kolide-launcher-fhs --enroll_secret_path=/etc/kolide-k2/secret --root_directory=/var/kolide-k2 --autoupdate=false";
       Restart = "on-failure";
       RestartSec = "10s";
 


### PR DESCRIPTION
## Changes
- Add `--autoupdate=false` flag to Kolide launcher

## Technical Details
- NixOS doesn't support Kolide's TUF-based auto-update mechanism
- TUF requires root keys and update library that aren't available on NixOS
- Disabling autoupdate allows the launcher to run with the installed version

## Testing
- Rebuild on matic and verify Kolide service starts

Generated with [Claude Code](https://claude.ai/code) by Claude

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled Kolide launcher autoupdate on NixOS (matic) by adding --autoupdate=false to the systemd ExecStart to work around TUF update incompatibilities. The service now runs with the installed version and starts reliably.

<sup>Written for commit 2c4fc5023e2f42ab865b0a7e686ebc230ddde8d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

