### PR TITLE
fix(falcon): remove immutable attributes before cleanup

### DIFF
--- a/named-hosts/matic/falcon.nix
+++ b/named-hosts/matic/falcon.nix
@@ -17,6 +17,11 @@ let
     #!${pkgs.bash}/bin/sh
     set -euo pipefail
 
+    # Remove immutable attributes set by CrowdStrike (security feature)
+    if [ -d /opt/CrowdStrike ]; then
+      ${pkgs.e2fsprogs}/bin/chattr -i -R /opt/CrowdStrike 2>/dev/null || true
+    fi
+
     rm -rf /opt/CrowdStrike
     install -d -m 0770 /opt/CrowdStrike
 


### PR DESCRIPTION
## Changes
- Add chattr to remove immutable flags before directory cleanup

## Technical Details
CrowdStrike Falcon sets immutable file attributes on its binaries to prevent tampering. The init script was failing with 'Operation not permitted' because files have the immutable flag set.

This fix removes the immutable attributes using chattr before cleanup.

## Testing
- Verified falcon-sensor service starts after this fix on NixOS (matic host)

Generated with Claude Code by claude-opus-4-5-20250101

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix init failures by clearing immutable flags on /opt/CrowdStrike before cleanup to prevent “Operation not permitted” errors. Runs chattr -i -R (if the directory exists) so cleanup succeeds and falcon-sensor starts correctly on NixOS.

<sup>Written for commit 13fbe3d8b02d16cabc32f15cbd7924ad8ac966e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

