### PR TITLE
feat: add git-ai CI workflow for authorship tracking

### DIFF
--- a/.github/workflows/git-ai.yaml
+++ b/.github/workflows/git-ai.yaml
@@ -1,0 +1,22 @@
+name: Git AI
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  git-ai:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Install git-ai
+        run: |
+          curl -fsSL https://usegitai.com/install.sh | bash
+          echo "$HOME/.git-ai/bin" >> $GITHUB_PATH
+      - name: Run git-ai
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git-ai ci github run


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow that runs `git-ai ci github run` on PR merge
- Tracks AI authorship via git notes (`refs/notes/`), no commits to main
- Compatible with merge queues — triggers on `pull_request: closed`

## Test plan
- [ ] Verify workflow triggers on merged PR
- [ ] Confirm authorship notes are pushed to `refs/notes/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow that runs git-ai on merged PRs and records authorship in refs/notes without changing history. Triggers on pull_request: closed, uses GITHUB_TOKEN with contents: write, and works with merge queues.

<sup>Written for commit 805a0172af9bb923ff480acb6e818ac74ad8ba98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

