### PR TITLE
feat: add yt-dlp to package lists in default.nix and homebrew.nix

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -91,7 +91,6 @@ with pkgs;
   yarn
   yazi
   yq
-  yt-dlp
   zellij
   zoxide
 ]
@@ -157,6 +156,7 @@ with pkgs;
   wl-clip-persist
   wl-clipboard
   wtype
+  yt-dlp
 ]
 ++ lib.optionals isDev [
   gopls

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -57,6 +57,7 @@
       "sshpass"
       "temporal"
       "watchexec"
+      "yt-dlp"
     ];
     casks = [
       "antigravity"


### PR DESCRIPTION
Entire-Checkpoint: 1ffdcbb52d73


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added yt-dlp to home-manager packages and the nix-darwin Homebrew formula list so the video downloader is installed by default across environments.

<sup>Written for commit beaaf4a023f4933c58b6548351f9ad726881803b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

