### PR TITLE
fix(hyprshell): add missing key field and upgrade config to v3

### DIFF
--- a/config/hyprshell/config.toml
+++ b/config/hyprshell/config.toml
@@ -1,7 +1,8 @@
-version = 1
+version = 3
 
 [windows]
 scale = 8.0
 
 [windows.switch]
 modifier = "super"
+key = "Tab"

--- a/config/hyprshell/default.nix
+++ b/config/hyprshell/default.nix
@@ -4,4 +4,8 @@
     source = ./config.toml;
     force = true;
   };
+  xdg.configFile."hyprshell/styles.css" = {
+    source = ./styles.css;
+    force = true;
+  };
 }

--- a/config/hyprshell/styles.css
+++ b/config/hyprshell/styles.css
@@ -1,0 +1,16 @@
+:root {
+    --border-color: rgba(75, 75, 90, 0.8);
+    --border-color-active: rgba(189, 147, 249, 0.9);
+
+    --bg-color: rgba(40, 42, 54, 0.8);
+    --bg-color-hover: rgba(53, 55, 70, 0.9);
+
+    --border-radius: 12px;
+    --border-size: 3px;
+    --border-style: solid;
+
+    --text-color: rgba(248, 248, 242, 1);
+
+    --window-padding: 2px;
+    --bg-window-color: rgba(42, 47, 66, 0.95);
+}

--- a/config/keyd/default.conf
+++ b/config/keyd/default.conf
@@ -32,6 +32,9 @@ rightshift = capslock
 # xremap then converts Hyper+key → Ctrl+key for apps.
 # Keys excluded from xremap (e.g. 3/4/5) pass through as Hyper to Hyprland.
 
+# Framework+Tab → Super+Tab for hyprshell window switcher
+tab = M-tab
+
 [cmd_hyper+control]
 # Framework+Ctrl+5 → terminal split in VS Code
 5 = C-5


### PR DESCRIPTION
## Summary
- Upgraded hyprshell config from version 1 to version 3
- Added missing `key = "Tab"` field to `[windows.switch]` section
- Fixes Super+Tab window switching not being triggered

## Root cause
The config was missing the explicit `key` field and using an outdated version 1 format. Without `key = "Tab"`, hyprshell didn't know which key to bind for window switching.

## Test plan
- [x] `make build` succeeds
- [x] `make switch` succeeds
- [ ] Press Super+Tab to verify window switcher opens

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade hyprshell to v3, add key = "Tab" in [windows.switch], map Framework+Tab to Super+Tab in keyd to fix Super+Tab switching, and include Dracula theme styles via styles.css.

<sup>Written for commit ca76f65b997621a8ce82904c811f819311560291. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

