### PR TITLE
fix(make): pass --impure flag to nixos-rebuild switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -404,12 +404,12 @@ nix-switch: ## Activate Nix configuration.
 		elif [ "$(NIX_CONFIG_TYPE)" = "nixosConfigurations" ]; then \
 			if [ -n "$(HOST)" ]; then \
 				echo "Switching named host: $(HOST)"; \
-				$(SUDO) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure nixpkgs#nixos-rebuild -- switch --flake .#$(HOST); \
+				$(SUDO) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- switch --flake .#$(HOST) --impure; \
 			elif [ -n "$(DETECTED_HOST)" ]; then \
 				echo "Auto-detected host: $(DETECTED_HOST)"; \
-				$(SUDO) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure nixpkgs#nixos-rebuild -- switch --flake .#$(DETECTED_HOST); \
+				$(SUDO) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- switch --flake .#$(DETECTED_HOST) --impure; \
 			else \
-				$(SUDO) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure nixpkgs#nixos-rebuild -- switch --flake .#$(NIX_SYSTEM); \
+				$(SUDO) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- switch --flake .#$(NIX_SYSTEM) --impure; \
 			fi; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "homeConfigurations" ]; then \
 			if [ -n "$(HOST)" ]; then \


### PR DESCRIPTION
## Changes
- Move `--impure` flag from `nix run` to `nixos-rebuild switch` command
- Ensures `builtins.pathExists` can access external paths during switch

## Technical Details
The `--impure` flag was being passed to `nix run` instead of `nixos-rebuild switch`. This prevented `builtins.pathExists /etc/nixos/falcon-sensor.deb` from working correctly since the impure evaluation mode wasn't being applied to the actual rebuild command.

## Testing
- Verified on NixOS (matic host) that `make switch` now correctly includes the falcon module when the .deb file exists

Generated with Claude Code by claude-opus-4-5-20250101

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the --impure flag from nix run to nixos-rebuild switch so NixOS switches evaluate in impure mode. This fixes external path checks (e.g., /etc/nixos/falcon-sensor.deb) and ensures the falcon module is applied when present.

- **Bug Fixes**
  - Apply --impure to nixos-rebuild switch across all host branches in nix-switch.
  - Verified make switch loads the falcon module when the .deb is present.

<sup>Written for commit add01c0556272d7af42ec79476b8a71175090239. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

