### PR TITLE
deps: add rtk dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,6 +1188,7 @@ name = "dotfiles"
 version = "0.1.0"
 dependencies = [
  "git-ai",
+ "rtk",
  "worktrunk",
 ]
 
@@ -3020,6 +3031,28 @@ dependencies = [
  "serde_derive",
  "typeid",
  "unicode-ident",
+]
+
+[[package]]
+name = "rtk"
+version = "0.22.1"
+source = "git+https://github.com/rtk-ai/rtk#7d561cca51e4e177d353e6514a618e5bb09eebc6"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "colored",
+ "dirs 5.0.1",
+ "ignore",
+ "lazy_static",
+ "regex",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "toml 0.8.23",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ path = "lib.rs"
 [dependencies]
 git-ai = { git = "https://github.com/git-ai-project/git-ai", branch = "main" }
 worktrunk = "0.26.1"
+rtk = { git = "https://github.com/rtk-ai/rtk" }


### PR DESCRIPTION
## Changes
- Added rtk from GitHub to Cargo.toml dependencies

## Technical Details
- rtk v0.22.1 from https://github.com/rtk-ai/rtk
- Regenerated Cargo.lock with new dependencies

Generated with opencode by GLM-4.7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added rtk as a git dependency and regenerated Cargo.lock. This enables using rtk in the codebase.

- **Dependencies**
  - Added rtk v0.22.1 from https://github.com/rtk-ai/rtk
  - Regenerated Cargo.lock to include transitive deps

<sup>Written for commit 4eb18e3e54e1b7db5a93b765420f451046553c53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

