### PR TITLE
feat(hyprpanel): add microphone module to bar layout

### DIFF
--- a/config/hyprpanel/default.nix
+++ b/config/hyprpanel/default.nix
@@ -17,6 +17,7 @@
             "cpu"
             "ram"
             "volume"
+            "microphone"
             "battery"
             "network"
             "bluetooth"


### PR DESCRIPTION
## Changes
- Add `microphone` module to hyprpanel bar layout (right section, between volume and battery)
- Enables mic mute/unmute and input volume control directly from the bar

## Testing
- Built and switched NixOS config successfully
- Microphone module appears on bar and is functional

Generated with Claude Code by claude-opus-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a microphone module to the Hyprpanel bar to let you mute/unmute and adjust input volume. It appears in the right section between Volume and Battery.

<sup>Written for commit 2bc986495ddbe5b644b7df80bfab9a708b60dabf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

