### PR TITLE
chore: use nixpkgs master for ai tools

### DIFF
--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -295,6 +295,18 @@ bind = $mod SHIFT, down, movewindow, d
 bind = $mod SHIFT, left, movetoworkspace, empty
 bind = $mod SHIFT, right, movetoworkspace, empty
 
+# Swap windows (vim keys)
+bind = $mod ALT, H, swapwindow, l
+bind = $mod ALT, L, swapwindow, r
+bind = $mod ALT, K, swapwindow, u
+bind = $mod ALT, J, swapwindow, d
+
+# Swap windows (arrow keys)
+bind = $mod ALT SHIFT, left, swapwindow, l
+bind = $mod ALT SHIFT, right, swapwindow, r
+bind = $mod ALT SHIFT, up, swapwindow, u
+bind = $mod ALT SHIFT, down, swapwindow, d
+
 # Resize windows (arrow keys)
 binde = $mod CTRL, left, resizeactive, -20 0
 binde = $mod CTRL, right, resizeactive, 20 0

--- a/config/serena/default.nix
+++ b/config/serena/default.nix
@@ -1,7 +1,7 @@
 { config, ... }:
 {
   home.file.".serena/serena_config.yml" = {
-    source = ./serena_config.yml;
+    text = builtins.readFile ./serena_config.yml;
     force = true;
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -531,22 +531,6 @@
         "type": "github"
       }
     },
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1770169770,
-        "narHash": "sha256-awR8qIwJxJJiOmcEGgP2KUqYmHG4v/z8XpL9z8FnT1A=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "aa290c9891fa4ebe88f8889e59633d20cc06a5f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-lib": {
       "locked": {
         "lastModified": 1769909678,
@@ -593,6 +577,38 @@
         "type": "github"
       }
     },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1770537093,
+        "narHash": "sha256-pF1quXG5wsgtyuPOHcLfYg/ft/QMr8NnX0i6tW2187s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fef9403a3e4d31b0a23f0bacebbec52c248fbb51",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nur": {
       "inputs": {
         "flake-parts": "flake-parts_4",
@@ -626,8 +642,12 @@
         "nix-darwin": "nix-darwin",
         "nix2container": "nix2container",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ],
         "nixpkgs-nightly": "nixpkgs-nightly",
+        "nixpkgs-stable": "nixpkgs-stable",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "nur": "nur",
         "treefmt-nix": "treefmt-nix_2",
         "xremap": "xremap"

--- a/flake.lock
+++ b/flake.lock
@@ -577,6 +577,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-nightly": {
+      "locked": {
+        "lastModified": 1770707594,
+        "narHash": "sha256-UPo/l9ZkFpcG5MHeXwoaaX15GN9nWDPKsAGPZzfRpUI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7c33b603fc9baa60caef3d52bf33a6d327a3d3f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nur": {
       "inputs": {
         "flake-parts": "flake-parts_4",
@@ -611,6 +627,7 @@
         "nix2container": "nix2container",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-nightly": "nixpkgs-nightly",
         "nur": "nur",
         "treefmt-nix": "treefmt-nix_2",
         "xremap": "xremap"

--- a/flake.nix
+++ b/flake.nix
@@ -2,11 +2,17 @@
   description = "Shun Kakinoki's Nix Configuration";
 
   inputs = {
-    nixpkgs = {
+    nixpkgs-stable = {
+      url = "github:NixOS/nixpkgs/nixos-24.11";
+    };
+    nixpkgs-unstable = {
       url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     };
     nixpkgs-nightly = {
       url = "github:NixOS/nixpkgs/master";
+    };
+    nixpkgs = {
+      follows = "nixpkgs-unstable";
     };
     home-manager = {
       url = "github:nix-community/home-manager";

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,9 @@
     nixpkgs = {
       url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     };
+    nixpkgs-nightly = {
+      url = "github:NixOS/nixpkgs/master";
+    };
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -123,6 +123,7 @@ with pkgs;
   chromium
   clickup
   cliphist
+  code-cursor
   discord
   evince
   ffmpeg

--- a/home-manager/services/code-syncer/default.nix
+++ b/home-manager/services/code-syncer/default.nix
@@ -32,7 +32,9 @@ in
         lib.makeBinPath [
           pkgs.bash
           pkgs.coreutils
+          pkgs.code-cursor
           pkgs.inotify-tools
+          pkgs.vscode
         ]
       }";
       ExecStart = "${pkgs.bash}/bin/bash ${./sync.sh}";

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -32,4 +32,14 @@
       '';
     });
   })
+  (final: prev: {
+    nightlyPkgs = import inputs.nixpkgs-nightly {
+      system = prev.system;
+      config = prev.config;
+      overlays = [ ];
+    };
+    codex = final.nightlyPkgs.codex;
+    claude-code = final.nightlyPkgs.claude-code;
+    opencode = final.nightlyPkgs.opencode;
+  })
 ]

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "repositories": ["shunkakinoki/dotfiles"],
+  "repositories": [
+    "shunkakinoki/dotfiles"
+  ],
   "extends": [
     "config:recommended",
     "group:allNonMajor",


### PR DESCRIPTION
## Changes
- Added a nixpkgs master input
- Override codex, claude-code, and opencode to use master
- Updated flake lockfile

## Technical Details
- Overlay imports nixpkgs master for just the AI tools

## Testing
- Not run (nix eval only)

Generated with Codex CLI by OpenAI ChatGPT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build codex, claude-code, and opencode from nixpkgs master via a scoped overlay; everything else stays on nixpkgs-unstable. Also added Hyprland window-swap keybindings and updated inputs/flake.lock.

- **Dependencies**
  - Added nixpkgs-nightly and nixpkgs-stable; nixpkgs now follows nixpkgs-unstable.
  - Exposed nightlyPkgs in overlays and mapped codex, claude-code, and opencode to it.
  - Included code-cursor in Home Manager and in the code-syncer PATH (with vscode).

<sup>Written for commit f4715c2754eefaeb156ce0bfc50f0a9f74fa7110. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

