### PR TITLE
fix(fish): add -- separator in _tsh_function string replace pattern

### DIFF
--- a/home-manager/programs/fish/functions/_tsh_function.fish
+++ b/home-manager/programs/fish/functions/_tsh_function.fish
@@ -22,7 +22,7 @@ function _tsh_function --description "Search tmux pane contents (live + archived
 
   # work--0--0.txt or work--0--0--20260226-103000.txt → sess=work, widx=0
   set -l fname (string replace -r '.*/' '' "$selected" \
-    | string replace -r '--\d{8}-\d{6}\.txt$' '' \
+    | string replace -r -- '--\d{8}-\d{6}\.txt$' '' \
     | string replace '.txt' '')
   set -l parts (string split -- '--' $fname)
   set -l sess $parts[1]


### PR DESCRIPTION
## Changes
- Add `--` end-of-options separator to `string replace -r` call in `_tsh_function`

## Problem
Fish's `string replace` parser treats `--\d{8}-\d{6}\.txt$` as an unknown flag because the pattern starts with `--`, producing:
```
string replace: --\d{8}-\d{6}\.txt$: unknown option
```

## Fix
Add `--` after `-r` to signal end of options, so the pattern is parsed as a literal argument:
```diff
-    | string replace -r '--\d{8}-\d{6}\.txt$' '' \
+    | string replace -r -- '--\d{8}-\d{6}\.txt$' '' \
```

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix a Fish shell parsing error in _tsh_function by adding the -- end-of-options separator to string replace -r. This makes the pattern '--\d{8}-\d{6}\.txt$' be treated as an argument instead of an option, preventing the "unknown option" error.

<sup>Written for commit 01cfc2d6716d14aea36297594154e35f4a142c7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

