### PR TITLE
feat(tmux): add shortcut to capture full pane history

### DIFF
--- a/home-manager/programs/tmux/tmux.conf
+++ b/home-manager/programs/tmux/tmux.conf
@@ -89,6 +89,9 @@ bind-key "_" split-window -fv -c "#{pane_current_path}"
 bind-key "%" split-window -h -c "#{pane_current_path}"
 bind-key '"' split-window -v -c "#{pane_current_path}"
 
+# Capture full pane history to file
+bind P capture-pane -pS - \; save-buffer ~/tmux-history.txt \; display-message "Pane history saved to ~/tmux-history.txt"
+
 # Pane number indicator
 set -g display-panes-colour colour233
 set -g display-panes-active-colour colour245


### PR DESCRIPTION
## Changes
- Add `prefix + P` keybinding to capture the full scrollback history of the current tmux pane and save it to `~/tmux-history.txt`
- Displays a confirmation message after saving

## Usage
Press `prefix + P` (capital P) to save the entire pane scrollback to `~/tmux-history.txt`.

Generated with Claude Code by claude-opus-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a tmux shortcut (prefix + P) to capture the full scrollback history of the current pane and save it to ~/tmux-history.txt. Shows a confirmation message after saving.

<sup>Written for commit 01cca60faf7f0e9fe35084058477148b89cb4f74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

