### PR TITLE
feat: add skill-codex plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # AI
 .claude
+.worktrees
 
 # CCS runtime state (lastUsedAt timestamps change frequently)
 config/ccs/accounts.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # AI
 .claude
 .worktrees
+prompts.db
 
 # CCS runtime state (lastUsedAt timestamps change frequently)
 config/ccs/accounts.json

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -15,6 +15,7 @@
     "ralph-loop@claude-plugins-official": true,
     "safety-net@cc-marketplace": true,
     "serena@claude-plugins-official": true,
+    "skill-codex@skill-codex": true,
     "typescript-lsp@claude-plugins-official": true,
     "worktrunk@worktrunk": true
   },
@@ -40,6 +41,12 @@
     "qmd": {
       "source": {
         "repo": "tobi/qmd",
+        "source": "github"
+      }
+    },
+    "skill-codex": {
+      "source": {
+        "repo": "skills-directory/skill-codex",
         "source": "github"
       }
     },


### PR DESCRIPTION
## Summary
- Add `skill-codex` plugin from `skills-directory/skill-codex` marketplace to Claude settings
- Registers the marketplace source and enables the plugin

## Test plan
- [ ] Verify `claude` loads the skill-codex plugin on next session
- [ ] Confirm `/codex` skill is available after plugin install

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds and enables the skill-codex plugin in Claude by registering the GitHub source (skills-directory/skill-codex). Also ignores .worktrees and prompts.db in Git.

<sup>Written for commit 3acd9cc7a40af7e8762c82650e67fad2ff5bf43d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

