### PR TITLE
Disable scheduled execution for Renovate

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,7 +1,7 @@
 name: Renovate
 on:
-  schedule:
-    - cron: '0 3 * * *'
+  # schedule:
+  #   - cron: '0 3 * * *'
   workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.sha }}


### PR DESCRIPTION
Comment out the scheduled cron job for Renovate workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the nightly cron for the Renovate workflow so it no longer runs on a schedule. Renovate now runs only when manually dispatched from GitHub Actions.

<sup>Written for commit e16ad59c72a200402f80f5552489176ad44ceba3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

