### PR TITLE
fix: run neovim-upgrade in dev shell on CI and add daily Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,31 @@
+name: Renovate
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Renovate
+        uses: renovatebot/github-action@v46.0.2
+        with:
+          configurationFile: renovate.json
+          token: ${{ secrets.PAT_TOKEN }}
+  renovate-check:
+    if: always()
+    needs:
+      - renovate
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Alls Green
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -2,7 +2,7 @@ name: Upgrade
 on:
   pull_request:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 3 * * *'
   workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.sha }}

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Upgrade
-        run: make upgrade
+        run: make upgrade-dev
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SKIP_HOME_MANAGER_SWITCH: "true"

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,5 +1,6 @@
 name: Upgrade
 on:
+  pull_request:
   schedule:
     - cron: '0 2 * * *'
   workflow_dispatch:
@@ -26,6 +27,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SKIP_HOME_MANAGER_SWITCH: "true"
       - name: Create Pull Request
+        if: github.action != 'pull_request'
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:

--- a/Makefile
+++ b/Makefile
@@ -583,8 +583,17 @@ neovim-dev: ## Set up local Neovim development environment.
 .PHONY: neovim-upgrade
 neovim-upgrade: ## Update Neovim plugins.
 	@echo "📦 Updating neovim plugins..."
-	@nvim --headless +"lua vim.pack.update()" +qa
+	@if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \
+		$(MAKE) neovim-upgrade-dev; \
+	else \
+		nvim --headless +"lua vim.pack.update()" +qa; \
+	fi
 	@echo "✅ Neovim plugins updated"
+
+.PHONY: neovim-upgrade-dev
+neovim-upgrade-dev: ## Update Neovim plugins inside the Nix dev shell (mirrors CI).
+	@echo "📦 Updating neovim plugins inside the Nix dev shell..."
+	@DEVENV_ROOT=$(CURDIR) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) develop $(NIX_FLAGS) .# --command $(MAKE) neovim-upgrade
 
 .PHONY: neovim-sync
 neovim-sync: neovim-upgrade ## Sync Neovim plugins.

--- a/Makefile
+++ b/Makefile
@@ -593,7 +593,7 @@ neovim-upgrade: ## Update Neovim plugins.
 .PHONY: neovim-upgrade-dev
 neovim-upgrade-dev: ## Update Neovim plugins inside the Nix dev shell (mirrors CI).
 	@echo "📦 Updating neovim plugins inside the Nix dev shell..."
-	@DEVENV_ROOT=$(CURDIR) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) develop $(NIX_FLAGS) .# --command nvim --headless +"lua vim.pack.update()" +qa
+	@DEVENV_ROOT=$(CURDIR) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) develop $(NIX_FLAGS) .# --command $(MAKE) neovim-upgrade
 
 .PHONY: neovim-sync
 neovim-sync: neovim-upgrade ## Sync Neovim plugins.

--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,11 @@ update-local-binaries: ## Update and rebuild local binaries from .local-binaries
 .PHONY: upgrade
 upgrade: nix-upgrade overlays-upgrade neovim-upgrade ## Upgrade Nix flake, overlays, Neovim plugins
 
+.PHONY: upgrade-dev
+upgrade-dev: ## Upgrade inside the Nix dev shell (mirrors CI).
+	@echo "🔄 Running upgrade inside the Nix dev shell..."
+	@DEVENV_ROOT=$(CURDIR) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) develop $(NIX_FLAGS) .# --command $(MAKE) upgrade
+
 .PHONY: dev
 dev: nix-develop ## Enter the Nix dev shell (alias for nix-develop).
 
@@ -583,17 +588,8 @@ neovim-dev: ## Set up local Neovim development environment.
 .PHONY: neovim-upgrade
 neovim-upgrade: ## Update Neovim plugins.
 	@echo "📦 Updating neovim plugins..."
-	@if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \
-		$(MAKE) neovim-upgrade-dev; \
-	else \
-		nvim --headless +"lua vim.pack.update()" +qa; \
-	fi
+	@nvim --headless +"lua vim.pack.update()" +qa
 	@echo "✅ Neovim plugins updated"
-
-.PHONY: neovim-upgrade-dev
-neovim-upgrade-dev: ## Update Neovim plugins inside the Nix dev shell (mirrors CI).
-	@echo "📦 Updating neovim plugins inside the Nix dev shell..."
-	@DEVENV_ROOT=$(CURDIR) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) develop $(NIX_FLAGS) .# --command $(MAKE) neovim-upgrade
 
 .PHONY: neovim-sync
 neovim-sync: neovim-upgrade ## Sync Neovim plugins.

--- a/Makefile
+++ b/Makefile
@@ -593,7 +593,7 @@ neovim-upgrade: ## Update Neovim plugins.
 .PHONY: neovim-upgrade-dev
 neovim-upgrade-dev: ## Update Neovim plugins inside the Nix dev shell (mirrors CI).
 	@echo "📦 Updating neovim plugins inside the Nix dev shell..."
-	@DEVENV_ROOT=$(CURDIR) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) develop $(NIX_FLAGS) .# --command $(MAKE) neovim-upgrade
+	@DEVENV_ROOT=$(CURDIR) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) develop $(NIX_FLAGS) .# --command nvim --headless +"lua vim.pack.update()" +qa
 
 .PHONY: neovim-sync
 neovim-sync: neovim-upgrade ## Sync Neovim plugins.

--- a/config/ghostty/default.nix
+++ b/config/ghostty/default.nix
@@ -2,10 +2,7 @@
 let
   fishPath = "${pkgs.fish}/bin/fish";
   staticConfig = builtins.readFile ./config;
-  configText = builtins.replaceStrings
-    [ "__FISH_PATH__" ]
-    [ fishPath ]
-    staticConfig;
+  configText = builtins.replaceStrings [ "__FISH_PATH__" ] [ fishPath ] staticConfig;
 in
 {
   xdg.configFile."ghostty/config" = {


### PR DESCRIPTION
## Changes
- Fix upgrade GHA that has been failing daily since Jan 31 — `neovim-upgrade` now auto-delegates to `neovim-upgrade-dev` in CI/Docker, running `nvim` via `nix develop` (fixes Error 127: command not found)
- Add self-hosted Renovate workflow (`renovate.yml`) running daily at 3am UTC for consistent dependency update checks

## Testing
- Upgrade workflow should pass on next scheduled or manual run
- Renovate workflow can be triggered via `workflow_dispatch`

Generated with Claude Code by claude-opus-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing upgrade job by running the whole upgrade inside the Nix dev shell via a new upgrade-dev target, and adds a daily Renovate workflow to keep dependencies up to date. Also updates the upgrade schedule and simplifies Ghostty config.

- **Bug Fixes and Refactors**
  - Makefile: add upgrade-dev to run make upgrade inside nix develop; CI uses this to ensure nvim is available and avoid recursion/CI guards.
  - Upgrade workflow: runs at 03:00 UTC, triggers on pull_request, uses make upgrade-dev, and skips PR creation when triggered by pull_request.
  - Ghostty: simplify configText assignment in config/ghostty/default.nix.

- **New Features**
  - Add .github/workflows/renovate.yml: nightly at 03:00 UTC, manual runs supported, uses renovatebot/github-action@v46.0.2 with PAT_TOKEN, includes an “Alls Green” check.

<sup>Written for commit 5666f8f2c9be4250a41b50eadce7924f0884d5e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

