### PR TITLE
chore(matic): fix nix formatting

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -23,177 +23,176 @@ inputs.nixpkgs.lib.nixosSystem {
   specialArgs = {
     inherit inputs username;
   };
-  modules =
-    [
-      # Framework 13" AMD AI 300 hardware support
-      inputs.nixos-hardware.nixosModules.framework-amd-ai-300-series
+  modules = [
+    # Framework 13" AMD AI 300 hardware support
+    inputs.nixos-hardware.nixosModules.framework-amd-ai-300-series
 
-      # Hardware configuration
-      ./hardware-configuration.nix
+    # Hardware configuration
+    ./hardware-configuration.nix
 
-      # Kolide launcher
-      ./kolide.nix
+    # Kolide launcher
+    ./kolide.nix
 
-      # Base system configuration
-      (
-        { config, lib, ... }:
-        {
-          # Boot loader (EFI/systemd-boot)
-          boot.loader.systemd-boot.enable = true;
-          boot.loader.systemd-boot.configurationLimit = 10;
-          boot.loader.efi.canTouchEfiVariables = true;
-          boot.loader.timeout = 3;
-
-          # Latest kernel for AMD AI 300 support
-          boot.kernelPackages = pkgs.linuxPackages_latest;
-
-          # Networking
-          networking.hostName = "matic";
-          networking.networkmanager.enable = true;
-          networking.networkmanager.wifi.powersave = false;
-
-          # Enable fish shell
-          programs.fish.enable = true;
-
-          # User configuration
-          users.users.${username} = {
-            isNormalUser = true;
-            extraGroups = [
-              "wheel"
-              "networkmanager"
-              "video"
-            ];
-            home = "/home/${username}";
-            shell = pkgs.fish;
-            initialPassword = "changemeow"; # Change this after first login with: passwd
-          };
-
-          security.sudo.wheelNeedsPassword = false;
-
-          # AMD graphics with hardware acceleration
-          hardware.graphics.enable = true;
-          hardware.graphics.extraPackages = with pkgs; [
-            libva
-            libva-vdpau-driver
-            libvdpau-va-gl
-          ];
-
-          # Thunderbolt support
-          services.hardware.bolt.enable = true;
-
-          # Fingerprint authentication
-          services.fprintd.enable = true;
-
-          # Firmware updates
-          services.fwupd.enable = true;
-
-          # Power management
-          services.power-profiles-daemon.enable = true;
-
-          # Desktop environment (GNOME)
-          services.xserver.enable = true;
-          services.displayManager.gdm.enable = true;
-          services.desktopManager.gnome.enable = true;
-
-          # WiFi MT7925e fix (disable ASPM)
-          boot.extraModprobeConfig = ''
-            options mt7925e disable_aspm=1
-          '';
-
-          # System packages
-          environment.systemPackages = with pkgs; [
-            curl
-            git
-            home-manager
-            vim
-            wget
-            zellij
-          ];
-
-          # Enable nix-ld for running dynamically linked binaries (CrowdStrike, Kolide, etc.)
-          programs.nix-ld.enable = true;
-          programs.nix-ld.libraries = with pkgs; [
-            # Common libraries needed by security tools
-            glibc
-            zlib
-            openssl
-            curl
-            libnl
-            libgcc
-          ];
-
-          # Nix settings
-          nix = {
-            settings = {
-              experimental-features = [
-                "nix-command"
-                "flakes"
-              ];
-              substituters = [
-                "https://cache.nixos.org"
-              ];
-              trusted-users = [
-                "root"
-                username
-              ];
-            };
-            package = pkgs.nixVersions.stable;
-          };
-
-          system.stateVersion = "24.11";
-        }
-      )
-
-      # Fonts
+    # Base system configuration
+    (
+      { config, lib, ... }:
       {
-        nixpkgs.pkgs = pkgs;
+        # Boot loader (EFI/systemd-boot)
+        boot.loader.systemd-boot.enable = true;
+        boot.loader.systemd-boot.configurationLimit = 10;
+        boot.loader.efi.canTouchEfiVariables = true;
+        boot.loader.timeout = 3;
 
-        fonts.fontconfig.enable = true;
-        fonts.packages = with pkgs; [
-          inter
-          ipaexfont
-          ipafont
-          joypixels
-          nerd-fonts.jetbrains-mono
-          noto-fonts-cjk-sans
-          noto-fonts-cjk-serif
-          noto-fonts-color-emoji
+        # Latest kernel for AMD AI 300 support
+        boot.kernelPackages = pkgs.linuxPackages_latest;
+
+        # Networking
+        networking.hostName = "matic";
+        networking.networkmanager.enable = true;
+        networking.networkmanager.wifi.powersave = false;
+
+        # Enable fish shell
+        programs.fish.enable = true;
+
+        # User configuration
+        users.users.${username} = {
+          isNormalUser = true;
+          extraGroups = [
+            "wheel"
+            "networkmanager"
+            "video"
+          ];
+          home = "/home/${username}";
+          shell = pkgs.fish;
+          initialPassword = "changemeow"; # Change this after first login with: passwd
+        };
+
+        security.sudo.wheelNeedsPassword = false;
+
+        # AMD graphics with hardware acceleration
+        hardware.graphics.enable = true;
+        hardware.graphics.extraPackages = with pkgs; [
+          libva
+          libva-vdpau-driver
+          libvdpau-va-gl
         ];
-        fonts.fontconfig.defaultFonts = {
-          serif = [
-            "Noto Serif CJK JP"
-            "DejaVu Serif"
-          ];
-          sansSerif = [
-            "Inter"
-            "Noto Sans CJK JP"
-            "DejaVu Sans"
-          ];
-          monospace = [
-            "JetBrainsMono Nerd Font"
-            "Noto Sans Mono CJK JP"
-          ];
-          emoji = [
-            "JoyPixels"
-            "Noto Color Emoji"
-          ];
-        };
-      }
 
-      # Home Manager integration
-      inputs.home-manager.nixosModules.home-manager
-      {
-        home-manager.backupFileExtension = "hm-backup";
-        home-manager.extraSpecialArgs = { inherit inputs; };
-        home-manager.useGlobalPkgs = true;
-        home-manager.useUserPackages = true;
-        home-manager.users.${username} = import ../../home-manager {
-          inherit inputs username;
-          lib = inputs.nixpkgs.lib;
-          pkgs = pkgs;
-          config = { };
+        # Thunderbolt support
+        services.hardware.bolt.enable = true;
+
+        # Fingerprint authentication
+        services.fprintd.enable = true;
+
+        # Firmware updates
+        services.fwupd.enable = true;
+
+        # Power management
+        services.power-profiles-daemon.enable = true;
+
+        # Desktop environment (GNOME)
+        services.xserver.enable = true;
+        services.displayManager.gdm.enable = true;
+        services.desktopManager.gnome.enable = true;
+
+        # WiFi MT7925e fix (disable ASPM)
+        boot.extraModprobeConfig = ''
+          options mt7925e disable_aspm=1
+        '';
+
+        # System packages
+        environment.systemPackages = with pkgs; [
+          curl
+          git
+          home-manager
+          vim
+          wget
+          zellij
+        ];
+
+        # Enable nix-ld for running dynamically linked binaries (CrowdStrike, Kolide, etc.)
+        programs.nix-ld.enable = true;
+        programs.nix-ld.libraries = with pkgs; [
+          # Common libraries needed by security tools
+          glibc
+          zlib
+          openssl
+          curl
+          libnl
+          libgcc
+        ];
+
+        # Nix settings
+        nix = {
+          settings = {
+            experimental-features = [
+              "nix-command"
+              "flakes"
+            ];
+            substituters = [
+              "https://cache.nixos.org"
+            ];
+            trusted-users = [
+              "root"
+              username
+            ];
+          };
+          package = pkgs.nixVersions.stable;
         };
+
+        system.stateVersion = "24.11";
       }
-    ]
-    ++ (if falconDebExists then [ ./falcon.nix ] else [ ]); # CrowdStrike Falcon (only if .deb exists)
+    )
+
+    # Fonts
+    {
+      nixpkgs.pkgs = pkgs;
+
+      fonts.fontconfig.enable = true;
+      fonts.packages = with pkgs; [
+        inter
+        ipaexfont
+        ipafont
+        joypixels
+        nerd-fonts.jetbrains-mono
+        noto-fonts-cjk-sans
+        noto-fonts-cjk-serif
+        noto-fonts-color-emoji
+      ];
+      fonts.fontconfig.defaultFonts = {
+        serif = [
+          "Noto Serif CJK JP"
+          "DejaVu Serif"
+        ];
+        sansSerif = [
+          "Inter"
+          "Noto Sans CJK JP"
+          "DejaVu Sans"
+        ];
+        monospace = [
+          "JetBrainsMono Nerd Font"
+          "Noto Sans Mono CJK JP"
+        ];
+        emoji = [
+          "JoyPixels"
+          "Noto Color Emoji"
+        ];
+      };
+    }
+
+    # Home Manager integration
+    inputs.home-manager.nixosModules.home-manager
+    {
+      home-manager.backupFileExtension = "hm-backup";
+      home-manager.extraSpecialArgs = { inherit inputs; };
+      home-manager.useGlobalPkgs = true;
+      home-manager.useUserPackages = true;
+      home-manager.users.${username} = import ../../home-manager {
+        inherit inputs username;
+        lib = inputs.nixpkgs.lib;
+        pkgs = pkgs;
+        config = { };
+      };
+    }
+  ]
+  ++ (if falconDebExists then [ ./falcon.nix ] else [ ]); # CrowdStrike Falcon (only if .deb exists)
 }


### PR DESCRIPTION
## Changes
- Fix nix formatting in matic default.nix

## Technical Details
- Previous commit had incorrect indentation
- Ran `make format` to fix

Generated with [Claude Code](https://claude.ai/code) by Claude

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reformatted named-hosts/matic/default.nix for consistent Nix style and readability. Consolidated the modules list and fixed indentation; no functional changes.

<sup>Written for commit ffd30f5362c70a67f1333a1176a82ed7073932f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

