### PR TITLE
feat(matic): enable PAM fingerprint auth and fix falcon init

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -82,6 +82,9 @@ inputs.nixpkgs.lib.nixosSystem {
 
         # Fingerprint authentication
         services.fprintd.enable = true;
+        security.pam.services.login.fprintAuth = true;
+        security.pam.services.gdm.fprintAuth = true;
+        security.pam.services.sudo.fprintAuth = true;
 
         # Firmware updates
         services.fwupd.enable = true;

--- a/named-hosts/matic/falcon.nix
+++ b/named-hosts/matic/falcon.nix
@@ -17,18 +17,12 @@ let
     #!${pkgs.bash}/bin/sh
     set -euo pipefail
 
-    # Remove immutable attributes set by CrowdStrike (security feature)
-    if [ -d /opt/CrowdStrike ]; then
-      ${pkgs.e2fsprogs}/bin/chattr -i -R /opt/CrowdStrike 2>/dev/null || true
+    # Only initialize if not already set up (CrowdStrike protects its files)
+    if [ ! -f /opt/CrowdStrike/falcond ]; then
+      install -d -m 0770 /opt/CrowdStrike
+      cp -a ${falcon}/opt/CrowdStrike/. /opt/CrowdStrike/
+      chown -R root:root /opt/CrowdStrike
     fi
-
-    rm -rf /opt/CrowdStrike
-    install -d -m 0770 /opt/CrowdStrike
-
-    # Copy real files so Falcon can write falconstore/CsConfig
-    cp -a ${falcon}/opt/CrowdStrike/. /opt/CrowdStrike/
-
-    chown -R root:root /opt/CrowdStrike
 
     # load CID from /etc/falcon-sensor.env (root-only)
     . /etc/falcon-sensor.env


### PR DESCRIPTION
## Changes
- Enable fingerprint authentication for login, GDM, and sudo via PAM services
- Fix CrowdStrike Falcon init script to skip cleanup when already installed

## Technical Details
- Added `security.pam.services.{login,gdm,sudo}.fprintAuth = true` for fingerprint at login
- Modified falcon init to check if falcond exists before trying to reinitialize (CrowdStrike's kernel module protects its files from removal)

## Testing
- Fingerprint enrollment via `sudo fprintd-enroll`
- Verify login/sudo with fingerprint after rebuild

Generated with Claude Code by claude-opus-4-5-20250101

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables fingerprint authentication for login, GDM, and sudo on matic, and updates the Falcon init script to avoid reinitializing when the sensor is already installed.

- **New Features**
  - Enabled fprintd and PAM fingerprint auth for login, gdm, and sudo.

- **Bug Fixes**
  - Falcon init now checks for /opt/CrowdStrike/falcond and skips cleanup/reinstall to prevent conflicts with protected files.

<sup>Written for commit 4ef7f137a0680455fad1ca4cc7569a5b27a2757c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

