### PR TITLE
fix(hyprland): use hyprpaper 0.8+ config format

### DIFF
--- a/config/hyprland/default.nix
+++ b/config/hyprland/default.nix
@@ -29,10 +29,11 @@ in
   };
   xdg.configFile."hypr/hyprpaper.conf" = {
     text = ''
-      splash = false
-      ipc = on
-      preload = ${wallpaper}/share/backgrounds/nixos/nix-wallpaper-nineish-catppuccin-mocha-alt.png
-      wallpaper = ,${wallpaper}/share/backgrounds/nixos/nix-wallpaper-nineish-catppuccin-mocha-alt.png
+      splash = 0
+
+      wallpaper {
+        path = ${wallpaper}/share/backgrounds/nixos/nix-wallpaper-nineish-catppuccin-mocha-alt.png
+      }
     '';
     force = true;
   };

--- a/config/hyprland/default.nix
+++ b/config/hyprland/default.nix
@@ -6,7 +6,7 @@
 }:
 let
   hyprexpoPlugin = pkgs.hyprlandPlugins.hyprexpo;
-  wallpaper = pkgs.nixos-artwork.wallpapers.nineish-catppuccin-mocha-alt;
+  wallpaper = "${pkgs.nixos-artwork.wallpapers.nineish-catppuccin-mocha-alt}/share/backgrounds/nixos/nix-wallpaper-nineish-catppuccin-mocha-alt.png";
 in
 {
   wayland.windowManager.hyprland = {
@@ -15,6 +15,7 @@ in
     systemd.enable = false;
     extraConfig = ''
       plugin = ${hyprexpoPlugin}/lib/libhyprexpo.so
+      exec-once = ${pkgs.swaybg}/bin/swaybg -i ${wallpaper} -m fill
     ''
     + builtins.readFile ./hyprland.conf;
   };
@@ -26,17 +27,5 @@ in
   xdg.configFile."hypr/hyprlock.conf" = {
     source = ./hyprlock.conf;
     force = true;
-  };
-  services.hyprpaper = {
-    enable = true;
-    settings = {
-      splash = false;
-      preload = [
-        "${wallpaper}/share/backgrounds/nixos/nix-wallpaper-nineish-catppuccin-mocha-alt.png"
-      ];
-      wallpaper = [
-        ",${wallpaper}/share/backgrounds/nixos/nix-wallpaper-nineish-catppuccin-mocha-alt.png"
-      ];
-    };
   };
 }

--- a/config/hyprland/default.nix
+++ b/config/hyprland/default.nix
@@ -15,7 +15,8 @@ in
     systemd.enable = false;
     extraConfig = ''
       plugin = ${hyprexpoPlugin}/lib/libhyprexpo.so
-      exec-once = ${pkgs.swaybg}/bin/swaybg -i ${wallpaper} -m fill
+      exec-once = ${pkgs.swww}/bin/swww-daemon
+      exec-once = sleep 1 && ${pkgs.swww}/bin/swww img ${wallpaper}
     ''
     + builtins.readFile ./hyprland.conf;
   };

--- a/config/hyprland/default.nix
+++ b/config/hyprland/default.nix
@@ -27,15 +27,16 @@ in
     source = ./hyprlock.conf;
     force = true;
   };
-  xdg.configFile."hypr/hyprpaper.conf" = {
-    text = ''
-      splash = 0
-
-      wallpaper {
-        monitor =
-        path = ${wallpaper}/share/backgrounds/nixos/nix-wallpaper-nineish-catppuccin-mocha-alt.png
-      }
-    '';
-    force = true;
+  services.hyprpaper = {
+    enable = true;
+    settings = {
+      splash = false;
+      preload = [
+        "${wallpaper}/share/backgrounds/nixos/nix-wallpaper-nineish-catppuccin-mocha-alt.png"
+      ];
+      wallpaper = [
+        ",${wallpaper}/share/backgrounds/nixos/nix-wallpaper-nineish-catppuccin-mocha-alt.png"
+      ];
+    };
   };
 }

--- a/config/hyprland/default.nix
+++ b/config/hyprland/default.nix
@@ -32,6 +32,7 @@ in
       splash = 0
 
       wallpaper {
+        monitor =
         path = ${wallpaper}/share/backgrounds/nixos/nix-wallpaper-nineish-catppuccin-mocha-alt.png
       }
     '';

--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -46,9 +46,6 @@ exec-once = wl-paste --type image --watch cliphist store
 # Idle management
 exec-once = hypridle
 
-# Wallpaper
-exec-once = hyprpaper
-
 # Volume/brightness OSD
 exec-once = rm -f /tmp/wobpipe && mkfifo /tmp/wobpipe && tail -f /tmp/wobpipe | wob
 

--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -52,7 +52,7 @@ exec-once = rm -f /tmp/wobpipe && mkfifo /tmp/wobpipe && tail -f /tmp/wobpipe | 
 # =============================================================================
 # Monitor (Framework 13" 2256x1504)
 # =============================================================================
-monitor = eDP-1, 2256x1504@60, auto, 1.5
+monitor = eDP-1, 2256x1504@60, auto, 1.566667
 
 # =============================================================================
 # XWayland (sharp rendering at fractional scale)
@@ -291,9 +291,9 @@ bindel = , F7, exec, brightnessctl set 5%-
 # F8: Brightness up
 bindel = , XF86MonBrightnessUp, exec, brightnessctl set 5%+
 bindel = , F8, exec, brightnessctl set 5%+
-# F9: Toggle display scale (1.0x <-> 1.5x)
-bindl = , XF86Display, exec, hyprctl -j monitors | grep -q '"scale": 1.5' && hyprctl keyword monitor "eDP-1, preferred, auto, 1.0" || hyprctl keyword monitor "eDP-1, preferred, auto, 1.5"
-bindl = , F9, exec, hyprctl -j monitors | grep -q '"scale": 1.5' && hyprctl keyword monitor "eDP-1, preferred, auto, 1.0" || hyprctl keyword monitor "eDP-1, preferred, auto, 1.5"
+# F9: Toggle display scale (1.0x <-> 1.567x)
+bindl = , XF86Display, exec, hyprctl -j monitors | jq -r '.[0].scale' | awk '{if($1>1.3) print "1.0"; else print "1.566667"}' | xargs -I{} hyprctl keyword monitor "eDP-1,preferred,auto,{}"
+bindl = , F9, exec, hyprctl -j monitors | jq -r '.[0].scale' | awk '{if($1>1.3) print "1.0"; else print "1.566667"}' | xargs -I{} hyprctl keyword monitor "eDP-1,preferred,auto,{}"
 # F10: Airplane mode
 bindl = , XF86RFKill, exec, nmcli radio wifi toggle
 bindl = , F10, exec, nmcli radio wifi toggle
@@ -305,8 +305,9 @@ bind = , F11, exec, grim -g "$(slurp)" - | swappy -f -
 # Display Zoom (Framework + / - , macOS-style)
 # =============================================================================
 # Keyd maps Framework+= / Framework+- to Ctrl+Alt+Shift+= / Ctrl+Alt+Shift+-
-binde = CTRL ALT SHIFT, equal, exec, hyprctl -j monitors | jq -r '.[0].scale' | awk '{v=int($1*4+0.5)/4+0.25; if(v>3)v=3; printf "%.2f",v}' | xargs -I{} hyprctl keyword monitor "eDP-1,preferred,auto,{}"
-binde = CTRL ALT SHIFT, minus, exec, hyprctl -j monitors | jq -r '.[0].scale' | awk '{v=int($1*4+0.5)/4-0.25; if(v<0.5)v=0.5; printf "%.2f",v}' | xargs -I{} hyprctl keyword monitor "eDP-1,preferred,auto,{}"
+# Valid scales for 2256x1504: 1.0, 1.333333, 1.566667, 2.0
+binde = CTRL ALT SHIFT, equal, exec, hyprctl -j monitors | jq -r '.[0].scale' | awk '{s=$1; if(s<1.16) s=1.333333; else if(s<1.45) s=1.566667; else if(s<1.78) s=2.0; else s=2.0; printf "%.6f",s}' | xargs -I{} hyprctl keyword monitor "eDP-1,preferred,auto,{}"
+binde = CTRL ALT SHIFT, minus, exec, hyprctl -j monitors | jq -r '.[0].scale' | awk '{s=$1; if(s>1.78) s=1.566667; else if(s>1.45) s=1.333333; else if(s>1.16) s=1.0; else s=1.0; printf "%.6f",s}' | xargs -I{} hyprctl keyword monitor "eDP-1,preferred,auto,{}"
 
 # =============================================================================
 # Lock Screen

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -139,6 +139,7 @@ with pkgs;
   slurp
   swappy
   swaynotificationcenter
+  swww
   vlc
   vscode
   waybar

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -130,7 +130,6 @@ with pkgs;
   grim
   hypridle
   hyprlock
-  hyprpaper
   libnotify
   networkmanagerapplet
   pavucontrol


### PR DESCRIPTION
## Changes
- Update `hyprpaper.conf` to use the 0.8+ wallpaper block syntax

## Technical Details
- hyprpaper 0.8+ replaced `preload`/`wallpaper = ,path` with `wallpaper { path = ... }` blocks
- `splash` is now an integer (`0`) instead of a boolean (`false`)
- Removed obsolete `ipc = on` (IPC is enabled by default)

## Testing
- Verify wallpaper displays on Hyprland login

Generated with [Claude Code](https://claude.ai/code) by Claude Opus 4.6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch wallpaper to swww so it loads reliably on Hyprland startup with user systemd disabled. Also fix fractional scaling presets and toggles for the 2256x1504 display.

- **Bug Fixes**
  - Start swww-daemon and set wallpaper via exec-once using an absolute Nix store path.
  - Remove hyprpaper package, exec-once, and hyprpaper.conf.
  - Use valid scales (1.0, 1.333333, 1.566667, 2.0); set default to 1.566667 and update F9/zoom bindings.

<sup>Written for commit 4e06a3b58adb5f38e3f740a74d734f7f4fd89c81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

