### PR TITLE
test: add shellcheck disable and spec for rtk-rewrite.sh

### DIFF
--- a/config/claude/rtk-rewrite.sh
+++ b/config/claude/rtk-rewrite.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2001
 # RTK auto-rewrite hook for Claude Code PreToolUse:Bash
 # Transparently rewrites raw commands to their rtk equivalents.
 # Outputs JSON with updatedInput to modify the command before execution.

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -13,6 +13,10 @@ It 'has spec file for config/claude/pushover.sh'
 The path "spec/pushover_spec.sh" should be exist
 End
 
+It 'has spec file for config/claude/rtk-rewrite.sh'
+The path "spec/rtk_rewrite_spec.sh" should be exist
+End
+
 It 'has spec file for config/claude/security.sh'
 The path "spec/security_spec.sh" should be exist
 End
@@ -132,6 +136,7 @@ It 'covers all non-spec shell scripts in the repository'
 covered_scripts="config/ccs/hydrate.sh
 config/claude/notify.sh
 config/claude/pushover.sh
+config/claude/rtk-rewrite.sh
 config/claude/security.sh
 config/claude/statusline-git.sh
 config/hyprland/scripts/record-screen.sh

--- a/spec/rtk_rewrite_spec.sh
+++ b/spec/rtk_rewrite_spec.sh
@@ -7,7 +7,7 @@ SCRIPT="$PWD/config/claude/rtk-rewrite.sh"
 # Create a mock rtk binary so the guard passes in CI where rtk is not installed
 MOCK_BIN="$SHELLSPEC_TMPBASE/mock_bin"
 mkdir -p "$MOCK_BIN"
-printf '#!/bin/bash\nexit 0\n' > "$MOCK_BIN/rtk"
+printf '#!/bin/bash\nexit 0\n' >"$MOCK_BIN/rtk"
 chmod +x "$MOCK_BIN/rtk"
 
 run_hook() {

--- a/spec/rtk_rewrite_spec.sh
+++ b/spec/rtk_rewrite_spec.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'rtk-rewrite.sh'
+SCRIPT="$PWD/config/claude/rtk-rewrite.sh"
+
+Describe 'guards'
+It 'exits silently when no command in input'
+Data '{"tool_input": {}}'
+When run bash -c "bash '$SCRIPT'"
+The status should be success
+The output should eq ''
+End
+
+It 'exits silently for empty command'
+Data '{"tool_input": {"command": ""}}'
+When run bash -c "bash '$SCRIPT'"
+The status should be success
+The output should eq ''
+End
+End
+
+Describe 'skip conditions'
+It 'skips commands already using rtk'
+Data '{"tool_input": {"command": "rtk git status"}}'
+When run bash -c "bash '$SCRIPT'"
+The status should be success
+The output should eq ''
+End
+
+It 'skips heredoc commands'
+Data '{"tool_input": {"command": "cat <<EOF\nhello\nEOF"}}'
+When run bash -c "bash '$SCRIPT'"
+The status should be success
+The output should eq ''
+End
+End
+
+Describe 'git rewrites'
+It 'rewrites git status'
+Data '{"tool_input": {"command": "git status"}}'
+When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+The status should be success
+The output should eq 'rtk git status'
+End
+
+It 'rewrites git diff'
+Data '{"tool_input": {"command": "git diff"}}'
+When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+The status should be success
+The output should eq 'rtk git diff'
+End
+
+It 'rewrites git log with options'
+Data '{"tool_input": {"command": "git log --oneline -5"}}'
+When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+The status should be success
+The output should eq 'rtk git log --oneline -5'
+End
+
+It 'does not rewrite git clone'
+Data '{"tool_input": {"command": "git clone https://example.com/repo"}}'
+When run bash -c "bash '$SCRIPT'"
+The status should be success
+The output should eq ''
+End
+End
+
+Describe 'gh rewrites'
+It 'rewrites gh pr list'
+Data '{"tool_input": {"command": "gh pr list"}}'
+When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+The status should be success
+The output should eq 'rtk gh pr list'
+End
+
+It 'does not rewrite gh auth'
+Data '{"tool_input": {"command": "gh auth status"}}'
+When run bash -c "bash '$SCRIPT'"
+The status should be success
+The output should eq ''
+End
+End
+
+Describe 'cargo rewrites'
+It 'rewrites cargo test'
+Data '{"tool_input": {"command": "cargo test"}}'
+When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+The status should be success
+The output should eq 'rtk cargo test'
+End
+
+It 'rewrites cargo build'
+Data '{"tool_input": {"command": "cargo build"}}'
+When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+The status should be success
+The output should eq 'rtk cargo build'
+End
+
+It 'does not rewrite cargo new'
+Data '{"tool_input": {"command": "cargo new myproject"}}'
+When run bash -c "bash '$SCRIPT'"
+The status should be success
+The output should eq ''
+End
+End
+
+Describe 'file operation rewrites'
+It 'rewrites cat to rtk read'
+Data '{"tool_input": {"command": "cat file.txt"}}'
+When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+The status should be success
+The output should eq 'rtk read file.txt'
+End
+
+It 'rewrites ls'
+Data '{"tool_input": {"command": "ls -la"}}'
+When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+The status should be success
+The output should eq 'rtk ls -la'
+End
+
+It 'rewrites find'
+Data '{"tool_input": {"command": "find . -name \"*.ts\""}}'
+When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+The status should be success
+The output should include 'rtk find'
+End
+End
+
+Describe 'JS/TS tooling rewrites'
+It 'rewrites vitest'
+Data '{"tool_input": {"command": "vitest run"}}'
+When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+The status should be success
+The output should eq 'rtk vitest run'
+End
+
+It 'rewrites pnpm test'
+Data '{"tool_input": {"command": "pnpm test"}}'
+When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+The status should be success
+The output should eq 'rtk vitest run'
+End
+
+It 'rewrites npm test'
+Data '{"tool_input": {"command": "npm test"}}'
+When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+The status should be success
+The output should eq 'rtk npm test'
+End
+End
+
+Describe 'network rewrites'
+It 'rewrites curl'
+Data '{"tool_input": {"command": "curl https://example.com"}}'
+When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+The status should be success
+The output should include 'rtk curl'
+End
+End
+
+Describe 'python rewrites'
+It 'rewrites pytest'
+Data '{"tool_input": {"command": "pytest tests/"}}'
+When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+The status should be success
+The output should include 'rtk pytest'
+End
+End
+
+Describe 'go rewrites'
+It 'rewrites go test'
+Data '{"tool_input": {"command": "go test ./..."}}'
+When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+The status should be success
+The output should include 'rtk go test'
+End
+End
+
+Describe 'env prefix preservation'
+It 'preserves env vars in rewritten command'
+Data '{"tool_input": {"command": "FOO=bar git status"}}'
+When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+The status should be success
+The output should include 'FOO=bar rtk git status'
+End
+End
+
+Describe 'output format'
+It 'outputs valid JSON with hookSpecificOutput'
+Data '{"tool_input": {"command": "git status"}}'
+When run bash -c "bash '$SCRIPT' | jq -e '.hookSpecificOutput.permissionDecision'"
+The status should be success
+The output should include 'allow'
+End
+
+It 'preserves original tool_input fields'
+Data '{"tool_input": {"command": "git status", "timeout": 5000}}'
+When run bash -c "bash '$SCRIPT' | jq -e '.hookSpecificOutput.updatedInput.timeout'"
+The status should be success
+The output should include '5000'
+End
+End
+
+End

--- a/spec/rtk_rewrite_spec.sh
+++ b/spec/rtk_rewrite_spec.sh
@@ -4,17 +4,31 @@
 Describe 'rtk-rewrite.sh'
 SCRIPT="$PWD/config/claude/rtk-rewrite.sh"
 
+# Create a mock rtk binary so the guard passes in CI where rtk is not installed
+MOCK_BIN="$SHELLSPEC_TMPBASE/mock_bin"
+mkdir -p "$MOCK_BIN"
+printf '#!/bin/bash\nexit 0\n' > "$MOCK_BIN/rtk"
+chmod +x "$MOCK_BIN/rtk"
+
+run_hook() {
+  PATH="$MOCK_BIN:$PATH" bash "$SCRIPT"
+}
+
+run_hook_jq() {
+  PATH="$MOCK_BIN:$PATH" bash "$SCRIPT" | jq -r '.hookSpecificOutput.updatedInput.command'
+}
+
 Describe 'guards'
 It 'exits silently when no command in input'
 Data '{"tool_input": {}}'
-When run bash -c "bash '$SCRIPT'"
+When run run_hook
 The status should be success
 The output should eq ''
 End
 
 It 'exits silently for empty command'
 Data '{"tool_input": {"command": ""}}'
-When run bash -c "bash '$SCRIPT'"
+When run run_hook
 The status should be success
 The output should eq ''
 End
@@ -23,14 +37,14 @@ End
 Describe 'skip conditions'
 It 'skips commands already using rtk'
 Data '{"tool_input": {"command": "rtk git status"}}'
-When run bash -c "bash '$SCRIPT'"
+When run run_hook
 The status should be success
 The output should eq ''
 End
 
 It 'skips heredoc commands'
 Data '{"tool_input": {"command": "cat <<EOF\nhello\nEOF"}}'
-When run bash -c "bash '$SCRIPT'"
+When run run_hook
 The status should be success
 The output should eq ''
 End
@@ -39,28 +53,28 @@ End
 Describe 'git rewrites'
 It 'rewrites git status'
 Data '{"tool_input": {"command": "git status"}}'
-When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+When run run_hook_jq
 The status should be success
 The output should eq 'rtk git status'
 End
 
 It 'rewrites git diff'
 Data '{"tool_input": {"command": "git diff"}}'
-When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+When run run_hook_jq
 The status should be success
 The output should eq 'rtk git diff'
 End
 
 It 'rewrites git log with options'
 Data '{"tool_input": {"command": "git log --oneline -5"}}'
-When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+When run run_hook_jq
 The status should be success
 The output should eq 'rtk git log --oneline -5'
 End
 
 It 'does not rewrite git clone'
 Data '{"tool_input": {"command": "git clone https://example.com/repo"}}'
-When run bash -c "bash '$SCRIPT'"
+When run run_hook
 The status should be success
 The output should eq ''
 End
@@ -69,14 +83,14 @@ End
 Describe 'gh rewrites'
 It 'rewrites gh pr list'
 Data '{"tool_input": {"command": "gh pr list"}}'
-When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+When run run_hook_jq
 The status should be success
 The output should eq 'rtk gh pr list'
 End
 
 It 'does not rewrite gh auth'
 Data '{"tool_input": {"command": "gh auth status"}}'
-When run bash -c "bash '$SCRIPT'"
+When run run_hook
 The status should be success
 The output should eq ''
 End
@@ -85,21 +99,21 @@ End
 Describe 'cargo rewrites'
 It 'rewrites cargo test'
 Data '{"tool_input": {"command": "cargo test"}}'
-When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+When run run_hook_jq
 The status should be success
 The output should eq 'rtk cargo test'
 End
 
 It 'rewrites cargo build'
 Data '{"tool_input": {"command": "cargo build"}}'
-When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+When run run_hook_jq
 The status should be success
 The output should eq 'rtk cargo build'
 End
 
 It 'does not rewrite cargo new'
 Data '{"tool_input": {"command": "cargo new myproject"}}'
-When run bash -c "bash '$SCRIPT'"
+When run run_hook
 The status should be success
 The output should eq ''
 End
@@ -108,21 +122,21 @@ End
 Describe 'file operation rewrites'
 It 'rewrites cat to rtk read'
 Data '{"tool_input": {"command": "cat file.txt"}}'
-When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+When run run_hook_jq
 The status should be success
 The output should eq 'rtk read file.txt'
 End
 
 It 'rewrites ls'
 Data '{"tool_input": {"command": "ls -la"}}'
-When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+When run run_hook_jq
 The status should be success
 The output should eq 'rtk ls -la'
 End
 
 It 'rewrites find'
 Data '{"tool_input": {"command": "find . -name \"*.ts\""}}'
-When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+When run run_hook_jq
 The status should be success
 The output should include 'rtk find'
 End
@@ -131,21 +145,21 @@ End
 Describe 'JS/TS tooling rewrites'
 It 'rewrites vitest'
 Data '{"tool_input": {"command": "vitest run"}}'
-When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+When run run_hook_jq
 The status should be success
 The output should eq 'rtk vitest run'
 End
 
 It 'rewrites pnpm test'
 Data '{"tool_input": {"command": "pnpm test"}}'
-When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+When run run_hook_jq
 The status should be success
 The output should eq 'rtk vitest run'
 End
 
 It 'rewrites npm test'
 Data '{"tool_input": {"command": "npm test"}}'
-When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+When run run_hook_jq
 The status should be success
 The output should eq 'rtk npm test'
 End
@@ -154,7 +168,7 @@ End
 Describe 'network rewrites'
 It 'rewrites curl'
 Data '{"tool_input": {"command": "curl https://example.com"}}'
-When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+When run run_hook_jq
 The status should be success
 The output should include 'rtk curl'
 End
@@ -163,7 +177,7 @@ End
 Describe 'python rewrites'
 It 'rewrites pytest'
 Data '{"tool_input": {"command": "pytest tests/"}}'
-When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+When run run_hook_jq
 The status should be success
 The output should include 'rtk pytest'
 End
@@ -172,7 +186,7 @@ End
 Describe 'go rewrites'
 It 'rewrites go test'
 Data '{"tool_input": {"command": "go test ./..."}}'
-When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+When run run_hook_jq
 The status should be success
 The output should include 'rtk go test'
 End
@@ -181,24 +195,26 @@ End
 Describe 'env prefix preservation'
 It 'preserves env vars in rewritten command'
 Data '{"tool_input": {"command": "FOO=bar git status"}}'
-When run bash -c "bash '$SCRIPT' | jq -r '.hookSpecificOutput.updatedInput.command'"
+When run run_hook_jq
 The status should be success
 The output should include 'FOO=bar rtk git status'
 End
 End
 
 Describe 'output format'
-It 'outputs valid JSON with hookSpecificOutput'
+It 'outputs valid JSON with permissionDecision'
 Data '{"tool_input": {"command": "git status"}}'
-When run bash -c "bash '$SCRIPT' | jq -e '.hookSpecificOutput.permissionDecision'"
+When run run_hook
 The status should be success
-The output should include 'allow'
+The output should include '"permissionDecision"'
+The output should include '"allow"'
 End
 
 It 'preserves original tool_input fields'
 Data '{"tool_input": {"command": "git status", "timeout": 5000}}'
-When run bash -c "bash '$SCRIPT' | jq -e '.hookSpecificOutput.updatedInput.timeout'"
+When run run_hook
 The status should be success
+The output should include '"timeout"'
 The output should include '5000'
 End
 End


### PR DESCRIPTION
## Summary
- Add `# shellcheck disable=SC2001` to `config/claude/rtk-rewrite.sh` — the sed patterns use `^` (start-of-string anchor) which bash parameter expansion cannot replicate
- Add `spec/rtk_rewrite_spec.sh` with 26 tests covering guards, skip conditions, git/gh/cargo/file/JS/Python/Go rewrites, env prefix preservation, and output format
- Register `rtk-rewrite.sh` in `spec/coverage_spec.sh` coverage list

## Test plan
- [x] `make shell-lint` passes (0 warnings)
- [x] `make shell-test` passes (523 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow sed-based rewrite patterns in rtk-rewrite.sh and add a comprehensive spec to lock down behavior. Suppresses a false shellcheck warning, expands coverage, keeps CI passing, and formats the new spec.

- **Bug Fixes**
  - Disable shellcheck SC2001 in rtk-rewrite.sh.
  - Mock the rtk binary in the spec to avoid guard exits in CI.
  - Format rtk_rewrite_spec.sh for consistency.

- **New Features**
  - Add spec/rtk_rewrite_spec.sh with 26 tests for guards, skip conditions, rewrites (git, gh, cargo, file ops, JS/TS, Python, Go), env var preservation, and JSON output.
  - Register rtk-rewrite.sh in spec/coverage_spec.sh.

<sup>Written for commit 339ba3ebb15d1ee9f85fc2e3d71058496a6d4085. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

