### PR TITLE
feat: add git-ai and worktrunk config modules

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -14,6 +14,7 @@ in
   ./direnv
   ./factory
   ./gemini
+  ./git-ai
   ./ghostty
   ./iterm2
   ./hammerspoon
@@ -26,6 +27,7 @@ in
   ./pi
   ./serena
   ./starship
+  ./worktrunk
   ./zellij
 ]
 ++ (

--- a/config/git-ai/config.json
+++ b/config/git-ai/config.json
@@ -1,0 +1,7 @@
+{
+  "prompt_storage": "notes",
+  "disable_auto_updates": true,
+  "disable_version_checks": true,
+  "quiet": false,
+  "update_channel": "latest"
+}

--- a/config/git-ai/default.nix
+++ b/config/git-ai/default.nix
@@ -1,14 +1,13 @@
+{ config, pkgs, ... }:
+let
+  baseConfig = builtins.fromJSON (builtins.readFile ./config.json);
+  hydratedConfig = baseConfig // {
+    git_path = "${pkgs.git}/bin/git";
+  };
+in
 {
-  config,
-  lib,
-  pkgs,
-  ...
-}:
-{
-  home.activation.gitAiConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    $DRY_RUN_CMD mkdir -p ~/.git-ai
-    GIT_PATH=$(${pkgs.which}/bin/which git 2>/dev/null || echo "${pkgs.git}/bin/git")
-    $DRY_RUN_CMD ${pkgs.jq}/bin/jq --arg gp "$GIT_PATH" '. + {git_path: $gp}' ${./config.json} > ~/.git-ai/config.json
-    $DRY_RUN_CMD chmod 600 ~/.git-ai/config.json
-  '';
+  home.file.".git-ai/config.json" = {
+    text = builtins.toJSON hydratedConfig;
+    force = true;
+  };
 }

--- a/config/git-ai/default.nix
+++ b/config/git-ai/default.nix
@@ -1,0 +1,14 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  home.activation.gitAiConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    $DRY_RUN_CMD mkdir -p ~/.git-ai
+    GIT_PATH=$(${pkgs.which}/bin/which git 2>/dev/null || echo "${pkgs.git}/bin/git")
+    $DRY_RUN_CMD ${pkgs.jq}/bin/jq --arg gp "$GIT_PATH" '. + {git_path: $gp}' ${./config.json} > ~/.git-ai/config.json
+    $DRY_RUN_CMD chmod 600 ~/.git-ai/config.json
+  '';
+}

--- a/config/worktrunk/config.toml
+++ b/config/worktrunk/config.toml
@@ -1,0 +1,14 @@
+worktree-path = "{{ repo_path }}/.worktrees/{{ branch | sanitize }}"
+
+[commit]
+stage = "all"
+
+[commit.generation]
+command = "MAX_THINKING_TOKENS=0 claude -p --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"
+
+[merge]
+squash = true
+commit = true
+rebase = true
+remove = true
+verify = true

--- a/config/worktrunk/config.toml
+++ b/config/worktrunk/config.toml
@@ -6,6 +6,9 @@ stage = "all"
 [commit.generation]
 command = "MAX_THINKING_TOKENS=0 claude -p --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"
 
+[list]
+summary = true
+
 [merge]
 squash = true
 commit = true

--- a/config/worktrunk/default.nix
+++ b/config/worktrunk/default.nix
@@ -1,0 +1,7 @@
+{ config, ... }:
+{
+  xdg.configFile."worktrunk/config.toml" = {
+    source = ./config.toml;
+    force = true;
+  };
+}


### PR DESCRIPTION
## Summary
- Add `config/git-ai/` to manage `~/.git-ai/config.json` with Nix profile git path and prompt storage via git notes
- Add `config/worktrunk/` to manage `~/.config/worktrunk/config.toml` with LLM commit generation (claude haiku) and squash merge defaults
- Register both in `config/default.nix`

## Test plan
- [ ] Verify `home-manager switch` applies both configs
- [ ] Confirm `git-ai status` works without "could not locate git" error
- [ ] Confirm `wt config show` picks up the new config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Home Manager modules for git-ai and worktrunk to manage configs and standardize behavior. git-ai uses Nix’s git and notes; worktrunk enables Claude Haiku commit generation, branch summaries in the picker, and squash merge defaults.

- **New Features**
  - Registered both modules in config/default.nix.
  - git-ai: writes ~/.git-ai/config.json, injects git_path from pkgs.git, uses notes for prompt storage, disables auto-updates/version checks.
  - worktrunk: writes ~/.config/worktrunk/config.toml with stage=all, Claude Haiku generation command, templated worktree path, squash merge defaults, and list summaries enabled in the picker.

- **Refactors**
  - git-ai config is hydrated via Nix and written declaratively with home.file.

<sup>Written for commit 00b412dac0dee5d11d89cf7bb2c8a46947da2f32. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

