### PR TITLE
fix: pin kernel to 6.12 and use nightly deno for build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -563,11 +563,11 @@
     },
     "nixpkgs-nightly": {
       "locked": {
-        "lastModified": 1771831258,
-        "narHash": "sha256-5SX2FkV16QliCbPH5osKzY5QaQP0Ui6SrAyr3cN6kCg=",
+        "lastModified": 1771852767,
+        "narHash": "sha256-bBspHl+rnPnzVHES1ibja2SLCf/c8a2uTJppPkk115o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "82d15e20c0d46bb0bdbba092cb4312b881a4b630",
+        "rev": "4ff420f3ac10c1e2be43e5a73e20aac6bed59298",
         "type": "github"
       },
       "original": {

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -43,8 +43,8 @@ inputs.nixpkgs.lib.nixosSystem {
         boot.loader.efi.canTouchEfiVariables = true;
         boot.loader.timeout = 3;
 
-        # Latest kernel for AMD AI 300 support
-        boot.kernelPackages = pkgs.linuxPackages_latest;
+        # Pin kernel to 6.12 for CrowdStrike Falcon compatibility (RFM on 6.19)
+        boot.kernelPackages = pkgs.linuxPackages_6_12;
 
         # Networking
         networking.hostName = "matic";

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -43,8 +43,8 @@ inputs.nixpkgs.lib.nixosSystem {
         boot.loader.efi.canTouchEfiVariables = true;
         boot.loader.timeout = 3;
 
-        # Pin kernel to 6.12 for CrowdStrike Falcon compatibility (RFM on 6.19)
-        boot.kernelPackages = pkgs.linuxPackages_6_12;
+        # Pin kernel to 6.18 for CrowdStrike Falcon compatibility (RFM on 6.19)
+        boot.kernelPackages = pkgs.linuxPackages_6_18;
 
         # Networking
         networking.hostName = "matic";

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -38,6 +38,9 @@
       config = prev.config;
       overlays = [ ];
     };
+    # deno 2.6.10 on nixpkgs-unstable has broken check phase (integration_tests vs integration_test)
+    # Use nightly (master) which has the fix and is in the binary cache
+    deno = final.nightlyPkgs.deno;
     codex = final.nightlyPkgs.codex;
     claude-code = final.nightlyPkgs.claude-code;
     opencode = final.nightlyPkgs.opencode;


### PR DESCRIPTION
## Summary
- Pin kernel to 6.12 for CrowdStrike Falcon compatibility (RFM on 6.19)
- Pull deno from nixpkgs-nightly to work around broken check phase in nixpkgs-unstable deno 2.6.10 (`integration_tests` vs `integration_test`)

## Test plan
- [x] `make build` succeeds (deno fetched from binary cache, no source compile)
- [x] `make switch` applies successfully
- [ ] Reboot to verify kernel 6.12 loads and CrowdStrike exits RFM

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned matic to Linux kernel 6.18 to avoid CrowdStrike Falcon RFM and support AMD AI 300 display. Switched Deno to nixpkgs-nightly to fix the 2.6.10 check phase and keep using cached binaries; resolved flake.lock merge from main.

- **Migration**
  - Reboot to load kernel 6.18 and confirm Falcon exits RFM.

<sup>Written for commit 006e324e126cef08b0503c1a5de4a771a694bcbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

