### PR TITLE
fix: tmux Wayland clipboard and serena mutable config

### DIFF
--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -386,7 +386,8 @@ bind = $mod, PRINT, exec, hyprpicker -a
 bind = $mod SHIFT, V, exec, cliphist list | rofi -dmenu -display-columns 2 | cliphist decode | wl-copy && sleep 0.1 && wtype -M ctrl -k v -m ctrl
 
 # Clipboard manager TUI with image preview (clipse)
-bind = CTRL ALT SHIFT SUPER, V, exec, ghostty --class clipse -e clipse
+# Use $mod+Ctrl+V instead of Hyper+V to avoid xremap conflict (Hyper+V → Ctrl+V)
+bind = $mod CTRL, V, exec, ghostty --class clipse -e clipse
 
 # =============================================================================
 # Media / Hardware Keys (Framework 13 AI 300)

--- a/config/serena/default.nix
+++ b/config/serena/default.nix
@@ -1,7 +1,15 @@
 { config, ... }:
+let
+  serenaConfigSrc = ./serena_config.yml;
+  serenaConfigDest = "${config.home.homeDirectory}/.serena/serena_config.yml";
+in
 {
-  home.file.".serena/serena_config.yml" = {
-    text = builtins.readFile ./serena_config.yml;
-    force = true;
-  };
+  home.activation.serenaConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    mkdir -p "$(dirname "${serenaConfigDest}")"
+    if [ ! -f "${serenaConfigDest}" ] || [ -L "${serenaConfigDest}" ]; then
+      rm -f "${serenaConfigDest}"
+      cp "${serenaConfigSrc}" "${serenaConfigDest}"
+      chmod u+w "${serenaConfigDest}"
+    fi
+  '';
 }

--- a/home-manager/programs/tmux/tmux.conf
+++ b/home-manager/programs/tmux/tmux.conf
@@ -10,7 +10,7 @@ setw -g mouse on
 
 # Fix SSH agent after reconnecting
 # https://blog.testdouble.com/posts/2016-11-18-reconciling-tmux-and-ssh-agent-forwarding/
-set -g update-environment "DISPLAY SSH_ASKPASS SSH_AGENT_PID SSH_CONNECTION WINDOWID XAUTHORITY"
+set -g update-environment "DISPLAY SSH_ASKPASS SSH_AGENT_PID SSH_CONNECTION WINDOWID XAUTHORITY WAYLAND_DISPLAY SWAYSOCK"
 setenv -g SSH_AUTH_SOCK $HOME/.ssh/ssh_auth_sock
 
 # Ensure window index numbers get reordered on delete.

--- a/home-manager/programs/tmux/tmux.conf
+++ b/home-manager/programs/tmux/tmux.conf
@@ -102,7 +102,7 @@ set -g clock-mode-style 24
 # =============================================================================
 set -g status-style "bg=colour22,fg=colour255"
 set -g status-left "#[bg=colour28,fg=colour255,bold] #S #[bg=colour22,fg=colour28] "
-set -g status-right "#[fg=colour250]#{?#{pane_current_command},#{pane_current_command},} #[fg=colour28]| #[fg=colour255]%Y/%m/%d %H:%M "
+set -g status-right "#[fg=colour250]#{?#{pane_current_command},#{pane_current_command},} #[fg=colour28]| #[fg=colour255]%Y/%m/%d %H:%M:%S "
 set -g status-left-length 30
 set -g status-right-length 60
 


### PR DESCRIPTION
## Summary
- **tmux**: Add `WAYLAND_DISPLAY` and `SWAYSOCK` to `update-environment` so `wl-copy`/`wl-paste` work inside tmux sessions
- **serena**: Replace `home.file` with an activation script so the config is a writable file instead of a read-only Nix store symlink

## Test plan
- [ ] Start a new tmux session and verify `pwd | wl-copy` works
- [ ] Verify `~/.serena/serena_config.yml` is a regular writable file after `make switch`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Wayland clipboard in tmux by adding WAYLAND_DISPLAY and SWAYSOCK to update-environment, show seconds in the tmux clock, and change the Hyprland clipse shortcut to $mod+Ctrl+V to avoid xremap conflicts. Make Serena config writable by replacing the read-only home.file symlink with an activation script that copies serena_config.yml to ~/.serena and sets permissions.

<sup>Written for commit 4a1f97a8c2d3043b010841887f39e724b27a7732. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

