### PR TITLE
fix: tolerate offline failures in cargo-globals and hyprpanel notifications

### DIFF
--- a/home-manager/modules/cargo-globals/default.nix
+++ b/home-manager/modules/cargo-globals/default.nix
@@ -17,8 +17,8 @@ in
   home.activation.installCargoGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     export PATH=${pkgs.rustup}/bin:${pkgs.cargo}/bin:${pkgs.rustc}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:$PATH
     export CARGO_HOME="$HOME/.cargo"
-    $DRY_RUN_CMD ${pkgs.rustup}/bin/rustup toolchain install stable
-    $DRY_RUN_CMD ${pkgs.rustup}/bin/rustup default stable
+    $DRY_RUN_CMD ${pkgs.rustup}/bin/rustup toolchain install stable --no-self-update || true
+    $DRY_RUN_CMD ${pkgs.rustup}/bin/rustup default stable || true
     export PKG_CONFIG_PATH="${pkgs.openssl.dev}/lib/pkgconfig${libiconvPkgConfigPath}''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
     export OPENSSL_DIR="${pkgs.openssl.dev}"
     export OPENSSL_LIB_DIR="${pkgs.openssl.out}/lib"

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -33,6 +33,25 @@
     });
   })
   (final: prev: {
+    # Hide empty action bar in hyprpanel notifications when no valid actions exist.
+    # Notifications with empty action IDs (e.g. from Claude Code) bypass the length
+    # guard and render a blank bar. Filter them out before the guard and the map.
+    hyprpanel = prev.hyprpanel.overrideAttrs (oldAttrs: {
+      postPatch =
+        (oldAttrs.postPatch or "")
+        + ''
+          substituteInPlace src/components/notifications/Notification/index.tsx \
+            --replace-fail \
+            'notification.get_actions().length' \
+            'notification.get_actions().filter((a) => a.id !== "").length'
+          substituteInPlace src/components/notifications/Actions/index.tsx \
+            --replace-fail \
+            'notification.get_actions().map' \
+            'notification.get_actions().filter((a) => a.id !== "").map'
+        '';
+    });
+  })
+  (final: prev: {
     nightlyPkgs = import inputs.nixpkgs-nightly {
       system = prev.system;
       config = prev.config;

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -37,18 +37,16 @@
     # Notifications with empty action IDs (e.g. from Claude Code) bypass the length
     # guard and render a blank bar. Filter them out before the guard and the map.
     hyprpanel = prev.hyprpanel.overrideAttrs (oldAttrs: {
-      postPatch =
-        (oldAttrs.postPatch or "")
-        + ''
-          substituteInPlace src/components/notifications/Notification/index.tsx \
-            --replace-fail \
-            'notification.get_actions().length' \
-            'notification.get_actions().filter((a) => a.id !== "").length'
-          substituteInPlace src/components/notifications/Actions/index.tsx \
-            --replace-fail \
-            'notification.get_actions().map' \
-            'notification.get_actions().filter((a) => a.id !== "").map'
-        '';
+      postPatch = (oldAttrs.postPatch or "") + ''
+        substituteInPlace src/components/notifications/Notification/index.tsx \
+          --replace-fail \
+          'notification.get_actions().length' \
+          'notification.get_actions().filter((a) => a.id !== "").length'
+        substituteInPlace src/components/notifications/Actions/index.tsx \
+          --replace-fail \
+          'notification.get_actions().map' \
+          'notification.get_actions().filter((a) => a.id !== "").map'
+      '';
     });
   })
   (final: prev: {


### PR DESCRIPTION
## Summary
- **cargo-globals**: `rustup toolchain install stable` fails with DNS errors when network is unavailable at Home Manager activation time, causing the entire service to fail. Add `--no-self-update` and `|| true` to make it non-fatal.
- **hyprpanel**: Notifications from apps like Claude Code send an empty action (`id: ""`), which bypasses the `get_actions().length` guard and renders a blank pale bar. A `postPatch` overlay filters out empty-ID actions before the guard and the render map.

## Test plan
- [ ] Apply Home Manager config while offline — service should succeed
- [ ] Apply Home Manager config while online — rustup installs/updates as normal
- [ ] Trigger a Claude Code "waiting for input" notification — no empty action bar should appear
- [ ] Trigger a notification with real actions — action buttons should still render normally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `cargo-globals` resilient to offline `rustup` failures and hide empty action bars in `hyprpanel` notifications. Home Manager activation works offline; Claude Code notifications no longer show blank bars.

- **Bug Fixes**
  - `cargo-globals`: add `--no-self-update` and `|| true` to `rustup toolchain install` and `rustup default` so DNS/network errors are non-fatal; online installs still proceed.
  - `hyprpanel`: filter out empty-ID actions in both the actions length check and the render map to hide the bar when all actions are empty, while keeping valid buttons.

<sup>Written for commit 2628dd536eb72cbcd30fd1e72de528c9cace57f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

