### PR TITLE
feat: add macOS split keybindings for ghostty

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -33,11 +33,23 @@ keybind = ctrl+alt+h=goto_split:left
 keybind = ctrl+alt+j=goto_split:down
 keybind = ctrl+alt+k=goto_split:up
 keybind = ctrl+alt+l=goto_split:right
+keybind = super+alt+h=goto_split:left
+keybind = super+alt+j=goto_split:down
+keybind = super+alt+k=goto_split:up
+keybind = super+alt+l=goto_split:right
+keybind = super+alt+left=goto_split:left
+keybind = super+alt+down=goto_split:down
+keybind = super+alt+up=goto_split:up
+keybind = super+alt+right=goto_split:right
 
 # Create new splits
 keybind = ctrl+shift+backslash=new_split:right
 keybind = ctrl+shift+equal=new_split:right
 keybind = ctrl+shift+minus=new_split:down
+keybind = super+d=new_split:right
+keybind = super+shift+d=new_split:down
+keybind = super+shift+backslash=new_split:right
+keybind = super+minus=new_split:down
 
 # Split management
 keybind = ctrl+shift+z=toggle_split_zoom


### PR DESCRIPTION
## Changes
- Add Cmd+D / Cmd+Shift+D for creating splits (iTerm2-style)
- Add Cmd+Shift+\ (Cmd+|) / Cmd+- for creating splits
- Add Cmd+Option+H/J/K/L for Vim-style split navigation
- Add Cmd+Option+Arrow keys for split navigation

## Testing
- Restart Ghostty and verify keybindings work

Generated with Claude Code by claude-opus-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add macOS-friendly keybindings for creating and navigating splits in Ghostty. Supports iTerm2-style creation and Vim-style navigation with Cmd and Cmd+Option.

- **New Features**
  - Split creation: Cmd+D (right), Cmd+Shift+D (down), Cmd+Shift+\ (right), Cmd+- (down).
  - Split navigation: Cmd+Option+H/J/K/L and Cmd+Option+Arrow keys.

- **Migration**
  - Restart Ghostty to load the updated config.

<sup>Written for commit f6e42ccd64cc49762e522d4dbff35e2ee9492a51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

