### PR TITLE
fix(git): set notes.displayRef to refs/notes/ai

### DIFF
--- a/home-manager/programs/git/default.nix
+++ b/home-manager/programs/git/default.nix
@@ -76,6 +76,9 @@
         merge = {
           conflictStyle = "zdiff3";
         };
+        notes = {
+          displayRef = "refs/notes/ai";
+        };
         "remote \"origin\"" = {
           fetch = "+refs/notes/*:refs/notes/*";
         };


### PR DESCRIPTION
## Summary

- Add `notes.displayRef = refs/notes/ai` to global git config
- git-ai stores notes under `refs/notes/ai`, not the default `refs/notes/commits`
- Without this, `git notes list` and `git log --notes` show nothing

## Test plan

- [ ] Rebuild home-manager and run `git notes list` — should show all git-ai notes
- [ ] Run `git log --notes` — should display AI notes inline

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set git notes.displayRef to refs/notes/ai so git notes list and git log --notes show notes stored under this ref. Fixes missing notes when not using the default refs/notes/commits.

- **Migration**
  - Rebuild home-manager to apply the new git config.

<sup>Written for commit f7d27be614a9e282dcb344250d7ee521f679c526. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

