### PR TITLE
feat(hyprland): comprehensive Hyprland desktop enhancement

### DIFF
--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -195,10 +195,10 @@ windowrule = stay_focused on, match:class ^(clipse)$
 windowrule = suppress_event maximize, match:class .*
 
 # Slight opacity for visual depth
-windowrule = opacity 0.95 0.90, match:class ^(com.mitchellh.ghostty)$
-windowrule = opacity 0.90 0.85, match:class ^(google-chrome.*)$
-windowrule = opacity 0.95 0.90, match:class ^(Slack)$
-windowrule = opacity 0.90 0.85, match:class ^(code-url-handler)$
+windowrule = opacity 0.90 0.80, match:class ^(com.mitchellh.ghostty)$
+windowrule = opacity 0.90 0.80, match:class ^(google-chrome)$
+windowrule = opacity 0.90 0.80, match:class ^(Slack)$
+windowrule = opacity 0.90 0.80, match:class ^(code)$
 
 # Full opacity in fullscreen
 windowrule = opacity 1.0 override 1.0 override, match:fullscreen 1


### PR DESCRIPTION
## Summary
- Replace waybar/swaync/wob/wofi/wlogout with HyprPanel + Walker
- Add HyprPanel with full Dracula theme, workspace icons, dashboard shortcuts
- Add Walker launcher with custom system commands (lock, screenshot, recording, etc.)
- Add translucent window opacity (90/80%) for Ghostty, Chrome, Slack, VS Code
- Add frosted glass notifications with blur layerrules
- Add Ghostty scratchpad terminal and screen recording toggle
- Add window rules for Meet PIP, screen-share indicator, clipboard manager
- Fix Framework 13 media keys, display zoom, scaling priority
- Clean up tmux config with green theme and session persistence

## Test plan
- [ ] `make build` passes on Darwin
- [ ] `make switch` on Framework applies all changes
- [ ] HyprPanel bar renders with Dracula theme
- [ ] Walker launches with Framework+Space
- [ ] Window opacity visible on Chrome, Slack, VS Code, Ghostty
- [ ] Fullscreen windows get full opacity
- [ ] Notifications show frosted glass effect
- [ ] Dashboard shortcuts show Chrome, Slack, Discord, Screen Saver, Files, Terminal

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces Waybar/SwayNC/WOB/Wofi/WLogout with HyprPanel and Walker for a unified, frosted panel, launcher, notifications, and power menu on Hyprland. Adds scratchpad terminal, screen recording toggles, translucent app windows, fingerprint lock, and matic host updates (greetd login and Wallpaper Engine).

- New Features
  - HyprPanel + Walker with Dracula/frosted theme, workspace icons, and dashboard shortcuts.
  - Scripts + keys: Ghostty scratchpad (Super+Ctrl+T), wf-recorder toggle (Super+Shift+R), Framework+Space → Walker, hyprshot/picker, power/notifications menus.
  - Window/layer rules: 90/80% opacity for Ghostty/Chrome/Slack/VS Code with fullscreen override; tighter class matches for Chrome (google-chrome) and VS Code (code); Meet PIP pinned; screen-share indicator to special WS; Clipse floats; blur for bar/notifications/walker.
  - System polish: fingerprint auth in hyprlock; clipboard persistence (wl-clip-persist + clipse); hyprsunset; Wayland env + media key fixes.
  - Host matic: greetd/tuigreet login, tuned XDG portals, power key locks screen, Wallpaper Engine via Steam.
  - DevX: tmux green status and session persistence; fish tmux helpers; shell specs for new scripts.

- Migration
  - Legacy Waybar/SwayNC/WOB/Wofi/WLogout configs are removed; HyprPanel and Walker replace them.
  - After upgrade, run make build && make switch; sign into Steam to fetch Wallpaper Engine assets.
  - Quick checks: Framework+Space opens Walker; bar/notifications render; apps are translucent; Super+Shift+L locks.

<sup>Written for commit 913310acacf9f6311018155b46d2695b64de9175. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

