### PR TITLE
fix: use Nix store path for sg binary instead of /usr/bin/sg

### DIFF
--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -23,7 +23,7 @@ let
   };
 
   dockerStartScript = pkgs.writeShellScript "cliproxyapi-docker-start" ''
-    exec /usr/bin/sg docker -c "${pkgs.bash}/bin/bash ${startScript}"
+    exec ${pkgs.shadow}/bin/sg docker -c "${pkgs.bash}/bin/bash ${startScript}"
   '';
 
   wrapperScript = pkgs.replaceVars ./scripts/wrapper.sh {

--- a/home-manager/services/docker-postgres/default.nix
+++ b/home-manager/services/docker-postgres/default.nix
@@ -2,7 +2,7 @@
 let
   inherit (pkgs) lib;
   startPostgresWrapper = pkgs.writeShellScript "start-postgres-wrapper" ''
-    exec /usr/bin/sg docker -c "${pkgs.bash}/bin/bash ${./start-postgres.sh}"
+    exec ${pkgs.shadow}/bin/sg docker -c "${pkgs.bash}/bin/bash ${./start-postgres.sh}"
   '';
 in
 {


### PR DESCRIPTION
## Changes
- Replace hardcoded `/usr/bin/sg` with `${pkgs.shadow}/bin/sg` in cliproxyapi and docker-postgres systemd services
- Fixes "no such file or directory" error on NixOS where FHS paths don't exist

## Technical Details
- `sg` (switch group) comes from the `shadow` package
- NixOS doesn't have `/usr/bin/sg` since it doesn't follow the Filesystem Hierarchy Standard
- Both `cliproxyapi` and `docker-postgres` services used the hardcoded path for running Docker commands under the `docker` group

## Testing
- `make build` to verify Nix evaluation
- Service should start without "no such file or directory" error on NixOS/Linux

Generated with [Claude Code](https://claude.ai/claude-code) by claude-opus-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace hardcoded /usr/bin/sg with ${pkgs.shadow}/bin/sg in cliproxyapi and docker-postgres service scripts. Fixes the “no such file or directory” error on NixOS and ensures Docker commands run under the docker group.

<sup>Written for commit 7f568d791b18d2128dd0c32cde2ae8a19c3ed84d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

