### PR TITLE
feat: add tmux clipboard yank bindings and LSP packages

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -3,7 +3,7 @@
   inputs,
 }:
 let
-  inherit (inputs.host) isDesktop;
+  inherit (inputs.host) isDesktop isLSP;
 in
 with pkgs;
 [
@@ -92,6 +92,13 @@ with pkgs;
   yq
   zellij
   zoxide
+]
+++ lib.optionals isLSP [
+  gopls
+  lua-language-server
+  nil
+  nodePackages.typescript-language-server
+  pyright
 ]
 ++ lib.optionals stdenv.isLinux [
   atop

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -3,7 +3,7 @@
   inputs,
 }:
 let
-  inherit (inputs.host) isDesktop isLSP;
+  inherit (inputs.host) isDesktop isDev;
 in
 with pkgs;
 [
@@ -93,7 +93,7 @@ with pkgs;
   zellij
   zoxide
 ]
-++ lib.optionals isLSP [
+++ lib.optionals isDev [
   gopls
   lua-language-server
   nil

--- a/home-manager/programs/tmux/tmux.conf
+++ b/home-manager/programs/tmux/tmux.conf
@@ -89,8 +89,9 @@ bind-key "_" split-window -fv -c "#{pane_current_path}"
 bind-key "%" split-window -h -c "#{pane_current_path}"
 bind-key '"' split-window -v -c "#{pane_current_path}"
 
-# Capture full pane history to file
-bind P capture-pane -S - \; save-buffer ~/tmux-history.txt \; delete-buffer \; display-message "Pane history saved to ~/tmux-history.txt"
+# Yank pane history to clipboard
+bind y run-shell 'tmux capture-pane -pS - | pbcopy && tmux display-message "Full pane history copied to clipboard"'
+bind v run-shell 'tmux capture-pane -p | pbcopy && tmux display-message "Visible pane copied to clipboard"'
 
 # Pane number indicator
 set -g display-panes-colour colour233

--- a/lib/host.nix
+++ b/lib/host.nix
@@ -11,6 +11,9 @@
   # Desktop machines with GUI - default false, override in named-hosts
   isDesktop = false;
 
+  # Install language server packages
+  isLSP = true;
+
   # Get the node name for OpenClaw remote mode
   # Falls back to "unknown" if no hostname is detected
   nodeName =

--- a/lib/host.nix
+++ b/lib/host.nix
@@ -12,7 +12,7 @@
   isDesktop = false;
 
   # Install language server packages
-  isLSP = true;
+  isDev = true;
 
   # Get the node name for OpenClaw remote mode
   # Falls back to "unknown" if no hostname is detected


### PR DESCRIPTION
## Changes
- Replace tmux `Ctrl+B P` file-save capture with clipboard-based yank bindings
- Add `Ctrl+B y` to copy full pane history to clipboard
- Add `Ctrl+B v` to copy visible pane to clipboard
- Add `isLSP` flag in `lib/host.nix` for conditional LSP package installation
- Add LSP packages: gopls, lua-language-server, nil, typescript-language-server, pyright

## Technical Details
- Uses `run-shell` with `capture-pane -p | pbcopy` to avoid the "Can't write to client" error from chained tmux commands
- `isLSP` follows the same pattern as `isDesktop` — defaults to `true`, can be overridden per-host
- Excluded `rust-analyzer` since `rustup` already provides it

## Testing
- Built and switched successfully on macOS (galactica)
- Verified `capture-pane -p | pbcopy` pipeline works end-to-end
- Confirmed no conflicts with existing tmux bindings

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch tmux from saving pane output to a file to copying to the clipboard, and add a per-host isDev toggle for installing LSP packages. This makes copying output easier and lets hosts opt into language servers.

- **New Features**
  - Tmux: Ctrl+B y copies full pane history; Ctrl+B v copies visible pane; replaces the old Ctrl+B P file-save.
  - Host config: isDev flag (default true) to conditionally install LSPs: gopls, lua-language-server, nil, typescript-language-server, pyright (rust-analyzer excluded via rustup).

<sup>Written for commit 78836f27901a55e745b43e9e7f943b483f91070d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

