### PR TITLE
fix: add PAM integration for GPG passphrase persistence across reboots

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -70,6 +70,9 @@ inputs.nixpkgs.lib.nixosSystem {
 
         security.sudo.wheelNeedsPassword = false;
 
+        # PAM integration for GNOME Keyring auto-unlock on login
+        security.pam.services.greetd.enableGnomeKeyring = true;
+
         # Keyd configuration (Linux desktop only)
         services.keyd.enable = true;
         users.groups.keyd = { };
@@ -396,9 +399,15 @@ inputs.nixpkgs.lib.nixosSystem {
           services.gpg-agent = {
             enable = true;
             enableSshSupport = false;
-            pinentry.package = pkgs.pinentry-tty;
+            pinentry.package = pkgs.pinentry-gnome3;
             defaultCacheTtl = 94608000; # 3 years
             maxCacheTtl = 94608000; # 3 years
+          };
+
+          # GNOME Keyring for persistent GPG passphrase storage across reboots
+          services.gnome-keyring = {
+            enable = true;
+            components = [ "secrets" ];
           };
 
           # GPG_TTY is set in fish shell init instead of sessionVariables

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -62,11 +62,15 @@ inputs.nixpkgs.lib.nixosSystem {
             "networkmanager"
             "input"
             "video"
+            "docker"
           ];
           home = "/home/${username}";
           shell = pkgs.fish;
           initialPassword = "changemeow"; # Change this after first login with: passwd
         };
+
+        # Docker
+        virtualisation.docker.enable = true;
 
         security.sudo.wheelNeedsPassword = false;
 

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -74,9 +74,6 @@ inputs.nixpkgs.lib.nixosSystem {
 
         security.sudo.wheelNeedsPassword = false;
 
-        # PAM integration for GNOME Keyring auto-unlock on login
-        security.pam.services.greetd.enableGnomeKeyring = true;
-
         # Keyd configuration (Linux desktop only)
         services.keyd.enable = true;
         users.groups.keyd = { };
@@ -403,15 +400,9 @@ inputs.nixpkgs.lib.nixosSystem {
           services.gpg-agent = {
             enable = true;
             enableSshSupport = false;
-            pinentry.package = pkgs.pinentry-gnome3;
+            pinentry.package = pkgs.pinentry-tty;
             defaultCacheTtl = 94608000; # 3 years
             maxCacheTtl = 94608000; # 3 years
-          };
-
-          # GNOME Keyring for persistent GPG passphrase storage across reboots
-          services.gnome-keyring = {
-            enable = true;
-            components = [ "secrets" ];
           };
 
           # GPG_TTY is set in fish shell init instead of sessionVariables


### PR DESCRIPTION
The original PR #844 was missing the critical PAM integration needed to auto-unlock GNOME Keyring on login via greetd. Without it, the keyring stays locked after reboot and GPG passphrases can't be auto-retrieved.

Changes:
- Add security.pam.services.greetd.enableGnomeKeyring for auto-unlock
- Switch pinentry from tty to gnome3 for keyring integration
- Enable GNOME Keyring secrets service for persistent storage

https://claude.ai/code/session_01MoWYgtw2oTthtJLLZFHqTo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures GPG passphrases persist across reboots by auto-unlocking GNOME Keyring on greetd login and integrating gpg-agent with GNOME pinentry.

- **Bug Fixes**
  - Enable PAM integration: security.pam.services.greetd.enableGnomeKeyring = true.
  - Switch gpg-agent pinentry to pkgs.pinentry-gnome3 for keyring integration.
  - Enable GNOME Keyring with the secrets component for persistent storage.

- **New Features**
  - Enable Docker and add the user to the docker group to support the docker-postgres service.

<sup>Written for commit 5fec16d134fba6157537ea5366be4ea79922dafb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

