### PR TITLE
fix: add git-ai bin to PATH for authorship tracking

### DIFF
--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -48,13 +48,14 @@
 
       # Add additional bin paths
       export PATH="$PATH:$GOPATH/bin"
-      export PATH="$HOME/.bun/bin:$PATH"
-      export PATH="$HOME/.cargo/bin:$PATH"
-      export PATH="$HOME/.local/bin:$PATH"
       export PATH="$HOME/.nix-profile/bin:$PATH"
       export PATH="/nix/var/nix/profiles/default/bin:$PATH"
       export PATH="/opt/homebrew/bin:$PATH"
       export PATH="/opt/homebrew/opt/postgresql@18/bin:$PATH"
+      export PATH="$HOME/.git-ai/bin:$PATH"
+      export PATH="$HOME/.cargo/bin:$PATH"
+      export PATH="$HOME/.bun/bin:$PATH"
+      export PATH="$HOME/.local/bin:$PATH"
 
       # Worktrunk shell init
       if command -v wt >/dev/null 2>&1; then

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -29,15 +29,16 @@
           eval "$(/opt/homebrew/bin/brew shellenv)"
       end
 
-      fish_add_path -p ~/.local/bin
-      fish_add_path -p ~/.bun/bin
-      fish_add_path -p ~/.cargo/bin
       fish_add_path -p ~/.nix-profile/bin
       fish_add_path -p ~/go/bin
       fish_add_path -p /nix/var/nix/profiles/default/bin
       fish_add_path -p /opt/homebrew/bin
       fish_add_path -p /opt/homebrew/opt/postgresql@18/bin
       fish_add_path -p /etc/profiles/per-user/${config.home.username}/bin
+      fish_add_path -p ~/.git-ai/bin
+      fish_add_path -p ~/.cargo/bin
+      fish_add_path -p ~/.bun/bin
+      fish_add_path -p ~/.local/bin
     '';
     interactiveShellInit = ''
       source ${config.home.homeDirectory}/.config/fish/functions/_hm_load_env_file.fish
@@ -49,15 +50,16 @@
           eval "$(/opt/homebrew/bin/brew shellenv)"
       end
 
-      fish_add_path -p ~/.local/bin
-      fish_add_path -p ~/.bun/bin
-      fish_add_path -p ~/.cargo/bin
       fish_add_path -p ~/.nix-profile/bin
       fish_add_path -p ~/go/bin
       fish_add_path -p /nix/var/nix/profiles/default/bin
       fish_add_path -p /opt/homebrew/bin
       fish_add_path -p /opt/homebrew/opt/postgresql@18/bin
       fish_add_path -p /etc/profiles/per-user/${config.home.username}/bin
+      fish_add_path -p ~/.git-ai/bin
+      fish_add_path -p ~/.cargo/bin
+      fish_add_path -p ~/.bun/bin
+      fish_add_path -p ~/.local/bin
       # Worktrunk shell init
       if type -q wt
         wt config shell init fish | source

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -49,13 +49,14 @@
 
       # Additional bin paths
       export PATH="$PATH:$GOPATH/bin"
-      export PATH="$HOME/.bun/bin:$PATH"
-      export PATH="$HOME/.cargo/bin:$PATH"
-      export PATH="$HOME/.local/bin:$PATH"
       export PATH="$HOME/.nix-profile/bin:$PATH"
       export PATH="/nix/var/nix/profiles/default/bin:$PATH"
       export PATH="/opt/homebrew/bin:$PATH"
       export PATH="/opt/homebrew/opt/postgresql@18/bin:$PATH"
+      export PATH="$HOME/.git-ai/bin:$PATH"
+      export PATH="$HOME/.cargo/bin:$PATH"
+      export PATH="$HOME/.bun/bin:$PATH"
+      export PATH="$HOME/.local/bin:$PATH"
 
       # FNM (Fast Node Manager) configuration
       export FNM_DIR="$HOME/Library/Application Support/fnm"


### PR DESCRIPTION
## Changes
- Reorder shell PATH so `~/.git-ai/bin` sits between nix system paths and `~/.cargo/bin`
- `git` resolves to the git-ai wrapper (`~/.git-ai/bin/git`) which intercepts commit/push to write and push `refs/notes/ai` authorship notes
- `git-ai` still resolves to `~/.cargo/bin/git-ai` (cargo-installed binary)
- Applied to both fish and zsh configs

## Technical Details
- `fish_add_path -p` prepends, so later calls get higher PATH priority
- Nix paths (lowest) → `~/.git-ai/bin` → `~/.cargo/bin` → `~/.bun/bin` → `~/.local/bin` (highest)
- The git-ai CI workflow was reporting "no AI authorship to track" because the git wrapper was never in PATH

## Testing
- Verified `which git` → `~/.git-ai/bin/git` (wrapper)
- Verified `which git-ai` → `~/.cargo/bin/git-ai` (cargo)

Generated with Claude Code by claude-opus-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures git authorship tracking works by putting ~/.git-ai/bin earlier in PATH so git resolves to the wrapper across fish, zsh, and bash. Fixes CI runs that showed “no authorship to track.”

- **Bug Fixes**
  - Reordered PATH in fish, zsh, and bash: nix paths → ~/.git-ai/bin → ~/.cargo/bin → ~/.bun/bin → ~/.local/bin.
  - git now resolves to ~/.git-ai/bin/git (wrapper); git-ai still resolves to ~/.cargo/bin/git-ai.
  - Verified with which git and which git-ai.

<sup>Written for commit 77009aaf26c9de60ffb7c9fafef3f768245ea18b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

