### PR TITLE
fix(cliproxyapi): add curl to Linux service PATH

### DIFF
--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -128,6 +128,7 @@ in
           pkgs.coreutils
           pkgs.awscli2
           pkgs.docker
+          pkgs.curl
         ]
       }";
       ExecStart = "${dockerStartScript}";


### PR DESCRIPTION
## Summary
- Add `pkgs.curl` to the Linux systemd service `PATH` for cliproxyapi
- Fixes `curl: command not found` errors in `start.sh` usage import/export functions (`wait_for_management`, `usage_import`, `usage_export`)

## Test plan
- [ ] Run `make build && make switch` to apply the change
- [ ] Run `systemctl --user daemon-reload && systemctl --user restart cliproxyapi`
- [ ] Verify no `curl: command not found` in `journalctl --user -u cliproxyapi`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add curl to the cliproxyapi Linux systemd service PATH to fix management API calls in start.sh.
Prevents “curl: command not found” errors and stops silent failures in wait_for_management, usage_import, and usage_export.

<sup>Written for commit 59b3eb246b3ee58b2c1500ab81a98da2ecc94327. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

