### PR TITLE
feat: add WhatsApp to homebrew and fix llm-update script

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -112,6 +112,7 @@
       "vscodium"
       "warp"
       "wezterm"
+      "whatsapp"
       "windsurf"
       "zed"
       "zoom"

--- a/scripts/llm-update.sh
+++ b/scripts/llm-update.sh
@@ -14,6 +14,7 @@ MODELS="$ROOT/models.json"
 
 # jq function: derive display name from a model ID
 # claude-opus-4.6 → "Claude Opus 4.6", claude-sonnet-4.5-20250929 → "Claude Sonnet 4.5"
+# shellcheck disable=SC2016
 JQ_PRETTY='def pretty:
   gsub("-20[0-9]{6}$";"") | gsub("-preview$";"") |
   split("-") |

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -52,7 +52,7 @@ The output should include 'def pretty'
 End
 
 It 'capitalizes Claude model names'
-When run bash -c "grep '"Claude"' '$SCRIPT'"
+When run bash -c "grep 'Claude' '$SCRIPT'"
 The output should include 'Claude'
 End
 End


### PR DESCRIPTION
## Changes Made
- Added WhatsApp to the list of brews in homebrew.nix
- Corrected shellcheck directive in llm-update.sh
- Updated grep command for Claude model names to fix pattern matching

## Technical Details
- Modified nix-darwin/config/homebrew.nix to include WhatsApp
- Fixed shellcheck directive in scripts/llm-update.sh
- Updated spec/llm_update_spec.sh with corrected grep pattern for model names

## Testing
- All pre-commit hooks pass (Biome formatting, linting)
- Shellcheck validation passes
- Manual testing completed

🤖 Generated with opencode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add WhatsApp to the nix-darwin Homebrew apps and fix the llm-update script/test so linting passes and Claude model names match correctly.

- **New Features**
  - Add "whatsapp" to nix-darwin/config/homebrew.nix for automatic install.

- **Bug Fixes**
  - Disable ShellCheck SC2016 for the JQ_PRETTY function in scripts/llm-update.sh.
  - Update grep in spec/llm_update_spec.sh to match Claude model names correctly.

<sup>Written for commit ee4103a568227bddd01a845deb9077a0f237679a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

