### PR TITLE
revert: PAM fingerprint auth and falcon init changes

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -82,9 +82,6 @@ inputs.nixpkgs.lib.nixosSystem {
 
         # Fingerprint authentication
         services.fprintd.enable = true;
-        security.pam.services.login.fprintAuth = true;
-        security.pam.services.gdm.fprintAuth = true;
-        security.pam.services.sudo.fprintAuth = true;
 
         # Firmware updates
         services.fwupd.enable = true;


### PR DESCRIPTION
## Changes
- Reverts feat(matic): enable PAM fingerprint auth and fix falcon init (#743)

## Reason
Fingerprint enrollment showing duplicate errors and failing to discover prints.

Generated with Claude Code by claude-opus-4-5-20250101

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable PAM fingerprint auth and force a clean Falcon sensor initialization to resolve fingerprint enrollment errors and ensure consistent Falcon setup on matic.

- **Bug Fixes**
  - Turn off PAM fingerprint auth for login, GDM, and sudo; keep fprintd enabled.
  - Reset Falcon init: remove immutable flags, wipe /opt/CrowdStrike, re-copy sensor files, and set root ownership before loading CID.

<sup>Written for commit fe3026918cec2d60f6ce09d64b9ba4729af2c93a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

