### PR TITLE
refactor(matic): use Taylan's CrowdStrike Falcon approach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -459,3 +459,4 @@ target
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+*.deb

--- a/named-hosts/matic/falcon/default.nix
+++ b/named-hosts/matic/falcon/default.nix
@@ -1,0 +1,69 @@
+# CrowdStrike Falcon sensor package for NixOS
+#
+# Prerequisites:
+# 1. Obtain the Falcon sensor .deb from IT
+# 2. Place it in this directory as: falcon-sensor_<version>_amd64.deb
+# 3. Update the version below to match
+{
+  stdenv,
+  lib,
+  pkgs,
+  dpkg,
+  openssl,
+  libnl,
+  zlib,
+  autoPatchelfHook,
+  buildFHSEnv,
+  ...
+}:
+let
+  pname = "falcon-sensor";
+  version = "7.31.0-18410";
+  arch = "amd64";
+
+  src = builtins.path {
+    path = ./${pname}_${version}_${arch}.deb;
+    name = "${pname}_${version}_${arch}.deb";
+  };
+
+  falcon-sensor = stdenv.mkDerivation {
+    name = pname;
+    inherit version arch src;
+
+    buildInputs = [
+      dpkg
+      zlib
+      autoPatchelfHook
+    ];
+    sourceRoot = ".";
+
+    unpackPhase = ''
+      dpkg-deb -x $src .
+    '';
+
+    installPhase = ''
+      cp -r . $out
+    '';
+
+    meta = with lib; {
+      description = "CrowdStrike Falcon Sensor";
+      homepage = "https://www.crowdstrike.com/";
+      license = licenses.unfree;
+      platforms = platforms.linux;
+    };
+  };
+in
+buildFHSEnv {
+  name = "fs-bash";
+  targetPkgs = pkgs: [
+    libnl
+    openssl
+    zlib
+  ];
+
+  extraInstallCommands = ''
+    ln -s ${falcon-sensor}/* $out/
+  '';
+
+  runScript = "bash";
+}


### PR DESCRIPTION
## Changes
- Rewrite CrowdStrike Falcon configuration to match Taylan's working approach
- Add `falcon/default.nix` package that extracts and patches the .deb
- Add `*.deb` to `.gitignore`

## Technical Details
- Uses `autoPatchelfHook` to patch ELF binaries for NixOS
- Builds FHS environment (`fs-bash`) with patched sensor
- Init script copies files from Nix store to `/opt/CrowdStrike` at service start
- Runs `falcond` inside FHS bash environment

## Prerequisites
1. Place `falcon-sensor_7.31.0-18410_amd64.deb` in `named-hosts/matic/falcon/`
2. Create `/etc/falcon-sensor.env` with `FALCON_CID=<your-cid>`

## Testing
- Rebuild on matic and verify CrowdStrike service starts and enrolls

Generated with [Claude Code](https://claude.ai/code) by Claude

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched matic’s CrowdStrike Falcon setup to Taylan’s NixOS approach for a more reliable sensor and simpler install. Packages the upstream .deb and runs falcond in an FHS environment with a proper init and CID configuration.

- **Refactors**
  - Added falcon/default.nix to extract the .deb and patch ELF with autoPatchelfHook.
  - Built a minimal FHS env (“fs-bash”) and run falcond inside it via systemd.
  - Init script copies sensor files to /opt/CrowdStrike and sets CID from /etc/falcon-sensor.env.
  - Simplified unit deps and restart behavior; ignore *.deb in .gitignore.

- **Migration**
  - Place falcon-sensor_<version>_amd64.deb in named-hosts/matic/falcon/.
  - Create /etc/falcon-sensor.env with FALCON_CID, rebuild matic, and verify the sensor enrolls.

<sup>Written for commit 161f34118ba8fde1856078dbb6da413d1621cbc4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

