### PR TITLE
Revert "fix: add git-ai bin to PATH for authorship tracking"

### DIFF
--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -48,14 +48,13 @@
 
       # Add additional bin paths
       export PATH="$PATH:$GOPATH/bin"
+      export PATH="$HOME/.bun/bin:$PATH"
+      export PATH="$HOME/.cargo/bin:$PATH"
+      export PATH="$HOME/.local/bin:$PATH"
       export PATH="$HOME/.nix-profile/bin:$PATH"
       export PATH="/nix/var/nix/profiles/default/bin:$PATH"
       export PATH="/opt/homebrew/bin:$PATH"
       export PATH="/opt/homebrew/opt/postgresql@18/bin:$PATH"
-      export PATH="$HOME/.git-ai/bin:$PATH"
-      export PATH="$HOME/.cargo/bin:$PATH"
-      export PATH="$HOME/.bun/bin:$PATH"
-      export PATH="$HOME/.local/bin:$PATH"
 
       # Worktrunk shell init
       if command -v wt >/dev/null 2>&1; then

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -29,16 +29,15 @@
           eval "$(/opt/homebrew/bin/brew shellenv)"
       end
 
+      fish_add_path -p ~/.local/bin
+      fish_add_path -p ~/.bun/bin
+      fish_add_path -p ~/.cargo/bin
       fish_add_path -p ~/.nix-profile/bin
       fish_add_path -p ~/go/bin
       fish_add_path -p /nix/var/nix/profiles/default/bin
       fish_add_path -p /opt/homebrew/bin
       fish_add_path -p /opt/homebrew/opt/postgresql@18/bin
       fish_add_path -p /etc/profiles/per-user/${config.home.username}/bin
-      fish_add_path -p ~/.git-ai/bin
-      fish_add_path -p ~/.cargo/bin
-      fish_add_path -p ~/.bun/bin
-      fish_add_path -p ~/.local/bin
     '';
     interactiveShellInit = ''
       source ${config.home.homeDirectory}/.config/fish/functions/_hm_load_env_file.fish
@@ -50,16 +49,15 @@
           eval "$(/opt/homebrew/bin/brew shellenv)"
       end
 
+      fish_add_path -p ~/.local/bin
+      fish_add_path -p ~/.bun/bin
+      fish_add_path -p ~/.cargo/bin
       fish_add_path -p ~/.nix-profile/bin
       fish_add_path -p ~/go/bin
       fish_add_path -p /nix/var/nix/profiles/default/bin
       fish_add_path -p /opt/homebrew/bin
       fish_add_path -p /opt/homebrew/opt/postgresql@18/bin
       fish_add_path -p /etc/profiles/per-user/${config.home.username}/bin
-      fish_add_path -p ~/.git-ai/bin
-      fish_add_path -p ~/.cargo/bin
-      fish_add_path -p ~/.bun/bin
-      fish_add_path -p ~/.local/bin
       # Worktrunk shell init
       if type -q wt
         wt config shell init fish | source

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -49,14 +49,13 @@
 
       # Additional bin paths
       export PATH="$PATH:$GOPATH/bin"
+      export PATH="$HOME/.bun/bin:$PATH"
+      export PATH="$HOME/.cargo/bin:$PATH"
+      export PATH="$HOME/.local/bin:$PATH"
       export PATH="$HOME/.nix-profile/bin:$PATH"
       export PATH="/nix/var/nix/profiles/default/bin:$PATH"
       export PATH="/opt/homebrew/bin:$PATH"
       export PATH="/opt/homebrew/opt/postgresql@18/bin:$PATH"
-      export PATH="$HOME/.git-ai/bin:$PATH"
-      export PATH="$HOME/.cargo/bin:$PATH"
-      export PATH="$HOME/.bun/bin:$PATH"
-      export PATH="$HOME/.local/bin:$PATH"
 
       # FNM (Fast Node Manager) configuration
       export FNM_DIR="$HOME/Library/Application Support/fnm"


### PR DESCRIPTION
Reverts shunkakinoki/dotfiles#876

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the change that added ~/.git-ai/bin to PATH. Removes the git-ai path from bash, zsh, and fish configs and restores the original PATH order.

<sup>Written for commit 5f9ccd4cdc30b2d9b996fa3631400e4673f651c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

