### PR TITLE
fix(openclaw): remove invalid config keys and add plugin entries

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -222,12 +222,6 @@
             "read",
             "exec"
           ]
-        },
-        "groupChat": {
-          "historyLimit": 100,
-          "mentionPatterns": [
-            ".*"
-          ]
         }
       },
       {
@@ -245,12 +239,6 @@
             "read",
             "exec"
           ]
-        },
-        "groupChat": {
-          "historyLimit": 100,
-          "mentionPatterns": [
-            ".*"
-          ]
         }
       },
       {
@@ -264,12 +252,6 @@
           "allow": [
             "read",
             "exec"
-          ]
-        },
-        "groupChat": {
-          "historyLimit": 100,
-          "mentionPatterns": [
-            ".*"
           ]
         }
       },
@@ -288,12 +270,6 @@
             "read",
             "exec"
           ]
-        },
-        "groupChat": {
-          "historyLimit": 100,
-          "mentionPatterns": [
-            ".*"
-          ]
         }
       },
       {
@@ -310,12 +286,6 @@
           "allow": [
             "read",
             "exec"
-          ]
-        },
-        "groupChat": {
-          "historyLimit": 100,
-          "mentionPatterns": [
-            ".*"
           ]
         }
       },
@@ -800,6 +770,14 @@
     },
     "slots": {
       "memory": ""
+    },
+    "entries": {
+      "telegram": {
+        "enabled": true
+      },
+      "whatsapp": {
+        "enabled": true
+      }
     }
   }
 }

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -222,12 +222,6 @@
             "read",
             "exec"
           ]
-        },
-        "groupChat": {
-          "historyLimit": 100,
-          "mentionPatterns": [
-            ".*"
-          ]
         }
       },
       {
@@ -245,12 +239,6 @@
             "read",
             "exec"
           ]
-        },
-        "groupChat": {
-          "historyLimit": 100,
-          "mentionPatterns": [
-            ".*"
-          ]
         }
       },
       {
@@ -264,12 +252,6 @@
           "allow": [
             "read",
             "exec"
-          ]
-        },
-        "groupChat": {
-          "historyLimit": 100,
-          "mentionPatterns": [
-            ".*"
           ]
         }
       },
@@ -288,12 +270,6 @@
             "read",
             "exec"
           ]
-        },
-        "groupChat": {
-          "historyLimit": 100,
-          "mentionPatterns": [
-            ".*"
-          ]
         }
       },
       {
@@ -310,12 +286,6 @@
           "allow": [
             "read",
             "exec"
-          ]
-        },
-        "groupChat": {
-          "historyLimit": 100,
-          "mentionPatterns": [
-            ".*"
           ]
         }
       },
@@ -800,6 +770,14 @@
     },
     "slots": {
       "memory": ""
+    },
+    "entries": {
+      "telegram": {
+        "enabled": true
+      },
+      "whatsapp": {
+        "enabled": true
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Remove `groupChat` blocks (`historyLimit`, `mentionPatterns`) from all 5 code reviewer agents — these are unrecognized keys that cause the gateway to crash-loop on startup
- Add `plugins.entries` with `telegram` and `whatsapp` enabled — without this, channel providers don't start and the bot is unresponsive

## Test plan
- [x] `openclaw doctor` reports 0 errors
- [x] Gateway starts without crash-loop
- [x] WhatsApp and Telegram providers start on boot
- [x] `make format` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes gateway startup by removing invalid groupChat keys from code reviewer agents and enables Telegram and WhatsApp so channel providers start correctly.

- **Bug Fixes**
  - Removed unrecognized groupChat historyLimit and mentionPatterns from all 5 code reviewer agents to prevent crash-loop.
  - Added plugins.entries with Telegram and WhatsApp enabled to start providers on boot.

<sup>Written for commit 02230a818b16ae6d02f986c41924d661d5946dc0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

