### PR TITLE
feat(openclaw): add broadcast groups with multi-model agents

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -196,7 +196,27 @@
       {
         "id": "main",
         "default": true
+      },
+      {
+        "id": "sonnet",
+        "model": {
+          "primary": "cliproxy/claude-sonnet-4-5-20250929"
+        }
+      },
+      {
+        "id": "glm",
+        "model": {
+          "primary": "cliproxy/glm-4.7"
+        }
       }
+    ]
+  },
+  "broadcast": {
+    "strategy": "parallel",
+    "*": [
+      "main",
+      "sonnet",
+      "glm"
     ]
   },
   "messages": {

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -196,7 +196,27 @@
       {
         "id": "main",
         "default": true
+      },
+      {
+        "id": "sonnet",
+        "model": {
+          "primary": "cliproxy/__CLAUDE_SONNET__"
+        }
+      },
+      {
+        "id": "glm",
+        "model": {
+          "primary": "cliproxy/__GLM__"
+        }
       }
+    ]
+  },
+  "broadcast": {
+    "strategy": "parallel",
+    "*": [
+      "main",
+      "sonnet",
+      "glm"
     ]
   },
   "messages": {


### PR DESCRIPTION
## Summary
- Add `sonnet` and `glm` agents to `agents.list` alongside `main`
- Add top-level `broadcast` section with `parallel` strategy routing all messages (`*`) to all three agents
- Every WhatsApp (and other channel) message now gets responses from Opus, Sonnet, and GLM in parallel

## Test plan
- [ ] Verify `llm-update.sh` regenerates `openclaw.template.json` correctly
- [ ] Verify `make format` passes cleanly
- [ ] Send a WhatsApp message and confirm all three models respond

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Sonnet and GLM agents and enable a parallel broadcast group so all inbound messages are routed to all three agents, returning multi-model replies across WhatsApp and other channels.

- **New Features**
  - Added sonnet and glm agents (real model IDs in openclaw.template.json; placeholders in openclaw.tpl.json).
  - Configured broadcast with parallel strategy routing "*" to main, sonnet, and glm.

- **Migration**
  - Run llm-update.sh to regenerate openclaw.template.json.
  - Send a test message to confirm parallel replies from all three agents.

<sup>Written for commit d279f7db5a9201e41bc99ecb56ab6ac23f0f71a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

