### PR TITLE
feat(fish): switch kyberd/kyberm from zellij to tmux

### DIFF
--- a/home-manager/programs/fish/functions/_kyberd_function.fish
+++ b/home-manager/programs/fish/functions/_kyberd_function.fish
@@ -1,3 +1,3 @@
-function _kyberd_function --description "SSH to Kyber with zellij desktop session"
-  ssh -t ubuntu@(tailscale ip -4 kyber) "zellij attach desktop -c"
+function _kyberd_function --description "SSH to Kyber with tmux desktop session"
+  ssh -t ubuntu@(tailscale ip -4 kyber) "tmux new-session -A -s desktop"
 end

--- a/home-manager/programs/fish/functions/_kyberm_function.fish
+++ b/home-manager/programs/fish/functions/_kyberm_function.fish
@@ -1,3 +1,3 @@
-function _kyberm_function --description "SSH to Kyber with zellij mobile session"
-  ssh -t ubuntu@(tailscale ip -4 kyber) "zellij attach mobile -c"
+function _kyberm_function --description "SSH to Kyber with tmux mobile session"
+  ssh -t ubuntu@(tailscale ip -4 kyber) "tmux new-session -A -s mobile"
 end


### PR DESCRIPTION
Switch Kyber SSH session managers from zellij to tmux.

- `kyberd`: `zellij attach desktop -c` → `tmux new-session -A -s desktop`
- `kyberm`: `zellij attach mobile -c` → `tmux new-session -A -s mobile`

`-A` attaches to existing session or creates new — same behavior as zellij's `-c` flag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Kyber SSH helpers from zellij to tmux while keeping attach-or-create behavior. kyberd now runs "tmux new-session -A -s desktop" and kyberm runs "tmux new-session -A -s mobile".

<sup>Written for commit 7802191de19b28a1ee2fb80f17ce2194e4bb21eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

