### PR TITLE
feat(hyprland): add hyprpaper wallpaper with Catppuccin Mocha

### DIFF
--- a/config/hyprland/default.nix
+++ b/config/hyprland/default.nix
@@ -6,6 +6,7 @@
 }:
 let
   hyprexpoPlugin = pkgs.hyprlandPlugins.hyprexpo;
+  wallpaper = pkgs.nixos-artwork.wallpapers.nineish-catppuccin-mocha-alt;
 in
 {
   wayland.windowManager.hyprland = {
@@ -24,6 +25,15 @@ in
   };
   xdg.configFile."hypr/hyprlock.conf" = {
     source = ./hyprlock.conf;
+    force = true;
+  };
+  xdg.configFile."hypr/hyprpaper.conf" = {
+    text = ''
+      splash = false
+      ipc = on
+      preload = ${wallpaper}/share/backgrounds/nixos/nix-wallpaper-nineish-catppuccin-mocha-alt.png
+      wallpaper = ,${wallpaper}/share/backgrounds/nixos/nix-wallpaper-nineish-catppuccin-mocha-alt.png
+    '';
     force = true;
   };
 }

--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -46,6 +46,9 @@ exec-once = wl-paste --type image --watch cliphist store
 # Idle management
 exec-once = hypridle
 
+# Wallpaper
+exec-once = hyprpaper
+
 # Volume/brightness OSD
 exec-once = rm -f /tmp/wobpipe && mkfifo /tmp/wobpipe && tail -f /tmp/wobpipe | wob
 

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -130,6 +130,7 @@ with pkgs;
   grim
   hypridle
   hyprlock
+  hyprpaper
   libnotify
   networkmanagerapplet
   pavucontrol


### PR DESCRIPTION
## Changes
- Add `hyprpaper` as wallpaper daemon for Hyprland
- Use `nixos-artwork.wallpapers.nineish-catppuccin-mocha-alt` from nixpkgs as the default wallpaper
- Generate `hyprpaper.conf` via Nix with store path interpolation (no manual downloads needed)

## Technical Details
- `hyprpaper` package added to desktop packages in `home-manager/packages/default.nix`
- `exec-once = hyprpaper` added to `hyprland.conf` startup section
- `hyprpaper.conf` generated in `config/hyprland/default.nix` using `xdg.configFile` with `text` attribute to interpolate the Nix store wallpaper path

## Testing
- Verify `make build` succeeds
- On matic: confirm wallpaper displays on login

Generated with [Claude Code](https://claude.ai/code) by Claude Opus 4.6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add hyprpaper to Hyprland for wallpaper management and set the default Catppuccin Mocha NixOS wallpaper. The config is generated via Nix using a store path, so no manual downloads are needed.

- **New Features**
  - Start hyprpaper on login (exec-once) and add it to home-manager packages.
  - Generate xdg config hypr/hyprpaper.conf with preload/wallpaper set to nixos-artwork nineish-catppuccin-mocha-alt.
  - Disable splash and enable IPC in hyprpaper.

<sup>Written for commit f4c973f9056e65d1a0c97b1c2f307db80716a5c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

