### PR TITLE
fix(fish): avoid option-parse ambiguity in tsh filename regex

### DIFF
--- a/home-manager/programs/fish/functions/_tsh_function.fish
+++ b/home-manager/programs/fish/functions/_tsh_function.fish
@@ -22,8 +22,7 @@ function _tsh_function --description "Search tmux pane contents (live + archived
 
   # work--0--0.txt or work--0--0--20260226-103000.txt → sess=work, widx=0
   set -l fname (string replace -r '.*/' '' "$selected" \
-    | string replace -r -- '--\d{8}-\d{6}\.txt$' '' \
-    | string replace '.txt' '')
+    | string replace -r '(\-\-[0-9]{8}-[0-9]{6})?\.txt$' '')
   set -l parts (string split -- '--' $fname)
   set -l sess $parts[1]
   set -l widx $parts[2]


### PR DESCRIPTION
## Summary

- Replace `-- '--\d{8}-\d{6}\.txt$'` with `'(\-\-[0-9]{8}-[0-9]{6})?\.txt$'`
- Pattern starting with `--` is misinterpreted as a CLI option by `string replace`, even with `--` separator in some Fish versions
- Using `\-\-` as the literal prefix sidesteps the option parser entirely
- Also consolidates the two-step `.txt` removal into one regex with an optional group

## Root cause

`string replace -r '--\d{8}-\d{6}\.txt$'` — Fish sees `--\d{8}...` as an unknown long option flag.

## Test plan

- [ ] Rebuild home-manager and run `_tsh_function` — no more `unknown option` error
- [ ] Verify both plain (`session--0--0.txt`) and timestamped (`session--0--0--20260226-103000.txt`) filenames parse correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix filename parsing in _tsh_function by updating the regex to treat the leading -- as literal and remove the timestamp in one step. This prevents the "unknown option" error in Fish and correctly handles both plain and timestamped .txt files.

<sup>Written for commit dec6eeb77d98e4fed76700db91e79c4e544e288d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

