### PR TITLE
feat(openclaw): add broadcast groups with multi-model agents

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -213,7 +213,7 @@
   },
   "broadcast": {
     "strategy": "parallel",
-    "*": [
+    "120363425572081403@g.us": [
       "main",
       "sonnet",
       "glm"

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -208,15 +208,29 @@
         "model": {
           "primary": "cliproxy/glm-4.7"
         }
+      },
+      {
+        "id": "gpt-codex",
+        "model": {
+          "primary": "cliproxy/gpt-5.3-codex"
+        }
+      },
+      {
+        "id": "gemini-pro",
+        "model": {
+          "primary": "cliproxy/gemini-3-pro-preview"
+        }
       }
     ]
   },
   "broadcast": {
     "strategy": "parallel",
-    "120363425572081403@g.us": [
+    "120363425148909388@g.us": [
       "main",
       "sonnet",
-      "glm"
+      "glm",
+      "gpt-codex",
+      "gemini-pro"
     ]
   },
   "messages": {

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -198,39 +198,106 @@
         "default": true
       },
       {
-        "id": "sonnet",
+        "id": "code-reviewer-opus",
+        "name": "Code Reviewer (Opus)",
+        "workspace": "__HOME__/agents/code-review",
         "model": {
-          "primary": "cliproxy/claude-sonnet-4-5-20250929"
-        }
+          "primary": "cliproxy/claude-opus-4-6",
+          "fallbacks": ["cliproxy/glm-4.7"]
+        },
+        "tools": { "allow": ["read", "exec"] }
       },
       {
-        "id": "glm",
+        "id": "code-reviewer-sonnet",
+        "name": "Code Reviewer (Sonnet)",
+        "workspace": "__HOME__/agents/code-review",
+        "model": {
+          "primary": "cliproxy/claude-sonnet-4-5-20250929",
+          "fallbacks": ["cliproxy/glm-4.7"]
+        },
+        "tools": { "allow": ["read", "exec"] }
+      },
+      {
+        "id": "code-reviewer-glm",
+        "name": "Code Reviewer (GLM)",
+        "workspace": "__HOME__/agents/code-review",
         "model": {
           "primary": "cliproxy/glm-4.7"
-        }
+        },
+        "tools": { "allow": ["read", "exec"] }
       },
       {
-        "id": "gpt-codex",
+        "id": "code-reviewer-gpt-codex",
+        "name": "Code Reviewer (GPT Codex)",
+        "workspace": "__HOME__/agents/code-review",
         "model": {
-          "primary": "cliproxy/gpt-5.3-codex"
-        }
+          "primary": "cliproxy/gpt-5.3-codex",
+          "fallbacks": ["cliproxy/glm-4.7"]
+        },
+        "tools": { "allow": ["read", "exec"] }
       },
       {
-        "id": "gemini-pro",
+        "id": "code-reviewer-gemini",
+        "name": "Code Reviewer (Gemini Pro)",
+        "workspace": "__HOME__/agents/code-review",
         "model": {
-          "primary": "cliproxy/gemini-3-pro-preview"
-        }
+          "primary": "cliproxy/gemini-3-pro-preview",
+          "fallbacks": ["cliproxy/glm-4.7"]
+        },
+        "tools": { "allow": ["read", "exec"] }
+      },
+      {
+        "id": "code-formatter",
+        "name": "Code Formatter",
+        "workspace": "__HOME__/agents/formatter",
+        "model": {
+          "primary": "cliproxy/glm-4.7"
+        },
+        "tools": { "allow": ["read", "write"] }
+      },
+      {
+        "id": "security-scanner",
+        "name": "Security Scanner",
+        "workspace": "__HOME__/agents/security",
+        "model": {
+          "primary": "cliproxy/claude-opus-4-6",
+          "fallbacks": ["cliproxy/claude-sonnet-4-5-20250929"]
+        },
+        "tools": { "allow": ["read", "exec"] }
+      },
+      {
+        "id": "test-coverage",
+        "name": "Test Coverage",
+        "workspace": "__HOME__/agents/testing",
+        "model": {
+          "primary": "cliproxy/glm-4.7"
+        },
+        "tools": { "allow": ["read", "exec"] }
+      },
+      {
+        "id": "docs-checker",
+        "name": "Docs Checker",
+        "workspace": "__HOME__/agents/docs",
+        "model": {
+          "primary": "cliproxy/claude-sonnet-4-5-20250929",
+          "fallbacks": ["cliproxy/glm-4.7"]
+        },
+        "tools": { "allow": ["read"] }
       }
     ]
   },
   "broadcast": {
     "strategy": "parallel",
     "120363425148909388@g.us": [
-      "main",
-      "sonnet",
-      "glm",
-      "gpt-codex",
-      "gemini-pro"
+      "code-reviewer-opus",
+      "code-reviewer-sonnet",
+      "code-reviewer-glm",
+      "code-reviewer-gpt-codex",
+      "code-reviewer-gemini",
+      "code-formatter",
+      "security-scanner",
+      "test-coverage",
+      "docs-checker"
     ]
   },
   "messages": {

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -203,9 +203,16 @@
         "workspace": "__HOME__/agents/code-review",
         "model": {
           "primary": "cliproxy/claude-opus-4-6",
-          "fallbacks": ["cliproxy/glm-4.7"]
+          "fallbacks": [
+            "cliproxy/glm-4.7"
+          ]
         },
-        "tools": { "allow": ["read", "exec"] }
+        "tools": {
+          "allow": [
+            "read",
+            "exec"
+          ]
+        }
       },
       {
         "id": "code-reviewer-sonnet",
@@ -213,9 +220,16 @@
         "workspace": "__HOME__/agents/code-review",
         "model": {
           "primary": "cliproxy/claude-sonnet-4-5-20250929",
-          "fallbacks": ["cliproxy/glm-4.7"]
+          "fallbacks": [
+            "cliproxy/glm-4.7"
+          ]
         },
-        "tools": { "allow": ["read", "exec"] }
+        "tools": {
+          "allow": [
+            "read",
+            "exec"
+          ]
+        }
       },
       {
         "id": "code-reviewer-glm",
@@ -224,7 +238,12 @@
         "model": {
           "primary": "cliproxy/glm-4.7"
         },
-        "tools": { "allow": ["read", "exec"] }
+        "tools": {
+          "allow": [
+            "read",
+            "exec"
+          ]
+        }
       },
       {
         "id": "code-reviewer-gpt-codex",
@@ -232,9 +251,16 @@
         "workspace": "__HOME__/agents/code-review",
         "model": {
           "primary": "cliproxy/gpt-5.3-codex",
-          "fallbacks": ["cliproxy/glm-4.7"]
+          "fallbacks": [
+            "cliproxy/glm-4.7"
+          ]
         },
-        "tools": { "allow": ["read", "exec"] }
+        "tools": {
+          "allow": [
+            "read",
+            "exec"
+          ]
+        }
       },
       {
         "id": "code-reviewer-gemini",
@@ -242,9 +268,16 @@
         "workspace": "__HOME__/agents/code-review",
         "model": {
           "primary": "cliproxy/gemini-3-pro-preview",
-          "fallbacks": ["cliproxy/glm-4.7"]
+          "fallbacks": [
+            "cliproxy/glm-4.7"
+          ]
         },
-        "tools": { "allow": ["read", "exec"] }
+        "tools": {
+          "allow": [
+            "read",
+            "exec"
+          ]
+        }
       },
       {
         "id": "code-formatter",
@@ -253,7 +286,12 @@
         "model": {
           "primary": "cliproxy/glm-4.7"
         },
-        "tools": { "allow": ["read", "write"] }
+        "tools": {
+          "allow": [
+            "read",
+            "write"
+          ]
+        }
       },
       {
         "id": "security-scanner",
@@ -261,9 +299,16 @@
         "workspace": "__HOME__/agents/security",
         "model": {
           "primary": "cliproxy/claude-opus-4-6",
-          "fallbacks": ["cliproxy/claude-sonnet-4-5-20250929"]
+          "fallbacks": [
+            "cliproxy/claude-sonnet-4-5-20250929"
+          ]
         },
-        "tools": { "allow": ["read", "exec"] }
+        "tools": {
+          "allow": [
+            "read",
+            "exec"
+          ]
+        }
       },
       {
         "id": "test-coverage",
@@ -272,7 +317,12 @@
         "model": {
           "primary": "cliproxy/glm-4.7"
         },
-        "tools": { "allow": ["read", "exec"] }
+        "tools": {
+          "allow": [
+            "read",
+            "exec"
+          ]
+        }
       },
       {
         "id": "docs-checker",
@@ -280,9 +330,15 @@
         "workspace": "__HOME__/agents/docs",
         "model": {
           "primary": "cliproxy/claude-sonnet-4-5-20250929",
-          "fallbacks": ["cliproxy/glm-4.7"]
+          "fallbacks": [
+            "cliproxy/glm-4.7"
+          ]
         },
-        "tools": { "allow": ["read"] }
+        "tools": {
+          "allow": [
+            "read"
+          ]
+        }
       }
     ]
   },
@@ -350,7 +406,7 @@
       },
       "sendReadReceipts": true,
       "ackReaction": {
-        "emoji": "\ud83d\udc40",
+        "emoji": "👀",
         "direct": true,
         "group": "mentions"
       }

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -196,7 +196,27 @@
       {
         "id": "main",
         "default": true
+      },
+      {
+        "id": "sonnet",
+        "model": {
+          "primary": "cliproxy/claude-sonnet-4-5-20250929"
+        }
+      },
+      {
+        "id": "glm",
+        "model": {
+          "primary": "cliproxy/glm-4.7"
+        }
       }
+    ]
+  },
+  "broadcast": {
+    "strategy": "parallel",
+    "*": [
+      "main",
+      "sonnet",
+      "glm"
     ]
   },
   "messages": {

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -213,7 +213,7 @@
   },
   "broadcast": {
     "strategy": "parallel",
-    "*": [
+    "120363425572081403@g.us": [
       "main",
       "sonnet",
       "glm"

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -208,15 +208,29 @@
         "model": {
           "primary": "cliproxy/__GLM__"
         }
+      },
+      {
+        "id": "gpt-codex",
+        "model": {
+          "primary": "cliproxy/__GPT_CODEX__"
+        }
+      },
+      {
+        "id": "gemini-pro",
+        "model": {
+          "primary": "cliproxy/__GEMINI_PRO__"
+        }
       }
     ]
   },
   "broadcast": {
     "strategy": "parallel",
-    "120363425572081403@g.us": [
+    "120363425148909388@g.us": [
       "main",
       "sonnet",
-      "glm"
+      "glm",
+      "gpt-codex",
+      "gemini-pro"
     ]
   },
   "messages": {

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -198,39 +198,106 @@
         "default": true
       },
       {
-        "id": "sonnet",
+        "id": "code-reviewer-opus",
+        "name": "Code Reviewer (Opus)",
+        "workspace": "__HOME__/agents/code-review",
         "model": {
-          "primary": "cliproxy/__CLAUDE_SONNET__"
-        }
+          "primary": "cliproxy/__CLAUDE_OPUS__",
+          "fallbacks": ["cliproxy/__GLM__"]
+        },
+        "tools": { "allow": ["read", "exec"] }
       },
       {
-        "id": "glm",
+        "id": "code-reviewer-sonnet",
+        "name": "Code Reviewer (Sonnet)",
+        "workspace": "__HOME__/agents/code-review",
+        "model": {
+          "primary": "cliproxy/__CLAUDE_SONNET__",
+          "fallbacks": ["cliproxy/__GLM__"]
+        },
+        "tools": { "allow": ["read", "exec"] }
+      },
+      {
+        "id": "code-reviewer-glm",
+        "name": "Code Reviewer (GLM)",
+        "workspace": "__HOME__/agents/code-review",
         "model": {
           "primary": "cliproxy/__GLM__"
-        }
+        },
+        "tools": { "allow": ["read", "exec"] }
       },
       {
-        "id": "gpt-codex",
+        "id": "code-reviewer-gpt-codex",
+        "name": "Code Reviewer (GPT Codex)",
+        "workspace": "__HOME__/agents/code-review",
         "model": {
-          "primary": "cliproxy/__GPT_CODEX__"
-        }
+          "primary": "cliproxy/__GPT_CODEX__",
+          "fallbacks": ["cliproxy/__GLM__"]
+        },
+        "tools": { "allow": ["read", "exec"] }
       },
       {
-        "id": "gemini-pro",
+        "id": "code-reviewer-gemini",
+        "name": "Code Reviewer (Gemini Pro)",
+        "workspace": "__HOME__/agents/code-review",
         "model": {
-          "primary": "cliproxy/__GEMINI_PRO__"
-        }
+          "primary": "cliproxy/__GEMINI_PRO__",
+          "fallbacks": ["cliproxy/__GLM__"]
+        },
+        "tools": { "allow": ["read", "exec"] }
+      },
+      {
+        "id": "code-formatter",
+        "name": "Code Formatter",
+        "workspace": "__HOME__/agents/formatter",
+        "model": {
+          "primary": "cliproxy/__GLM__"
+        },
+        "tools": { "allow": ["read", "write"] }
+      },
+      {
+        "id": "security-scanner",
+        "name": "Security Scanner",
+        "workspace": "__HOME__/agents/security",
+        "model": {
+          "primary": "cliproxy/__CLAUDE_OPUS__",
+          "fallbacks": ["cliproxy/__CLAUDE_SONNET__"]
+        },
+        "tools": { "allow": ["read", "exec"] }
+      },
+      {
+        "id": "test-coverage",
+        "name": "Test Coverage",
+        "workspace": "__HOME__/agents/testing",
+        "model": {
+          "primary": "cliproxy/__GLM__"
+        },
+        "tools": { "allow": ["read", "exec"] }
+      },
+      {
+        "id": "docs-checker",
+        "name": "Docs Checker",
+        "workspace": "__HOME__/agents/docs",
+        "model": {
+          "primary": "cliproxy/__CLAUDE_SONNET__",
+          "fallbacks": ["cliproxy/__GLM__"]
+        },
+        "tools": { "allow": ["read"] }
       }
     ]
   },
   "broadcast": {
     "strategy": "parallel",
     "120363425148909388@g.us": [
-      "main",
-      "sonnet",
-      "glm",
-      "gpt-codex",
-      "gemini-pro"
+      "code-reviewer-opus",
+      "code-reviewer-sonnet",
+      "code-reviewer-glm",
+      "code-reviewer-gpt-codex",
+      "code-reviewer-gemini",
+      "code-formatter",
+      "security-scanner",
+      "test-coverage",
+      "docs-checker"
     ]
   },
   "messages": {

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -196,7 +196,27 @@
       {
         "id": "main",
         "default": true
+      },
+      {
+        "id": "sonnet",
+        "model": {
+          "primary": "cliproxy/__CLAUDE_SONNET__"
+        }
+      },
+      {
+        "id": "glm",
+        "model": {
+          "primary": "cliproxy/__GLM__"
+        }
       }
+    ]
+  },
+  "broadcast": {
+    "strategy": "parallel",
+    "*": [
+      "main",
+      "sonnet",
+      "glm"
     ]
   },
   "messages": {

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -203,9 +203,16 @@
         "workspace": "__HOME__/agents/code-review",
         "model": {
           "primary": "cliproxy/__CLAUDE_OPUS__",
-          "fallbacks": ["cliproxy/__GLM__"]
+          "fallbacks": [
+            "cliproxy/__GLM__"
+          ]
         },
-        "tools": { "allow": ["read", "exec"] }
+        "tools": {
+          "allow": [
+            "read",
+            "exec"
+          ]
+        }
       },
       {
         "id": "code-reviewer-sonnet",
@@ -213,9 +220,16 @@
         "workspace": "__HOME__/agents/code-review",
         "model": {
           "primary": "cliproxy/__CLAUDE_SONNET__",
-          "fallbacks": ["cliproxy/__GLM__"]
+          "fallbacks": [
+            "cliproxy/__GLM__"
+          ]
         },
-        "tools": { "allow": ["read", "exec"] }
+        "tools": {
+          "allow": [
+            "read",
+            "exec"
+          ]
+        }
       },
       {
         "id": "code-reviewer-glm",
@@ -224,7 +238,12 @@
         "model": {
           "primary": "cliproxy/__GLM__"
         },
-        "tools": { "allow": ["read", "exec"] }
+        "tools": {
+          "allow": [
+            "read",
+            "exec"
+          ]
+        }
       },
       {
         "id": "code-reviewer-gpt-codex",
@@ -232,9 +251,16 @@
         "workspace": "__HOME__/agents/code-review",
         "model": {
           "primary": "cliproxy/__GPT_CODEX__",
-          "fallbacks": ["cliproxy/__GLM__"]
+          "fallbacks": [
+            "cliproxy/__GLM__"
+          ]
         },
-        "tools": { "allow": ["read", "exec"] }
+        "tools": {
+          "allow": [
+            "read",
+            "exec"
+          ]
+        }
       },
       {
         "id": "code-reviewer-gemini",
@@ -242,9 +268,16 @@
         "workspace": "__HOME__/agents/code-review",
         "model": {
           "primary": "cliproxy/__GEMINI_PRO__",
-          "fallbacks": ["cliproxy/__GLM__"]
+          "fallbacks": [
+            "cliproxy/__GLM__"
+          ]
         },
-        "tools": { "allow": ["read", "exec"] }
+        "tools": {
+          "allow": [
+            "read",
+            "exec"
+          ]
+        }
       },
       {
         "id": "code-formatter",
@@ -253,7 +286,12 @@
         "model": {
           "primary": "cliproxy/__GLM__"
         },
-        "tools": { "allow": ["read", "write"] }
+        "tools": {
+          "allow": [
+            "read",
+            "write"
+          ]
+        }
       },
       {
         "id": "security-scanner",
@@ -261,9 +299,16 @@
         "workspace": "__HOME__/agents/security",
         "model": {
           "primary": "cliproxy/__CLAUDE_OPUS__",
-          "fallbacks": ["cliproxy/__CLAUDE_SONNET__"]
+          "fallbacks": [
+            "cliproxy/__CLAUDE_SONNET__"
+          ]
         },
-        "tools": { "allow": ["read", "exec"] }
+        "tools": {
+          "allow": [
+            "read",
+            "exec"
+          ]
+        }
       },
       {
         "id": "test-coverage",
@@ -272,7 +317,12 @@
         "model": {
           "primary": "cliproxy/__GLM__"
         },
-        "tools": { "allow": ["read", "exec"] }
+        "tools": {
+          "allow": [
+            "read",
+            "exec"
+          ]
+        }
       },
       {
         "id": "docs-checker",
@@ -280,9 +330,15 @@
         "workspace": "__HOME__/agents/docs",
         "model": {
           "primary": "cliproxy/__CLAUDE_SONNET__",
-          "fallbacks": ["cliproxy/__GLM__"]
+          "fallbacks": [
+            "cliproxy/__GLM__"
+          ]
         },
-        "tools": { "allow": ["read"] }
+        "tools": {
+          "allow": [
+            "read"
+          ]
+        }
       }
     ]
   },
@@ -350,7 +406,7 @@
       },
       "sendReadReceipts": true,
       "ackReaction": {
-        "emoji": "\ud83d\udc40",
+        "emoji": "👀",
         "direct": true,
         "group": "mentions"
       }


### PR DESCRIPTION
## Summary
- Add `sonnet` and `glm` agents to `agents.list` alongside `main`
- Add `broadcast` section with `parallel` strategy targeting WhatsApp group `120363425572081403@g.us`
- All three models (Opus, Sonnet, GLM) now respond in parallel to every message in the broadcast group

## Details
- Uses the specific WhatsApp group JID as the broadcast peer key (wildcard `*` is not supported)
- Each agent maintains separate session state and conversation history

## Test plan
- [x] `llm-update.sh` regenerates `openclaw.template.json` correctly
- [x] `make format` passes cleanly
- [x] Live config updated and gateway restarted
- [ ] Send a WhatsApp message and confirm all three models respond

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable parallel multi-model replies in the Code Review WhatsApp group (120363425148909388@g.us) using a broadcast strategy. Nine agents now respond to every message (5 reviewers + 4 specialists), and the config is formatted for nix with the ack reaction emoji set to 👀.

<sup>Written for commit ac3981ed6fe768d4dad0ac274614b2388ee03c7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

