### PR TITLE
feat: improve Hyprland keybindings, add /bin shell symlinks, fix clipboard

### DIFF
--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -54,7 +54,7 @@ exec-once = hypridle
 exec-once = hyprsunset
 
 # Clipboard persistence
-exec-once = wl-clip-persist --clipboard regular & clipse -listen
+exec-once = wl-clip-persist --clipboard regular
 
 # =============================================================================
 # Monitor (Framework 13" 2256x1504)
@@ -187,11 +187,6 @@ windowrule = move 100%-340 60, $meetPip
 # Settings management (float for audio/bluetooth GUIs)
 windowrule = float on, match:class ^(org.pulseaudio.pavucontrol|.blueman-manager-wrapped|blueman-manager)$
 
-# Clipse clipboard manager (float centered)
-windowrule = float on, match:class ^(clipse)$
-windowrule = size 622 652, match:class ^(clipse)$
-windowrule = stay_focused on, match:class ^(clipse)$
-
 # Suppress maximize for all windows
 windowrule = suppress_event maximize, match:class .*
 
@@ -265,7 +260,7 @@ bind = $mod SHIFT, W, exec, hyprctl -j clients | jq -r '.[] | select(.workspace.
 bind = $mod, Q, killactive,
 bind = $mod SHIFT, F, togglefloating,
 bind = CTRL ALT SHIFT SUPER, F, exec, hyprctl --batch "dispatch movetoworkspace empty; dispatch fullscreen 0"
-bind = SUPER CTRL, F, fullscreen, 0
+bind = SUPER CTRL, F, fullscreen, 1
 bind = $mod SHIFT, Q, exec, hyprpanel toggleWindow power-menu
 bind = $mod, TAB, hyprexpo:expo, toggle
 
@@ -282,8 +277,8 @@ bind = $mod, up, movefocus, u
 bind = $mod, down, movefocus, d
 
 # Move windows (vim keys)
-bind = $mod SHIFT, H, movewindow, l
-bind = $mod SHIFT, L, movewindow, r
+bind = $mod SHIFT, H, movetoworkspace, r-1
+bind = $mod SHIFT, L, movetoworkspace, r+1
 bind = $mod SHIFT, K, movewindow, u
 bind = $mod SHIFT, J, movewindow, d
 
@@ -385,10 +380,6 @@ bind = $mod, PRINT, exec, hyprpicker -a
 # Clipboard manager (cliphist + rofi, auto-paste on selection)
 bind = $mod SHIFT, V, exec, cliphist list | rofi -dmenu -display-columns 2 | cliphist decode | wl-copy && sleep 0.1 && wtype -M ctrl -k v -m ctrl
 
-# Clipboard manager TUI with image preview (clipse)
-# Use $mod+Ctrl+V instead of Hyper+V to avoid xremap conflict (Hyper+V → Ctrl+V)
-bind = $mod CTRL, V, exec, ghostty --class clipse -e clipse
-
 # =============================================================================
 # Media / Hardware Keys (Framework 13 AI 300)
 # =============================================================================
@@ -437,7 +428,7 @@ binde = CTRL ALT SHIFT SUPER, minus, exec, hyprctl -j monitors | jq -r '.[0].sca
 # =============================================================================
 # Lock Screen
 # =============================================================================
-bind = $mod SHIFT, L, exec, hyprlock
+bind = CTRL ALT SHIFT SUPER, L, exec, hyprlock
 
 # =============================================================================
 # Notification Toggle

--- a/home-manager/modules/bin-shells/default.nix
+++ b/home-manager/modules/bin-shells/default.nix
@@ -5,10 +5,30 @@ in
 {
   config = lib.mkIf isLinux {
     home.activation.binShells = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      /run/wrappers/bin/sudo mkdir -p /bin
-      /run/wrappers/bin/sudo ln -sf ${pkgs.bash}/bin/bash /bin/bash
-      /run/wrappers/bin/sudo ln -sf ${pkgs.fish}/bin/fish /bin/fish
-      /run/wrappers/bin/sudo ln -sf ${pkgs.zsh}/bin/zsh /bin/zsh
+      SUDO_CMD=""
+      if command -v sudo >/dev/null 2>&1; then
+        SUDO_CMD="sudo"
+      elif [ -x /run/wrappers/bin/sudo ]; then
+        SUDO_CMD="/run/wrappers/bin/sudo"
+      elif [ -x /usr/bin/sudo ]; then
+        SUDO_CMD="/usr/bin/sudo"
+      elif [ "$(id -u)" -ne 0 ]; then
+        echo "Creating /bin shell symlinks requires root privileges, but sudo is not available." >&2
+        exit 1
+      fi
+
+      run_root_cmd() {
+        if [ -n "$SUDO_CMD" ]; then
+          ''${DRY_RUN_CMD:-} "$SUDO_CMD" "$@"
+        else
+          ''${DRY_RUN_CMD:-} "$@"
+        fi
+      }
+
+      run_root_cmd mkdir -p /bin
+      run_root_cmd ln -sf ${pkgs.bash}/bin/bash /bin/bash
+      run_root_cmd ln -sf ${pkgs.fish}/bin/fish /bin/fish
+      run_root_cmd ln -sf ${pkgs.zsh}/bin/zsh /bin/zsh
     '';
   };
 }

--- a/home-manager/modules/bin-shells/default.nix
+++ b/home-manager/modules/bin-shells/default.nix
@@ -1,0 +1,14 @@
+{ lib, pkgs, ... }:
+let
+  inherit (pkgs.stdenv) isLinux;
+in
+{
+  config = lib.mkIf isLinux {
+    home.activation.binShells = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      /run/wrappers/bin/sudo mkdir -p /bin
+      /run/wrappers/bin/sudo ln -sf ${pkgs.bash}/bin/bash /bin/bash
+      /run/wrappers/bin/sudo ln -sf ${pkgs.fish}/bin/fish /bin/fish
+      /run/wrappers/bin/sudo ln -sf ${pkgs.zsh}/bin/zsh /bin/zsh
+    '';
+  };
+}

--- a/home-manager/modules/default.nix
+++ b/home-manager/modules/default.nix
@@ -1,4 +1,5 @@
 [
+  ./bin-shells
   ./cargo-globals
   ./openclaw
   ./local-binaries

--- a/home-manager/modules/xremap/default.nix
+++ b/home-manager/modules/xremap/default.nix
@@ -13,7 +13,8 @@ let
   hyperPrefix = "C-Alt-Shift-Super-";
   ctrlPrefix = "C-";
   # "f" is excluded — passes through as Hyper+F for Hyprland fullscreen bind.
-  # See: config/hyprland/hyprland.conf (Window Management section)
+  # "l" is excluded — passes through as Hyper+L for Hyprland lock screen bind.
+  # See: config/hyprland/hyprland.conf (Window Management section, Lock Screen section)
   letters = [
     "a"
     "b"
@@ -25,7 +26,6 @@ let
     "i"
     "j"
     "k"
-    "l"
     "m"
     "n"
     "o"


### PR DESCRIPTION
## Summary
- Change `movewindow` h/l to `movetoworkspace` r-1/r+1 for cross-workspace window movement
- Move lock screen binding from `Super+Shift+L` to `Framework+L` to resolve conflict with workspace movement
- Exclude `l` from xremap so `Framework+L` passes through as Hyper to Hyprland
- Switch fullscreen toggle to maximize mode (`fullscreen 1`) to fix Chrome overlapping hyprpanel
- Remove clipse clipboard manager in favor of cliphist only (fixes clipboard history not working)
- Add `/bin/{bash,fish,zsh}` symlinks via home-manager activation for script compatibility on NixOS

## Test plan
- [x] `Super+Shift+H/L` moves windows between workspaces
- [x] `Framework+L` locks screen via hyprlock
- [x] `Super+Ctrl+F` maximizes without overlapping panel
- [x] `Super+Shift+V` opens cliphist clipboard history
- [x] `/bin/bash`, `/bin/fish`, `/bin/zsh` symlinks exist after switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved Hyprland window movement and lock screen shortcut, fixed fullscreen overlap and clipboard persistence, and added /bin shell symlinks with portable sudo detection for Linux.

- **New Features**
  - Super+Shift+H/L now move windows to previous/next workspace (movetoworkspace r-1/r+1).
  - Lock screen moved to Hyper+L (Framework+L); xremap now passes Hyper+L through.
  - Added /bin/bash, /bin/fish, /bin/zsh symlinks via home-manager; uses portable sudo detection (works on non-NixOS).

- **Bug Fixes**
  - Fullscreen bind uses maximize mode (fullscreen 1) to prevent Chrome overlapping hyprpanel.
  - Removed clipse and its binds/rules; rely on cliphist with wl-clip-persist for stable clipboard history.

<sup>Written for commit 8578c8aa505b950a988b027332fe1932920412e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

