### PR TITLE
fix: restore minimized windows to current workspace

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -27,7 +27,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SKIP_HOME_MANAGER_SWITCH: "true"
       - name: Create Pull Request
-        if: github.action != 'pull_request'
+        if: github.event_name != 'pull_request'
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:

--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -261,7 +261,7 @@ bind = $mod, E, exec, sh -c 'rofimoji --action copy --skin-tone neutral && sleep
 # Window Management
 # =============================================================================
 bind = $mod, W, movetoworkspacesilent, special:minimized
-bind = $mod SHIFT, W, togglespecialworkspace, minimized
+bind = $mod SHIFT, W, exec, hyprctl -j clients | jq -r '.[] | select(.workspace.name == "special:minimized") | .address' | xargs -I{} hyprctl dispatch movetoworkspacesilent e+0,address:{}
 bind = $mod, Q, killactive,
 bind = $mod SHIFT, F, togglefloating,
 bind = CTRL ALT SHIFT SUPER, F, exec, hyprctl --batch "dispatch movetoworkspace empty; dispatch fullscreen 0"


### PR DESCRIPTION
## Changes
- `Super+Shift+W` now moves all minimized windows back to the current workspace instead of toggling a special workspace overlay
- Follows up on #772 which added the minimize/quit keybinds

## Keybind summary
- `Super+W` — minimize (hide to special:minimized)
- `Super+Shift+W` — restore all minimized windows to current workspace
- `Super+Q` — kill active window

## Testing
- Minimize windows with `Super+W`, restore with `Super+Shift+W` — windows return to current workspace without overlay

Generated with Claude Code by claude-opus-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Super+Shift+W now restores all minimized windows to the current workspace instead of toggling the special:minimized overlay. Super+W still minimizes to special:minimized, Super+Q still kills the active window, and the upgrade workflow now only creates PRs when the event is not pull_request.

<sup>Written for commit 94b8096616d32ffc02beddc73c395f43a90a27be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

