### PR TITLE
feat(openclaw): add group chat history for code review agents

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -222,6 +222,12 @@
             "read",
             "exec"
           ]
+        },
+        "groupChat": {
+          "historyLimit": 100,
+          "mentionPatterns": [
+            ".*"
+          ]
         }
       },
       {
@@ -239,6 +245,12 @@
             "read",
             "exec"
           ]
+        },
+        "groupChat": {
+          "historyLimit": 100,
+          "mentionPatterns": [
+            ".*"
+          ]
         }
       },
       {
@@ -252,6 +264,12 @@
           "allow": [
             "read",
             "exec"
+          ]
+        },
+        "groupChat": {
+          "historyLimit": 100,
+          "mentionPatterns": [
+            ".*"
           ]
         }
       },
@@ -270,6 +288,12 @@
             "read",
             "exec"
           ]
+        },
+        "groupChat": {
+          "historyLimit": 100,
+          "mentionPatterns": [
+            ".*"
+          ]
         }
       },
       {
@@ -286,6 +310,12 @@
           "allow": [
             "read",
             "exec"
+          ]
+        },
+        "groupChat": {
+          "historyLimit": 100,
+          "mentionPatterns": [
+            ".*"
           ]
         }
       },

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -222,6 +222,12 @@
             "read",
             "exec"
           ]
+        },
+        "groupChat": {
+          "historyLimit": 100,
+          "mentionPatterns": [
+            ".*"
+          ]
         }
       },
       {
@@ -239,6 +245,12 @@
             "read",
             "exec"
           ]
+        },
+        "groupChat": {
+          "historyLimit": 100,
+          "mentionPatterns": [
+            ".*"
+          ]
         }
       },
       {
@@ -252,6 +264,12 @@
           "allow": [
             "read",
             "exec"
+          ]
+        },
+        "groupChat": {
+          "historyLimit": 100,
+          "mentionPatterns": [
+            ".*"
           ]
         }
       },
@@ -270,6 +288,12 @@
             "read",
             "exec"
           ]
+        },
+        "groupChat": {
+          "historyLimit": 100,
+          "mentionPatterns": [
+            ".*"
+          ]
         }
       },
       {
@@ -286,6 +310,12 @@
           "allow": [
             "read",
             "exec"
+          ]
+        },
+        "groupChat": {
+          "historyLimit": 100,
+          "mentionPatterns": [
+            ".*"
           ]
         }
       },


### PR DESCRIPTION
Enable historyLimit=100 for all code-reviewer agents in WhatsApp group. This allows agents to see the last 100 messages in the Code Review group for better context when consolidating reviews and discussions.

## Changes
- Set `groupChat.historyLimit` to 100 for all code-reviewer agents
- Pattern matches all messages (`.*`) to capture full context

## Impact
Agents in the Code Review WhatsApp group will now receive the last 100 messages as context, enabling them to:
- Consolidate reviews from multiple agents
- Reference previous discussions
- Better understand conversation flow

Token cost per message will increase due to larger context, but improves review quality significantly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enabled group chat history for code-reviewer agents in the Code Review WhatsApp group. Agents now load the last 100 messages for better context when reviewing and consolidating feedback; this may slightly increase token usage.

- **New Features**
  - Set groupChat.historyLimit to 100 for all code-reviewer agents.
  - Set groupChat.mentionPatterns to ".*" to include all messages.

<sup>Written for commit 48dfbeb7efd805641a2881bcedcb6ecc923f9c83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

