### PR TITLE
fix(tmux): resolve capture-pane "Can't write to client" error

### DIFF
--- a/home-manager/programs/tmux/tmux.conf
+++ b/home-manager/programs/tmux/tmux.conf
@@ -90,7 +90,7 @@ bind-key "%" split-window -h -c "#{pane_current_path}"
 bind-key '"' split-window -v -c "#{pane_current_path}"
 
 # Capture full pane history to file
-bind P capture-pane -pS - \; save-buffer ~/tmux-history.txt \; display-message "Pane history saved to ~/tmux-history.txt"
+bind P capture-pane -S - \; save-buffer ~/tmux-history.txt \; delete-buffer \; display-message "Pane history saved to ~/tmux-history.txt"
 
 # Pane number indicator
 set -g display-panes-colour colour233


### PR DESCRIPTION
## Changes
- Remove `-p` flag from `capture-pane` which outputs to stdout (causing the error)
- Use buffer-based flow: capture → save buffer to file → delete buffer
- Add `delete-buffer` to clean up the temporary paste buffer

## Technical Details
The `-p` flag on `capture-pane` sends output to the client's stdout rather than storing it in a tmux paste buffer. When chained with `save-buffer`, there's nothing in the buffer to save, resulting in "Can't write to client". Removing `-p` stores the captured history in a paste buffer, which `save-buffer` can then write to the file.

## Testing
- Press `prefix + P` in tmux to capture full pane history
- Verify `~/tmux-history.txt` is created with pane contents
- No "Can't write to client" error

Generated with Claude Code by claude-opus-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix tmux capture-pane binding to stop the "Can't write to client" error by capturing to a paste buffer instead of stdout. Pressing prefix+P now saves full pane history to ~/tmux-history.txt without errors.

- **Bug Fixes**
  - Removed the -p flag so capture-pane writes to a paste buffer.
  - Save the buffer to ~/tmux-history.txt, then delete the buffer to clean up.

<sup>Written for commit c6b24c6538d3e87ab4b0c9a3cccd9898e7c0c863. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

