### PR TITLE
fix(ci): add checkout step to git-ai workflow

### DIFF
--- a/.github/workflows/git-ai.yaml
+++ b/.github/workflows/git-ai.yaml
@@ -9,6 +9,11 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install git-ai
         run: |
           curl -fsSL https://usegitai.com/install.sh | bash


### PR DESCRIPTION
## Summary

- Add `actions/checkout@v4` with `fetch-depth: 0` before installing and running git-ai
- Without checkout, no local git repo exists and git-notes cannot be pushed to remote

## Test plan

- [ ] Merge a PR and verify the git-ai workflow runs successfully and pushes git-notes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add actions/checkout@v4 (fetch-depth: 0) to the git-ai workflow so the job has a local repo with full history and can push git-notes to the remote.

<sup>Written for commit 1ce29da9c54a6239eb60d48f2efcca32ababe10e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

