### PR TITLE
Revert password requirement for sudo and enhance host detection

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -3,7 +3,7 @@
   inputs,
 }:
 let
-  inherit (inputs.env) isCI;
+  inherit (inputs.host) isDesktop;
 in
 with pkgs;
 [
@@ -115,12 +115,15 @@ with pkgs;
   tailscale
   trashy
 ]
-++ lib.optionals (stdenv.isLinux && !isCI) [
+++ lib.optionals (stdenv.isLinux && isDesktop) [
+  _1password-gui
   chromium
+  clickup
   ffmpeg
   ghostty
   github-desktop
   google-chrome
   signal-desktop
+  slack
   vlc
 ]

--- a/lib/host.nix
+++ b/lib/host.nix
@@ -1,12 +1,20 @@
 {
-  # Detect if running on kyber (requires --impure flag, which Makefile already uses)
+  # Detect if running on kyber (linux)
   isKyber = builtins.getEnv "HOSTNAME" == "kyber" || builtins.getEnv "HOST" == "kyber";
 
   # Detect if running on galactica (macOS node)
   isGalactica = builtins.getEnv "HOSTNAME" == "galactica" || builtins.getEnv "HOST" == "galactica";
 
-  # Detect if running on matic (Framework 13" AMD AI 300)
+  # Detect if running on matic (Framework 13)
   isMatic = builtins.getEnv "HOSTNAME" == "matic" || builtins.getEnv "HOST" == "matic";
+
+  # Desktop machines with GUI (matic, galactica)
+  isDesktop =
+    let
+      hostname = builtins.getEnv "HOSTNAME";
+      host = builtins.getEnv "HOST";
+    in
+    hostname == "matic" || host == "matic" || hostname == "galactica" || host == "galactica";
 
   # Get the node name for OpenClaw remote mode
   # Falls back to "unknown" if no hostname is detected

--- a/lib/nixpkgs-config.nix
+++ b/lib/nixpkgs-config.nix
@@ -4,9 +4,12 @@
   allowUnfreePredicate =
     pkg:
     builtins.elem (nixpkgsLib.getName pkg) [
+      "1password"
       "claude-code"
-      "qwen-code"
+      "clickup"
       "crush"
+      "qwen-code"
+      "slack"
     ];
   joypixels.acceptLicense = true;
 }

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -67,7 +67,7 @@ inputs.nixpkgs.lib.nixosSystem {
           initialPassword = "changemeow"; # Change this after first login with: passwd
         };
 
-        security.sudo.wheelNeedsPassword = true;
+        security.sudo.wheelNeedsPassword = false;
 
         # AMD graphics with hardware acceleration
         hardware.graphics.enable = true;

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -44,6 +44,12 @@ in
       else
         ''echo "FAIL: host.nodeName must exist and be a string" && exit 1''
     }
+    ${
+      if host ? isDesktop && builtins.isBool host.isDesktop then
+        ''echo "lib/host.nix: isDesktop is a boolean (value: ${builtins.toString host.isDesktop})"''
+      else
+        ''echo "FAIL: host.isDesktop must exist and be a boolean" && exit 1''
+    }
     touch $out
   '';
 


### PR DESCRIPTION
Revert the change that required a password for sudo access. Enhance host detection for desktop environments and update package configurations accordingly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores passwordless sudo on matic. Adds isDesktop host detection and uses it to install desktop apps only on desktop machines, with updated allowlist and tests.

- **New Features**
  - Add host.isDesktop flag for matic and galactica.
  - Replace isCI with isDesktop to gate Linux GUI apps in home-manager.
  - Add desktop apps: 1Password GUI, ClickUp, Slack.
  - Extend unfree allow list for 1password, clickup, slack.
  - Add test to ensure host.isDesktop exists and is boolean.

- **Bug Fixes**
  - Revert matic’s sudo policy: wheel users no longer need a password.

<sup>Written for commit 8a237c1b034d127f7712188eba234fdb9f040b52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

