### PR TITLE
fix(openclaw): remove unsupported enabled key from whatsapp channel

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -237,7 +237,6 @@
       "streamMode": "partial"
     },
     "whatsapp": {
-      "enabled": true,
       "dmPolicy": "pairing",
       "allowFrom": [
         "__WHATSAPP_ALLOW_FROM__"

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -237,7 +237,6 @@
       "streamMode": "partial"
     },
     "whatsapp": {
-      "enabled": true,
       "dmPolicy": "pairing",
       "allowFrom": [
         "__WHATSAPP_ALLOW_FROM__"


### PR DESCRIPTION
## Summary

- Remove `"enabled": true` from WhatsApp channel config — OpenClaw auto-enables channels when configured, and the explicit key causes a validation error (`Unrecognized key: "enabled"`)

## Test plan

- [ ] `openclaw channels list` no longer shows config validation errors
- [ ] `openclaw channels login --channel whatsapp` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unsupported "enabled" key from the WhatsApp channel config to fix OpenClaw validation errors. OpenClaw auto-enables WhatsApp when configured, so this prevents startup errors and keeps login working.

<sup>Written for commit 58df55f3c8b4bfda1b55ba4bc83bffab67c54c48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

