### PR TITLE
chore: update desktop configs

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -19,8 +19,8 @@ clipboard-write = "allow"
 clipboard-paste-protection = false
 copy-on-select = clipboard
 
-keybind = ctrl+c=copy_to_clipboard
-keybind = ctrl+v=paste_from_clipboard
+keybind = ctrl+shift+c=copy_to_clipboard
+keybind = ctrl+shift+v=paste_from_clipboard
 keybind = super+alt+left=previous_tab
 keybind = super+alt+right=next_tab
 keybind = super+shift+left=move_tab:-1
@@ -29,13 +29,14 @@ keybind = super+shift+right=move_tab:1
 keybind = super+shift+down=move_tab:1
 
 # Navigate between splits (Vim-style)
-keybind = super+h=goto_split:left
-keybind = super+j=goto_split:down
-keybind = super+k=goto_split:up
-keybind = super+l=goto_split:right
+keybind = ctrl+alt+h=goto_split:left
+keybind = ctrl+alt+j=goto_split:down
+keybind = ctrl+alt+k=goto_split:up
+keybind = ctrl+alt+l=goto_split:right
 
 # Create new splits
 keybind = ctrl+shift+backslash=new_split:right
+keybind = ctrl+shift+equal=new_split:right
 keybind = ctrl+shift+minus=new_split:down
 
 # Split management

--- a/config/hyprland/hypridle.conf
+++ b/config/hyprland/hypridle.conf
@@ -5,9 +5,9 @@ general {
     inhibit_sleep = 3
 }
 
-# Dim screen after 2.5 minutes
+# Dim screen after 3 minutes
 listener {
-    timeout = 150
+    timeout = 180
     on-timeout = brightnessctl -s set 10
     on-resume = brightnessctl -r
 }

--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -58,7 +58,7 @@ exec-once = wl-clip-persist --clipboard regular & clipse -listen
 # =============================================================================
 # Monitor (Framework 13" 2256x1504)
 # =============================================================================
-monitor = eDP-1, 2256x1504@60, auto, 1.566667
+monitor = eDP-1, 2256x1504@60, auto, 1.0
 
 # =============================================================================
 # XWayland (sharp rendering at fractional scale)
@@ -237,7 +237,7 @@ bind = $mod, V, exec, code
 bind = $mod, P, exec, gtk-launch 1password
 bind = $mod, M, exec, gtk-launch signal-desktop
 bind = $mod, D, exec, hyprctl clients -j | grep -q '"class": "discord"' && hyprctl dispatch focuswindow class:discord || discord
-bind = $mod, N, exec, ghostty -e yazi
+bind = $mod, F, exec, ghostty -e yazi
 
 # =============================================================================
 # System GUIs (WiFi / Bluetooth / Audio)
@@ -249,15 +249,15 @@ bind = $mod, A, exec, pavucontrol
 # =============================================================================
 # Launcher & Clipboard
 # =============================================================================
-bind = CTRL ALT SHIFT, SPACE, exec, walker
+bind = CTRL ALT SHIFT SUPER, SPACE, exec, walker
 bind = $mod, E, exec, emote
 
 # =============================================================================
 # Window Management
 # =============================================================================
 bind = $mod, W, killactive,
-bind = $mod, F, togglefloating,
-bind = CTRL ALT SHIFT, F, exec, hyprctl --batch "dispatch movetoworkspace empty; dispatch fullscreen 0"
+bind = $mod SHIFT, F, togglefloating,
+bind = CTRL ALT SHIFT SUPER, F, exec, hyprctl --batch "dispatch movetoworkspace empty; dispatch fullscreen 0"
 bind = SUPER CTRL, F, fullscreen, 0
 bind = $mod SHIFT, Q, exec, hyprpanel toggleWindow power-menu
 bind = $mod, TAB, hyprexpo:expo, toggle
@@ -281,10 +281,12 @@ bind = $mod SHIFT, K, movewindow, u
 bind = $mod SHIFT, J, movewindow, d
 
 # Move windows (arrow keys)
-bind = $mod SHIFT, left, movewindow, l
-bind = $mod SHIFT, right, movewindow, r
 bind = $mod SHIFT, up, movewindow, u
 bind = $mod SHIFT, down, movewindow, d
+
+# Move windows to empty workspace (arrow keys)
+bind = $mod SHIFT, left, movetoworkspace, empty
+bind = $mod SHIFT, right, movetoworkspace, empty
 
 # Resize windows (arrow keys)
 binde = $mod CTRL, left, resizeactive, -20 0
@@ -326,6 +328,7 @@ bind = $mod SHIFT, 9, movetoworkspace, 9
 # Scroll through workspaces
 bind = $mod, mouse_down, workspace, e+1
 bind = $mod, mouse_up, workspace, e-1
+bind = $mod, n, workspace, empty
 
 # Switch workspaces with Ctrl+Arrow (macOS-style)
 bind = CTRL, left, workspace, e-1
@@ -352,10 +355,10 @@ bind = , PRINT, exec, hyprshot -m region
 bind = SHIFT, PRINT, exec, hyprshot -m window
 bind = CTRL, PRINT, exec, hyprshot -m output
 
-# macOS-style screenshot & recording (Framework+Shift+3/5 via keyd → Ctrl+Shift+3/5)
-bind = CTRL SHIFT, 3, exec, hyprshot -m output
-bind = CTRL SHIFT, 4, exec, hyprshot -m region
-bind = CTRL SHIFT, 5, exec, ~/.config/hypr/scripts/record-screen.sh
+# macOS-style screenshot & recording (Framework+Shift+3/5 via keyd → Hyper+3/4/5)
+bind = CTRL ALT SHIFT SUPER, 3, exec, hyprshot -m output
+bind = CTRL ALT SHIFT SUPER, 4, exec, hyprshot -m region
+bind = CTRL ALT SHIFT SUPER, 5, exec, ~/.config/hypr/scripts/record-screen.sh
 
 # Color picker
 bind = $mod, PRINT, exec, hyprpicker -a
@@ -403,10 +406,10 @@ bind = , F11, exec, hyprshot -m output
 # =============================================================================
 # Display Zoom (Framework + / - , macOS-style)
 # =============================================================================
-# Keyd maps Framework+= / Framework+- to Ctrl+Alt+Shift+= / Ctrl+Alt+Shift+-
+# Keyd maps Framework+= / Framework+- to Hyper+= / Hyper+-
 # Valid scales for 2256x1504: 1.0, 1.333333, 1.566667, 2.0
-binde = CTRL ALT SHIFT, equal, exec, hyprctl -j monitors | jq -r '.[0].scale' | awk '{s=$1; if(s<1.16) s=1.333333; else if(s<1.45) s=1.566667; else if(s<1.78) s=2.0; else s=2.0; printf "%.6f",s}' | xargs -I{} hyprctl keyword monitor "eDP-1,preferred,auto,{}"
-binde = CTRL ALT SHIFT, minus, exec, hyprctl -j monitors | jq -r '.[0].scale' | awk '{s=$1; if(s>1.78) s=1.566667; else if(s>1.45) s=1.333333; else if(s>1.16) s=1.0; else s=1.0; printf "%.6f",s}' | xargs -I{} hyprctl keyword monitor "eDP-1,preferred,auto,{}"
+binde = CTRL ALT SHIFT SUPER, equal, exec, hyprctl -j monitors | jq -r '.[0].scale' | awk '{s=$1; if(s<1.16) s=1.333333; else if(s<1.45) s=1.566667; else if(s<1.78) s=2.0; else s=2.0; printf "%.6f",s}' | xargs -I{} hyprctl keyword monitor "eDP-1,preferred,auto,{}"
+binde = CTRL ALT SHIFT SUPER, minus, exec, hyprctl -j monitors | jq -r '.[0].scale' | awk '{s=$1; if(s>1.78) s=1.566667; else if(s>1.45) s=1.333333; else if(s>1.16) s=1.0; else s=1.0; printf "%.6f",s}' | xargs -I{} hyprctl keyword monitor "eDP-1,preferred,auto,{}"
 
 # =============================================================================
 # Lock Screen

--- a/config/hyprpanel/default.nix
+++ b/config/hyprpanel/default.nix
@@ -13,6 +13,7 @@
           ];
           middle = [ "clock" ];
           right = [
+            "netstat"
             "cpu"
             "ram"
             "volume"
@@ -192,15 +193,15 @@
 
       # RAM
       "theme.bar.buttons.modules.ram.icon_background" = "#ffffff0d";
-      "theme.bar.buttons.modules.ram.icon" = "#a3be8c";
-      "theme.bar.buttons.modules.ram.text" = "#a3be8c";
+      "theme.bar.buttons.modules.ram.icon" = "#ffffffcc";
+      "theme.bar.buttons.modules.ram.text" = "#ffffffcc";
       "theme.bar.buttons.modules.ram.background" = "#ffffff0d";
       "theme.bar.buttons.modules.ram.border" = "#ffffff18";
 
       # CPU
       "theme.bar.buttons.modules.cpu.icon_background" = "#ffffff0d";
-      "theme.bar.buttons.modules.cpu.icon" = "#88c0d0";
-      "theme.bar.buttons.modules.cpu.text" = "#88c0d0";
+      "theme.bar.buttons.modules.cpu.icon" = "#ffffffcc";
+      "theme.bar.buttons.modules.cpu.text" = "#ffffffcc";
       "theme.bar.buttons.modules.cpu.background" = "#ffffff0d";
       "theme.bar.buttons.modules.cpu.border" = "#ffffff18";
 
@@ -213,8 +214,8 @@
 
       # Netstat
       "theme.bar.buttons.modules.netstat.icon_background" = "#ffffff0d";
-      "theme.bar.buttons.modules.netstat.icon" = "#a3be8c";
-      "theme.bar.buttons.modules.netstat.text" = "#a3be8c";
+      "theme.bar.buttons.modules.netstat.icon" = "#ffffffcc";
+      "theme.bar.buttons.modules.netstat.text" = "#ffffffcc";
       "theme.bar.buttons.modules.netstat.background" = "#ffffff0d";
       "theme.bar.buttons.modules.netstat.border" = "#ffffff18";
 
@@ -288,7 +289,7 @@
       "theme.bar.buttons.modules.worldclock.border" = "#ffffff18";
 
       # ── Menu Theme (frosted glass) ──────────────────────────────────
-      "theme.bar.menus.background" = "#1a1b26cc";
+      "theme.bar.menus.background" = "#1a1b26";
       "theme.bar.menus.cards" = "#ffffff0d";
       "theme.bar.menus.border.color" = "#ffffff18";
       "theme.bar.menus.text" = "#ffffffdd";
@@ -296,7 +297,7 @@
       "theme.bar.menus.feinttext" = "#ffffff33";
       "theme.bar.menus.label" = "#88c0d0";
       "theme.bar.menus.popover.border" = "#ffffff18";
-      "theme.bar.menus.popover.background" = "#1a1b26ee";
+      "theme.bar.menus.popover.background" = "#1a1b26";
       "theme.bar.menus.popover.text" = "#88c0d0";
       "theme.bar.menus.listitems.active" = "#88c0d0";
       "theme.bar.menus.listitems.passive" = "#ffffffdd";
@@ -319,15 +320,15 @@
       "theme.bar.menus.slider.background" = "#ffffff22";
       "theme.bar.menus.slider.backgroundhover" = "#ffffff33";
       "theme.bar.menus.slider.puck" = "#ffffff44";
-      "theme.bar.menus.dropdownmenu.background" = "#1a1b26ee";
+      "theme.bar.menus.dropdownmenu.background" = "#1a1b26";
       "theme.bar.menus.dropdownmenu.text" = "#ffffffdd";
       "theme.bar.menus.dropdownmenu.divider" = "#ffffff18";
-      "theme.bar.menus.tooltip.background" = "#1a1b26ee";
+      "theme.bar.menus.tooltip.background" = "#1a1b26";
       "theme.bar.menus.tooltip.text" = "#ffffffdd";
 
       # Volume menu
       "theme.bar.menus.menu.volume.card.color" = "#ffffff0d";
-      "theme.bar.menus.menu.volume.background.color" = "#1a1b26cc";
+      "theme.bar.menus.menu.volume.background.color" = "#1a1b26";
       "theme.bar.menus.menu.volume.border.color" = "#ffffff18";
       "theme.bar.menus.menu.volume.label.color" = "#ebcb8b";
       "theme.bar.menus.menu.volume.text" = "#ffffffdd";
@@ -347,7 +348,7 @@
       "theme.bar.menus.menu.volume.input_slider.puck" = "#ffffff44";
 
       # Media menu
-      "theme.bar.menus.menu.media.background.color" = "#1a1b26cc";
+      "theme.bar.menus.menu.media.background.color" = "#1a1b26";
       "theme.bar.menus.menu.media.card.color" = "#ffffff0d";
       "theme.bar.menus.menu.media.border.color" = "#ffffff18";
       "theme.bar.menus.menu.media.song" = "#88c0d0";
@@ -365,7 +366,7 @@
 
       # Network menu
       "theme.bar.menus.menu.network.card.color" = "#ffffff0d";
-      "theme.bar.menus.menu.network.background.color" = "#1a1b26cc";
+      "theme.bar.menus.menu.network.background.color" = "#1a1b26";
       "theme.bar.menus.menu.network.border.color" = "#ffffff18";
       "theme.bar.menus.menu.network.label.color" = "#88c0d0";
       "theme.bar.menus.menu.network.text" = "#ffffffdd";
@@ -383,7 +384,7 @@
 
       # Bluetooth menu
       "theme.bar.menus.menu.bluetooth.card.color" = "#ffffff0d";
-      "theme.bar.menus.menu.bluetooth.background.color" = "#1a1b26cc";
+      "theme.bar.menus.menu.bluetooth.background.color" = "#1a1b26";
       "theme.bar.menus.menu.bluetooth.border.color" = "#ffffff18";
       "theme.bar.menus.menu.bluetooth.label.color" = "#81a1c1";
       "theme.bar.menus.menu.bluetooth.text" = "#ffffffdd";
@@ -401,13 +402,13 @@
       "theme.bar.menus.menu.bluetooth.scroller.color" = "#81a1c1";
 
       # Systray menu
-      "theme.bar.menus.menu.systray.dropdownmenu.background" = "#1a1b26ee";
+      "theme.bar.menus.menu.systray.dropdownmenu.background" = "#1a1b26";
       "theme.bar.menus.menu.systray.dropdownmenu.text" = "#ffffffdd";
       "theme.bar.menus.menu.systray.dropdownmenu.divider" = "#ffffff18";
 
       # Battery menu
       "theme.bar.menus.menu.battery.card.color" = "#ffffff0d";
-      "theme.bar.menus.menu.battery.background.color" = "#1a1b26cc";
+      "theme.bar.menus.menu.battery.background.color" = "#1a1b26";
       "theme.bar.menus.menu.battery.border.color" = "#ffffff18";
       "theme.bar.menus.menu.battery.label.color" = "#a3be8c";
       "theme.bar.menus.menu.battery.text" = "#ffffffdd";
@@ -422,7 +423,7 @@
 
       # Clock menu
       "theme.bar.menus.menu.clock.card.color" = "#ffffff0d";
-      "theme.bar.menus.menu.clock.background.color" = "#1a1b26cc";
+      "theme.bar.menus.menu.clock.background.color" = "#1a1b26";
       "theme.bar.menus.menu.clock.border.color" = "#ffffff18";
       "theme.bar.menus.menu.clock.text" = "#ffffffdd";
       "theme.bar.menus.menu.clock.time.time" = "#88c0d0";
@@ -448,7 +449,7 @@
 
       # Dashboard menu
       "theme.bar.menus.menu.dashboard.card.color" = "#ffffff0d";
-      "theme.bar.menus.menu.dashboard.background.color" = "#1a1b26cc";
+      "theme.bar.menus.menu.dashboard.background.color" = "#1a1b26";
       "theme.bar.menus.menu.dashboard.border.color" = "#ffffff18";
       "theme.bar.menus.menu.dashboard.profile.name" = "#88c0d0";
       "theme.bar.menus.menu.dashboard.powermenu.shutdown" = "#bf616a";
@@ -456,7 +457,7 @@
       "theme.bar.menus.menu.dashboard.powermenu.logout" = "#a3be8c";
       "theme.bar.menus.menu.dashboard.powermenu.sleep" = "#88c0d0";
       "theme.bar.menus.menu.dashboard.powermenu.confirmation.card" = "#ffffff0d";
-      "theme.bar.menus.menu.dashboard.powermenu.confirmation.background" = "#1a1b26ee";
+      "theme.bar.menus.menu.dashboard.powermenu.confirmation.background" = "#1a1b26";
       "theme.bar.menus.menu.dashboard.powermenu.confirmation.border" = "#ffffff18";
       "theme.bar.menus.menu.dashboard.powermenu.confirmation.label" = "#88c0d0";
       "theme.bar.menus.menu.dashboard.powermenu.confirmation.body" = "#ffffffdd";
@@ -498,7 +499,7 @@
       "theme.bar.menus.menu.dashboard.monitors.disk.label" = "#b48ead";
 
       # Power menu
-      "theme.bar.menus.menu.power.background.color" = "#1a1b26cc";
+      "theme.bar.menus.menu.power.background.color" = "#1a1b26";
       "theme.bar.menus.menu.power.border.color" = "#ffffff18";
       "theme.bar.menus.menu.power.buttons.shutdown.background" = "#ffffff0d";
       "theme.bar.menus.menu.power.buttons.shutdown.icon_background" = "#bf616a";
@@ -518,7 +519,7 @@
       "theme.bar.menus.menu.power.buttons.sleep.icon" = "#1a1b26";
 
       # Notifications menu
-      "theme.bar.menus.menu.notifications.background" = "#1a1b26cc";
+      "theme.bar.menus.menu.notifications.background" = "#1a1b26";
       "theme.bar.menus.menu.notifications.card" = "#ffffff0d";
       "theme.bar.menus.menu.notifications.border" = "#ffffff18";
       "theme.bar.menus.menu.notifications.label" = "#88c0d0";

--- a/config/keyd/default.conf
+++ b/config/keyd/default.conf
@@ -8,11 +8,11 @@ capslock = layer(meta)
 # Right Alt = pure Super (right-hand mirror of Caps Lock)
 rightalt = layer(meta)
 
-# Framework key = macOS-style Command (Ctrl for all keys)
+# Framework key = macOS-style Command (Hyper for all keys)
 # leftmeta is the actual keycode on Framework 13 AI 300
-leftmeta = layer(cmd_mac)
-prog1 = layer(cmd_mac)
-f13 = layer(cmd_mac)
+leftmeta = layer(cmd_hyper)
+prog1 = layer(cmd_hyper)
+f13 = layer(cmd_hyper)
 
 # Right Shift double-tap -> Caps Lock (tap twice)
 rightshift = overload(shift, oneshot(rshift))
@@ -20,69 +20,9 @@ rightshift = overload(shift, oneshot(rshift))
 [rshift]
 rightshift = capslock
 
-[cmd_mac]
-# macOS-style Command → Ctrl for all keys
-a = C-a
-b = C-b
-c = C-c
-d = C-d
-e = C-e
-f = C-f
-g = C-g
-h = C-h
-i = C-i
-j = C-j
-k = C-k
-l = C-l
-m = C-m
-n = C-n
-o = C-o
-p = C-p
-q = C-q
-r = C-r
-s = C-s
-t = C-t
-u = C-u
-v = C-v
-w = C-w
-x = C-x
-y = C-y
-z = C-z
-0 = C-0
-1 = C-1
-2 = C-2
-3 = C-3
-4 = C-4
-5 = C-5
-6 = C-6
-7 = C-7
-8 = C-8
-9 = C-9
-semicolon = C-semicolon
-dot = C-dot
-comma = C-comma
-slash = C-slash
-grave = C-grave
-backslash = C-backslash
-leftbrace = C-leftbrace
-rightbrace = C-rightbrace
-apostrophe = C-apostrophe
-tab = C-tab
-backspace = C-backspace
-left = C-left
-right = C-right
-up = C-up
-down = C-down
+[cmd_hyper:C-A-S-M]
+# macOS-style Command → Hyper (Ctrl+Alt+Shift+Super)
 
-# Walker launcher (Framework+Space → Ctrl+Alt+Shift+Space)
-space = C-A-S-space
-
-# Display zoom (Hyprland intercepts these globally)
-equal = C-A-S-equal
-minus = C-A-S-minus
-
-[cmd_mac+control]
-# Framework+Ctrl+F → Ctrl+Alt+Shift+F (fullscreen in Hyprland)
-f = C-A-S-f
+[cmd_hyper+control]
 # Framework+Ctrl+5 → terminal split in VS Code
 5 = C-5

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -125,11 +125,10 @@ with pkgs;
   cliphist
   discord
   emote
+  evince
   ffmpeg
   ghostty
   github-desktop
-  gnome.evince
-  gnome.totem
   google-chrome
   grim
   hypridle
@@ -138,13 +137,14 @@ with pkgs;
   hyprshot
   hyprsunset
   libnotify
+  linux-wallpaperengine
   pavucontrol
   playerctl
   signal-desktop
   slack
   slurp
   swappy
-  linux-wallpaperengine
+  totem
   vlc
   vscode
   walker

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -67,6 +67,7 @@ with pkgs;
   mariadb
   mkcert
   navi
+  pingu
   postgresql
   procs
   qwen-code
@@ -127,6 +128,8 @@ with pkgs;
   ffmpeg
   ghostty
   github-desktop
+  gnome.evince
+  gnome.totem
   google-chrome
   grim
   hypridle

--- a/home-manager/programs/default.nix
+++ b/home-manager/programs/default.nix
@@ -15,7 +15,7 @@ let
   fish = import ./fish;
   fnm = import ./fnm;
   fzf = import ./fzf;
-  gh = import ./gh;
+  gh = import ./gh { inherit pkgs; };
   ghq = import ./ghq;
   git = import ./git;
   go = import ./go;

--- a/home-manager/programs/gh/default.nix
+++ b/home-manager/programs/gh/default.nix
@@ -1,3 +1,4 @@
+{ pkgs, ... }:
 {
   programs.gh = {
     enable = true;

--- a/home-manager/programs/gh/default.nix
+++ b/home-manager/programs/gh/default.nix
@@ -1,7 +1,9 @@
 {
   programs.gh = {
     enable = true;
+    extensions = with pkgs; [ gh-markdown-preview ];
     settings = {
+      editor = "nvim";
       git_protocol = "ssh";
       prompt = "enabled";
     };

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -10,6 +10,7 @@
     enable = true;
     dotDir = "${config.xdg.configHome}/zsh";
     enableCompletion = true;
+    autocd = true;
     autosuggestion.enable = true;
     syntaxHighlighting.enable = true;
     historySubstringSearch.enable = true;

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -219,6 +219,7 @@ inputs.nixpkgs.lib.nixosSystem {
         ipaexfont
         ipafont
         joypixels
+        nerdfonts
         nerd-fonts.jetbrains-mono
         noto-fonts-cjk-sans
         noto-fonts-cjk-serif


### PR DESCRIPTION
## Changes
- Update Ghostty copy/paste and split keybindings
- Adjust Hyprland keybindings, monitor scale, and workspace actions
- Tweak Hyprpanel theming and add the netstat module
- Update keyd Framework key to Hyper mapping

## Technical Details
- Switch macOS-style bindings to Hyper (Ctrl+Alt+Shift+Super)
- Align Hyprland screenshot/zoom bindings with the Hyper layer

## Testing
- make switch

Generated with GitHub Copilot CLI by Claude Sonnet 4.5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized desktop keybindings on a Hyper layer (Ctrl+Alt+Shift+Super) across Ghostty, Hyprland, and keyd. Added a Hyprpanel netstat widget, tuned theming and display scaling, and refreshed program configs and packages, including non-GNOME Evince/Totem.

- **New Features**
  - Hyprpanel: netstat module on the right.

- **Refactors**
  - keyd: map the Framework key to a Hyper layer; remove the old Ctrl-based Command layer.
  - Ghostty: use Ctrl+Shift+C/V for copy/paste; navigate splits with Ctrl+Alt+H/J/K/L; add Ctrl+Shift+= for a right split.
  - Hyprland: move launcher, screenshots, and display zoom to Hyper; $mod+F opens yazi; floating toggle is $mod+Shift+F; add empty-workspace moves and $mod+n; set internal display scale to 1.0; dim after 3 minutes.
  - Hyprpanel theme: neutral white module icons/text and solid (non-frosted) menu backgrounds.
  - Programs/Packages: add pingu; switch to Evince and Totem (non-GNOME); gh uses nvim, installs gh-markdown-preview, and now inherits pkgs; enable zsh autocd; include nerdfonts on matic.

<sup>Written for commit 27536a283c92e4e5757ef3f16d360245275fd86f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

