### PR TITLE
fix(git): set core.notesRef to refs/notes/ai

### DIFF
--- a/home-manager/programs/git/default.nix
+++ b/home-manager/programs/git/default.nix
@@ -27,6 +27,7 @@
           whitespace = "trailing-space,space-before-tab";
           precomposeunicode = true;
           ignorecase = false;
+          notesRef = "refs/notes/ai";
         };
         color = {
           diff = "auto";
@@ -75,9 +76,6 @@
         };
         merge = {
           conflictStyle = "zdiff3";
-        };
-        notes = {
-          displayRef = "refs/notes/ai";
         };
         "remote \"origin\"" = {
           fetch = "+refs/notes/*:refs/notes/*";

--- a/home-manager/programs/git/default.nix
+++ b/home-manager/programs/git/default.nix
@@ -76,6 +76,9 @@
         merge = {
           conflictStyle = "zdiff3";
         };
+        notes = {
+          displayRef = "refs/notes/ai";
+        };
         "remote \"origin\"" = {
           fetch = "+refs/notes/*:refs/notes/*";
         };


### PR DESCRIPTION
## Summary

- Replace `notes.displayRef` (wrong key) with `core.notesRef = refs/notes/ai`
- `notes.displayRef` only affects `git log` display — `git notes list` reads from `core.notesRef`
- Without this, `git notes list` shows nothing even though notes exist under `refs/notes/ai`

## Test plan

- [ ] Rebuild home-manager and run `git notes list` — should show all 73 git-ai notes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set core.notesRef to refs/notes/ai in the Git Home Manager config so git notes list reads from the correct ref and shows existing notes. Replaces the incorrect notes.displayRef, which only affects git log.

<sup>Written for commit a71f9d462800714fd010d34cab4dcdf466715d3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

