### PR TITLE
feat(hyprland): increase hypridle dim timeout to 15 minutes

### DIFF
--- a/config/hyprland/hypridle.conf
+++ b/config/hyprland/hypridle.conf
@@ -5,9 +5,9 @@ general {
     inhibit_sleep = 3
 }
 
-# Dim screen after 3 minutes
+# Dim screen after 15 minutes
 listener {
-    timeout = 180
+    timeout = 900
     on-timeout = brightnessctl -s set 10
     on-resume = brightnessctl -r
 }


### PR DESCRIPTION
## Summary
- Increase the hypridle screen dim timeout from 3 minutes to 15 minutes on matic

## Test plan
- [ ] Verify hypridle picks up the new config after restart
- [ ] Confirm screen dims after 15 minutes of inactivity

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase hypridle screen dim timeout on matic from 3 minutes to 15 minutes. Prevents premature dimming during longer tasks.

- **Migration**
  - Restart hypridle or Hyprland to apply the config.
  - Verify the screen dims after 15 minutes of inactivity and brightness restores on resume.

<sup>Written for commit 9e7fc28054231df5c9daa050a679215a2d989d22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

