### PR TITLE
feat(matic): persist GPG passphrase across reboots

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -396,9 +396,15 @@ inputs.nixpkgs.lib.nixosSystem {
           services.gpg-agent = {
             enable = true;
             enableSshSupport = false;
-            pinentry.package = pkgs.pinentry-tty;
+            pinentry.package = pkgs.pinentry-gnome3;
             defaultCacheTtl = 94608000; # 3 years
             maxCacheTtl = 94608000; # 3 years
+          };
+
+          # GNOME Keyring for persistent GPG passphrase storage across reboots
+          services.gnome-keyring = {
+            enable = true;
+            components = [ "secrets" ];
           };
 
           # GPG_TTY is set in fish shell init instead of sessionVariables


### PR DESCRIPTION
## Summary
- Switch `pinentry-tty` to `pinentry-gnome3` for GNOME Keyring (libsecret) integration
- Enable `services.gnome-keyring` with `secrets` component for persistent storage
- GPG signing passphrase now survives reboots instead of being lost from in-memory cache

## Test plan
- [ ] `sudo nixos-rebuild switch`
- [ ] Sign a commit — GUI pinentry dialog should appear
- [ ] Check "Save in password manager" checkbox
- [ ] Reboot and sign another commit — passphrase should be retrieved automatically

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the GPG signing passphrase across reboots on matic by switching to pinentry-gnome3 and enabling GNOME Keyring (secrets). Signing prompts can be saved to the keyring and are loaded automatically after reboot.

<sup>Written for commit ee3698877f4499c170368dc4f923b8e39c517b47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

