### PR TITLE
feat(tmux): session logging, pane archive, and tmuxinator integration

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -27,6 +27,7 @@ in
   ./pi
   ./serena
   ./starship
+  ./tmuxinator
   ./worktrunk
   ./zellij
 ]

--- a/config/tmuxinator/default.nix
+++ b/config/tmuxinator/default.nix
@@ -1,0 +1,4 @@
+{ ... }:
+{
+  xdg.configFile."tmuxinator".source = ./tmuxinator;
+}

--- a/config/tmuxinator/tmuxinator/desktop.yml
+++ b/config/tmuxinator/tmuxinator/desktop.yml
@@ -1,4 +1,9 @@
 name: desktop
 windows:
-  - editor: nvim
-  - server: bun run dev
+  - btop: btop
+  - dotfiles:
+      layout: even-horizontal
+      root: ~/dotfiles
+      panes:
+        -
+        -

--- a/config/tmuxinator/tmuxinator/desktop.yml
+++ b/config/tmuxinator/tmuxinator/desktop.yml
@@ -1,0 +1,4 @@
+name: desktop
+windows:
+  - editor: nvim
+  - server: bun run dev

--- a/config/tmuxinator/tmuxinator/mobile.yml
+++ b/config/tmuxinator/tmuxinator/mobile.yml
@@ -1,4 +1,9 @@
 name: mobile
 windows:
-  - editor: nvim
-  - server: bun run dev
+  - btop: btop
+  - dotfiles:
+      layout: even-horizontal
+      root: ~/dotfiles
+      panes:
+        -
+        -

--- a/config/tmuxinator/tmuxinator/mobile.yml
+++ b/config/tmuxinator/tmuxinator/mobile.yml
@@ -1,0 +1,4 @@
+name: mobile
+windows:
+  - editor: nvim
+  - server: bun run dev

--- a/config/tmuxinator/tmuxinator/primary.yml
+++ b/config/tmuxinator/tmuxinator/primary.yml
@@ -1,0 +1,5 @@
+name: primary
+windows:
+  - editor: nvim
+  - shell:
+  - server: bun run dev

--- a/config/tmuxinator/tmuxinator/primary.yml
+++ b/config/tmuxinator/tmuxinator/primary.yml
@@ -1,5 +1,9 @@
 name: primary
 windows:
-  - editor: nvim
-  - shell:
-  - server: bun run dev
+  - btop: btop
+  - dotfiles:
+      layout: even-horizontal
+      root: ~/dotfiles
+      panes:
+        -
+        -

--- a/config/tmuxinator/tmuxinator/work.yml
+++ b/config/tmuxinator/tmuxinator/work.yml
@@ -1,0 +1,4 @@
+name: work
+windows:
+  - editor: nvim
+  - shell:

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -81,6 +81,7 @@ with pkgs;
   sqlite
   stern
   tealdeer
+  tmuxinator
   tokei
   tree
   turso-cli

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -77,7 +77,6 @@
       j = "jj";
       lzd = "lazydocker";
       lzg = "lazygit";
-      ta = "tmux new -A -s default";
       v = "nvim";
 
       # Function-based abbreviations
@@ -119,6 +118,10 @@
       tdo = "_tdo_function";
       tmo = "_tmo_function";
       tpo = "_tpo_function";
+      tsh = "_tsh_function";
+      tss = "_tss_function";
+      tsw = "_tsw_function";
+      two = "_two_function";
       zdo = "_zdo_function";
       zmo = "_zmo_function";
       zpo = "_zpo_function";
@@ -207,6 +210,10 @@
         "_tdo_function"
         "_tmo_function"
         "_tpo_function"
+        "_tsh_function"
+        "_tss_function"
+        "_tsw_function"
+        "_two_function"
         "_zdo_function"
         "_zmo_function"
         "_zpo_function"

--- a/home-manager/programs/fish/functions/_tdo_function.fish
+++ b/home-manager/programs/fish/functions/_tdo_function.fish
@@ -1,3 +1,11 @@
 function _tdo_function --description "Attach to tmux desktop session"
-  tmux new-session -A -s desktop
+  if tmux has-session -t desktop 2>/dev/null
+    if test -n "$TMUX"
+      tmux switch-client -t desktop
+    else
+      tmux attach-session -t desktop
+    end
+  else
+    tmuxinator start desktop
+  end
 end

--- a/home-manager/programs/fish/functions/_tmo_function.fish
+++ b/home-manager/programs/fish/functions/_tmo_function.fish
@@ -1,3 +1,11 @@
 function _tmo_function --description "Attach to tmux mobile session"
-  tmux new-session -A -s mobile
+  if tmux has-session -t mobile 2>/dev/null
+    if test -n "$TMUX"
+      tmux switch-client -t mobile
+    else
+      tmux attach-session -t mobile
+    end
+  else
+    tmuxinator start mobile
+  end
 end

--- a/home-manager/programs/fish/functions/_tpo_function.fish
+++ b/home-manager/programs/fish/functions/_tpo_function.fish
@@ -1,3 +1,11 @@
 function _tpo_function --description "Attach to tmux primary session"
-  tmux new-session -A -s primary
+  if tmux has-session -t primary 2>/dev/null
+    if test -n "$TMUX"
+      tmux switch-client -t primary
+    else
+      tmux attach-session -t primary
+    end
+  else
+    tmuxinator start primary
+  end
 end

--- a/home-manager/programs/fish/functions/_tsh_function.fish
+++ b/home-manager/programs/fish/functions/_tsh_function.fish
@@ -1,0 +1,79 @@
+function _tsh_function --description "Search tmux session history log or pane contents"
+  set -l log ~/.local/share/tmux/session-history.log
+  set -l pane_dir ~/.local/share/tmux/panes
+  set -l archive_dir ~/.local/share/tmux/archive
+
+  # With argument(s): search stored pane content files (live + archived)
+  if test (count $argv) -gt 0
+    if not test -d "$pane_dir"
+      echo "No pane content store found at $pane_dir"
+      return
+    end
+
+    set -l query (string join ' ' $argv)
+    set -l selected (rg -l -- "$query" "$pane_dir" "$archive_dir" 2>/dev/null \
+      | fzf --prompt="pane-search> " \
+            --height=40% \
+            --preview="rg -n -- '$query' {} 2>/dev/null | head -80" \
+            --preview-window=right:60%)
+
+    if test -z "$selected"
+      return
+    end
+
+    # work--0--0.txt or work--0--0--20260226-103000.txt → sess=work, widx=0
+    set -l fname (string replace -r '.*/' '' "$selected" \
+      | string replace -r '--\d{8}-\d{6}\.txt$' '' \
+      | string replace '.txt' '')
+    set -l parts (string split -- '--' $fname)
+    set -l sess $parts[1]
+    set -l widx $parts[2]
+
+    if not tmux has-session -t "$sess" 2>/dev/null
+      echo "Session '$sess' no longer exists (archived pane — content shown above in preview)"
+      return
+    end
+
+    if test -n "$TMUX"
+      tmux switch-client -t "$sess"
+      tmux select-window -t "$sess:$widx" 2>/dev/null
+    else
+      tmux attach-session -t "$sess" \; select-window -t "$sess:$widx"
+    end
+    return
+  end
+
+  # No argument: fzf over the history log (session/window/path metadata)
+  if not test -f "$log"
+    echo "No session history found at $log"
+    return
+  end
+
+  set -l selected (cat "$log" | fzf \
+    --prompt="session-history> " \
+    --height=40% \
+    --tac \
+    --no-sort \
+    --preview='echo {}')
+
+  if test -z "$selected"
+    return
+  end
+
+  set -l target (string split '  ' $selected)[2]
+  set -l parts (string split ':' $target)
+  set -l sess $parts[1]
+  set -l widx $parts[2]
+
+  if not tmux has-session -t "$sess" 2>/dev/null
+    echo "Session '$sess' no longer exists"
+    return
+  end
+
+  if test -n "$TMUX"
+    tmux switch-client -t "$sess"
+    tmux select-window -t "$sess:$widx" 2>/dev/null
+  else
+    tmux attach-session -t "$sess" \; select-window -t "$sess:$widx"
+  end
+end

--- a/home-manager/programs/fish/functions/_tss_function.fish
+++ b/home-manager/programs/fish/functions/_tss_function.fish
@@ -1,0 +1,52 @@
+function _tss_function --description "Fuzzy-pick or create a tmux session"
+  set -l default_sessions primary mobile desktop work
+
+  # Build candidate list: default sessions first, then any extra existing sessions
+  set -l existing (tmux list-sessions -F '#S' 2>/dev/null)
+  set -l candidates $default_sessions
+  for s in $existing
+    if not contains $s $default_sessions
+      set -a candidates $s
+    end
+  end
+
+  set -l selected (printf '%s\n' $candidates | fzf \
+    --prompt="session> " \
+    --height=40% \
+    --preview='tmux list-windows -F "#I: #W" -t {} 2>/dev/null' \
+    --bind='ctrl-x:execute-silent(tmux kill-session -t {})+abort')
+
+  if test -n "$selected"
+    if tmux has-session -t "$selected" 2>/dev/null
+      if test -n "$TMUX"
+        tmux switch-client -t "$selected"
+      else
+        tmux attach-session -t "$selected"
+      end
+    else if test "$selected" = work
+      set -l restore (tmux list-keys 2>/dev/null | string match -rg '(/\S+/resurrect/scripts/restore\.sh)')
+      set -l restore $restore[1]
+      if test -n "$restore"
+        tmux run-shell "$restore"
+      end
+      if tmux has-session -t work 2>/dev/null
+        if test -n "$TMUX"
+          tmux switch-client -t work
+        else
+          tmux attach-session -t work
+        end
+      else
+        tmuxinator start work
+      end
+    else if contains $selected $default_sessions
+      tmuxinator start "$selected"
+    else
+      tmux new-session -d -s "$selected"
+      if test -n "$TMUX"
+        tmux switch-client -t "$selected"
+      else
+        tmux attach-session -t "$selected"
+      end
+    end
+  end
+end

--- a/home-manager/programs/fish/functions/_tsw_function.fish
+++ b/home-manager/programs/fish/functions/_tsw_function.fish
@@ -1,0 +1,21 @@
+function _tsw_function --description "Fuzzy-pick any window across all sessions"
+  set -l selected (tmux list-windows -a -F '#{session_name}:#{window_index}  #{window_name}' 2>/dev/null \
+    | fzf --prompt="window> " --height=40% \
+          --preview='set t (string split "  " {})[1]; tmux list-panes -t $t -F "#P: #{pane_current_command}  #{pane_current_path}" 2>/dev/null')
+
+  if test -z "$selected"
+    return
+  end
+
+  set -l target (string split '  ' $selected)[1]   # "session:index"
+  set -l parts (string split ':' $target)
+  set -l sess $parts[1]
+  set -l widx $parts[2]
+
+  if test -n "$TMUX"
+    tmux switch-client -t "$sess"
+    tmux select-window -t "$sess:$widx"
+  else
+    tmux attach-session -t "$sess" \; select-window -t "$sess:$widx"
+  end
+end

--- a/home-manager/programs/fish/functions/_two_function.fish
+++ b/home-manager/programs/fish/functions/_two_function.fish
@@ -1,0 +1,17 @@
+function _two_function --description "Attach to tmux work session"
+  set -l restore (tmux list-keys 2>/dev/null | string match -rg '(/\S+/resurrect/scripts/restore\.sh)')
+  set -l restore $restore[1]
+  if test -n "$restore"
+    tmux run-shell "$restore"
+  end
+
+  if tmux has-session -t work 2>/dev/null
+    if test -n "$TMUX"
+      tmux switch-client -t work
+    else
+      tmux attach-session -t work
+    end
+  else
+    tmuxinator start work
+  end
+end

--- a/home-manager/programs/tmux/default.nix
+++ b/home-manager/programs/tmux/default.nix
@@ -1,5 +1,12 @@
 { pkgs, ... }:
 {
+  home.packages = [ pkgs.tmuxinator ];
+
+  home.file.".config/tmux/session-logger.sh" = {
+    executable = true;
+    source = ./session-logger.sh;
+  };
+
   programs.tmux = {
     enable = true;
     extraConfig = builtins.readFile ./tmux.conf;

--- a/home-manager/programs/tmux/default.nix
+++ b/home-manager/programs/tmux/default.nix
@@ -1,7 +1,5 @@
 { pkgs, ... }:
 {
-  home.packages = [ pkgs.tmuxinator ];
-
   home.file.".config/tmux/session-logger.sh" = {
     executable = true;
     source = ./session-logger.sh;

--- a/home-manager/programs/tmux/session-logger.sh
+++ b/home-manager/programs/tmux/session-logger.sh
@@ -11,7 +11,7 @@ while true; do
   # Append window metadata
   tmux list-windows -a \
     -F "$(date +%Y-%m-%dT%H:%M:%S)  #{session_name}:#{window_index}  #{window_name}  #{pane_current_path}" \
-    >> "$LOG" 2>/dev/null
+    >>"$LOG" 2>/dev/null
 
   # Rotate existing live snapshots to .old
   for f in "$PANE_DIR"/*.txt; do
@@ -21,13 +21,13 @@ while true; do
   # Recapture all currently live panes
   tmux list-panes -a -F "#{session_name} #{window_index} #{pane_index} #{pane_id}" \
     2>/dev/null | while IFS= read -r line; do
-      sess=$(printf '%s' "$line" | cut -d' ' -f1)
-      widx=$(printf '%s' "$line" | cut -d' ' -f2)
-      pidx=$(printf '%s' "$line" | cut -d' ' -f3)
-      pane_id=$(printf '%s' "$line" | cut -d' ' -f4)
-      tmux capture-pane -pt "$pane_id" -S - 2>/dev/null \
-        > "$PANE_DIR/$sess--$widx--$pidx.txt"
-    done
+    sess=$(printf '%s' "$line" | cut -d' ' -f1)
+    widx=$(printf '%s' "$line" | cut -d' ' -f2)
+    pidx=$(printf '%s' "$line" | cut -d' ' -f3)
+    pane_id=$(printf '%s' "$line" | cut -d' ' -f4)
+    tmux capture-pane -pt "$pane_id" -S - 2>/dev/null \
+      >"$PANE_DIR/$sess--$widx--$pidx.txt"
+  done
 
   # For each .old: if a live .txt exists → pane survived → delete .old
   #                if no live .txt  → pane closed  → archive with timestamp

--- a/home-manager/programs/tmux/session-logger.sh
+++ b/home-manager/programs/tmux/session-logger.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env sh
+mkdir -p ~/.local/share/tmux/panes
+mkdir -p ~/.local/share/tmux/archive
+LOG=~/.local/share/tmux/session-history.log
+PANE_DIR=~/.local/share/tmux/panes
+ARCHIVE_DIR=~/.local/share/tmux/archive
+
+while true; do
+  sleep 30
+
+  # Append window metadata
+  tmux list-windows -a \
+    -F "$(date +%Y-%m-%dT%H:%M:%S)  #{session_name}:#{window_index}  #{window_name}  #{pane_current_path}" \
+    >> "$LOG" 2>/dev/null
+
+  # Rotate existing live snapshots to .old
+  for f in "$PANE_DIR"/*.txt; do
+    [ -f "$f" ] && mv "$f" "${f%.txt}.old"
+  done
+
+  # Recapture all currently live panes
+  tmux list-panes -a -F "#{session_name} #{window_index} #{pane_index} #{pane_id}" \
+    2>/dev/null | while IFS= read -r line; do
+      sess=$(printf '%s' "$line" | cut -d' ' -f1)
+      widx=$(printf '%s' "$line" | cut -d' ' -f2)
+      pidx=$(printf '%s' "$line" | cut -d' ' -f3)
+      pane_id=$(printf '%s' "$line" | cut -d' ' -f4)
+      tmux capture-pane -pt "$pane_id" -S - 2>/dev/null \
+        > "$PANE_DIR/$sess--$widx--$pidx.txt"
+    done
+
+  # For each .old: if a live .txt exists → pane survived → delete .old
+  #                if no live .txt  → pane closed  → archive with timestamp
+  ts=$(date +%Y%m%d-%H%M%S)
+  for old in "$PANE_DIR"/*.old; do
+    [ -f "$old" ] || continue
+    base=$(basename "${old%.old}")
+    if [ -f "$PANE_DIR/$base.txt" ]; then
+      rm -f "$old"
+    else
+      mv "$old" "$ARCHIVE_DIR/${base}--${ts}.txt"
+    fi
+  done
+done

--- a/home-manager/programs/tmux/tmux.conf
+++ b/home-manager/programs/tmux/tmux.conf
@@ -136,5 +136,19 @@ set -g @thumbs-key Space
 # Sessionx (session manager)
 set -g @sessionx-bind 'o'
 
+# Tmux sessionizer (fzf session picker)
+bind S run-shell "tmux new-window 'fish -c _tss_function'"
+
+# Last session (quick flip)
+bind Tab switch-client -l
+
+# Cross-session window picker
+bind W run-shell "tmux new-window 'fish -c _tsw_function'"
+
 # Extrakto (text extraction)
 set -g @extrakto_key 'tab'
+
+set -g history-limit 0
+
+# Persistent session history logger (starts once per server boot)
+set-hook -g 'server-startup' 'run-shell -b "~/.config/tmux/session-logger.sh"'

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -149,6 +149,7 @@ home-manager/modules/uv-globals/install-uv-globals.sh
 home-manager/modules/yek/install-yek.sh
 home-manager/modules/yek/yek.sh
 home-manager/programs/neovim/run_tests.sh
+home-manager/programs/tmux/session-logger.sh
 home-manager/services/brew-upgrader/upgrade.sh
 home-manager/services/cliproxyapi/scripts/backup.sh
 home-manager/services/cliproxyapi/scripts/hydrate.sh


### PR DESCRIPTION
## Summary

- **session-logger.sh**: captures full scrollback of every pane every 30s as `sess--widx--pidx.txt`; closed panes are moved to `archive/` with a timestamp suffix (`work--0--0--20260226-103000.txt`) rather than deleted
- **`history-limit 0`**: unlimited tmux scrollback so `capture-pane -S -` covers the entire pane lifetime
- **`_tsh_function`**: `tsh <query>` searches both live `panes/` and `archive/` via `rg`+`fzf`, jumping to the session/window for live panes or printing a graceful message for archived ones
- **`_tss_function`, `_tsw_function`, `_two_function`**: fzf-based session picker, cross-session window picker, and work-session attacher
- **`_tdo`, `_tmo`, `_tpo`**: updated to use `tmuxinator start` when the session doesn't yet exist
- **tmuxinator configs**: desktop/mobile/primary/work layouts wired into `config/default.nix`

## Directory layout after deploy

```
~/.local/share/tmux/
├── session-history.log          # window metadata, grows unbounded
├── panes/
│   └── work--0--0.txt           # live pane snapshots (overwritten each cycle)
└── archive/
    └── work--0--0--20260226-103000.txt  # closed pane last snapshot
```

## Test plan

- [ ] After server restart, `~/.local/share/tmux/panes/` shows `sess--widx--pidx.txt` files
- [ ] Close a pane → next 30s cycle moves it to `archive/` with timestamp
- [ ] `tsh <query>` finds matches in both live and archived files
- [ ] Selecting an archived pane prints graceful message instead of erroring
- [ ] `tsh <query>` for live pane navigates to correct session/window
- [ ] `make shell-lint` and `make shell-test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persistent tmux session logging with a searchable pane archive, plus tmuxinator-backed session launchers and fzf pickers for faster navigation. Unlimited scrollback captures full pane history.

- **New Features**
  - Logger: captures all panes every 30s to ~/.local/share/tmux/panes; closed panes move to archive/ with timestamps; runs once per server via server-startup hook; history-limit set to 0.
  - Search: tsh queries live and archived panes with previews; jumps to session/window for live panes; prints a note for archived panes.
  - Pickers: tss (sessions), tsw (cross-session windows), two (work with optional resurrect restore). Keybindings: S for sessions, W for windows, Tab to toggle last session.
  - Tmuxinator: installed globally; configs managed under ~/.config/tmuxinator via Home Manager; tdo/tmo/tpo start or attach via tmuxinator. desktop/mobile/primary open btop + split dotfiles; work has editor and shell.
  - Coverage: session-logger.sh added to spec/coverage_spec.sh.

- **Migration**
  - Apply Home Manager changes and restart the tmux server (tmux kill-server) to start the logger.
  - Use tsh for searches and S/W/Tab for navigation; first use will create sessions via tmuxinator if missing.

<sup>Written for commit f6d5f043ed4154461bf54b44fedc7dea30f4cd51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

