### PR TITLE
fix(ghostty): start fish as login shell for proper initialization

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -9,6 +9,7 @@ confirm-close-surface = true
 macos-option-as-alt = true
 macos-titlebar-style = "tabs"
 shell-integration = fish
+command = fish --login
 cursor-style = bar
 cursor-style-blink = true
 mouse-hide-while-typing = true


### PR DESCRIPTION
## Changes
- Add `command = fish --login` to Ghostty config

## Technical Details
- Ghostty by default may not start the shell as a login shell
- Fish `loginShellInit` and proper abbreviation loading requires login shell
- Using `fish --login` ensures all init scripts (shellInit, loginShellInit, interactiveShellInit) run properly

## Testing
- Open Ghostty and verify `abbr` shows all abbreviations
- Verify PATH and environment variables are set correctly

Generated with [Claude Code](https://claude.ai/code) by Claude

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Start fish as a login shell in Ghostty so all init scripts run and abbreviations and env vars load correctly.
Adds command = fish --login to the Ghostty config.

<sup>Written for commit 45ae67929aef8a71d420525ce98d16a2d9a005cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

