### PR TITLE
fix: add repositories field to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "repositories": ["shunkakinoki/dotfiles"],
   "extends": [
     "config:recommended",
     "group:allNonMajor",


### PR DESCRIPTION
## Changes
- Added `repositories` field to `renovate.json` so the self-hosted Renovate bot knows which repo to scan

## Technical Details
- The `renovatebot/github-action` runs Renovate as a self-hosted bot, which requires a `repositories` field in the config
- Without it, the action fails with "No repositories found - did you want to run with flag --autodiscover?"
- This field is ignored when the hosted Renovate service reads the same file as repo-level config

## Testing
- Renovate workflow should no longer fail with "No repositories found"

Generated with [Claude Code](https://claude.ai/code) by Claude Opus 4.6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the repositories field to renovate.json so the self-hosted Renovate GitHub Action scans shunkakinoki/dotfiles and stops failing with "No repositories found".

- **Bug Fixes**
  - Set repositories to ["shunkakinoki/dotfiles"] for self-hosted runs; the hosted Renovate service ignores this field.

<sup>Written for commit 6ca6cb003b86bcfc73a953200969ca4fe809d6ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

