### PR TITLE
fix: remove --yes flag and update Claude Code settings

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -253,7 +253,7 @@
       }
     ]
   },
-  "model": "sonnet",
+  "model": "claude-sonnet-4-6",
   "permissions": {
     "allow": [
       "Bash(bun:*)",

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -356,6 +356,7 @@
       ]
     }
   },
+  "skipDangerousModePermissionPrompt": true,
   "statusLine": {
     "command": "$HOME/.claude/statusline-git.sh",
     "type": "command"

--- a/home-manager/programs/fish/functions/_clxe_function.fish
+++ b/home-manager/programs/fish/functions/_clxe_function.fish
@@ -3,8 +3,9 @@ function _clxe_function --description "Run Claude Code with a free-form prompt w
   # Usage: clxe [<prompt words...>]
 
   if test (count $argv) -eq 0
-    claude --dangerously-skip-permissions  else
+    claude --dangerously-skip-permissions
+  else
     set -l prompt (string join " " -- $argv)
-    claude --dangerously-skip-permissions --yes --print -- "$prompt"
+    claude --dangerously-skip-permissions --print -- "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_clxe_function.fish
+++ b/home-manager/programs/fish/functions/_clxe_function.fish
@@ -3,8 +3,7 @@ function _clxe_function --description "Run Claude Code with a free-form prompt w
   # Usage: clxe [<prompt words...>]
 
   if test (count $argv) -eq 0
-    claude --dangerously-skip-permissions --yes
-  else
+    claude --dangerously-skip-permissions  else
     set -l prompt (string join " " -- $argv)
     claude --dangerously-skip-permissions --yes --print -- "$prompt"
   end

--- a/home-manager/programs/fish/functions/_clxeh_function.fish
+++ b/home-manager/programs/fish/functions/_clxeh_function.fish
@@ -8,5 +8,5 @@ function _clxeh_function --description "Run Claude Code headlessly with a prompt
     return 1
   end
 
-  claude --dangerously-skip-permissions --yes --print -- "$prompt"
+  claude --dangerously-skip-permissions --print -- "$prompt"
 end

--- a/home-manager/programs/fish/functions/_clxte_function.fish
+++ b/home-manager/programs/fish/functions/_clxte_function.fish
@@ -3,9 +3,9 @@ function _clxte_function --description "Run Claude Code with a free-form prompt 
   # Usage: clxte [<prompt words...>]
 
   if test (count $argv) -eq 0
-    claude --dangerously-skip-permissions --yes --worktree --tmux
+    claude --dangerously-skip-permissions --worktree --tmux
   else
     set -l prompt (string join " " -- $argv)
-    claude --dangerously-skip-permissions --yes --worktree --tmux --print -- "$prompt"
+    claude --dangerously-skip-permissions --worktree --tmux --print -- "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_clxteh_function.fish
+++ b/home-manager/programs/fish/functions/_clxteh_function.fish
@@ -8,5 +8,5 @@ function _clxteh_function --description "Run Claude Code headlessly with a promp
     return 1
   end
 
-  claude --dangerously-skip-permissions --yes --worktree --tmux --print -- "$prompt"
+  claude --dangerously-skip-permissions --worktree --tmux --print -- "$prompt"
 end

--- a/home-manager/programs/fish/functions/_clxwe_function.fish
+++ b/home-manager/programs/fish/functions/_clxwe_function.fish
@@ -3,9 +3,9 @@ function _clxwe_function --description "Run Claude Code with a free-form prompt 
   # Usage: clxwe [<prompt words...>]
 
   if test (count $argv) -eq 0
-    claude --dangerously-skip-permissions --yes --worktree
+    claude --dangerously-skip-permissions --worktree
   else
     set -l prompt (string join " " -- $argv)
-    claude --dangerously-skip-permissions --yes --worktree --print -- "$prompt"
+    claude --dangerously-skip-permissions --worktree --print -- "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_clxweh_function.fish
+++ b/home-manager/programs/fish/functions/_clxweh_function.fish
@@ -8,5 +8,5 @@ function _clxweh_function --description "Run Claude Code headlessly with a promp
     return 1
   end
 
-  claude --dangerously-skip-permissions --yes --worktree --print -- "$prompt"
+  claude --dangerously-skip-permissions --worktree --print -- "$prompt"
 end


### PR DESCRIPTION
## Changes
- Remove unnecessary `--yes` flag from all `_clx*` Fish functions (6 files)
- Add `skipDangerousModePermissionPrompt: true` to Claude Code settings to handle the bypass permission prompt natively
- Update model version to `claude-sonnet-4-6` in settings.json

## Technical Details
- The `--yes` flag was previously used to skip the dangerous mode permission prompt, but this is now handled via the `skipDangerousModePermissionPrompt` setting in `settings.json`
- Affects: `_clxe`, `_clxeh`, `_clxte`, `_clxteh`, `_clxwe`, `_clxweh` functions

## Testing
- Functions work without `--yes` flag when `skipDangerousModePermissionPrompt` is set

Generated with Claude Code by claude-sonnet-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the --yes flag from all _clx* Fish functions and now handle the dangerous mode bypass via settings using skipDangerousModePermissionPrompt. Also updated the Claude Code model to claude-sonnet-4-6.

<sup>Written for commit 61ad7ec8217558f75c45d33134afdfc7d10e207b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

