### PR TITLE
chore: remove waybar systemd service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -749,7 +749,7 @@ launchctl-ollama: ## Restart ollama launchd agent.
 ##@ Systemd Services (Linux)
 
 .PHONY: systemctl
-systemctl: systemctl-cliproxyapi systemctl-code-syncer systemctl-docker-postgres systemctl-dotfiles-updater systemctl-ollama systemctl-openclaw systemctl-waybar ## Restart all systemd user services.
+systemctl: systemctl-cliproxyapi systemctl-code-syncer systemctl-docker-postgres systemctl-dotfiles-updater systemctl-ollama systemctl-openclaw ## Restart all systemd user services.
 
 .PHONY: systemctl-cliproxyapi
 systemctl-cliproxyapi: ## Pull latest image and restart cliproxyapi systemd user service.
@@ -787,15 +787,6 @@ systemctl-openclaw: ## Restart OpenClaw gateway systemd user service.
 	@systemctl --user restart openclaw-gateway.service || true
 	@echo "✅ openclaw restarted"
 
-.PHONY: systemctl-waybar
-systemctl-waybar: ## Restart waybar.
-	@echo "🔄 Restarting waybar..."
-	@pkill waybar 2>/dev/null || true
-	@sleep 1
-	@hyprctl dispatch exec waybar 2>/dev/null || true
-	@echo "✅ waybar restarted"
-
-##@ Git Submodule
 
 .PHONY: git-submodule-sync
 git-submodule-sync: ## Sync and update git submodules.


### PR DESCRIPTION
## Changes
- Removed waybar systemd service target from Makefile
- Removed waybar-related systemd restart command

## Technical Details
Removed `systemctl-waybar` target and its dependency from the `systemctl` target.

## Testing
- Verified systemctl target still restarts remaining services

Generated with Claude Code by Claude (Anthropic)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed Waybar from systemd targets in the Makefile so make systemctl only restarts actual systemd user services, not Waybar. Deleted the systemctl-waybar target and removed it from the systemctl meta-target.

<sup>Written for commit 08a3b47819c611680d04b7346d4027dc4b556f90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

