### PR TITLE
fix: remove invalid opencode transparent theme and pr-create auto variant

### DIFF
--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -1,279 +1,265 @@
 {
-	"$schema": "https://opencode.ai/config.json",
-	"theme": "transparent",
-	"model": "cliproxyapi/glm-4.7",
-	"small_model": "cliproxyapi/glm-4.7",
-	"autoupdate": true,
-	"agent": {
-		"code-reviewer": {
-			"description": "Reviews code for best practices and potential issues",
-			"model": "anthropic/claude-sonnet-4-20250514",
-			"prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
-			"tools": {
-				// Disable file modification tools for review-only agent
-				"write": false,
-				"edit": false
-			}
-		}
-	},
-	"provider": {
-		"shunkakinoki": {
-			"npm": "@ai-sdk/openai-compatible",
-			"name": "CLIProxyAPI (remote)",
-			"options": {
-				"baseURL": "https://cliproxy.shunkakinoki.com/v1",
-				"apiKey": "{env:CLIPROXY_API_KEY}"
-			},
-			"models": {
-				"claude-opus-4-6": {
-					"name": "Claude Opus 4.6 (via shunkakinoki's CLIProxy)"
-				},
-				"claude-sonnet-4-6": {
-					"name": "Claude Sonnet 4.6 (via shunkakinoki's CLIProxy)"
-				},
-				"claude-haiku-4-5-20251001": {
-					"name": "Claude Haiku 4.5 (via shunkakinoki's CLIProxy)"
-				},
-				"gpt-5.2": {
-					"name": "GPT 5.2 (via shunkakinoki's CLIProxy)"
-				},
-				"gpt-5.3-codex": {
-					"name": "GPT 5.3 Codex (via shunkakinoki's CLIProxy)"
-				},
-				"gemini-3-pro-preview": {
-					"name": "Gemini 3 Pro (via shunkakinoki's CLIProxy)"
-				},
-				"gemini-3-flash-preview": {
-					"name": "Gemini 3 Flash (via shunkakinoki's CLIProxy)"
-				},
-				"z-ai/glm-4.7": {
-					"name": "GLM 4.7 (via shunkakinoki's CLIProxy)"
-				}
-			}
-		},
-		"cliproxyapi": {
-			"npm": "@ai-sdk/openai-compatible",
-			"name": "CLIProxyAPI (local)",
-			"options": {
-				"baseURL": "http://localhost:8317/v1",
-				"apiKey": "{env:CLIPROXY_API_KEY}"
-			},
-			"models": {
-				"claude-opus-4-6": {
-					"name": "Claude Opus 4.6 (via local CLIProxyAPI)"
-				},
-				"claude-sonnet-4-6": {
-					"name": "Claude Sonnet 4.6 (via local CLIProxyAPI)"
-				},
-				"claude-haiku-4-5-20251001": {
-					"name": "Claude Haiku 4.5 (via local CLIProxyAPI)"
-				},
-				"gpt-5.2": {
-					"name": "GPT 5.2 (via local CLIProxyAPI)"
-				},
-				"gpt-5.3-codex": {
-					"name": "GPT 5.3 Codex (via local CLIProxyAPI)"
-				},
-				"gemini-3-pro-preview": {
-					"name": "Gemini 3 Pro (via local CLIProxyAPI)"
-				},
-				"gemini-3-flash-preview": {
-					"name": "Gemini 3 Flash (via local CLIProxyAPI)"
-				},
-				"glm-4.7": {
-					"name": "GLM 4.7 (via local CLIProxyAPI)"
-				}
-			}
-		},
-		"lmstudio": {
-			"npm": "@ai-sdk/openai-compatible",
-			"name": "LM Studio (local)",
-			"options": {
-				"baseURL": "http://127.0.0.1:1234/v1"
-			},
-			"models": {
-				"openai/gpt-oss-20b": {
-					"name": "OpenAI: gpt-oss-20b"
-				},
-				"openai/gpt-oss-120b": {
-					"name": "OpenAI: gpt-oss-120b"
-				},
-				"zai-org/glm-4.7-flash": {
-					"name": "GLM-4.7 Flash (via LM Studio)"
-				}
-			}
-		},
-		"ollama": {
-			"npm": "@ai-sdk/openai-compatible",
-			"name": "Ollama (local)",
-			"options": {
-				"baseURL": "http://localhost:11434/v1"
-			},
-			"models": {
-				"openai/gpt-oss-20b": {
-					"name": "OpenAI: gpt-oss-20b"
-				}
-			}
-		},
-		"openai": {
-			"options": {
-				"reasoningEffort": "medium",
-				"reasoningSummary": "auto",
-				"textVerbosity": "medium",
-				"include": [
-					"reasoning.encrypted_content"
-				]
-			},
-			"models": {
-				"gpt-5-codex-low-oauth": {
-					"name": "GPT-5 Codex Low (OAuth)",
-					"options": {
-						"reasoningEffort": "low",
-						"reasoningSummary": "auto",
-						"textVerbosity": "medium"
-					}
-				},
-				"gpt-5-codex-medium-oauth": {
-					"name": "GPT-5 Codex Medium (OAuth)",
-					"options": {
-						"reasoningEffort": "medium",
-						"reasoningSummary": "auto",
-						"textVerbosity": "medium"
-					}
-				},
-				"gpt-5-codex-high-oauth": {
-					"name": "GPT-5 Codex High (OAuth)",
-					"options": {
-						"reasoningEffort": "high",
-						"reasoningSummary": "detailed",
-						"textVerbosity": "medium"
-					}
-				},
-				"gpt-5-minimal-oauth": {
-					"name": "GPT-5 Minimal (OAuth)",
-					"options": {
-						"reasoningEffort": "minimal",
-						"reasoningSummary": "auto",
-						"textVerbosity": "low"
-					}
-				},
-				"gpt-5-low-oauth": {
-					"name": "GPT-5 Low (OAuth)",
-					"options": {
-						"reasoningEffort": "low",
-						"reasoningSummary": "auto",
-						"textVerbosity": "low"
-					}
-				},
-				"gpt-5-medium-oauth": {
-					"name": "GPT-5 Medium (OAuth)",
-					"options": {
-						"reasoningEffort": "medium",
-						"reasoningSummary": "auto",
-						"textVerbosity": "medium"
-					}
-				},
-				"gpt-5-high-oauth": {
-					"name": "GPT-5 High (OAuth)",
-					"options": {
-						"reasoningEffort": "high",
-						"reasoningSummary": "detailed",
-						"textVerbosity": "high"
-					}
-				}
-			}
-		},
-		"openrouter-preset": {
-			"npm": "@ai-sdk/openai-compatible",
-			"name": "OpenRouter Presets",
-			"options": {
-				"baseURL": "https://openrouter.ai/api/v1",
-				"apiKey": "{env:OPENROUTER_API_KEY}"
-			},
-			"models": {
-				"glm-4.7": {
-					"id": "@preset/glm-4-7",
-					"name": "Preset GLM-4.7 (via OpenRouter)"
-				}
-			}
-		},
-		"openrouter": {
-			"models": {
-				"deepseek/deepseek-chat-v3.1:free": {
-					"name": "DeepSeek Chat V3.1 (via OpenRouter)",
-					"options": {
-						"provider": {
-							"order": [
-								"open-inference"
-							],
-							"allow_fallbacks": false
-						}
-					}
-				},
-				"moonshotai/kimi-k2": {
-					"name": "Kimi K2 (via OpenRouter)",
-					"options": {
-						"provider": {
-							"order": [
-								"open-inference"
-							],
-							"allow_fallbacks": false
-						}
-					}
-				},
-				"moonshotai/kimi-k2:free": {
-					"name": "Kimi K2 Free (via OpenRouter)",
-					"options": {
-						"provider": {
-							"order": [
-								"open-inference"
-							],
-							"allow_fallbacks": false
-						}
-					}
-				},
-				"openai/gpt-oss-120b:free": {
-					"name": "GPT-OSS 120B Free (via OpenRouter)",
-					"options": {
-						"provider": {
-							"order": [
-								"open-inference"
-							],
-							"allow_fallbacks": false
-						}
-					}
-				},
-				"qwen/qwen3-coder:free": {
-					"name": "Qwen3 Coder Free (via OpenRouter)",
-					"options": {
-						"provider": {
-							"order": [
-								"open-inference"
-							],
-							"allow_fallbacks": false
-						}
-					}
-				}
-			},
-			"options": {
-				"apiKey": "{env:OPENROUTER_API_KEY}"
-			}
-		},
-		"zai-coding-plan": {
-			"models": {
-				"glm-4.7": {
-					"name": "GLM-4.7 Coding Plan (via Z-AI)"
-				}
-			},
-			"options": {
-				"apiKey": "{env:ZAI_API_KEY}"
-			}
-		}
-	},
-	"plugin": [
-		"cc-safety-net"
-	],
-	"tui": {
-		"scroll_speed": 3
-	}
+  "$schema": "https://opencode.ai/config.json",
+
+  "model": "cliproxyapi/glm-4.7",
+  "small_model": "cliproxyapi/glm-4.7",
+  "autoupdate": true,
+  "agent": {
+    "code-reviewer": {
+      "description": "Reviews code for best practices and potential issues",
+      "model": "anthropic/claude-sonnet-4-20250514",
+      "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
+      "tools": {
+        // Disable file modification tools for review-only agent
+        "write": false,
+        "edit": false
+      }
+    }
+  },
+  "provider": {
+    "shunkakinoki": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "CLIProxyAPI (remote)",
+      "options": {
+        "baseURL": "https://cliproxy.shunkakinoki.com/v1",
+        "apiKey": "{env:CLIPROXY_API_KEY}"
+      },
+      "models": {
+        "claude-opus-4-6": {
+          "name": "Claude Opus 4.6 (via shunkakinoki's CLIProxy)"
+        },
+        "claude-sonnet-4-6": {
+          "name": "Claude Sonnet 4.6 (via shunkakinoki's CLIProxy)"
+        },
+        "claude-haiku-4-5-20251001": {
+          "name": "Claude Haiku 4.5 (via shunkakinoki's CLIProxy)"
+        },
+        "gpt-5.2": {
+          "name": "GPT 5.2 (via shunkakinoki's CLIProxy)"
+        },
+        "gpt-5.3-codex": {
+          "name": "GPT 5.3 Codex (via shunkakinoki's CLIProxy)"
+        },
+        "gemini-3-pro-preview": {
+          "name": "Gemini 3 Pro (via shunkakinoki's CLIProxy)"
+        },
+        "gemini-3-flash-preview": {
+          "name": "Gemini 3 Flash (via shunkakinoki's CLIProxy)"
+        },
+        "z-ai/glm-4.7": {
+          "name": "GLM 4.7 (via shunkakinoki's CLIProxy)"
+        }
+      }
+    },
+    "cliproxyapi": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "CLIProxyAPI (local)",
+      "options": {
+        "baseURL": "http://localhost:8317/v1",
+        "apiKey": "{env:CLIPROXY_API_KEY}"
+      },
+      "models": {
+        "claude-opus-4-6": {
+          "name": "Claude Opus 4.6 (via local CLIProxyAPI)"
+        },
+        "claude-sonnet-4-6": {
+          "name": "Claude Sonnet 4.6 (via local CLIProxyAPI)"
+        },
+        "claude-haiku-4-5-20251001": {
+          "name": "Claude Haiku 4.5 (via local CLIProxyAPI)"
+        },
+        "gpt-5.2": {
+          "name": "GPT 5.2 (via local CLIProxyAPI)"
+        },
+        "gpt-5.3-codex": {
+          "name": "GPT 5.3 Codex (via local CLIProxyAPI)"
+        },
+        "gemini-3-pro-preview": {
+          "name": "Gemini 3 Pro (via local CLIProxyAPI)"
+        },
+        "gemini-3-flash-preview": {
+          "name": "Gemini 3 Flash (via local CLIProxyAPI)"
+        },
+        "glm-4.7": {
+          "name": "GLM 4.7 (via local CLIProxyAPI)"
+        }
+      }
+    },
+    "lmstudio": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "LM Studio (local)",
+      "options": {
+        "baseURL": "http://127.0.0.1:1234/v1"
+      },
+      "models": {
+        "openai/gpt-oss-20b": {
+          "name": "OpenAI: gpt-oss-20b"
+        },
+        "openai/gpt-oss-120b": {
+          "name": "OpenAI: gpt-oss-120b"
+        },
+        "zai-org/glm-4.7-flash": {
+          "name": "GLM-4.7 Flash (via LM Studio)"
+        }
+      }
+    },
+    "ollama": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Ollama (local)",
+      "options": {
+        "baseURL": "http://localhost:11434/v1"
+      },
+      "models": {
+        "openai/gpt-oss-20b": {
+          "name": "OpenAI: gpt-oss-20b"
+        }
+      }
+    },
+    "openai": {
+      "options": {
+        "reasoningEffort": "medium",
+        "reasoningSummary": "auto",
+        "textVerbosity": "medium",
+        "include": ["reasoning.encrypted_content"]
+      },
+      "models": {
+        "gpt-5-codex-low-oauth": {
+          "name": "GPT-5 Codex Low (OAuth)",
+          "options": {
+            "reasoningEffort": "low",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium"
+          }
+        },
+        "gpt-5-codex-medium-oauth": {
+          "name": "GPT-5 Codex Medium (OAuth)",
+          "options": {
+            "reasoningEffort": "medium",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium"
+          }
+        },
+        "gpt-5-codex-high-oauth": {
+          "name": "GPT-5 Codex High (OAuth)",
+          "options": {
+            "reasoningEffort": "high",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium"
+          }
+        },
+        "gpt-5-minimal-oauth": {
+          "name": "GPT-5 Minimal (OAuth)",
+          "options": {
+            "reasoningEffort": "minimal",
+            "reasoningSummary": "auto",
+            "textVerbosity": "low"
+          }
+        },
+        "gpt-5-low-oauth": {
+          "name": "GPT-5 Low (OAuth)",
+          "options": {
+            "reasoningEffort": "low",
+            "reasoningSummary": "auto",
+            "textVerbosity": "low"
+          }
+        },
+        "gpt-5-medium-oauth": {
+          "name": "GPT-5 Medium (OAuth)",
+          "options": {
+            "reasoningEffort": "medium",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium"
+          }
+        },
+        "gpt-5-high-oauth": {
+          "name": "GPT-5 High (OAuth)",
+          "options": {
+            "reasoningEffort": "high",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "high"
+          }
+        }
+      }
+    },
+    "openrouter-preset": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "OpenRouter Presets",
+      "options": {
+        "baseURL": "https://openrouter.ai/api/v1",
+        "apiKey": "{env:OPENROUTER_API_KEY}"
+      },
+      "models": {
+        "glm-4.7": {
+          "id": "@preset/glm-4-7",
+          "name": "Preset GLM-4.7 (via OpenRouter)"
+        }
+      }
+    },
+    "openrouter": {
+      "models": {
+        "deepseek/deepseek-chat-v3.1:free": {
+          "name": "DeepSeek Chat V3.1 (via OpenRouter)",
+          "options": {
+            "provider": {
+              "order": ["open-inference"],
+              "allow_fallbacks": false
+            }
+          }
+        },
+        "moonshotai/kimi-k2": {
+          "name": "Kimi K2 (via OpenRouter)",
+          "options": {
+            "provider": {
+              "order": ["open-inference"],
+              "allow_fallbacks": false
+            }
+          }
+        },
+        "moonshotai/kimi-k2:free": {
+          "name": "Kimi K2 Free (via OpenRouter)",
+          "options": {
+            "provider": {
+              "order": ["open-inference"],
+              "allow_fallbacks": false
+            }
+          }
+        },
+        "openai/gpt-oss-120b:free": {
+          "name": "GPT-OSS 120B Free (via OpenRouter)",
+          "options": {
+            "provider": {
+              "order": ["open-inference"],
+              "allow_fallbacks": false
+            }
+          }
+        },
+        "qwen/qwen3-coder:free": {
+          "name": "Qwen3 Coder Free (via OpenRouter)",
+          "options": {
+            "provider": {
+              "order": ["open-inference"],
+              "allow_fallbacks": false
+            }
+          }
+        }
+      },
+      "options": {
+        "apiKey": "{env:OPENROUTER_API_KEY}"
+      }
+    },
+    "zai-coding-plan": {
+      "models": {
+        "glm-4.7": {
+          "name": "GLM-4.7 Coding Plan (via Z-AI)"
+        }
+      },
+      "options": {
+        "apiKey": "{env:ZAI_API_KEY}"
+      }
+    }
+  },
+  "plugin": ["cc-safety-net"],
+  "tui": {
+    "scroll_speed": 3
+  }
 }

--- a/config/opencode/opencode.tpl.jsonc
+++ b/config/opencode/opencode.tpl.jsonc
@@ -1,279 +1,265 @@
 {
-	"$schema": "https://opencode.ai/config.json",
-	"theme": "transparent",
-	"model": "cliproxyapi/__GLM__",
-	"small_model": "cliproxyapi/__GLM__",
-	"autoupdate": true,
-	"agent": {
-		"code-reviewer": {
-			"description": "Reviews code for best practices and potential issues",
-			"model": "anthropic/claude-sonnet-4-20250514",
-			"prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
-			"tools": {
-				// Disable file modification tools for review-only agent
-				"write": false,
-				"edit": false
-			}
-		}
-	},
-	"provider": {
-		"shunkakinoki": {
-			"npm": "@ai-sdk/openai-compatible",
-			"name": "CLIProxyAPI (remote)",
-			"options": {
-				"baseURL": "https://cliproxy.shunkakinoki.com/v1",
-				"apiKey": "{env:CLIPROXY_API_KEY}"
-			},
-			"models": {
-				"__CLAUDE_OPUS__": {
-					"name": "__CLAUDE_OPUS_PRETTY__ (via shunkakinoki's CLIProxy)"
-				},
-				"__CLAUDE_SONNET__": {
-					"name": "__CLAUDE_SONNET_PRETTY__ (via shunkakinoki's CLIProxy)"
-				},
-				"__CLAUDE_HAIKU__": {
-					"name": "__CLAUDE_HAIKU_PRETTY__ (via shunkakinoki's CLIProxy)"
-				},
-				"__GPT__": {
-					"name": "__GPT_PRETTY__ (via shunkakinoki's CLIProxy)"
-				},
-				"__GPT_CODEX__": {
-					"name": "__GPT_CODEX_PRETTY__ (via shunkakinoki's CLIProxy)"
-				},
-				"__GEMINI_PRO__": {
-					"name": "__GEMINI_PRO_PRETTY__ (via shunkakinoki's CLIProxy)"
-				},
-				"__GEMINI_FLASH__": {
-					"name": "__GEMINI_FLASH_PRETTY__ (via shunkakinoki's CLIProxy)"
-				},
-				"z-ai/__GLM__": {
-					"name": "__GLM_PRETTY__ (via shunkakinoki's CLIProxy)"
-				}
-			}
-		},
-		"cliproxyapi": {
-			"npm": "@ai-sdk/openai-compatible",
-			"name": "CLIProxyAPI (local)",
-			"options": {
-				"baseURL": "http://localhost:8317/v1",
-				"apiKey": "{env:CLIPROXY_API_KEY}"
-			},
-			"models": {
-				"__CLAUDE_OPUS__": {
-					"name": "__CLAUDE_OPUS_PRETTY__ (via local CLIProxyAPI)"
-				},
-				"__CLAUDE_SONNET__": {
-					"name": "__CLAUDE_SONNET_PRETTY__ (via local CLIProxyAPI)"
-				},
-				"__CLAUDE_HAIKU__": {
-					"name": "__CLAUDE_HAIKU_PRETTY__ (via local CLIProxyAPI)"
-				},
-				"__GPT__": {
-					"name": "__GPT_PRETTY__ (via local CLIProxyAPI)"
-				},
-				"__GPT_CODEX__": {
-					"name": "__GPT_CODEX_PRETTY__ (via local CLIProxyAPI)"
-				},
-				"__GEMINI_PRO__": {
-					"name": "__GEMINI_PRO_PRETTY__ (via local CLIProxyAPI)"
-				},
-				"__GEMINI_FLASH__": {
-					"name": "__GEMINI_FLASH_PRETTY__ (via local CLIProxyAPI)"
-				},
-				"__GLM__": {
-					"name": "__GLM_PRETTY__ (via local CLIProxyAPI)"
-				}
-			}
-		},
-		"lmstudio": {
-			"npm": "@ai-sdk/openai-compatible",
-			"name": "LM Studio (local)",
-			"options": {
-				"baseURL": "http://127.0.0.1:1234/v1"
-			},
-			"models": {
-				"openai/gpt-oss-20b": {
-					"name": "OpenAI: gpt-oss-20b"
-				},
-				"openai/gpt-oss-120b": {
-					"name": "OpenAI: gpt-oss-120b"
-				},
-				"zai-org/glm-4.7-flash": {
-					"name": "GLM-4.7 Flash (via LM Studio)"
-				}
-			}
-		},
-		"ollama": {
-			"npm": "@ai-sdk/openai-compatible",
-			"name": "Ollama (local)",
-			"options": {
-				"baseURL": "http://localhost:11434/v1"
-			},
-			"models": {
-				"openai/gpt-oss-20b": {
-					"name": "OpenAI: gpt-oss-20b"
-				}
-			}
-		},
-		"openai": {
-			"options": {
-				"reasoningEffort": "medium",
-				"reasoningSummary": "auto",
-				"textVerbosity": "medium",
-				"include": [
-					"reasoning.encrypted_content"
-				]
-			},
-			"models": {
-				"gpt-5-codex-low-oauth": {
-					"name": "GPT-5 Codex Low (OAuth)",
-					"options": {
-						"reasoningEffort": "low",
-						"reasoningSummary": "auto",
-						"textVerbosity": "medium"
-					}
-				},
-				"gpt-5-codex-medium-oauth": {
-					"name": "GPT-5 Codex Medium (OAuth)",
-					"options": {
-						"reasoningEffort": "medium",
-						"reasoningSummary": "auto",
-						"textVerbosity": "medium"
-					}
-				},
-				"gpt-5-codex-high-oauth": {
-					"name": "GPT-5 Codex High (OAuth)",
-					"options": {
-						"reasoningEffort": "high",
-						"reasoningSummary": "detailed",
-						"textVerbosity": "medium"
-					}
-				},
-				"gpt-5-minimal-oauth": {
-					"name": "GPT-5 Minimal (OAuth)",
-					"options": {
-						"reasoningEffort": "minimal",
-						"reasoningSummary": "auto",
-						"textVerbosity": "low"
-					}
-				},
-				"gpt-5-low-oauth": {
-					"name": "GPT-5 Low (OAuth)",
-					"options": {
-						"reasoningEffort": "low",
-						"reasoningSummary": "auto",
-						"textVerbosity": "low"
-					}
-				},
-				"gpt-5-medium-oauth": {
-					"name": "GPT-5 Medium (OAuth)",
-					"options": {
-						"reasoningEffort": "medium",
-						"reasoningSummary": "auto",
-						"textVerbosity": "medium"
-					}
-				},
-				"gpt-5-high-oauth": {
-					"name": "GPT-5 High (OAuth)",
-					"options": {
-						"reasoningEffort": "high",
-						"reasoningSummary": "detailed",
-						"textVerbosity": "high"
-					}
-				}
-			}
-		},
-		"openrouter-preset": {
-			"npm": "@ai-sdk/openai-compatible",
-			"name": "OpenRouter Presets",
-			"options": {
-				"baseURL": "https://openrouter.ai/api/v1",
-				"apiKey": "{env:OPENROUTER_API_KEY}"
-			},
-			"models": {
-				"glm-4.7": {
-					"id": "@preset/glm-4-7",
-					"name": "Preset GLM-4.7 (via OpenRouter)"
-				}
-			}
-		},
-		"openrouter": {
-			"models": {
-				"deepseek/deepseek-chat-v3.1:free": {
-					"name": "DeepSeek Chat V3.1 (via OpenRouter)",
-					"options": {
-						"provider": {
-							"order": [
-								"open-inference"
-							],
-							"allow_fallbacks": false
-						}
-					}
-				},
-				"moonshotai/kimi-k2": {
-					"name": "Kimi K2 (via OpenRouter)",
-					"options": {
-						"provider": {
-							"order": [
-								"open-inference"
-							],
-							"allow_fallbacks": false
-						}
-					}
-				},
-				"moonshotai/kimi-k2:free": {
-					"name": "Kimi K2 Free (via OpenRouter)",
-					"options": {
-						"provider": {
-							"order": [
-								"open-inference"
-							],
-							"allow_fallbacks": false
-						}
-					}
-				},
-				"openai/gpt-oss-120b:free": {
-					"name": "GPT-OSS 120B Free (via OpenRouter)",
-					"options": {
-						"provider": {
-							"order": [
-								"open-inference"
-							],
-							"allow_fallbacks": false
-						}
-					}
-				},
-				"qwen/qwen3-coder:free": {
-					"name": "Qwen3 Coder Free (via OpenRouter)",
-					"options": {
-						"provider": {
-							"order": [
-								"open-inference"
-							],
-							"allow_fallbacks": false
-						}
-					}
-				}
-			},
-			"options": {
-				"apiKey": "{env:OPENROUTER_API_KEY}"
-			}
-		},
-		"zai-coding-plan": {
-			"models": {
-				"glm-4.7": {
-					"name": "GLM-4.7 Coding Plan (via Z-AI)"
-				}
-			},
-			"options": {
-				"apiKey": "{env:ZAI_API_KEY}"
-			}
-		}
-	},
-	"plugin": [
-		"cc-safety-net"
-	],
-	"tui": {
-		"scroll_speed": 3
-	}
+  "$schema": "https://opencode.ai/config.json",
+
+  "model": "cliproxyapi/__GLM__",
+  "small_model": "cliproxyapi/__GLM__",
+  "autoupdate": true,
+  "agent": {
+    "code-reviewer": {
+      "description": "Reviews code for best practices and potential issues",
+      "model": "anthropic/claude-sonnet-4-20250514",
+      "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
+      "tools": {
+        // Disable file modification tools for review-only agent
+        "write": false,
+        "edit": false
+      }
+    }
+  },
+  "provider": {
+    "shunkakinoki": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "CLIProxyAPI (remote)",
+      "options": {
+        "baseURL": "https://cliproxy.shunkakinoki.com/v1",
+        "apiKey": "{env:CLIPROXY_API_KEY}"
+      },
+      "models": {
+        "__CLAUDE_OPUS__": {
+          "name": "__CLAUDE_OPUS_PRETTY__ (via shunkakinoki's CLIProxy)"
+        },
+        "__CLAUDE_SONNET__": {
+          "name": "__CLAUDE_SONNET_PRETTY__ (via shunkakinoki's CLIProxy)"
+        },
+        "__CLAUDE_HAIKU__": {
+          "name": "__CLAUDE_HAIKU_PRETTY__ (via shunkakinoki's CLIProxy)"
+        },
+        "__GPT__": {
+          "name": "__GPT_PRETTY__ (via shunkakinoki's CLIProxy)"
+        },
+        "__GPT_CODEX__": {
+          "name": "__GPT_CODEX_PRETTY__ (via shunkakinoki's CLIProxy)"
+        },
+        "__GEMINI_PRO__": {
+          "name": "__GEMINI_PRO_PRETTY__ (via shunkakinoki's CLIProxy)"
+        },
+        "__GEMINI_FLASH__": {
+          "name": "__GEMINI_FLASH_PRETTY__ (via shunkakinoki's CLIProxy)"
+        },
+        "z-ai/__GLM__": {
+          "name": "__GLM_PRETTY__ (via shunkakinoki's CLIProxy)"
+        }
+      }
+    },
+    "cliproxyapi": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "CLIProxyAPI (local)",
+      "options": {
+        "baseURL": "http://localhost:8317/v1",
+        "apiKey": "{env:CLIPROXY_API_KEY}"
+      },
+      "models": {
+        "__CLAUDE_OPUS__": {
+          "name": "__CLAUDE_OPUS_PRETTY__ (via local CLIProxyAPI)"
+        },
+        "__CLAUDE_SONNET__": {
+          "name": "__CLAUDE_SONNET_PRETTY__ (via local CLIProxyAPI)"
+        },
+        "__CLAUDE_HAIKU__": {
+          "name": "__CLAUDE_HAIKU_PRETTY__ (via local CLIProxyAPI)"
+        },
+        "__GPT__": {
+          "name": "__GPT_PRETTY__ (via local CLIProxyAPI)"
+        },
+        "__GPT_CODEX__": {
+          "name": "__GPT_CODEX_PRETTY__ (via local CLIProxyAPI)"
+        },
+        "__GEMINI_PRO__": {
+          "name": "__GEMINI_PRO_PRETTY__ (via local CLIProxyAPI)"
+        },
+        "__GEMINI_FLASH__": {
+          "name": "__GEMINI_FLASH_PRETTY__ (via local CLIProxyAPI)"
+        },
+        "__GLM__": {
+          "name": "__GLM_PRETTY__ (via local CLIProxyAPI)"
+        }
+      }
+    },
+    "lmstudio": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "LM Studio (local)",
+      "options": {
+        "baseURL": "http://127.0.0.1:1234/v1"
+      },
+      "models": {
+        "openai/gpt-oss-20b": {
+          "name": "OpenAI: gpt-oss-20b"
+        },
+        "openai/gpt-oss-120b": {
+          "name": "OpenAI: gpt-oss-120b"
+        },
+        "zai-org/glm-4.7-flash": {
+          "name": "GLM-4.7 Flash (via LM Studio)"
+        }
+      }
+    },
+    "ollama": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Ollama (local)",
+      "options": {
+        "baseURL": "http://localhost:11434/v1"
+      },
+      "models": {
+        "openai/gpt-oss-20b": {
+          "name": "OpenAI: gpt-oss-20b"
+        }
+      }
+    },
+    "openai": {
+      "options": {
+        "reasoningEffort": "medium",
+        "reasoningSummary": "auto",
+        "textVerbosity": "medium",
+        "include": ["reasoning.encrypted_content"]
+      },
+      "models": {
+        "gpt-5-codex-low-oauth": {
+          "name": "GPT-5 Codex Low (OAuth)",
+          "options": {
+            "reasoningEffort": "low",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium"
+          }
+        },
+        "gpt-5-codex-medium-oauth": {
+          "name": "GPT-5 Codex Medium (OAuth)",
+          "options": {
+            "reasoningEffort": "medium",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium"
+          }
+        },
+        "gpt-5-codex-high-oauth": {
+          "name": "GPT-5 Codex High (OAuth)",
+          "options": {
+            "reasoningEffort": "high",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "medium"
+          }
+        },
+        "gpt-5-minimal-oauth": {
+          "name": "GPT-5 Minimal (OAuth)",
+          "options": {
+            "reasoningEffort": "minimal",
+            "reasoningSummary": "auto",
+            "textVerbosity": "low"
+          }
+        },
+        "gpt-5-low-oauth": {
+          "name": "GPT-5 Low (OAuth)",
+          "options": {
+            "reasoningEffort": "low",
+            "reasoningSummary": "auto",
+            "textVerbosity": "low"
+          }
+        },
+        "gpt-5-medium-oauth": {
+          "name": "GPT-5 Medium (OAuth)",
+          "options": {
+            "reasoningEffort": "medium",
+            "reasoningSummary": "auto",
+            "textVerbosity": "medium"
+          }
+        },
+        "gpt-5-high-oauth": {
+          "name": "GPT-5 High (OAuth)",
+          "options": {
+            "reasoningEffort": "high",
+            "reasoningSummary": "detailed",
+            "textVerbosity": "high"
+          }
+        }
+      }
+    },
+    "openrouter-preset": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "OpenRouter Presets",
+      "options": {
+        "baseURL": "https://openrouter.ai/api/v1",
+        "apiKey": "{env:OPENROUTER_API_KEY}"
+      },
+      "models": {
+        "glm-4.7": {
+          "id": "@preset/glm-4-7",
+          "name": "Preset GLM-4.7 (via OpenRouter)"
+        }
+      }
+    },
+    "openrouter": {
+      "models": {
+        "deepseek/deepseek-chat-v3.1:free": {
+          "name": "DeepSeek Chat V3.1 (via OpenRouter)",
+          "options": {
+            "provider": {
+              "order": ["open-inference"],
+              "allow_fallbacks": false
+            }
+          }
+        },
+        "moonshotai/kimi-k2": {
+          "name": "Kimi K2 (via OpenRouter)",
+          "options": {
+            "provider": {
+              "order": ["open-inference"],
+              "allow_fallbacks": false
+            }
+          }
+        },
+        "moonshotai/kimi-k2:free": {
+          "name": "Kimi K2 Free (via OpenRouter)",
+          "options": {
+            "provider": {
+              "order": ["open-inference"],
+              "allow_fallbacks": false
+            }
+          }
+        },
+        "openai/gpt-oss-120b:free": {
+          "name": "GPT-OSS 120B Free (via OpenRouter)",
+          "options": {
+            "provider": {
+              "order": ["open-inference"],
+              "allow_fallbacks": false
+            }
+          }
+        },
+        "qwen/qwen3-coder:free": {
+          "name": "Qwen3 Coder Free (via OpenRouter)",
+          "options": {
+            "provider": {
+              "order": ["open-inference"],
+              "allow_fallbacks": false
+            }
+          }
+        }
+      },
+      "options": {
+        "apiKey": "{env:OPENROUTER_API_KEY}"
+      }
+    },
+    "zai-coding-plan": {
+      "models": {
+        "glm-4.7": {
+          "name": "GLM-4.7 Coding Plan (via Z-AI)"
+        }
+      },
+      "options": {
+        "apiKey": "{env:ZAI_API_KEY}"
+      }
+    }
+  },
+  "plugin": ["cc-safety-net"],
+  "tui": {
+    "scroll_speed": 3
+  }
 }


### PR DESCRIPTION
## Changes Made
- Removed invalid 'transparent' theme from opencode config files (theme name doesn't exist)
- Removed /pr-create auto variant from pr-create skill documentation
- Updated dotagents submodule to sync changes

## Technical Details
The opencode config had 'transparent' set as the theme, but this is not a valid built-in theme name. OpenCode supports: system, tokyonight, everforest, ayu, catppuccin, catppuccin-macchiato, gruvbox, kanagawa, nord, matrix, one-dark, and opencode (default).

The /pr-create auto variant was removed to simplify the skill and remove unused functionality. For transparent backgrounds, users should use the 'system' theme which adapts to the terminal's native background color.

## Testing
- Manual verification of config file changes
- Confirmed dotagents submodule commits are properly synced
- Tested that changes align with opencode documentation

🤖 Generated with OpenCode by GLM-4.7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the invalid "transparent" theme from OpenCode configs and dropped the "/pr-create auto" variant. Fixes the theme not applying and simplifies the pr-create skill; reset the dotagents submodule to origin/main while upstream changes are pending.

- **Migration**
  - For transparent backgrounds, set theme to "system".
  - Replace any "/pr-create auto" usage with "/pr-create".

<sup>Written for commit 4a06658046d17413603161b72a5f296cdbc501d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

