### PR TITLE
fix: declarative build for telescope-fzf-native.nvim

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -7,6 +7,8 @@
     pkgs.neovim
     pkgs.shellcheck
     pkgs.shellspec
+    pkgs.gnumake
+    pkgs.gcc
   ];
 
   containers = pkgs.lib.mkIf (!pkgs.stdenv.hostPlatform.isLinux) (pkgs.lib.mkForce { });

--- a/home-manager/programs/neovim/default.nix
+++ b/home-manager/programs/neovim/default.nix
@@ -7,6 +7,9 @@
 let
   nvimInitLua = ./init.lua;
   nvimPackLockJson = ./nvim-pack-lock.json;
+  packDir = "$HOME/.local/share/nvim/site/pack";
+  buildTools = if pkgs.stdenv.isDarwin then [ pkgs.gnumake pkgs.clang ] else [ pkgs.gnumake pkgs.gcc ];
+  libExt = "so";
 in
 {
   programs.neovim = {
@@ -32,5 +35,20 @@ in
     $DRY_RUN_CMD mkdir -p "$HOME/.config/nvim"
     $DRY_RUN_CMD cp -f ${nvimPackLockJson} "$HOME/.config/nvim/nvim-pack-lock.json"
     $DRY_RUN_CMD chmod 644 "$HOME/.config/nvim/nvim-pack-lock.json"
+  '';
+
+  home.activation.buildNvimNativePlugins = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    export PATH="${lib.makeBinPath buildTools}:$PATH"
+    fzf_dir=""
+    for d in ${packDir}/*/opt/telescope-fzf-native.nvim ${packDir}/*/start/telescope-fzf-native.nvim; do
+      if [ -d "$d" ]; then
+        fzf_dir="$d"
+        break
+      fi
+    done
+    if [ -n "$fzf_dir" ] && [ ! -f "$fzf_dir/build/libfzf.${libExt}" ]; then
+      echo "Building telescope-fzf-native.nvim in $fzf_dir..."
+      $DRY_RUN_CMD make -C "$fzf_dir" clean all
+    fi
   '';
 }

--- a/home-manager/programs/neovim/default.nix
+++ b/home-manager/programs/neovim/default.nix
@@ -8,7 +8,17 @@ let
   nvimInitLua = ./init.lua;
   nvimPackLockJson = ./nvim-pack-lock.json;
   packDir = "$HOME/.local/share/nvim/site/pack";
-  buildTools = if pkgs.stdenv.isDarwin then [ pkgs.gnumake pkgs.clang ] else [ pkgs.gnumake pkgs.gcc ];
+  buildTools =
+    if pkgs.stdenv.isDarwin then
+      [
+        pkgs.gnumake
+        pkgs.clang
+      ]
+    else
+      [
+        pkgs.gnumake
+        pkgs.gcc
+      ];
   libExt = "so";
 in
 {

--- a/home-manager/programs/neovim/lua/config/keymaps.lua
+++ b/home-manager/programs/neovim/lua/config/keymaps.lua
@@ -40,8 +40,14 @@ end, opts)
 keymap("n", "[b", function()
 	utils.cycle_buffer("prev")
 end, opts)
--- @keymap <leader>q: Close current buffer
-keymap("n", "<leader>q", ":Bdelete<CR>", opts)
+-- @keymap <leader>q: Close current window/split, or delete buffer if last window
+keymap("n", "<leader>q", function()
+	if #vim.api.nvim_tabpage_list_wins(0) > 1 then
+		vim.cmd("close")
+	else
+		vim.cmd("Bdelete")
+	end
+end, opts)
 -- @keymap <leader>bad: Wipe all buffers
 keymap("n", "<leader>bad", ":%bwipeout!<cr>:intro<cr>", opts)
 -- @keymap <leader>w: Write file
@@ -200,12 +206,12 @@ keymap("n", "<leader>dl", vim.diagnostic.open_float, { desc = "Line Diagnostics"
 -- ====================================================================================
 -- @keymap <leader>ff: Open fff file picker
 keymap("n", "<leader>ff", function()
-	require("fff").open()
+	require("fff").find_files()
 end, { desc = "FFF File Picker" })
 
 -- @keymap <leader>fp: Open fff file picker (alternate)
 keymap("n", "<leader>fp", function()
-	require("fff").open()
+	require("fff").find_files()
 end, { desc = "FFF File Picker" })
 
 -- ====================================================================================

--- a/home-manager/programs/neovim/lua/config/keymaps.lua
+++ b/home-manager/programs/neovim/lua/config/keymaps.lua
@@ -52,6 +52,8 @@ end, opts)
 keymap("n", "<leader>bad", ":%bwipeout!<cr>:intro<cr>", opts)
 -- @keymap <leader>w: Write file
 keymap("n", "<leader>w", ":write<CR>", opts)
+-- @keymap <leader>W: Save all and quit
+keymap("n", "<leader>W", ":wall | qall<CR>", opts)
 -- @keymap <leader>r: Reload Neovim configuration
 keymap("n", "<leader>r", function()
 	vim.cmd("source $MYVIMRC")

--- a/home-manager/programs/neovim/lua/config/settings.lua
+++ b/home-manager/programs/neovim/lua/config/settings.lua
@@ -103,6 +103,7 @@ vim.diagnostic.config({
 vim.opt.shortmess:append("c")
 vim.opt.timeoutlen = 300
 vim.opt.winborder = "none"
+vim.opt.fillchars:append({ vert = " ", vertsplit = " " })
 -- Suppress deprecation warnings (temporary until plugins update)
 vim.deprecate = function() end
 vim.hl.priorities.semantic_tokens = 10

--- a/home-manager/programs/neovim/lua/config/settings.lua
+++ b/home-manager/programs/neovim/lua/config/settings.lua
@@ -103,7 +103,7 @@ vim.diagnostic.config({
 vim.opt.shortmess:append("c")
 vim.opt.timeoutlen = 300
 vim.opt.winborder = "none"
-vim.opt.fillchars:append({ vert = " ", vertsplit = " " })
+vim.opt.fillchars:append({ vert = " " })
 -- Suppress deprecation warnings (temporary until plugins update)
 vim.deprecate = function() end
 vim.hl.priorities.semantic_tokens = 10

--- a/home-manager/programs/neovim/lua/config/telescope.lua
+++ b/home-manager/programs/neovim/lua/config/telescope.lua
@@ -40,7 +40,7 @@ telescope.setup({
 	},
 })
 telescope.load_extension("gh")
-pcall(telescope.load_extension, "fzf")
+telescope.load_extension("fzf")
 telescope.load_extension("ui-select")
 
 local function ivy(iopts)

--- a/home-manager/programs/neovim/lua/config/telescope.lua
+++ b/home-manager/programs/neovim/lua/config/telescope.lua
@@ -40,7 +40,7 @@ telescope.setup({
 	},
 })
 telescope.load_extension("gh")
-telescope.load_extension("fzf")
+pcall(telescope.load_extension, "fzf")
 telescope.load_extension("ui-select")
 
 local function ivy(iopts)

--- a/home-manager/programs/neovim/run_tests.sh
+++ b/home-manager/programs/neovim/run_tests.sh
@@ -38,13 +38,14 @@ cd "$NVIM_DIR"
 echo -e "${YELLOW}Executing tests...${NC}"
 nvim --headless \
   -u tests/minimal_init.lua \
-  -c "lua require('plenary.test_harness').test_directory('tests/', { minimal_init = 'tests/minimal_init.lua', sequential = true })" 2>&1 | tee /tmp/nvim-test-output.txt
+  -c "lua require('plenary.test_harness').test_directory('tests/', { minimal_init = 'tests/minimal_init.lua', sequential = true })"
 
-# Plenary exits with code 2 even on success, so check output for failures instead
-if grep -q "Failed : \s*[1-9]" /tmp/nvim-test-output.txt || grep -q "Errors : \s*[1-9]" /tmp/nvim-test-output.txt; then
-  echo -e "${RED}Tests failed!${NC}"
-  exit 1
-else
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -eq 0 ]; then
   echo -e "${GREEN}All tests passed!${NC}"
-  exit 0
+else
+  echo -e "${RED}Tests failed with exit code: $EXIT_CODE${NC}"
 fi
+
+exit $EXIT_CODE

--- a/home-manager/programs/neovim/run_tests.sh
+++ b/home-manager/programs/neovim/run_tests.sh
@@ -31,6 +31,15 @@ fi
 # Export plenary directory for minimal_init.lua
 export PLENARY_DIR
 
+# Build telescope-fzf-native if libfzf.so is missing
+PACK_DIR="$HOME/.local/share/nvim/site/pack"
+for d in "$PACK_DIR"/*/opt/telescope-fzf-native.nvim "$PACK_DIR"/*/start/telescope-fzf-native.nvim; do
+  if [ -d "$d" ] && [ ! -f "$d/build/libfzf.so" ]; then
+    echo -e "${YELLOW}Building telescope-fzf-native.nvim...${NC}"
+    make -C "$d" clean all
+  fi
+done
+
 # Change to the nvim config directory
 cd "$NVIM_DIR"
 

--- a/home-manager/programs/neovim/run_tests.sh
+++ b/home-manager/programs/neovim/run_tests.sh
@@ -38,14 +38,13 @@ cd "$NVIM_DIR"
 echo -e "${YELLOW}Executing tests...${NC}"
 nvim --headless \
   -u tests/minimal_init.lua \
-  -c "lua require('plenary.test_harness').test_directory('tests/', { minimal_init = 'tests/minimal_init.lua', sequential = true })"
+  -c "lua require('plenary.test_harness').test_directory('tests/', { minimal_init = 'tests/minimal_init.lua', sequential = true })" 2>&1 | tee /tmp/nvim-test-output.txt
 
-EXIT_CODE=$?
-
-if [ $EXIT_CODE -eq 0 ]; then
-  echo -e "${GREEN}All tests passed!${NC}"
+# Plenary exits with code 2 even on success, so check output for failures instead
+if grep -q "Failed : \s*[1-9]" /tmp/nvim-test-output.txt || grep -q "Errors : \s*[1-9]" /tmp/nvim-test-output.txt; then
+  echo -e "${RED}Tests failed!${NC}"
+  exit 1
 else
-  echo -e "${RED}Tests failed with exit code: $EXIT_CODE${NC}"
+  echo -e "${GREEN}All tests passed!${NC}"
+  exit 0
 fi
-
-exit $EXIT_CODE

--- a/home-manager/programs/neovim/run_tests.sh
+++ b/home-manager/programs/neovim/run_tests.sh
@@ -31,8 +31,22 @@ fi
 # Export plenary directory for minimal_init.lua
 export PLENARY_DIR
 
-# Build telescope-fzf-native if libfzf.so is missing
+# Bootstrap plugins so vim.pack installs them before tests run
 PACK_DIR="$HOME/.local/share/nvim/site/pack"
+FZF_NATIVE_FOUND=false
+for d in "$PACK_DIR"/*/opt/telescope-fzf-native.nvim "$PACK_DIR"/*/start/telescope-fzf-native.nvim; do
+  if [ -d "$d" ]; then
+    FZF_NATIVE_FOUND=true
+    break
+  fi
+done
+
+if [ "$FZF_NATIVE_FOUND" = false ]; then
+  echo -e "${YELLOW}Bootstrapping plugins (first run)...${NC}"
+  nvim --headless -u "$NVIM_DIR/init.lua" -c 'qall!' 2>/dev/null || true
+fi
+
+# Build telescope-fzf-native if libfzf.so is missing
 for d in "$PACK_DIR"/*/opt/telescope-fzf-native.nvim "$PACK_DIR"/*/start/telescope-fzf-native.nvim; do
   if [ -d "$d" ] && [ ! -f "$d/build/libfzf.so" ]; then
     echo -e "${YELLOW}Building telescope-fzf-native.nvim...${NC}"

--- a/home-manager/programs/neovim/tests/plugins_spec.lua
+++ b/home-manager/programs/neovim/tests/plugins_spec.lua
@@ -79,34 +79,4 @@ describe("plugins", function()
 		end)
 	end)
 
-	describe("e2e init.lua loading", function()
-		it("should load full config without Lua errors", function()
-			-- Capture any Lua errors that occur during init.lua sourcing
-			local errors = {}
-			local orig_notify = vim.notify
-			vim.notify = function(msg, level)
-				if level == vim.log.levels.ERROR then
-					table.insert(errors, msg)
-				end
-			end
-
-			-- Locate init.lua relative to this test file
-			local tests_dir = debug.getinfo(1, "S").source:sub(2):match("(.*/)")
-			local nvim_dir = vim.fn.fnamemodify(tests_dir, ":h")
-			local init_lua = nvim_dir .. "/init.lua"
-
-			local ok, err = pcall(function()
-				vim.cmd("source " .. init_lua)
-			end)
-
-			vim.notify = orig_notify
-
-			-- If pcall caught an error, the config has a loading problem
-			if not ok then
-				-- Allow known CI-only failures (missing plugins in test env)
-				-- but flag unexpected errors
-				assert.is_true(ok, "init.lua raised an error: " .. tostring(err))
-			end
-		end)
-	end)
 end)

--- a/home-manager/programs/neovim/tests/plugins_spec.lua
+++ b/home-manager/programs/neovim/tests/plugins_spec.lua
@@ -105,10 +105,7 @@ describe("plugins", function()
 			if not ok then
 				-- Allow known CI-only failures (missing plugins in test env)
 				-- but flag unexpected errors
-				assert.is_true(
-					ok,
-					"init.lua raised an error: " .. tostring(err)
-				)
+				assert.is_true(ok, "init.lua raised an error: " .. tostring(err))
 			end
 		end)
 	end)

--- a/home-manager/programs/neovim/tests/plugins_spec.lua
+++ b/home-manager/programs/neovim/tests/plugins_spec.lua
@@ -79,4 +79,34 @@ describe("plugins", function()
 		end)
 	end)
 
+	describe("e2e init.lua loading", function()
+		it("should load full config without Lua errors", function()
+			-- Capture any Lua errors that occur during init.lua sourcing
+			local errors = {}
+			local orig_notify = vim.notify
+			vim.notify = function(msg, level)
+				if level == vim.log.levels.ERROR then
+					table.insert(errors, msg)
+				end
+			end
+
+			-- Locate init.lua relative to this test file (tests/ -> parent nvim dir)
+			local source = debug.getinfo(1, "S").source:sub(2)
+			local nvim_dir = vim.fn.fnamemodify(source, ":p:h:h")
+			local init_lua = nvim_dir .. "/init.lua"
+
+			local ok, err = pcall(function()
+				vim.cmd("source " .. init_lua)
+			end)
+
+			vim.notify = orig_notify
+
+			-- If pcall caught an error, the config has a loading problem
+			if not ok then
+				-- Allow known CI-only failures (missing plugins in test env)
+				-- but flag unexpected errors
+				assert.is_true(ok, "init.lua raised an error: " .. tostring(err))
+			end
+		end)
+	end)
 end)

--- a/home-manager/programs/neovim/tests/plugins_spec.lua
+++ b/home-manager/programs/neovim/tests/plugins_spec.lua
@@ -78,4 +78,38 @@ describe("plugins", function()
 			assert.equals("~", signs_config.change.text)
 		end)
 	end)
+
+	describe("e2e init.lua loading", function()
+		it("should load full config without Lua errors", function()
+			-- Capture any Lua errors that occur during init.lua sourcing
+			local errors = {}
+			local orig_notify = vim.notify
+			vim.notify = function(msg, level)
+				if level == vim.log.levels.ERROR then
+					table.insert(errors, msg)
+				end
+			end
+
+			-- Locate init.lua relative to this test file
+			local tests_dir = debug.getinfo(1, "S").source:sub(2):match("(.*/)")
+			local nvim_dir = vim.fn.fnamemodify(tests_dir, ":h")
+			local init_lua = nvim_dir .. "/init.lua"
+
+			local ok, err = pcall(function()
+				vim.cmd("source " .. init_lua)
+			end)
+
+			vim.notify = orig_notify
+
+			-- If pcall caught an error, the config has a loading problem
+			if not ok then
+				-- Allow known CI-only failures (missing plugins in test env)
+				-- but flag unexpected errors
+				assert.is_true(
+					ok,
+					"init.lua raised an error: " .. tostring(err)
+				)
+			end
+		end)
+	end)
 end)


### PR DESCRIPTION
## Summary
- Add `buildNvimNativePlugins` home-manager activation script that compiles `libfzf.so` on `make switch` when missing
- Wrap `telescope.load_extension("fzf")` in `pcall` as defense-in-depth
- Add e2e test that sources full `init.lua` headlessly to catch plugin loading errors

## Test plan
- [x] `make build` succeeds
- [x] `make switch` succeeds and activation script compiles `libfzf.so`
- [x] `nvim` starts without E5113 error
- [x] `ls ~/.local/share/nvim/site/pack/core/opt/telescope-fzf-native.nvim/build/` shows `libfzf.so`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declarative build for telescope-fzf-native.nvim so libfzf.so compiles on switch and in CI before tests, with plugin bootstrap and a subprocess e2e check to ensure init.lua loads cleanly.

- **Bug Fixes**
  - Build libfzf.so on Home Manager activation by scanning pack dirs; run make clean all if missing. In CI, bootstrap plugins headlessly, then compile if lib is missing (gnumake/gcc added to devenv).
  - Load telescope fzf extension normally; remove pcall guard to surface real errors.
  - Keymaps: fff uses find_files; <leader>q closes window or deletes buffer if last; <leader>W saves all and quits.
  - Hide split separators with fillchars vert=" "; remove deprecated vertsplit to avoid E474.
  - E2E: run init.lua in a separate headless Neovim process so vim.pack loads opt plugins; fix path resolution.

- **Refactors**
  - Format Nix and Lua files.

<sup>Written for commit 2794bed1e5dbbb9d412d35ac2e54e1dc73344f7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

