### PR TITLE
feat: add clipboard manager with auto-paste and improve emoji picker

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -34,6 +34,7 @@ in
       ./gtk
       ./hyprland
       ./hyprpanel
+      ./rofi
       ./walker
     ]
   else

--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -255,7 +255,7 @@ bind = $mod, A, exec, pavucontrol
 # Launcher & Clipboard
 # =============================================================================
 bind = CTRL ALT SHIFT SUPER, SPACE, exec, walker
-bind = $mod, E, exec, rofimoji --action clipboard --clipboarder wl-copy && sleep 0.1 && wtype -M ctrl -k v -m ctrl
+bind = $mod, E, exec, sh -c 'rofimoji --action copy && sleep 0.2 && wtype -M ctrl -k v -m ctrl'
 
 # =============================================================================
 # Window Management

--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -227,6 +227,10 @@ layerrule = blur on, match:namespace ^(walker)$
 layerrule = ignore_alpha on, match:namespace ^(walker)$
 layerrule = animation slide top, match:namespace ^(walker)$
 
+# Blur for rofi
+layerrule = blur on, match:namespace ^(rofi)$
+layerrule = ignore_alpha 0.3, match:namespace ^(rofi)$
+
 # =============================================================================
 # App Launch Hotkeys (Super + letter)
 # =============================================================================

--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -255,7 +255,7 @@ bind = $mod, A, exec, pavucontrol
 # Launcher & Clipboard
 # =============================================================================
 bind = CTRL ALT SHIFT SUPER, SPACE, exec, walker
-bind = $mod, E, exec, sh -c 'rofimoji --action copy && sleep 0.2 && wtype -M ctrl -k v -m ctrl'
+bind = $mod, E, exec, sh -c 'rofimoji --action copy --skin-tone neutral && sleep 0.2 && wtype -M ctrl -k v -m ctrl'
 
 # =============================================================================
 # Window Management

--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -251,7 +251,7 @@ bind = $mod, A, exec, pavucontrol
 # Launcher & Clipboard
 # =============================================================================
 bind = CTRL ALT SHIFT SUPER, SPACE, exec, walker
-bind = $mod, E, exec, emote
+bind = $mod, E, exec, rofimoji --action type
 
 # =============================================================================
 # Window Management
@@ -364,8 +364,8 @@ bind = CTRL ALT SHIFT SUPER, 5, exec, ~/.config/hypr/scripts/record-screen.sh
 # Color picker
 bind = $mod, PRINT, exec, hyprpicker -a
 
-# Clipboard manager (clipse)
-bind = CTRL $mod, V, exec, ghostty --class clipse -e clipse
+# Clipboard manager (cliphist + rofi, auto-paste on selection)
+bind = $mod SHIFT, V, exec, cliphist list | rofi -dmenu -display-columns 2 | cliphist decode | wl-copy && sleep 0.1 && wtype -M ctrl -k v -m ctrl
 
 # =============================================================================
 # Media / Hardware Keys (Framework 13 AI 300)

--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -255,7 +255,7 @@ bind = $mod, A, exec, pavucontrol
 # Launcher & Clipboard
 # =============================================================================
 bind = CTRL ALT SHIFT SUPER, SPACE, exec, walker
-bind = $mod, E, exec, rofimoji --action type
+bind = $mod, E, exec, rofimoji --action clipboard --clipboarder wl-copy && sleep 0.1 && wtype -M ctrl -k v -m ctrl
 
 # =============================================================================
 # Window Management

--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -371,6 +371,9 @@ bind = $mod, PRINT, exec, hyprpicker -a
 # Clipboard manager (cliphist + rofi, auto-paste on selection)
 bind = $mod SHIFT, V, exec, cliphist list | rofi -dmenu -display-columns 2 | cliphist decode | wl-copy && sleep 0.1 && wtype -M ctrl -k v -m ctrl
 
+# Clipboard manager TUI with image preview (clipse)
+bind = CTRL ALT SHIFT SUPER, V, exec, ghostty --class clipse -e clipse
+
 # =============================================================================
 # Media / Hardware Keys (Framework 13 AI 300)
 # =============================================================================

--- a/config/rofi/config.rasi
+++ b/config/rofi/config.rasi
@@ -81,7 +81,7 @@ element normal.normal {
 }
 
 element alternate.normal {
-    background-color: transparent;
+    background-color: #ffffff06;
     text-color:       @fg;
 }
 

--- a/config/rofi/config.rasi
+++ b/config/rofi/config.rasi
@@ -1,0 +1,101 @@
+/**
+ * Frosted Glass theme — matches HyprPanel frosty translucent palette.
+ * Relies on Hyprland layer-rule blur for the translucency effect.
+ */
+
+* {
+    bg:           #1a1b26cc;
+    bg-solid:     #1a1b26ee;
+    fg:           #ffffffdd;
+    fg-dim:       #ffffff66;
+    accent:       #88c0d0;
+    border-clr:   #ffffff18;
+    selected-bg:  #88c0d033;
+    selected-fg:  #88c0d0;
+    urgent:       #bf616a;
+
+    font: "JetBrainsMono Nerd Font 13";
+
+    background-color: transparent;
+    text-color:       @fg;
+}
+
+window {
+    transparency:     "real";
+    background-color: @bg;
+    border:           2px;
+    border-color:     @border-clr;
+    border-radius:    12px;
+    width:            600px;
+}
+
+mainbox {
+    background-color: transparent;
+    children:         [ inputbar, listview ];
+}
+
+inputbar {
+    background-color: @bg-solid;
+    border:           0 0 1px 0;
+    border-color:     @border-clr;
+    border-radius:    12px 12px 0 0;
+    padding:          14px 16px;
+    children:         [ prompt, entry ];
+    spacing:          10px;
+}
+
+prompt {
+    background-color: transparent;
+    text-color:       @accent;
+}
+
+entry {
+    background-color:  transparent;
+    text-color:        @fg;
+    placeholder:       "Search...";
+    placeholder-color: @fg-dim;
+}
+
+listview {
+    background-color: transparent;
+    lines:            8;
+    padding:          8px 0;
+    scrollbar:        false;
+    fixed-height:     false;
+}
+
+element {
+    background-color: transparent;
+    padding:          10px 16px;
+    spacing:          10px;
+}
+
+element selected.normal {
+    background-color: @selected-bg;
+    text-color:       @selected-fg;
+}
+
+element normal.normal {
+    background-color: transparent;
+    text-color:       @fg;
+}
+
+element normal.urgent {
+    text-color: @urgent;
+}
+
+element selected.urgent {
+    background-color: @selected-bg;
+    text-color:       @urgent;
+}
+
+element-text {
+    background-color: transparent;
+    text-color:       inherit;
+    highlight:        bold underline;
+}
+
+element-icon {
+    background-color: transparent;
+    size:             1.2em;
+}

--- a/config/rofi/config.rasi
+++ b/config/rofi/config.rasi
@@ -6,13 +6,13 @@
 * {
     bg:           #1a1b26cc;
     bg-solid:     #1a1b26ee;
-    fg:           #ffffffdd;
-    fg-dim:       #ffffff66;
-    accent:       #88c0d0;
-    border-clr:   #ffffff18;
-    selected-bg:  #88c0d033;
-    selected-fg:  #88c0d0;
-    urgent:       #bf616a;
+    fg:           #ffffffbb;
+    fg-dim:       #ffffff44;
+    accent:       #a0a8c0;
+    border-clr:   #ffffff12;
+    selected-bg:  #252836;
+    selected-fg:  #ffffffee;
+    urgent:       #8a3a42;
 
     font: "JetBrainsMono Nerd Font 13";
 

--- a/config/rofi/config.rasi
+++ b/config/rofi/config.rasi
@@ -80,7 +80,16 @@ element normal.normal {
     text-color:       @fg;
 }
 
+element alternate.normal {
+    background-color: transparent;
+    text-color:       @fg;
+}
+
 element normal.urgent {
+    text-color: @urgent;
+}
+
+element alternate.urgent {
     text-color: @urgent;
 }
 

--- a/config/rofi/default.nix
+++ b/config/rofi/default.nix
@@ -1,0 +1,7 @@
+{ ... }:
+{
+  xdg.configFile."rofi/config.rasi" = {
+    source = ./config.rasi;
+    force = true;
+  };
+}

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -124,7 +124,6 @@ with pkgs;
   clickup
   cliphist
   discord
-  emote
   evince
   ffmpeg
   ghostty

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -139,7 +139,7 @@ with pkgs;
   linux-wallpaperengine
   pavucontrol
   playerctl
-  rofi-wayland
+  rofi
   rofimoji
   signal-desktop
   slack

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -140,6 +140,8 @@ with pkgs;
   linux-wallpaperengine
   pavucontrol
   playerctl
+  rofi-wayland
+  rofimoji
   signal-desktop
   slack
   slurp
@@ -151,4 +153,5 @@ with pkgs;
   wf-recorder
   wl-clip-persist
   wl-clipboard
+  wtype
 ]


### PR DESCRIPTION
## Changes
- Add `rofi-wayland`, `rofimoji`, and `wtype` to desktop packages
- Bind `Super+Shift+V` to cliphist + rofi clipboard history with auto-paste via wtype
- Replace `emote` with `rofimoji --action type` on `Super+E` for auto-type on selection

## Technical Details
- Clipboard: `cliphist list | rofi -dmenu | cliphist decode | wl-copy && wtype Ctrl+V` — selects, copies, pastes, closes
- Emoji: `rofimoji --action type` — selects emoji, types it at cursor, closes
- Existing `wl-clip-persist` and `cliphist` watchers remain unchanged

## Testing
- [ ] `Super+Shift+V` opens rofi clipboard picker, pastes on selection
- [ ] `Super+E` opens rofimoji emoji picker, types emoji on selection
- [ ] `wl-clip-persist` keeps clipboard alive after source app closes

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds clipboard history with auto-paste and switches the emoji picker to copy-then-paste. Includes a frosted glass rofi theme with Hyprland blur and a Hyper+V clipse TUI with image preview.

- **New Features**
  - Super+Shift+V: cliphist + rofi; auto-pastes selection.
  - Super+E: rofimoji copies, then pastes; neutral skin tone (selector off).
  - Hyper+V: clipse TUI in Ghostty with image preview.
  - Rofi theme: translucent, blurred, dark palette, rounded corners, JetBrainsMono Nerd Font; alternating rows tinted.

- **Dependencies**
  - Adds rofi, rofimoji, and wtype.
  - Removes emote.

<sup>Written for commit f1209d44682163ba2d656aa7db1e2d8a37816432. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

