### PR TITLE
fix(tmux): restore scrollback — history-limit 0 means zero lines not unlimited

### DIFF
--- a/home-manager/programs/fish/functions/_tsh_function.fish
+++ b/home-manager/programs/fish/functions/_tsh_function.fish
@@ -22,7 +22,7 @@ function _tsh_function --description "Search tmux pane contents (live + archived
 
   # work--0--0.txt or work--0--0--20260226-103000.txt → sess=work, widx=0
   set -l fname (string replace -r '.*/' '' "$selected" \
-    | string replace -r '--\d{8}-\d{6}\.txt$' '' \
+    | string replace -r -- '--\d{8}-\d{6}\.txt$' '' \
     | string replace '.txt' '')
   set -l parts (string split -- '--' $fname)
   set -l sess $parts[1]

--- a/home-manager/programs/tmux/tmux.conf
+++ b/home-manager/programs/tmux/tmux.conf
@@ -154,7 +154,7 @@ bind K run-shell "tmux new-window 'fish -c _tsk_function'"
 # Extrakto (text extraction)
 set -g @extrakto_key 'tab'
 
-set -g history-limit 0
+set -g history-limit 2000000
 
 # Persistent session history logger (starts once per server boot)
 run-shell "pgrep -f 'session-logger.sh' > /dev/null 2>&1 || (nohup ~/.config/tmux/session-logger.sh > /dev/null 2>&1 &)"

--- a/home-manager/programs/tmux/tmux.conf
+++ b/home-manager/programs/tmux/tmux.conf
@@ -154,7 +154,7 @@ bind K run-shell "tmux new-window 'fish -c _tsk_function'"
 # Extrakto (text extraction)
 set -g @extrakto_key 'tab'
 
-set -g history-limit 2000000
+set -g history-limit 2147483647
 
 # Persistent session history logger (starts once per server boot)
 run-shell "pgrep -f 'session-logger.sh' > /dev/null 2>&1 || (nohup ~/.config/tmux/session-logger.sh > /dev/null 2>&1 &)"


### PR DESCRIPTION
## Summary

- `history-limit 0` in tmux means **zero lines of scrollback** (not unlimited), which completely breaks pane scrolling
- This was introduced in #934 (`c7ae4d77`) which mistakenly assumed `0` = unlimited
- Fix: use `2147483647` (max int32), the largest value tmux accepts, giving effectively unlimited scrollable history

## Test plan

- [ ] Reload tmux config: `prefix + t`
- [ ] Verify scrollback works: produce output, then scroll up with `prefix + [`

Fixes regression from #934.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore tmux scrollback by setting history-limit to 2147483647 (max int) instead of 0, which disabled history. Also fix the fish _tsh_function by adding -- to string replace -r so the '--YYYYMMDD-HHMMSS.txt' regex is parsed correctly.

<sup>Written for commit 725ed92ee9a17fa18989c0faa8dc162cd139271b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

