### PR TITLE
chore: add env vars to claude settings

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -20,10 +20,14 @@
     "worktrunk@worktrunk": true
   },
   "env": {
+    "AIKIDO_DISABLE": "true",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-4-6",
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-6",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6",
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "NO_COLOR": "1",
+    "SAFE_CHAIN_LOGGING": "silent",
+    "TURBO_NO_UPDATE_NOTIFIER": "1"
   },
   "extraKnownMarketplaces": {
     "cc-marketplace": {


### PR DESCRIPTION
## Summary
- Add `TURBO_NO_UPDATE_NOTIFIER`, `AIKIDO_DISABLE`, `SAFE_CHAIN_LOGGING`, and `NO_COLOR` env vars to Claude Code settings to reduce noisy output

## Test plan
- [ ] Verify env vars are set in Claude Code sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added environment variables to Claude Code settings to reduce noisy output and keep sessions cleaner. Set AIKIDO_DISABLE=true, NO_COLOR=1, SAFE_CHAIN_LOGGING=silent, and TURBO_NO_UPDATE_NOTIFIER=1.

<sup>Written for commit 9f424453d20c3c7645fba1a556a5b8afbd8b1c0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

