### PR TITLE
feat(openclaw): add WhatsApp channel support

### DIFF
--- a/config/openclaw/hydrate.sh
+++ b/config/openclaw/hydrate.sh
@@ -44,12 +44,14 @@ if [ "$MODE" = "gateway" ]; then
   # Gateway mode (Kyber): hydrate full template and start gateway
   CLIPROXY_API_KEY="${OPENCLAW_CLIPROXY_API_KEY:-${CLIPROXY_API_KEY:-$(read_secret "${SECRETS_DIR}/cliproxy-key")}}"
   TELEGRAM_TOKEN="${OPENCLAW_TELEGRAM_TOKEN:-${TELEGRAM_TOKEN:-$(read_secret "${SECRETS_DIR}/telegram-token")}}"
+  WHATSAPP_ALLOW_FROM="${OPENCLAW_WHATSAPP_ALLOW_FROM:-${WHATSAPP_ALLOW_FROM:-$(read_secret "${SECRETS_DIR}/whatsapp-allow-from")}}"
   ANTHROPIC_API_KEY="${OPENCLAW_ANTHROPIC_API_KEY:-${ANTHROPIC_API_KEY:-$(read_secret "${SECRETS_DIR}/anthropic-key")}}"
   CHROMIUM_PATH="@chromium@/bin/chromium"
 
   @sed@ \
     -e "s|__CLIPROXY_API_KEY__|${CLIPROXY_API_KEY}|g" \
     -e "s|__TELEGRAM_TOKEN__|${TELEGRAM_TOKEN}|g" \
+    -e "s|__WHATSAPP_ALLOW_FROM__|${WHATSAPP_ALLOW_FROM}|g" \
     -e "s|__GATEWAY_TOKEN__|${GATEWAY_TOKEN}|g" \
     -e "s|__CHROMIUM_PATH__|${CHROMIUM_PATH}|g" \
     -e "s|__HOME__|${HOME}|g" \

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -235,6 +235,25 @@
       "reactionLevel": "extensive",
       "replyToMode": "first",
       "streamMode": "partial"
+    },
+    "whatsapp": {
+      "enabled": true,
+      "dmPolicy": "pairing",
+      "allowFrom": [
+        "__WHATSAPP_ALLOW_FROM__"
+      ],
+      "groupPolicy": "allowlist",
+      "groups": {
+        "*": {
+          "requireMention": false
+        }
+      },
+      "sendReadReceipts": true,
+      "ackReaction": {
+        "emoji": "\ud83d\udc40",
+        "direct": true,
+        "group": "mentions"
+      }
     }
   },
   "gateway": {

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -235,6 +235,25 @@
       "reactionLevel": "extensive",
       "replyToMode": "first",
       "streamMode": "partial"
+    },
+    "whatsapp": {
+      "enabled": true,
+      "dmPolicy": "pairing",
+      "allowFrom": [
+        "__WHATSAPP_ALLOW_FROM__"
+      ],
+      "groupPolicy": "allowlist",
+      "groups": {
+        "*": {
+          "requireMention": false
+        }
+      },
+      "sendReadReceipts": true,
+      "ackReaction": {
+        "emoji": "\ud83d\udc40",
+        "direct": true,
+        "group": "mentions"
+      }
     }
   },
   "gateway": {

--- a/spec/openclaw_hydrate_spec.sh
+++ b/spec/openclaw_hydrate_spec.sh
@@ -53,6 +53,11 @@ It 'loads ANTHROPIC_API_KEY from file'
 When run bash -c "grep 'ANTHROPIC_API_KEY' '$SCRIPT'"
 The output should include 'anthropic-key'
 End
+
+It 'loads WHATSAPP_ALLOW_FROM from file'
+When run bash -c "grep 'WHATSAPP_ALLOW_FROM' '$SCRIPT'"
+The output should include 'whatsapp-allow-from'
+End
 End
 
 Describe 'config generation'
@@ -69,6 +74,11 @@ End
 It 'substitutes TELEGRAM_TOKEN in template'
 When run bash -c "grep '__TELEGRAM_TOKEN__' '$SCRIPT'"
 The output should include 'TELEGRAM_TOKEN'
+End
+
+It 'substitutes WHATSAPP_ALLOW_FROM in template'
+When run bash -c "grep '__WHATSAPP_ALLOW_FROM__' '$SCRIPT'"
+The output should include 'WHATSAPP_ALLOW_FROM'
 End
 
 It 'creates state directory'


### PR DESCRIPTION
## Summary

- Add WhatsApp channel config to `openclaw.tpl.json` with pairing-based DM policy and allowlist group policy
- Wire `__WHATSAPP_ALLOW_FROM__` placeholder through `hydrate.sh` (reads from `~/.config/openclaw/whatsapp-allow-from` file, `WHATSAPP_ALLOW_FROM` env var, or `OPENCLAW_WHATSAPP_ALLOW_FROM` env var)
- Add spec tests for the new secret loading and template substitution

## Setup after merge

1. Create the allow-from secret: `echo "+15551234567" > ~/.config/openclaw/whatsapp-allow-from`
2. Rebuild/deploy the config
3. Link WhatsApp: `openclaw channels login --channel whatsapp`
4. Scan the QR code from your phone (WhatsApp → Linked Devices)

## Test plan

- [ ] Verify `jq .channels.whatsapp` renders correctly in generated template
- [ ] Run `shellspec spec/openclaw_hydrate_spec.sh` — new WhatsApp tests pass
- [ ] Deploy config and run `openclaw channels login --channel whatsapp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds WhatsApp channel support with pairing-based DMs and allowlist group policy. Hydrates the allowed sender via secret file or env vars, with read receipts and 👀 ack reactions on mentions.

- **New Features**
  - WhatsApp channel in template: dmPolicy=pairing, groupPolicy=allowlist with "*" group (no mention required), read receipts, and 👀 ack reactions on mentions.
  - __WHATSAPP_ALLOW_FROM__ wired in hydrate.sh; loads from ~/.config/openclaw/whatsapp-allow-from or WHATSAPP_ALLOW_FROM/OPENCLAW_WHATSAPP_ALLOW_FROM.
  - Spec tests for secret loading and template substitution.

- **Migration**
  - Create secret: echo "+15551234567" > ~/.config/openclaw/whatsapp-allow-from
  - Rebuild and deploy the config
  - Link WhatsApp: openclaw channels login --channel whatsapp
  - Scan the QR code in WhatsApp → Linked Devices

<sup>Written for commit ba83603a1a7dea499e038170be8c0c21019538b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

