### PR TITLE
feat(openclaw): switch broadcast strategy to sequential

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -695,7 +695,7 @@
     }
   ],
   "broadcast": {
-    "strategy": "parallel",
+    "strategy": "sequential",
     "120363425148909388@g.us": [
       "code-reviewer-opus",
       "code-reviewer-sonnet",

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -695,7 +695,7 @@
     }
   ],
   "broadcast": {
-    "strategy": "parallel",
+    "strategy": "sequential",
     "120363425148909388@g.us": [
       "code-reviewer-opus",
       "code-reviewer-sonnet",


### PR DESCRIPTION
Switch broadcast from parallel to sequential so agents can see each other's responses via the shared group context buffer.

- Code Review: 9 agents run in order, each building on previous feedback
- Twitter/Dev/Strategy: same — sequential responses that reference each other

2-file change: `openclaw.tpl.json` + `openclaw.template.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set broadcast.strategy to "sequential" in openclaw.template.json and openclaw.tpl.json to let agents read and build on prior messages via the shared group context. Code Review and Twitter/Dev/Strategy pipelines now run agents one-by-one for incremental, referenced responses.

<sup>Written for commit b2342112033d53c35d47cd10f3165a616c4200e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

