### PR TITLE
fix: shell test coverage and llm-update.sh formatting

### DIFF
--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -95,7 +95,6 @@ openai-compatibility:
     models:
       - name: "glm-4.7"
         alias: "glm-4.7"
-
 # payload: # Optional payload configuration
 #   default: # Default rules only set parameters when they are missing in the payload.
 #     - models:
@@ -109,7 +108,6 @@ openai-compatibility:
 #           protocol: "codex" # restricts the rule to a specific protocol, options: openai, gemini, claude, codex
 #       params: # JSON path (gjson/sjson syntax) -> value
 #         "reasoning.effort": "high"
-
 oauth-model-alias:
   antigravity:
     - name: "claude-opus-4-6-thinking"

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -95,7 +95,6 @@ openai-compatibility:
     models:
       - name: "glm-4.7"
         alias: "glm-4.7"
-
 # payload: # Optional payload configuration
 #   default: # Default rules only set parameters when they are missing in the payload.
 #     - models:
@@ -109,7 +108,6 @@ openai-compatibility:
 #           protocol: "codex" # restricts the rule to a specific protocol, options: openai, gemini, claude, codex
 #       params: # JSON path (gjson/sjson syntax) -> value
 #         "reasoning.effort": "high"
-
 oauth-model-alias:
   antigravity:
     - name: "__CLAUDE_OPUS_THINKING__"

--- a/scripts/llm-update.sh
+++ b/scripts/llm-update.sh
@@ -7,7 +7,10 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MODELS="$ROOT/models.json"
 
-[[ -f "$MODELS" ]] || { echo "ERROR: models.json not found" >&2; exit 1; }
+[[ -f $MODELS ]] || {
+  echo "ERROR: models.json not found" >&2
+  exit 1
+}
 
 # jq function: derive display name from a model ID
 # claude-opus-4.6 → "Claude Opus 4.6", claude-sonnet-4.5-20250929 → "Claude Sonnet 4.5"
@@ -41,15 +44,15 @@ done < <(jq -r "$JQ_PRETTY"'
 
 # Template → output pairs
 declare -A TEMPLATES=(
-  [config/openclaw/openclaw.tpl.json]=config/openclaw/openclaw.template.json
-  [config/opencode/opencode.tpl.jsonc]=config/opencode/opencode.jsonc
-  [config/llm/extra-openai-models.tpl.yaml]=config/llm/extra-openai-models.yaml
-  [config/ccs/agy.settings.tpl.json]=config/ccs/agy.settings.template.json
-  [config/ccs/codex.settings.tpl.json]=config/ccs/codex.settings.template.json
-  [config/ccs/gemini.settings.tpl.json]=config/ccs/gemini.settings.template.json
-  [config/ccs/glm.settings.tpl.json]=config/ccs/glm.settings.template.json
-  [config/codex/config.tpl.toml]=config/codex/config.toml
-  [config/cliproxyapi/config.tpl.yaml]=config/cliproxyapi/config.template.yaml
+  ["config/openclaw/openclaw.tpl.json"]=config/openclaw/openclaw.template.json
+  ["config/opencode/opencode.tpl.jsonc"]=config/opencode/opencode.jsonc
+  ["config/llm/extra-openai-models.tpl.yaml"]=config/llm/extra-openai-models.yaml
+  ["config/ccs/agy.settings.tpl.json"]=config/ccs/agy.settings.template.json
+  ["config/ccs/codex.settings.tpl.json"]=config/ccs/codex.settings.template.json
+  ["config/ccs/gemini.settings.tpl.json"]=config/ccs/gemini.settings.template.json
+  ["config/ccs/glm.settings.tpl.json"]=config/ccs/glm.settings.template.json
+  ["config/codex/config.tpl.toml"]=config/codex/config.toml
+  ["config/cliproxyapi/config.tpl.yaml"]=config/cliproxyapi/config.template.yaml
 )
 
 echo "Updating tool configs from $MODELS ..."
@@ -57,8 +60,11 @@ echo
 
 for src in "${!TEMPLATES[@]}"; do
   dst="${TEMPLATES[$src]}"
-  [[ -f "$ROOT/$src" ]] || { echo "SKIP: $src"; continue; }
-  sed "${sed_args[@]}" "$ROOT/$src" > "$ROOT/$dst"
+  [[ -f "$ROOT/$src" ]] || {
+    echo "SKIP: $src"
+    continue
+  }
+  sed "${sed_args[@]}" "$ROOT/$src" >"$ROOT/$dst"
   echo "OK: $dst"
 done
 

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -157,6 +157,7 @@ home-manager/services/neverssl-keepalive/keepalive.sh
 install.sh
 named-hosts/kyber/rekey-galactica.sh
 named-hosts/kyber/setup.sh
+scripts/llm-update.sh
 scripts/update-gitalias.sh
 scripts/update-local-binaries.sh
 scripts/upgrade-overlays.sh"

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329,SC2034
+
+Describe 'scripts/llm-update.sh'
+SCRIPT="$PWD/scripts/llm-update.sh"
+
+Describe 'script properties'
+It 'uses bash shebang'
+When run bash -c "head -1 '$SCRIPT'"
+The output should include '#!/usr/bin/env bash'
+End
+
+It 'uses strict mode'
+When run bash -c "head -5 '$SCRIPT'"
+The output should include 'set -euo pipefail'
+End
+End
+
+Describe 'models.json dependency'
+It 'references models.json'
+When run bash -c "grep 'models.json' '$SCRIPT'"
+The output should include 'models.json'
+End
+
+It 'exits if models.json is missing'
+When run bash -c "grep 'models.json not found' '$SCRIPT'"
+The output should include 'ERROR'
+End
+End
+
+Describe 'template processing'
+It 'uses sed for substitution'
+When run bash -c "grep 'sed' '$SCRIPT'"
+The output should include 'sed'
+End
+
+It 'defines template-to-output mappings'
+When run bash -c "grep 'TEMPLATES' '$SCRIPT'"
+The output should include 'TEMPLATES'
+End
+
+It 'processes .tpl. template files'
+When run bash -c "grep '\.tpl\.' '$SCRIPT'"
+The output should include '.tpl.'
+End
+End
+
+Describe 'jq pretty-printing'
+It 'defines a jq pretty function for model names'
+When run bash -c "grep 'def pretty' '$SCRIPT'"
+The output should include 'def pretty'
+End
+
+It 'capitalizes Claude model names'
+When run bash -c "grep '"Claude"' '$SCRIPT'"
+The output should include 'Claude'
+End
+End
+
+Describe 'placeholder generation'
+It 'converts keys to uppercase placeholders'
+When run bash -c "grep 'placeholder=' '$SCRIPT'"
+The output should include '__'
+End
+
+It 'generates PRETTY variant placeholders'
+When run bash -c "grep '_PRETTY__' '$SCRIPT'"
+The output should include '_PRETTY__'
+End
+
+It 'generates NONDOT variant placeholders'
+When run bash -c "grep '_NONDOT__' '$SCRIPT'"
+The output should include '_NONDOT__'
+End
+End
+
+End


### PR DESCRIPTION
## Changes
- Add `scripts/llm-update.sh` to `coverage_spec.sh` tracking list (fixes shell-test failure)
- Add `spec/llm_update_spec.sh` with tests for the new script
- Quote associative array keys in `llm-update.sh` to prevent shfmt from mangling file paths (e.g. `config/openclaw/...` → `config / openclaw / ...`)
- Apply formatter fixes to cliproxyapi config YAML files

## Testing
- `make shell-test` — 491 examples, 0 failures
- `make format` — 0 files changed (stable)

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix shell test coverage and shfmt formatting issues in llm-update.sh, and add a focused test suite for the script. Shell tests now pass and formatting is stable.

- **Bug Fixes**
  - Track scripts/llm-update.sh in coverage_spec to prevent shell-test failure.
  - Add spec/llm_update_spec.sh to test strict mode, jq pretty names, placeholders, and template mapping.
  - Quote associative array keys in llm-update.sh to stop shfmt from splitting paths.
  - Apply small formatter cleanups to cliproxyapi config YAMLs.

<sup>Written for commit 97f10c11f62345d19ac43da0b32d12183691f2fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

