### PR TITLE
feat: add xremap command key

### DIFF
--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -40,6 +40,7 @@ env = GDK_BACKEND,wayland
 # =============================================================================
 exec-once = dbus-update-activation-environment --systemd --all
 exec-once = systemctl --user import-environment WAYLAND_DISPLAY XDG_CURRENT_DESKTOP XDG_SESSION_TYPE XDG_RUNTIME_DIR HYPRLAND_INSTANCE_SIGNATURE XDG_SESSION_DESKTOP
+exec-once = sleep 1 && systemctl --user restart xremap
 exec-once = sleep 1 && systemctl --user restart xdg-desktop-portal-hyprland && sleep 0.5 && systemctl --user restart xdg-desktop-portal-gtk && sleep 0.5 && systemctl --user restart xdg-desktop-portal
 
 # Clipboard history

--- a/config/keyd/default.conf
+++ b/config/keyd/default.conf
@@ -1,5 +1,12 @@
 [ids]
 *
+# xremap creates its own virtual keyboard device via uinput. By default, xremap
+# uses vendor/product 0x1234/0x5678 for that output device.
+#
+# When keyd matches all keyboards via `*`, it can end up grabbing xremap's
+# virtual device too, which may cause event feedback/loops and effectively kill
+# input. Exclude the default xremap device id to prevent that.
+-1234:5678
 
 [main]
 # Caps Lock = pure Super (for Hyprland hotkeys)

--- a/flake.lock
+++ b/flake.lock
@@ -58,6 +58,21 @@
         "type": "github"
       }
     },
+    "crane": {
+      "locked": {
+        "lastModified": 1766774972,
+        "narHash": "sha256-8qxEFpj4dVmIuPn9j9z6NTbU+hrcGjBOvaxTzre5HmM=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "01bc1d404a51a0a07e9d8759cd50a7903e218c82",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "darwin": {
       "inputs": {
         "nixpkgs": [
@@ -195,6 +210,24 @@
         "owner": "hercules-ci",
         "repo": "flake-parts",
         "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_5": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1765835352,
+        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
         "type": "github"
       },
       "original": {
@@ -529,6 +562,21 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nur": {
       "inputs": {
         "flake-parts": "flake-parts_4",
@@ -564,7 +612,8 @@
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs",
         "nur": "nur",
-        "treefmt-nix": "treefmt-nix_2"
+        "treefmt-nix": "treefmt-nix_2",
+        "xremap": "xremap"
       }
     },
     "systems": {
@@ -621,6 +670,46 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "xremap": {
+      "inputs": {
+        "crane": "crane",
+        "flake-parts": "flake-parts_5",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "xremap": "xremap_2"
+      },
+      "locked": {
+        "lastModified": 1769636170,
+        "narHash": "sha256-X000Dgg053Dv9NIzm1b9QYSAHYtW2jHMVALQezui7L0=",
+        "owner": "xremap",
+        "repo": "nix-flake",
+        "rev": "00bc6dd4275d4b003a17ef7f5f271ba87f73d698",
+        "type": "github"
+      },
+      "original": {
+        "owner": "xremap",
+        "repo": "nix-flake",
+        "type": "github"
+      }
+    },
+    "xremap_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1769021727,
+        "narHash": "sha256-2wylBk3+Zu1pHa41dhKwvUtxOVyHSMRDfOD9fIp8x2I=",
+        "owner": "k0kubun",
+        "repo": "xremap",
+        "rev": "890e0a6ca92e90f3bcbd1e235abcf2192e233a46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "k0kubun",
+        "ref": "v0.14.10",
+        "repo": "xremap",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,10 @@
     nixos-hardware = {
       url = "github:NixOS/nixos-hardware/master";
     };
+    xremap = {
+      url = "github:xremap/nix-flake";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -84,7 +84,7 @@ inputs.nixpkgs.lib.nixosSystem {
         '';
         services.xremap =
           let
-            hyperPrefix = "C-A-S-Super-";
+            hyperPrefix = "C-Alt-Shift-Super-";
             ctrlPrefix = "C-";
             letters = [
               "a"
@@ -158,7 +158,7 @@ inputs.nixpkgs.lib.nixosSystem {
             enable = true;
             serviceMode = "user";
             userName = username;
-            withWlroots = true;
+            withHypr = true;
             watch = true;
             deviceNames = [ "keyd virtual keyboard" ];
             config = {

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -61,6 +61,8 @@ inputs.nixpkgs.lib.nixosSystem {
         programs.fish.enable = true;
 
         # User configuration
+        users.groups.uinput.members = [ username ];
+        users.group.input.members = [ username ];
         users.users.${username} = {
           isNormalUser = true;
           extraGroups = [

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -66,7 +66,7 @@ inputs.nixpkgs.lib.nixosSystem {
           extraGroups = [
             "wheel"
             "networkmanager"
-            "inputs"
+            "input"
             "video"
           ];
           home = "/home/${username}";

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -78,7 +78,6 @@ inputs.nixpkgs.lib.nixosSystem {
 
         # Input remapping (xremap)
         hardware.uinput.enable = true;
-        boot.kernelModules = [ "uinput" ];
         services.udev.extraRules = ''
           KERNEL=="uinput", GROUP="input", TAG+="uaccess", MODE:="0660", OPTIONS+="static_node=uinput"
           KERNEL=="event*", ATTRS{name}=="keyd virtual keyboard", GROUP="input", MODE:="0660"
@@ -116,6 +115,9 @@ inputs.nixpkgs.lib.nixosSystem {
               "y"
               "z"
             ];
+            # Numbers 3, 4, 5 are intentionally excluded — they pass through as
+            # Hyper+3/4/5 for Hyprland screenshot/recording bindings.
+            # See: config/hyprland/hyprland.conf (screenshot section)
             numbers = [
               "0"
               "1"
@@ -154,10 +156,11 @@ inputs.nixpkgs.lib.nixosSystem {
                 }) keys
               );
             globalRemap = mkRemap remapKeys;
+            # Override copy/paste to Ctrl+Shift (terminal convention: Ctrl+C = SIGINT).
+            # All other keys (including z for undo) inherit from globalRemap.
             ghosttyRemap = globalRemap // {
               "${hyperPrefix}c" = "C-Shift-c";
               "${hyperPrefix}v" = "C-Shift-v";
-              "${hyperPrefix}z" = "C-z";
             };
           in
           {
@@ -190,10 +193,9 @@ inputs.nixpkgs.lib.nixosSystem {
           serviceConfig = {
             Restart = "on-failure";
             RestartSec = 3;
-
-            # Avoid systemd giving up during session startup races.
-            StartLimitIntervalSec = 0;
           };
+          # StartLimitIntervalSec is a [Unit] directive, not [Service].
+          unitConfig.StartLimitIntervalSec = 0;
         };
 
         # AMD graphics with hardware acceleration

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -324,7 +324,6 @@ inputs.nixpkgs.lib.nixosSystem {
         ipaexfont
         ipafont
         joypixels
-        nerdfonts
         nerd-fonts.jetbrains-mono
         noto-fonts-cjk-sans
         noto-fonts-cjk-serif

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -179,6 +179,16 @@ inputs.nixpkgs.lib.nixosSystem {
             };
           };
 
+        # Ensure xremap starts after Hyprland and auto-restarts on failure
+        systemd.user.services.xremap = {
+          after = [ "graphical-session.target" ];
+          partOf = [ "graphical-session.target" ];
+          serviceConfig = {
+            Restart = "on-failure";
+            RestartSec = 3;
+          };
+        };
+
         # AMD graphics with hardware acceleration
         hardware.graphics.enable = true;
         hardware.graphics.extraPackages = with pkgs; [

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -156,7 +156,7 @@ inputs.nixpkgs.lib.nixosSystem {
           in
           {
             enable = true;
-            serviceMode = "user";
+            serviceMode = "system";
             userName = username;
             withHypr = true;
             watch = true;

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -81,6 +81,8 @@ inputs.nixpkgs.lib.nixosSystem {
         boot.kernelModules = [ "uinput" ];
         services.udev.extraRules = ''
           KERNEL=="uinput", GROUP="input", TAG+="uaccess", MODE:="0660", OPTIONS+="static_node=uinput"
+          KERNEL=="event*", ATTRS{name}=="keyd virtual keyboard", GROUP="input", MODE:="0660"
+          KERNEL=="event*", ATTRS{name}=="keyd virtual pointer", GROUP="input", MODE:="0660"
         '';
         services.xremap =
           let
@@ -156,7 +158,7 @@ inputs.nixpkgs.lib.nixosSystem {
           in
           {
             enable = true;
-            serviceMode = "system";
+            serviceMode = "user";
             userName = username;
             withHypr = true;
             watch = true;

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -61,8 +61,8 @@ inputs.nixpkgs.lib.nixosSystem {
         programs.fish.enable = true;
 
         # User configuration
-        users.groups.uinput.members = [ username ];
-        users.group.input.members = [ username ];
+        users.users.groups.uinput.members = [ username ];
+        users.users.group.input.members = [ username ];
         users.users.${username} = {
           isNormalUser = true;
           extraGroups = [

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -61,14 +61,12 @@ inputs.nixpkgs.lib.nixosSystem {
         programs.fish.enable = true;
 
         # User configuration
-        users.users.groups.uinput.members = [ username ];
-        users.users.group.input.members = [ username ];
         users.users.${username} = {
           isNormalUser = true;
           extraGroups = [
             "wheel"
             "networkmanager"
-            "input"
+            "inputs"
             "video"
           ];
           home = "/home/${username}";

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -160,6 +160,7 @@ inputs.nixpkgs.lib.nixosSystem {
             userName = username;
             withWlroots = true;
             watch = true;
+            deviceNames = [ "keyd virtual keyboard" ];
             config = {
               keymap = [
                 {

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -160,7 +160,7 @@ inputs.nixpkgs.lib.nixosSystem {
             enable = true;
             serviceMode = "user";
             userName = username;
-            withHypr = true;
+            withWlroots = true;
             watch = true;
             deviceNames = [ "keyd virtual keyboard" ];
             config = {

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -145,10 +145,14 @@ inputs.nixpkgs.lib.nixosSystem {
               "down"
             ];
             remapKeys = letters ++ numbers ++ symbols ++ navigation;
-            mkRemap = keys: builtins.listToAttrs (map (key: {
-              name = "${hyperPrefix}${key}";
-              value = "${ctrlPrefix}${key}";
-            }) keys);
+            mkRemap =
+              keys:
+              builtins.listToAttrs (
+                map (key: {
+                  name = "${hyperPrefix}${key}";
+                  value = "${ctrlPrefix}${key}";
+                }) keys
+              );
             globalRemap = mkRemap remapKeys;
             ghosttyRemap = globalRemap // {
               "${hyperPrefix}c" = "C-Shift-c";

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -186,6 +186,9 @@ inputs.nixpkgs.lib.nixosSystem {
           serviceConfig = {
             Restart = "on-failure";
             RestartSec = 3;
+
+            # Avoid systemd giving up during session startup races.
+            StartLimitIntervalSec = 0;
           };
         };
 


### PR DESCRIPTION
## Changes
- Add xremap/nix-flake input and NixOS module on matic
- Enable xremap user service with wlroots support and device watching
- Map Framework Hyper to Command-style Ctrl combos with Ghostty overrides

## Technical Details
- Restore uinput/input group + udev rule for xremap (requires log out/in)
- Ghostty remaps Hyper+C/V to Ctrl+Shift+C/V to avoid SIGINT

## Testing
- make build
- make switch
- systemctl --user start xremap.service
- systemctl --user status xremap.service

Generated with GitHub Copilot CLI by Claude Sonnet 4.5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds xremap on matic for a “Command key” feel by mapping the Framework Hyper key to Ctrl. Runs as a wlroots-backed user service that starts after the graphical session, restarts after Hyprland env import, and removes the nerdfonts meta package (keeps nerd-fonts.jetbrains-mono).

- **New Features**
  - Integrates xremap module; user service with uinput + wlroots, watches the “keyd virtual keyboard.”
  - Adds udev rules for uinput/keyd devices and excludes xremap’s 1234:5678 in keyd to prevent input loops.
  - Ensures reliable startup: after graphical-session.target, Hyprland triggers a restart post env import, restart-on-failure with no rate limit.
  - Remaps Hyper→Ctrl globally; in Ghostty Hyper+C/V → Ctrl+Shift+C/V; leaves Hyper+3/4/5 for Hyprland screenshots/recording.

- **Migration**
  - Ensure the user is in the input group; log out and back in to apply.
  - Build and switch, then start/check the user service: make build && make switch; systemctl --user start xremap.service; systemctl --user status xremap.service.

<sup>Written for commit 7fd66119835af821cd7a14fa6f147c0c27d5e034. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

