### PR TITLE
feat: add clxwe and clxweh fish functions

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -86,6 +86,8 @@
       clxeh = "_clxeh_function";
       clxte = "_clxte_function";
       clxteh = "_clxteh_function";
+      clxwe = "_clxwe_function";
+      clxweh = "_clxweh_function";
       coxe = "_coxe_function";
       coxeh = "_coxeh_function";
       coxel = "_coxel_function";
@@ -173,6 +175,8 @@
         "_clxeh_function"
         "_clxte_function"
         "_clxteh_function"
+        "_clxwe_function"
+        "_clxweh_function"
         "_coxe_function"
         "_coxeh_function"
         "_coxel_function"

--- a/home-manager/programs/fish/functions/_clxwe_function.fish
+++ b/home-manager/programs/fish/functions/_clxwe_function.fish
@@ -1,0 +1,11 @@
+function _clxwe_function --description "Run Claude Code with a free-form prompt while skipping permissions with git worktree integration"
+  # Run Claude Code with a free-form prompt (spaces allowed) and bypass permission checks
+  # Usage: clxwe [<prompt words...>]
+
+  if test (count $argv) -eq 0
+    claude --dangerously-skip-permissions --worktree
+  else
+    set -l prompt (string join " " -- $argv)
+    claude --dangerously-skip-permissions --worktree --print -- "$prompt"
+  end
+end

--- a/home-manager/programs/fish/functions/_clxweh_function.fish
+++ b/home-manager/programs/fish/functions/_clxweh_function.fish
@@ -1,0 +1,12 @@
+function _clxweh_function --description "Run Claude Code headlessly with a prompted input with git worktree integration"
+  # Prompt for input and run Claude Code
+  # Usage: clxweh
+
+  read -P "Prompt: " prompt
+  if test -z "$prompt"
+    echo "No prompt provided, aborting." >&2
+    return 1
+  end
+
+  claude --dangerously-skip-permissions --worktree --print -- "$prompt"
+end


### PR DESCRIPTION
## Changes
- Added `clxwe` function: Run Claude Code with free-form prompt and skip permissions with git worktree integration
- Added `clxweh` function: Run Claude Code headlessly with prompted input and git worktree integration

## Technical Details
- Both functions use `--dangerously-skip-permissions` flag
- Both functions use `--worktree` flag for git worktree integration
- `clxwe` accepts optional prompt arguments or runs without prompt
- `clxweh` prompts user for input before running

## Testing
- Both functions successfully register in fish shell
- Functions correctly pass arguments to Claude Code CLI

Generated with opencode by glm-4.7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two fish functions, clxwe and clxweh, to run Claude Code with git worktree integration while skipping permission checks. Supports free-form prompts or interactive input.

- **New Features**
  - clxwe: accepts an optional free-form prompt; runs without prompt if none; prints output.
  - clxweh: prompts for input; aborts on empty; prints output.
  - Both use --dangerously-skip-permissions and --worktree, and are registered in default.nix for autoloading.

<sup>Written for commit 40ce689083009b67d9246ff581616eba78a6b7da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

