### PR TITLE
revert(fish): switch kyberd/kyberm back to zellij

### DIFF
--- a/home-manager/programs/fish/functions/_kyberd_function.fish
+++ b/home-manager/programs/fish/functions/_kyberd_function.fish
@@ -1,3 +1,3 @@
-function _kyberd_function --description "SSH to Kyber with tmux desktop session"
-  ssh -t ubuntu@(tailscale ip -4 kyber) "tmux new-session -A -s desktop"
+function _kyberd_function --description "SSH to Kyber with zellij desktop session"
+  ssh -t ubuntu@(tailscale ip -4 kyber) "zellij attach desktop -c"
 end

--- a/home-manager/programs/fish/functions/_kyberm_function.fish
+++ b/home-manager/programs/fish/functions/_kyberm_function.fish
@@ -1,3 +1,3 @@
-function _kyberm_function --description "SSH to Kyber with tmux mobile session"
-  ssh -t ubuntu@(tailscale ip -4 kyber) "tmux new-session -A -s mobile"
+function _kyberm_function --description "SSH to Kyber with zellij mobile session"
+  ssh -t ubuntu@(tailscale ip -4 kyber) "zellij attach mobile -c"
 end


### PR DESCRIPTION
Reverts the tmux change from #823. Back to zellij for Kyber SSH sessions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts Kyber SSH helpers to zellij to restore the previous session workflow. _kyberd_function and _kyberm_function now run "zellij attach desktop -c" and "zellij attach mobile -c" instead of tmux new-session.

<sup>Written for commit 659078c3e1d45d89776f8b70aff15a49785903ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

