### PR TITLE
feat: add macOS-style window keybinds (minimize + quit)

### DIFF
--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -260,7 +260,9 @@ bind = $mod, E, exec, sh -c 'rofimoji --action copy --skin-tone neutral && sleep
 # =============================================================================
 # Window Management
 # =============================================================================
-bind = $mod, W, killactive,
+bind = $mod, W, movetoworkspacesilent, special:minimized
+bind = $mod SHIFT, W, togglespecialworkspace, minimized
+bind = $mod, Q, killactive,
 bind = $mod SHIFT, F, togglefloating,
 bind = CTRL ALT SHIFT SUPER, F, exec, hyprctl --batch "dispatch movetoworkspace empty; dispatch fullscreen 0"
 bind = SUPER CTRL, F, fullscreen, 0


### PR DESCRIPTION
## Changes
- `Super+W` now minimizes windows (moves to `special:minimized` workspace) instead of killing them
- `Super+Shift+W` toggles the minimized workspace overlay to restore hidden windows
- `Super+Q` kills the active window (matches macOS `Cmd+Q` convention)

## Testing
- `Super+W` hides the focused window
- `Super+Shift+W` toggles the minimized workspace overlay
- `Super+Q` kills the focused window

Generated with Claude Code by claude-opus-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add macOS-style window keybinds to minimize and quit windows for a more familiar workflow.

- **New Features**
  - Super+W moves the focused window to special:minimized (minimize).
  - Super+Shift+W toggles the minimized workspace overlay to restore windows.
  - Super+Q kills the focused window (replaces the old Super+W behavior).

<sup>Written for commit 3f532f9e134a79e70d88fea88da0fc20501a3ec6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

