### PR TITLE
fix(matic): update Kolide nix-agent hash

### DIFF
--- a/named-hosts/matic/kolide.nix
+++ b/named-hosts/matic/kolide.nix
@@ -24,7 +24,7 @@ let
   # Get sha256 via: nix-prefetch-url --unpack https://github.com/kolide/nix-agent/archive/refs/heads/main.tar.gz
   kolideSrc = builtins.fetchTarball {
     url = "https://github.com/kolide/nix-agent/archive/refs/heads/main.tar.gz";
-    sha256 = "1d52jvm8rk7sb1x61h8wkmfldif3xcabwssvbz006clr72afnb2j";
+    sha256 = "0g9694ckraaqm2bcqwdfn7gb23rpnw59clc1pca2c2sxgfgj5285";
   };
 in
 {


### PR DESCRIPTION
## Changes
- Update Kolide nix-agent tarball hash (upstream changed)

## Technical Details
- Old hash: `1d52jvm8rk7sb1x61h8wkmfldif3xcabwssvbz006clr72afnb2j`
- New hash: `0g9694ckraaqm2bcqwdfn7gb23rpnw59clc1pca2c2sxgfgj5285`

## Testing
- Build should succeed on matic

Generated with [Claude Code](https://claude.ai/code) by Claude

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Nix build on matic by updating the Kolide nix-agent tarball hash after an upstream change. fetchTarball now succeeds again.

- **Bug Fixes**
  - Updated sha256 for Kolide nix-agent main tarball: 1d52jvm8rk7sb1x61h8wkmfldif3xcabwssvbz006clr72afnb2j -> 0g9694ckraaqm2bcqwdfn7gb23rpnw59clc1pca2c2sxgfgj5285

<sup>Written for commit b4957eecfd435f3d5e597ed735d3f052fc450712. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

