### PR TITLE
fix(fish): adjust keychain redirection

### DIFF
--- a/home-manager/services/ssh-agent/default.nix
+++ b/home-manager/services/ssh-agent/default.nix
@@ -27,7 +27,7 @@ in
         if test (count $keys) -gt 0
           # Use --quiet to suppress most output, --eval to set environment variables
           # --confirm will skip keys that need a passphrase in non-interactive contexts
-          eval (keychain --eval --quiet --confirm $keys ^/dev/null; or true)
+          eval (keychain --eval --quiet --confirm $keys 2>/dev/null; or true)
         end
       end
     ''


### PR DESCRIPTION
## Changes
- Fix fish keychain init redirection to avoid invalid key binding warnings

## Testing
- make check && make build && make test (fails: shellspec spec/code_syncer_spec.sh expected "VS Code CLI not found" but got "bash: command not found")

Generated with GitHub Copilot CLI by GPT-5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silence keychain stderr during fish startup to stop “invalid key binding” warnings. Switch the eval call to use 2>/dev/null instead of ^/dev/null.

<sup>Written for commit f2bfc5ed693c2971b0d0ea4ca6789611a717e216. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

