### PR TITLE
fix(matic): remove conditional check for falcon .deb

### DIFF
--- a/named-hosts/matic/falcon.nix
+++ b/named-hosts/matic/falcon.nix
@@ -6,14 +6,9 @@
 #    sudo cp ~/Downloads/falcon-sensor*.deb /etc/nixos/falcon-sensor.deb
 # 3. Create /etc/falcon-sensor.env with: FALCON_CID=<your-cid>
 #
-# This module is automatically disabled if the .deb file doesn't exist.
-#
 # Based on: https://github.com/taylanpince/nixos-config
 { pkgs, lib, ... }:
 let
-  falconDebPath = /etc/nixos/falcon-sensor.deb;
-  falconDebExists = builtins.pathExists falconDebPath;
-
   falcon = pkgs.callPackage ./falcon { };
 
   initScript = pkgs.writeScript "init-falcon" ''
@@ -38,43 +33,38 @@ let
     ${falcon}/bin/fs-bash -c "/opt/CrowdStrike/falconctl -g --cid"
   '';
 in
-if falconDebExists then
-  {
-    systemd.tmpfiles.rules = [
-      "d /opt/CrowdStrike 0770 root root -"
+{
+  systemd.tmpfiles.rules = [
+    "d /opt/CrowdStrike 0770 root root -"
+  ];
+
+  systemd.services.falcon-sensor = {
+    description = "CrowdStrike Falcon Sensor";
+    wantedBy = [ "multi-user.target" ];
+
+    unitConfig.DefaultDependencies = false;
+    after = [ "local-fs.target" ];
+    conflicts = [ "shutdown.target" ];
+    before = [
+      "sysinit.target"
+      "shutdown.target"
     ];
 
-    systemd.services.falcon-sensor = {
-      description = "CrowdStrike Falcon Sensor";
-      wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "forking";
+      PIDFile = "/run/falcond.pid";
+      ExecStartPre = initScript;
+      ExecStart = "${falcon}/bin/fs-bash -c \"/opt/CrowdStrike/falcond\"";
 
-      unitConfig.DefaultDependencies = false;
-      after = [ "local-fs.target" ];
-      conflicts = [ "shutdown.target" ];
-      before = [
-        "sysinit.target"
-        "shutdown.target"
-      ];
+      Restart = "on-failure";
+      RestartSec = "15s";
 
-      serviceConfig = {
-        Type = "forking";
-        PIDFile = "/run/falcond.pid";
-        ExecStartPre = initScript;
-        ExecStart = "${falcon}/bin/fs-bash -c \"/opt/CrowdStrike/falcond\"";
+      # Avoid systemd giving up during flapping
+      StartLimitIntervalSec = 0;
 
-        Restart = "on-failure";
-        RestartSec = "15s";
-
-        # Avoid systemd giving up during flapping
-        StartLimitIntervalSec = 0;
-
-        TimeoutStopSec = "60s";
-        KillMode = "process";
-        Delegate = true;
-      };
+      TimeoutStopSec = "60s";
+      KillMode = "process";
+      Delegate = true;
     };
-  }
-else
-  {
-    # Falcon sensor disabled - /etc/nixos/falcon-sensor.deb not found
-  }
+  };
+}


### PR DESCRIPTION
## Changes
- Remove `builtins.pathExists` conditional from falcon.nix

## Technical Details
- `builtins.pathExists` doesn't work reliably with flakes for paths outside the flake
- The check happens during pure evaluation, which doesn't see external paths
- Now the module is always enabled - if .deb is missing, build fails with clear error

## Prerequisites (on matic)
```bash
sudo cp ~/Downloads/falcon-sensor*.deb /etc/nixos/falcon-sensor.deb
```

## Testing
- Rebuild on matic and verify falcon-sensor service is registered

Generated with [Claude Code](https://claude.ai/code) by Claude

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always enable the Falcon sensor module on matic by removing the unreliable builtins.pathExists check for the .deb. Builds now fail fast with a clear error if the package is missing, preventing silent disables under flakes.

- **Migration**
  - Copy the sensor .deb to /etc/nixos/falcon-sensor.deb.
  - Create /etc/falcon-sensor.env with FALCON_CID=<your-cid>, then rebuild and verify the falcon-sensor service.

<sup>Written for commit aa862296d9bb82038346c081157785dc344ad869. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

