### PR TITLE
feat: add iTerm2 with agent teams tmux mode

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -321,5 +321,6 @@
     "type": "command",
     "command": "$HOME/.claude/statusline-git.sh"
   },
+  "teammateMode": "tmux",
   "defaultMode": "bypassPermissions"
 }

--- a/config/default.nix
+++ b/config/default.nix
@@ -15,6 +15,7 @@ in
   ./factory
   ./gemini
   ./ghostty
+  ./iterm2
   ./hammerspoon
   ./jj
   ./k3s

--- a/config/iterm2/default.nix
+++ b/config/iterm2/default.nix
@@ -1,0 +1,7 @@
+{ config, ... }:
+{
+  home.file."Library/Application Support/iTerm2/DynamicProfiles/dotfiles.json" = {
+    source = ./profile.json;
+    force = true;
+  };
+}

--- a/config/iterm2/profile.json
+++ b/config/iterm2/profile.json
@@ -1,0 +1,41 @@
+{
+  "Profiles": [
+    {
+      "Name": "Default",
+      "Guid": "dotfiles-default-profile",
+      "Dynamic Profile Parent Name": "Default",
+      "Custom Command": "Yes",
+      "Command": "/etc/profiles/per-user/shunkakinoki/bin/fish",
+      "Normal Font": "HackNerdFont-Regular 14",
+      "Horizontal Spacing": 1.0,
+      "Vertical Spacing": 1.1,
+      "Use Non-ASCII Font": false,
+      "ASCII Anti Aliased": true,
+      "Non-ASCII Anti Aliased": true,
+      "Columns": 120,
+      "Rows": 36,
+      "Terminal Type": "xterm-256color",
+      "Scrollback Lines": 10000,
+      "Unlimited Scrollback": true,
+      "Option Key Sends": 2,
+      "Right Option Key Sends": 2,
+      "Silence Bell": true,
+      "Visual Bell": false,
+      "Flashing Bell": false,
+      "BM Growl": false,
+      "Close Sessions On End": true,
+      "Prompt Before Closing 2": 0,
+      "Mouse Reporting": true,
+      "Cursor Type": 2,
+      "Blinking Cursor": true,
+      "Use Bold Font": true,
+      "Use Bright Bold": true,
+      "Use Italic Font": true,
+      "Minimum Contrast": 0.0,
+      "Transparency": 0.0,
+      "Blur": false,
+      "Window Type": 0,
+      "Initial Use Transparency": false
+    }
+  ]
+}

--- a/nix-darwin/config/dock.nix
+++ b/nix-darwin/config/dock.nix
@@ -27,6 +27,7 @@
       "/Applications/Screen Studio.app"
       "/Applications/Figma.app"
       "/Applications/Notion.app"
+      "/Applications/iTerm.app"
       "/Applications/Ghostty.app"
       "/Applications/Linear.app"
       "/Applications/Tailscale.app"

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -89,6 +89,7 @@
       "google-chrome"
       "google-drive"
       "hammerspoon"
+      "iterm2"
       "karabiner-elements"
       "linear-linear"
       "lm-studio"


### PR DESCRIPTION
## Changes
- Install iTerm2 via Homebrew cask
- Add Dynamic Profile config (Fish shell, Hack Nerd Font 14pt, unlimited scrollback, Option as Meta)
- Add iTerm2 to dock (left of Ghostty)
- Set Claude Code `teammateMode` to `tmux` for agent teams split panes

## Testing
- Verify `make switch` applies without errors
- Confirm iTerm2 appears in dock and loads Dynamic Profile

Generated with Claude Code by claude-opus-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds iTerm2 to the macOS setup with an auto-synced dynamic profile. Also switches Claude Code agent teams to tmux.

- **New Features**
  - Install iTerm2 via Homebrew and add it to the Dock.
  - Ship Dynamic Profile via home config (dotfiles.json): Fish shell, Hack Nerd Font 14pt, unlimited scrollback, Option as Meta.
  - Enable teammateMode: "tmux" in Claude Code settings.

- **Migration**
  - Run make switch.
  - Open iTerm2 and confirm the "Default" dynamic profile loads.
  - Verify iTerm2 appears in the Dock.

<sup>Written for commit c8cf22273cca543b4b72471986cda9f24cd49c84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

