### PR TITLE
fix(openclaw): remove unrecognized groupChat.historyLimit

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -222,12 +222,6 @@
             "read",
             "exec"
           ]
-        },
-        "groupChat": {
-          "historyLimit": 100,
-          "mentionPatterns": [
-            ".*"
-          ]
         }
       },
       {
@@ -245,12 +239,6 @@
             "read",
             "exec"
           ]
-        },
-        "groupChat": {
-          "historyLimit": 100,
-          "mentionPatterns": [
-            ".*"
-          ]
         }
       },
       {
@@ -264,12 +252,6 @@
           "allow": [
             "read",
             "exec"
-          ]
-        },
-        "groupChat": {
-          "historyLimit": 100,
-          "mentionPatterns": [
-            ".*"
           ]
         }
       },
@@ -288,12 +270,6 @@
             "read",
             "exec"
           ]
-        },
-        "groupChat": {
-          "historyLimit": 100,
-          "mentionPatterns": [
-            ".*"
-          ]
         }
       },
       {
@@ -310,12 +286,6 @@
           "allow": [
             "read",
             "exec"
-          ]
-        },
-        "groupChat": {
-          "historyLimit": 100,
-          "mentionPatterns": [
-            ".*"
           ]
         }
       },

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -222,12 +222,6 @@
             "read",
             "exec"
           ]
-        },
-        "groupChat": {
-          "historyLimit": 100,
-          "mentionPatterns": [
-            ".*"
-          ]
         }
       },
       {
@@ -245,12 +239,6 @@
             "read",
             "exec"
           ]
-        },
-        "groupChat": {
-          "historyLimit": 100,
-          "mentionPatterns": [
-            ".*"
-          ]
         }
       },
       {
@@ -264,12 +252,6 @@
           "allow": [
             "read",
             "exec"
-          ]
-        },
-        "groupChat": {
-          "historyLimit": 100,
-          "mentionPatterns": [
-            ".*"
           ]
         }
       },
@@ -288,12 +270,6 @@
             "read",
             "exec"
           ]
-        },
-        "groupChat": {
-          "historyLimit": 100,
-          "mentionPatterns": [
-            ".*"
-          ]
         }
       },
       {
@@ -310,12 +286,6 @@
           "allow": [
             "read",
             "exec"
-          ]
-        },
-        "groupChat": {
-          "historyLimit": 100,
-          "mentionPatterns": [
-            ".*"
           ]
         }
       },


### PR DESCRIPTION
## Summary
- Remove `groupChat` blocks (containing `historyLimit` and `mentionPatterns`) from all 5 code reviewer agents
- `historyLimit` is not a recognized key in OpenClaw's config schema, causing the gateway to crash-loop with a validation error on startup

## Test plan
- [x] `openclaw doctor` reports 0 errors after fix
- [x] Gateway starts successfully after removing the key
- [x] `make format` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed invalid groupChat.historyLimit keys from all code reviewer agents to fix OpenClaw gateway startup validation errors. The gateway now starts cleanly without crash-loops.

- **Bug Fixes**
  - Removed groupChat blocks from 5 code reviewer agents in openclaw.template.json and openclaw.tpl.json.
  - Verified with openclaw doctor (0 errors); gateway starts; formatting checks pass.

<sup>Written for commit c41edcf64858c07545aab88d694d8bcd37f974bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

