### PR TITLE
fix(matic): use absolute path for falcon-sensor.deb

### DIFF
--- a/named-hosts/matic/falcon/default.nix
+++ b/named-hosts/matic/falcon/default.nix
@@ -2,8 +2,9 @@
 #
 # Prerequisites:
 # 1. Obtain the Falcon sensor .deb from IT
-# 2. Place it in this directory as: falcon-sensor_<version>_amd64.deb
-# 3. Update the version below to match
+# 2. Place it at: /etc/nixos/falcon-sensor.deb
+#    sudo cp ~/Downloads/falcon-sensor*.deb /etc/nixos/falcon-sensor.deb
+# 3. Update the version below to match if different
 {
   stdenv,
   lib,
@@ -21,10 +22,8 @@ let
   version = "7.31.0-18410";
   arch = "amd64";
 
-  src = builtins.path {
-    path = ./${pname}_${version}_${arch}.deb;
-    name = "${pname}_${version}_${arch}.deb";
-  };
+  # Use absolute path outside the flake (gitignored files aren't visible to flakes)
+  src = /etc/nixos/falcon-sensor.deb;
 
   falcon-sensor = stdenv.mkDerivation {
     name = pname;


### PR DESCRIPTION
## Changes
- Use absolute path `/etc/nixos/falcon-sensor.deb` instead of relative path in flake

## Technical Details
- Flakes only see files tracked by Git
- Gitignored `.deb` files are invisible to `builtins.path`
- Using absolute path outside the flake works around this limitation

## Prerequisites (on matic)
```bash
sudo cp ~/Downloads/falcon-sensor*.deb /etc/nixos/falcon-sensor.deb
```

## Testing
- Build should succeed after placing .deb at `/etc/nixos/falcon-sensor.deb`

Generated with [Claude Code](https://claude.ai/code) by Claude

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch matic’s Falcon sensor package to use an absolute path for the .deb to prevent build failures when the file is gitignored. This works around flake visibility limits for untracked files.

- **Migration**
  - Copy the .deb to /etc/nixos/falcon-sensor.deb: sudo cp ~/Downloads/falcon-sensor*.deb /etc/nixos/falcon-sensor.deb

<sup>Written for commit 809d7744e0e74d4c6d28cc284281e6022632fb1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

