### PR TITLE
chore: add mise and entire to configuration

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -65,6 +65,7 @@ with pkgs;
   llama-cpp
   llm
   mariadb
+  mise
   mkcert
   navi
   pingu

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -13,6 +13,7 @@
       "kurtosis-tech/tap"
       "oven-sh/bun"
       "paradigmxyz/brew"
+      "entireio/tap"
       "sst/tap"
       "steipete/tap"
     ];
@@ -24,6 +25,7 @@
       "coder"
       "colima"
       "coreutils"
+      "entire"
       "ffmpeg"
       "gemini-cli"
       "geth"


### PR DESCRIPTION
## Changes
- Added mise package to home-manager configuration
- Added entireio/tap and entire cask to Homebrew configuration

## Technical Details
mise is a modern version manager for various tools and languages. entire is a utility for managing entire development environments.

## Testing
- Configuration changes follow existing patterns
- No runtime tests needed

Generated with OpenCode by Claude

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added mise to home-manager and added entireio tap + entire cask to Homebrew. This improves tool versioning and environment setup across Nix-managed dev environments.

<sup>Written for commit 8da2246b740ab0a2a4afbb9870f16b61fec0128b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

