### PR TITLE
fix(tmux): use run-shell guard to prevent duplicate session loggers

### DIFF
--- a/home-manager/programs/tmux/tmux.conf
+++ b/home-manager/programs/tmux/tmux.conf
@@ -148,7 +148,7 @@ bind W run-shell "tmux new-window 'fish -c _tsw_function'"
 # Extrakto (text extraction)
 set -g @extrakto_key 'tab'
 
-set -g history-limit 50000
+set -g history-limit 0
 
 # Persistent session history logger (starts once per server boot)
 run-shell "pgrep -f 'session-logger.sh' > /dev/null 2>&1 || (nohup ~/.config/tmux/session-logger.sh > /dev/null 2>&1 &)"

--- a/home-manager/programs/tmux/tmux.conf
+++ b/home-manager/programs/tmux/tmux.conf
@@ -148,7 +148,7 @@ bind W run-shell "tmux new-window 'fish -c _tsw_function'"
 # Extrakto (text extraction)
 set -g @extrakto_key 'tab'
 
-set -g history-limit 0
+set -g history-limit 50000
 
 # Persistent session history logger (starts once per server boot)
-set-hook -g 'server-startup' 'run-shell -b "~/.config/tmux/session-logger.sh"'
+run-shell "pgrep -f 'session-logger.sh' > /dev/null 2>&1 || (nohup ~/.config/tmux/session-logger.sh > /dev/null 2>&1 &)"


### PR DESCRIPTION
## Summary

- Replaces `set-hook -g server-startup` with a `run-shell` + `pgrep` guard to start `session-logger.sh`
- Prevents duplicate logger processes when tmux config is reloaded (`bind t source-file ...`) — the hook fires again on reload but `pgrep` skips the launch if already running

## Test plan

- [ ] Reload tmux config (`prefix + t`) multiple times and verify only one `session-logger.sh` process runs (`pgrep -fl session-logger.sh`)
- [ ] Start a fresh tmux server and confirm the logger starts automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure tmux starts only one session-logger by replacing the server-startup hook with a guarded run-shell. This prevents duplicate logger processes on config reloads while still starting the logger on fresh server boot.

<sup>Written for commit c7ae4d7737c9b22ec942f1d4c2cd691c9e646b5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

