### PR TITLE
fix(docker-postgres): use system sg binary with SUID for group switching

### DIFF
--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -22,8 +22,26 @@ let
     aws = "${pkgs.awscli2}/bin/aws";
   };
 
+  # Smart wrapper that handles both NixOS and non-NixOS Linux
+  # On NixOS: docker group is properly inherited, or use /run/wrappers/bin/sg
+  # On non-NixOS: systemd user session may lack docker group, use /usr/bin/sg
   dockerStartScript = pkgs.writeShellScript "cliproxyapi-docker-start" ''
-    exec ${pkgs.shadow}/bin/sg docker -c "${pkgs.bash}/bin/bash ${startScript}"
+    SCRIPT="${pkgs.bash}/bin/bash ${startScript}"
+
+    # Try docker directly first (works on NixOS or when user has docker group)
+    if ${pkgs.docker}/bin/docker info >/dev/null 2>&1; then
+      exec $SCRIPT
+    fi
+
+    # Docker not accessible directly, try sg to switch group
+    if [ -x /run/wrappers/bin/sg ]; then
+      exec /run/wrappers/bin/sg docker -c "$SCRIPT"
+    elif [ -x /usr/bin/sg ]; then
+      exec /usr/bin/sg docker -c "$SCRIPT"
+    else
+      echo "ERROR: Cannot access Docker. User not in docker group and no sg binary found." >&2
+      exit 1
+    fi
   '';
 
   wrapperScript = pkgs.replaceVars ./scripts/wrapper.sh {

--- a/home-manager/services/docker-postgres/default.nix
+++ b/home-manager/services/docker-postgres/default.nix
@@ -1,8 +1,30 @@
 { pkgs, ... }:
 let
   inherit (pkgs) lib;
+  startScript = ./start-postgres.sh;
+
+  # Smart wrapper that handles both NixOS and non-NixOS Linux
+  # On NixOS: docker group is properly inherited, or use /run/wrappers/bin/sg
+  # On non-NixOS: systemd user session may lack docker group, use /usr/bin/sg
   startPostgresWrapper = pkgs.writeShellScript "start-postgres-wrapper" ''
-    exec ${pkgs.shadow}/bin/sg docker -c "${pkgs.bash}/bin/bash ${./start-postgres.sh}"
+    SCRIPT="${pkgs.bash}/bin/bash ${startScript}"
+
+    # Try docker directly first (works on NixOS or when user has docker group)
+    if ${pkgs.docker}/bin/docker info >/dev/null 2>&1; then
+      exec $SCRIPT
+    fi
+
+    # Docker not accessible directly, try sg to switch group
+    # NixOS: /run/wrappers/bin/sg (SUID wrapper)
+    # Non-NixOS: /usr/bin/sg (system binary with SUID)
+    if [ -x /run/wrappers/bin/sg ]; then
+      exec /run/wrappers/bin/sg docker -c "$SCRIPT"
+    elif [ -x /usr/bin/sg ]; then
+      exec /usr/bin/sg docker -c "$SCRIPT"
+    else
+      echo "ERROR: Cannot access Docker. User not in docker group and no sg binary found." >&2
+      exit 1
+    fi
   '';
 in
 {


### PR DESCRIPTION
## Changes
Use a smart wrapper script for docker group switching that works on both NixOS and non-NixOS Linux:

- **docker-postgres**: Updated wrapper for PostgreSQL container service
- **cliproxyapi**: Updated wrapper for CLI Proxy API service

## Technical Details
The wrapper tries in order:
1. **Docker directly** - works on NixOS or when user session has docker group
2. **`/run/wrappers/bin/sg`** - NixOS SUID wrapper (if available)
3. **`/usr/bin/sg`** - System binary with SUID (non-NixOS)

This is needed because:
- The Nix-packaged `${pkgs.shadow}/bin/sg` lacks the SUID bit (Nix store can't have setuid binaries)
- On non-NixOS, the systemd user session may not have the docker group (user added to group after session started)
- On NixOS, groups are properly inherited OR `/run/wrappers/bin/sg` is available via `security.wrappers`

## Test plan
- [x] `make build` passes
- [x] docker-postgres service starts successfully
- [x] cliproxyapi service starts successfully  
- [x] Both services use sg fallback correctly on non-NixOS
- [x] System reports 0 failed units

Generated with [Claude Code](https://claude.com/code) by Claude Opus 4.5