### PR TITLE
fix: add --yes flag to skip bypass permissions prompt

### DIFF
--- a/home-manager/programs/fish/functions/_clxe_function.fish
+++ b/home-manager/programs/fish/functions/_clxe_function.fish
@@ -3,9 +3,9 @@ function _clxe_function --description "Run Claude Code with a free-form prompt w
   # Usage: clxe [<prompt words...>]
 
   if test (count $argv) -eq 0
-    claude --dangerously-skip-permissions
+    claude --dangerously-skip-permissions --yes
   else
     set -l prompt (string join " " -- $argv)
-    claude --dangerously-skip-permissions --print -- "$prompt"
+    claude --dangerously-skip-permissions --yes --print -- "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_clxeh_function.fish
+++ b/home-manager/programs/fish/functions/_clxeh_function.fish
@@ -8,5 +8,5 @@ function _clxeh_function --description "Run Claude Code headlessly with a prompt
     return 1
   end
 
-  claude --dangerously-skip-permissions --print -- "$prompt"
+  claude --dangerously-skip-permissions --yes --print -- "$prompt"
 end

--- a/home-manager/programs/fish/functions/_clxte_function.fish
+++ b/home-manager/programs/fish/functions/_clxte_function.fish
@@ -3,9 +3,9 @@ function _clxte_function --description "Run Claude Code with a free-form prompt 
   # Usage: clxte [<prompt words...>]
 
   if test (count $argv) -eq 0
-    claude --dangerously-skip-permissions --worktree --tmux
+    claude --dangerously-skip-permissions --yes --worktree --tmux
   else
     set -l prompt (string join " " -- $argv)
-    claude --dangerously-skip-permissions --worktree --tmux --print -- "$prompt"
+    claude --dangerously-skip-permissions --yes --worktree --tmux --print -- "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_clxteh_function.fish
+++ b/home-manager/programs/fish/functions/_clxteh_function.fish
@@ -8,5 +8,5 @@ function _clxteh_function --description "Run Claude Code headlessly with a promp
     return 1
   end
 
-  claude --dangerously-skip-permissions --worktree --tmux --print -- "$prompt"
+  claude --dangerously-skip-permissions --yes --worktree --tmux --print -- "$prompt"
 end

--- a/home-manager/programs/fish/functions/_clxwe_function.fish
+++ b/home-manager/programs/fish/functions/_clxwe_function.fish
@@ -3,9 +3,9 @@ function _clxwe_function --description "Run Claude Code with a free-form prompt 
   # Usage: clxwe [<prompt words...>]
 
   if test (count $argv) -eq 0
-    claude --dangerously-skip-permissions --worktree
+    claude --dangerously-skip-permissions --yes --worktree
   else
     set -l prompt (string join " " -- $argv)
-    claude --dangerously-skip-permissions --worktree --print -- "$prompt"
+    claude --dangerously-skip-permissions --yes --worktree --print -- "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_clxweh_function.fish
+++ b/home-manager/programs/fish/functions/_clxweh_function.fish
@@ -8,5 +8,5 @@ function _clxweh_function --description "Run Claude Code headlessly with a promp
     return 1
   end
 
-  claude --dangerously-skip-permissions --worktree --print -- "$prompt"
+  claude --dangerously-skip-permissions --yes --worktree --print -- "$prompt"
 end


### PR DESCRIPTION
## Summary
- Add `--yes` flag to all `--dangerously-skip-permissions` Claude Code invocations across 6 fish functions (`clxe`, `clxwe`, `clxte`, `clxeh`, `clxweh`, `clxteh`)
- Suppresses the bypass permissions confirmation warning on startup

## Test plan
- [ ] Run `clxe` and verify no confirmation prompt appears
- [ ] Run `clxwe` / `clxte` variants and confirm same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the --yes flag to all Claude Code commands that use --dangerously-skip-permissions, so the bypass permissions confirmation prompt is skipped on startup.

- **Bug Fixes**
  - Applied --yes in clxe, clxwe, clxte, clxeh, clxweh, clxteh (including worktree/tmux variants) to run without the confirmation prompt.

<sup>Written for commit 36a4205ad6fbc12d2fe45d4d548a85d38201b9bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

