### PR TITLE
fix: guard worktrunk init and globals

### DIFF
--- a/home-manager/modules/cargo-globals/default.nix
+++ b/home-manager/modules/cargo-globals/default.nix
@@ -15,8 +15,10 @@ in
 {
   # Install cargo global packages from Cargo.toml using home-manager activation
   home.activation.installCargoGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
-    export PATH=${pkgs.rustup}/bin:${pkgs.cargo}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:$PATH
+    export PATH=${pkgs.rustup}/bin:${pkgs.cargo}/bin:${pkgs.rustc}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:$PATH
     export CARGO_HOME="$HOME/.cargo"
+    $DRY_RUN_CMD ${pkgs.rustup}/bin/rustup toolchain install stable
+    $DRY_RUN_CMD ${pkgs.rustup}/bin/rustup default stable
     export PKG_CONFIG_PATH="${pkgs.openssl.dev}/lib/pkgconfig${libiconvPkgConfigPath}''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
     export OPENSSL_DIR="${pkgs.openssl.dev}"
     export OPENSSL_LIB_DIR="${pkgs.openssl.out}/lib"

--- a/home-manager/modules/npm-globals/default.nix
+++ b/home-manager/modules/npm-globals/default.nix
@@ -7,6 +7,10 @@
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash ${./install-npm-globals.sh}
   '';
 
+  home.sessionVariables = {
+    BUN_INSTALL = "$HOME/.bun";
+  };
+
   # Add local and bun bins to PATH
   home.sessionPath = [
     "$HOME/.local/bin"

--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -57,7 +57,9 @@
       export PATH="/opt/homebrew/opt/postgresql@18/bin:$PATH"
 
       # Worktrunk shell init
-      eval "$(wt config shell init bash)"
+      if command -v wt >/dev/null 2>&1; then
+        eval "$(wt config shell init bash)"
+      fi
     '';
 
     profileExtra = ''

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -23,9 +23,6 @@
       set -gx GOPATH $HOME/go
 
       direnv hook fish | source
-
-      # Worktrunk shell init
-      wt config shell init fish | source
     '';
     loginShellInit = ''
       if test -f /opt/homebrew/bin/brew
@@ -61,6 +58,10 @@
       fish_add_path -p /opt/homebrew/bin
       fish_add_path -p /opt/homebrew/opt/postgresql@18/bin
       fish_add_path -p /etc/profiles/per-user/${config.home.username}/bin
+      # Worktrunk shell init
+      if type -q wt
+        wt config shell init fish | source
+      end
       set -a fish_complete_path ~/.nix-profile/share/fish/completions/ ~/.nix-profile/share/fish/vendor_completions.d/
       set -x FISH_HISTFILE fish
       fish_vi_key_bindings

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -66,7 +66,9 @@
       export FNM_VERSION_FILE_STRATEGY="local"
 
       # Worktrunk shell init
-      eval "$(wt config shell init zsh)"
+      if command -v wt >/dev/null 2>&1; then
+        eval "$(wt config shell init zsh)"
+      fi
     '';
   };
 }


### PR DESCRIPTION
## Changes\n- Guard worktrunk shell init across fish/bash/zsh\n- Ensure rustup stable toolchain for cargo globals\n- Export BUN_INSTALL via home session vars\n\n## Technical Details\n- Move worktrunk init to fish interactive shell after PATH setup\n- Run rustup toolchain install/default in cargo globals activation\n- Set BUN_INSTALL for consistent bun global paths\n\n## Testing\n- make build && make switch\n\nGenerated with GitHub Copilot CLI by GPT-5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded Worktrunk shell initialization and hardened global toolchains to prevent shell errors and ensure consistent paths. Adds rustup stable toolchain for cargo globals and sets BUN_INSTALL for predictable bun installs.

- **Bug Fixes**
  - bash/zsh: only run Worktrunk init if wt exists.
  - fish: run Worktrunk init after PATH setup and guard with type check.
  - cargo globals: add rustc to PATH; install and set rustup stable before activation.
  - npm globals: export BUN_INSTALL="$HOME/.bun" for consistent bun global paths.

<sup>Written for commit 5cbc1db2601bcb00a32d000d29ca258aa4ca8358. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

