### PR TITLE
feat(hyprland): add window resize, split toggle, and macOS-style screenshot keybindings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -749,7 +749,7 @@ launchctl-ollama: ## Restart ollama launchd agent.
 ##@ Systemd Services (Linux)
 
 .PHONY: systemctl
-systemctl: systemctl-cliproxyapi systemctl-code-syncer systemctl-docker-postgres systemctl-dotfiles-updater systemctl-ollama systemctl-openclaw systemctl-waybar ## Restart all systemd user services.
+systemctl: systemctl-cliproxyapi systemctl-code-syncer systemctl-docker-postgres systemctl-dotfiles-updater systemctl-ollama systemctl-openclaw ## Restart all systemd user services.
 
 .PHONY: systemctl-cliproxyapi
 systemctl-cliproxyapi: ## Pull latest image and restart cliproxyapi systemd user service.
@@ -787,15 +787,6 @@ systemctl-openclaw: ## Restart OpenClaw gateway systemd user service.
 	@systemctl --user restart openclaw-gateway.service || true
 	@echo "✅ openclaw restarted"
 
-.PHONY: systemctl-waybar
-systemctl-waybar: ## Restart waybar.
-	@echo "🔄 Restarting waybar..."
-	@pkill waybar 2>/dev/null || true
-	@sleep 1
-	@hyprctl dispatch exec waybar 2>/dev/null || true
-	@echo "✅ waybar restarted"
-
-##@ Git Submodule
 
 .PHONY: git-submodule-sync
 git-submodule-sync: ## Sync and update git submodules.

--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -249,7 +249,6 @@ bind = $mod, A, exec, pavucontrol
 # Launcher & Clipboard
 # =============================================================================
 bind = CTRL ALT SHIFT, SPACE, exec, walker
-bind = $mod, V, exec, code
 bind = $mod, E, exec, emote
 
 # =============================================================================
@@ -286,11 +285,22 @@ bind = $mod SHIFT, right, movewindow, r
 bind = $mod SHIFT, up, movewindow, u
 bind = $mod SHIFT, down, movewindow, d
 
-# Resize windows
+# Resize windows (arrow keys)
 binde = $mod CTRL, left, resizeactive, -20 0
 binde = $mod CTRL, right, resizeactive, 20 0
 binde = $mod CTRL, up, resizeactive, 0 -20
 binde = $mod CTRL, down, resizeactive, 0 20
+
+# Resize windows (horizontal: ; and ')
+binde = $mod, semicolon, resizeactive, -20 0
+binde = $mod, apostrophe, resizeactive, 20 0
+
+# Resize windows (vertical: Ctrl + ; and ')
+binde = $mod CTRL, semicolon, resizeactive, 0 -20
+binde = $mod CTRL, apostrophe, resizeactive, 0 20
+
+# Toggle split orientation (vertical/horizontal)
+bind = $mod, V, layoutmsg, togglesplit
 
 # =============================================================================
 # Workspaces
@@ -343,6 +353,11 @@ bind = $mod SHIFT, S, exec, grim -g "$(slurp)" - | swappy -f -
 bind = , PRINT, exec, hyprshot -m region
 bind = SHIFT, PRINT, exec, hyprshot -m window
 bind = CTRL, PRINT, exec, hyprshot -m output
+
+# macOS-style screenshot & recording (Framework+Shift+3/5 via keyd → Ctrl+Shift+3/5)
+bind = CTRL SHIFT, 3, exec, hyprshot -m output
+bind = CTRL SHIFT, 4, exec, hyprshot -m region
+bind = CTRL SHIFT, 5, exec, ~/.config/hypr/scripts/record-screen.sh
 
 # Color picker
 bind = $mod, PRINT, exec, hyprpicker -a


### PR DESCRIPTION
## Changes
- Add `SUPER + ;` / `SUPER + '` for horizontal window resize
- Add `SUPER + CTRL + ;` / `SUPER + CTRL + '` for vertical window resize
- Add `SUPER + V` for toggling split orientation (vertical/horizontal)
- Add macOS-style screenshot/recording via Framework key:
  - `Framework + Shift + 3` → full output screenshot
  - `Framework + Shift + 4` → region select screenshot
  - `Framework + Shift + 5` → screen recording
- Remove `SUPER + V` VS Code launch binding

## Testing
- Verify keybindings work on matic (Framework 13 AI 300)

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add ergonomic Hyprland keybindings for window resize, split toggle, and macOS‑style screenshots/recording. Also cleans up old bindings and removes the Waybar restart helper.

- **New Features**
  - Window resize: SUPER+;/' (horizontal), SUPER+CTRL+;/' (vertical)
  - Split orientation toggle: SUPER+V
  - Screenshots/recording: Framework+Shift+3/4/5 (output, region, record)

- **Refactors**
  - Removed SUPER+V VS Code launch binding
  - Dropped Waybar restart from Makefile systemctl helpers

<sup>Written for commit 3664b26f0ea390f83154d49ffc729b3d4401076e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

