### PR TITLE
feat(hyprland): bind super+v to vscode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -784,7 +784,11 @@ systemctl-ollama: ## Restart ollama systemd user service.
 .PHONY: systemctl-openclaw
 systemctl-openclaw: ## Restart OpenClaw gateway systemd user service.
 	@echo "🔄 Restarting openclaw..."
-	@systemctl --user restart openclaw-gateway.service || true
+	@if [ "$(DETECTED_HOST)" = "kyber" ] || [ "$(HOST)" = "kyber" ]; then \
+		systemctl --user restart openclaw-gateway.service; \
+	else \
+		echo "Skipping openclaw-gateway.service (host not kyber)"; \
+	fi
 	@echo "✅ openclaw restarted"
 
 

--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -233,6 +233,7 @@ bind = $mod, T, exec, ghostty
 bind = $mod, G, exec, hyprctl clients -j | grep -q '"class": "google-chrome"' && hyprctl dispatch focuswindow class:google-chrome || google-chrome-stable
 bind = $mod, S, exec, hyprctl clients -j | grep -q '"class": "Slack"' && hyprctl dispatch focuswindow class:Slack || slack
 bind = $mod, C, exec, cursor
+bind = $mod, V, exec, code
 bind = $mod, P, exec, gtk-launch 1password
 bind = $mod, M, exec, gtk-launch signal-desktop
 bind = $mod, D, exec, hyprctl clients -j | grep -q '"class": "discord"' && hyprctl dispatch focuswindow class:discord || discord
@@ -298,9 +299,6 @@ binde = $mod, apostrophe, resizeactive, 20 0
 # Resize windows (vertical: Ctrl + ; and ')
 binde = $mod CTRL, semicolon, resizeactive, 0 -20
 binde = $mod CTRL, apostrophe, resizeactive, 0 20
-
-# Toggle split orientation (vertical/horizontal)
-bind = $mod, V, layoutmsg, togglesplit
 
 # =============================================================================
 # Workspaces


### PR DESCRIPTION
## Changes
- Bind Super+V to launch VS Code
- Remove Super+V split toggle binding

## Testing
- make check && make build && make test (fails: shellspec spec/code_syncer_spec.sh expected "VS Code CLI not found" but got "bash: command not found")

Generated with GitHub Copilot CLI by GPT-5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind Super+V in Hyprland to launch VS Code, replacing the split toggle. Also limit the openclaw systemd restart in the Makefile to run only on the "kyber" host.

- **Migration**
  - Ensure the VS Code CLI (code) is installed and on PATH so Super+V works.

<sup>Written for commit 8b13eab04f9a68af917839c5405fbec74238f9ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

