### PR TITLE
refactor: move isDev packages section after isDesktop

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -93,13 +93,6 @@ with pkgs;
   zellij
   zoxide
 ]
-++ lib.optionals isDev [
-  gopls
-  lua-language-server
-  nil
-  nodePackages.typescript-language-server
-  pyright
-]
 ++ lib.optionals stdenv.isLinux [
   atop
   below
@@ -162,4 +155,11 @@ with pkgs;
   wl-clip-persist
   wl-clipboard
   wtype
+]
+++ lib.optionals isDev [
+  gopls
+  lua-language-server
+  nil
+  nodePackages.typescript-language-server
+  pyright
 ]


### PR DESCRIPTION
## Changes
- Move `isDev` LSP packages section to the bottom of `default.nix`, after `isDesktop`

## Technical Details
- Ordering now follows: base packages → Linux → Linux+Desktop → Dev (LSPs)
- No functional change, just reordering for consistency

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the isDev LSP packages block to the end of home-manager/packages/default.nix, after the isDesktop/Linux+Desktop section. This aligns the order (base → Linux → Linux+Desktop → Dev) and does not change behavior.

<sup>Written for commit f211604186d340ad4594914783ffa73899a2b7c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

