### PR TITLE
feat: replace walker with rofi as launcher

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -37,7 +37,6 @@ in
       ./hyprland
       ./hyprpanel
       ./rofi
-      ./walker
     ]
   else
     [ ]

--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -218,11 +218,6 @@ layerrule = ignore_alpha 0.3, match:namespace ^(bar-\d+)$
 layerrule = blur on, match:namespace ^(notifications-window)$
 layerrule = ignore_alpha 0.3, match:namespace ^(notifications-window)$
 
-# Blur for walker
-layerrule = blur on, match:namespace ^(walker)$
-layerrule = ignore_alpha on, match:namespace ^(walker)$
-layerrule = animation slide top, match:namespace ^(walker)$
-
 # Blur for rofi
 layerrule = blur on, match:namespace ^(rofi)$
 layerrule = ignore_alpha 0.3, match:namespace ^(rofi)$
@@ -250,7 +245,7 @@ bind = $mod, A, exec, pavucontrol
 # =============================================================================
 # Launcher & Clipboard
 # =============================================================================
-bind = CTRL ALT SHIFT SUPER, SPACE, exec, walker
+bind = CTRL ALT SHIFT SUPER, SPACE, exec, rofi -show drun -show-icons
 bind = $mod, E, exec, sh -c 'rofimoji --action copy --skin-tone neutral && sleep 0.2 && wtype -M ctrl -k v -m ctrl'
 
 # =============================================================================

--- a/config/rofi/default.nix
+++ b/config/rofi/default.nix
@@ -4,4 +4,84 @@
     source = ./config.rasi;
     force = true;
   };
+
+  xdg.desktopEntries = {
+    restart = {
+      name = "Restart";
+      exec = "systemctl reboot";
+      icon = "system-reboot";
+      categories = [ "System" ];
+      noDisplay = false;
+    };
+    shutdown = {
+      name = "Shutdown";
+      exec = "systemctl poweroff";
+      icon = "system-shutdown";
+      categories = [ "System" ];
+      noDisplay = false;
+    };
+    suspend = {
+      name = "Suspend";
+      exec = "systemctl suspend";
+      icon = "system-suspend";
+      categories = [ "System" ];
+      noDisplay = false;
+    };
+    lock-screen = {
+      name = "Lock Screen";
+      exec = "hyprlock";
+      icon = "system-lock-screen";
+      categories = [ "System" ];
+      noDisplay = false;
+    };
+    screen-saver = {
+      name = "Screen Saver";
+      exec = "hyprlock";
+      icon = "preferences-desktop-screensaver";
+      categories = [ "System" ];
+      noDisplay = false;
+    };
+    logout = {
+      name = "Logout";
+      exec = "hyprctl dispatch exit";
+      icon = "system-log-out";
+      categories = [ "System" ];
+      noDisplay = false;
+    };
+    toggle-wifi = {
+      name = "Toggle WiFi";
+      exec = "nmcli radio wifi toggle";
+      icon = "network-wireless";
+      categories = [ "System" ];
+      noDisplay = false;
+    };
+    audio-settings = {
+      name = "Audio Settings";
+      exec = "pavucontrol";
+      icon = "audio-volume-high";
+      categories = [ "System" "Settings" ];
+      noDisplay = false;
+    };
+    bluetooth-settings = {
+      name = "Bluetooth Settings";
+      exec = "blueman-manager";
+      icon = "bluetooth";
+      categories = [ "System" "Settings" ];
+      noDisplay = false;
+    };
+    screenshot-region = {
+      name = "Screenshot Region";
+      exec = "hyprshot -m region";
+      icon = "accessories-screenshot";
+      categories = [ "Utility" ];
+      noDisplay = false;
+    };
+    color-picker = {
+      name = "Color Picker";
+      exec = "hyprpicker -a";
+      icon = "color-select";
+      categories = [ "Utility" ];
+      noDisplay = false;
+    };
+  };
 }

--- a/config/rofi/default.nix
+++ b/config/rofi/default.nix
@@ -59,14 +59,20 @@
       name = "Audio Settings";
       exec = "pavucontrol";
       icon = "audio-volume-high";
-      categories = [ "System" "Settings" ];
+      categories = [
+        "System"
+        "Settings"
+      ];
       noDisplay = false;
     };
     bluetooth-settings = {
       name = "Bluetooth Settings";
       exec = "blueman-manager";
       icon = "bluetooth";
-      categories = [ "System" "Settings" ];
+      categories = [
+        "System"
+        "Settings"
+      ];
       noDisplay = false;
     };
     screenshot-region = {

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -150,7 +150,6 @@ with pkgs;
   totem
   vlc
   vscode
-  walker
   wf-recorder
   wl-clip-persist
   wl-clipboard


### PR DESCRIPTION
## Summary
- Replace walker/elephant launcher with rofi (`rofi -show drun -show-icons`)
- Remove walker package, config, and hyprland layer rules
- Add desktop entries for system commands (restart, shutdown, suspend, lock, logout, etc.)

## Test plan
- [ ] Verify `Ctrl+Alt+Shift+Super+Space` opens rofi launcher
- [ ] Verify system commands (Restart, Shutdown, etc.) appear in rofi search
- [ ] Verify rofi frosted glass blur effect works

Generated with Claude Code by claude-opus-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced Walker with Rofi as the app launcher to simplify launching and make common system actions searchable. Updated the launcher keybind to run "rofi -show drun -show-icons" and removed Walker config and packages.

- **New Features**
  - Added desktop entries for system actions (restart, shutdown, suspend, lock, screen saver, logout, WiFi toggle, audio/bluetooth settings, screenshot, color picker).
  - Rofi uses Hyprland’s blur for the frosted-glass effect.

- **Refactors**
  - Removed Walker module, package, and Hyprland layer rules.
  - Dropped Walker from home-manager packages.
  - Ran make format on configs.

<sup>Written for commit 0b3ea9ea6a14bc582c079cb41bb3fe33dda17150. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

