### PR TITLE
fix(matic): require password for sudo

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -67,7 +67,7 @@ inputs.nixpkgs.lib.nixosSystem {
           initialPassword = "changemeow"; # Change this after first login with: passwd
         };
 
-        security.sudo.wheelNeedsPassword = false;
+        security.sudo.wheelNeedsPassword = true;
 
         # AMD graphics with hardware acceleration
         hardware.graphics.enable = true;


### PR DESCRIPTION
## Changes
- Set `security.sudo.wheelNeedsPassword = true`

## Reason
Kolide compliance check failing: 'Sudo Can Be Invoked Without a Password'

Generated with Claude Code by claude-opus-4-5-20250101

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a password for sudo on matic to pass Kolide compliance and prevent passwordless sudo for wheel users.

Set security.sudo.wheelNeedsPassword = true in named-hosts/matic/default.nix.

<sup>Written for commit a8bdf68b523295143ea048791eb898ebc9d44056. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

