### PR TITLE
Revert sudo password requirement and enhance host detection

### DIFF
--- a/lib/host.nix
+++ b/lib/host.nix
@@ -8,13 +8,8 @@
   # Detect if running on matic (Framework 13)
   isMatic = builtins.getEnv "HOSTNAME" == "matic" || builtins.getEnv "HOST" == "matic";
 
-  # Desktop machines with GUI (matic, galactica)
-  isDesktop =
-    let
-      hostname = builtins.getEnv "HOSTNAME";
-      host = builtins.getEnv "HOST";
-    in
-    hostname == "matic" || host == "matic" || hostname == "galactica" || host == "galactica";
+  # Desktop machines with GUI - default false, override in named-hosts
+  isDesktop = false;
 
   # Get the node name for OpenClaw remote mode
   # Falls back to "unknown" if no hostname is detected

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -183,11 +183,24 @@ inputs.nixpkgs.lib.nixosSystem {
     inputs.home-manager.nixosModules.home-manager
     {
       home-manager.backupFileExtension = "hm-backup";
-      home-manager.extraSpecialArgs = { inherit inputs; };
+      home-manager.extraSpecialArgs = {
+        # Override host detection for matic (isDesktop = true)
+        inputs = inputs // {
+          host = (import ../../lib/host.nix) // {
+            isDesktop = true;
+          };
+        };
+      };
       home-manager.useGlobalPkgs = true;
       home-manager.useUserPackages = true;
       home-manager.users.${username} = import ../../home-manager {
-        inherit inputs username;
+        inherit username;
+        # Override host detection for matic (isDesktop = true)
+        inputs = inputs // {
+          host = (import ../../lib/host.nix) // {
+            isDesktop = true;
+          };
+        };
         lib = inputs.nixpkgs.lib;
         pkgs = pkgs;
         config = { };

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -39,6 +39,12 @@ in
         ''echo "FAIL: host.isGalactica must exist and be a boolean" && exit 1''
     }
     ${
+      if host ? isMatic && builtins.isBool host.isMatic then
+        ''echo "lib/host.nix: isMatic is a boolean"''
+      else
+        ''echo "FAIL: host.isMatic must exist and be a boolean" && exit 1''
+    }
+    ${
       if host ? nodeName && builtins.isString host.nodeName then
         ''echo "lib/host.nix: nodeName is a string (value: ${host.nodeName})"''
       else
@@ -82,9 +88,12 @@ in
           ''echo "FAIL: ${name} should be allowed by unfree predicate" && exit 1''
       )
       [
+        "1password"
         "claude-code"
-        "qwen-code"
+        "clickup"
         "crush"
+        "qwen-code"
+        "slack"
       ]
     }
     touch $out


### PR DESCRIPTION
Revert the requirement for a password for sudo on matic and improve host detection for desktop environments. Update package configurations to reflect these changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the sudo password requirement on matic and adds a desktop host flag to correctly install GUI apps on desktop machines. Improves host detection and updates package and test configs.

- **New Features**
  - Added host.isDesktop (default false) and used it to gate Linux GUI packages.
  - Enabled desktop apps when isDesktop: 1Password GUI, Chromium/Chrome, ClickUp, Signal, Slack, VLC, etc.
  - Set isDesktop = true for matic via named-host override.
  - Allowed non-free packages: 1Password, ClickUp, Slack.

- **Bug Fixes**
  - Restored matic to not require a password for sudo (wheelNeedsPassword = false).
  - Expanded tests to validate isMatic, isDesktop, and unfree allow list.

<sup>Written for commit f110c99c68fd1cfe6cd5820725497b772e64c81d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

