### PR TITLE
chore: migrate opencode theme config to tui.json

### DIFF
--- a/config/opencode/default.nix
+++ b/config/opencode/default.nix
@@ -5,6 +5,11 @@
     force = true;
   };
 
+  home.file.".config/opencode/tui.json" = {
+    source = ./tui.json;
+    force = true;
+  };
+
   home.file.".config/opencode/themes/transparent.json" = {
     source = ./themes/transparent.json;
     force = true;

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -1,6 +1,5 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "theme": "dracula",
   "model": "cliproxyapi/glm-4.7",
   "small_model": "cliproxyapi/glm-4.7",
   "autoupdate": true,
@@ -120,9 +119,7 @@
         "reasoningEffort": "medium",
         "reasoningSummary": "auto",
         "textVerbosity": "medium",
-        "include": [
-          "reasoning.encrypted_content"
-        ]
+        "include": ["reasoning.encrypted_content"]
       },
       "models": {
         "gpt-5-codex-low-oauth": {
@@ -203,9 +200,7 @@
           "name": "DeepSeek Chat V3.1 (via OpenRouter)",
           "options": {
             "provider": {
-              "order": [
-                "open-inference"
-              ],
+              "order": ["open-inference"],
               "allow_fallbacks": false
             }
           }
@@ -214,9 +209,7 @@
           "name": "Kimi K2 (via OpenRouter)",
           "options": {
             "provider": {
-              "order": [
-                "open-inference"
-              ],
+              "order": ["open-inference"],
               "allow_fallbacks": false
             }
           }
@@ -225,9 +218,7 @@
           "name": "Kimi K2 Free (via OpenRouter)",
           "options": {
             "provider": {
-              "order": [
-                "open-inference"
-              ],
+              "order": ["open-inference"],
               "allow_fallbacks": false
             }
           }
@@ -236,9 +227,7 @@
           "name": "GPT-OSS 120B Free (via OpenRouter)",
           "options": {
             "provider": {
-              "order": [
-                "open-inference"
-              ],
+              "order": ["open-inference"],
               "allow_fallbacks": false
             }
           }
@@ -247,9 +236,7 @@
           "name": "Qwen3 Coder Free (via OpenRouter)",
           "options": {
             "provider": {
-              "order": [
-                "open-inference"
-              ],
+              "order": ["open-inference"],
               "allow_fallbacks": false
             }
           }
@@ -270,10 +257,5 @@
       }
     }
   },
-  "plugin": [
-    "cc-safety-net"
-  ],
-  "tui": {
-    "scroll_speed": 3
-  }
+  "plugin": ["cc-safety-net"]
 }

--- a/config/opencode/opencode.tpl.jsonc
+++ b/config/opencode/opencode.tpl.jsonc
@@ -1,6 +1,5 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "theme": "dracula",
   "model": "cliproxyapi/__GLM__",
   "small_model": "cliproxyapi/__GLM__",
   "autoupdate": true,
@@ -120,9 +119,7 @@
         "reasoningEffort": "medium",
         "reasoningSummary": "auto",
         "textVerbosity": "medium",
-        "include": [
-          "reasoning.encrypted_content"
-        ]
+        "include": ["reasoning.encrypted_content"]
       },
       "models": {
         "gpt-5-codex-low-oauth": {
@@ -203,9 +200,7 @@
           "name": "DeepSeek Chat V3.1 (via OpenRouter)",
           "options": {
             "provider": {
-              "order": [
-                "open-inference"
-              ],
+              "order": ["open-inference"],
               "allow_fallbacks": false
             }
           }
@@ -214,9 +209,7 @@
           "name": "Kimi K2 (via OpenRouter)",
           "options": {
             "provider": {
-              "order": [
-                "open-inference"
-              ],
+              "order": ["open-inference"],
               "allow_fallbacks": false
             }
           }
@@ -225,9 +218,7 @@
           "name": "Kimi K2 Free (via OpenRouter)",
           "options": {
             "provider": {
-              "order": [
-                "open-inference"
-              ],
+              "order": ["open-inference"],
               "allow_fallbacks": false
             }
           }
@@ -236,9 +227,7 @@
           "name": "GPT-OSS 120B Free (via OpenRouter)",
           "options": {
             "provider": {
-              "order": [
-                "open-inference"
-              ],
+              "order": ["open-inference"],
               "allow_fallbacks": false
             }
           }
@@ -247,9 +236,7 @@
           "name": "Qwen3 Coder Free (via OpenRouter)",
           "options": {
             "provider": {
-              "order": [
-                "open-inference"
-              ],
+              "order": ["open-inference"],
               "allow_fallbacks": false
             }
           }
@@ -270,10 +257,5 @@
       }
     }
   },
-  "plugin": [
-    "cc-safety-net"
-  ],
-  "tui": {
-    "scroll_speed": 3
-  }
+  "plugin": ["cc-safety-net"]
 }

--- a/config/opencode/tui.json
+++ b/config/opencode/tui.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://opencode.ai/tui.json",
+  "theme": "tokyonight",
+  "scroll_speed": 3
+}

--- a/config/opencode/tui.tpl.json
+++ b/config/opencode/tui.tpl.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://opencode.ai/tui.json",
-  "theme": "tokyonight",
-  "scroll_speed": 3
-}

--- a/config/opencode/tui.tpl.json
+++ b/config/opencode/tui.tpl.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://opencode.ai/tui.json",
+  "theme": "tokyonight",
+  "scroll_speed": 3
+}


### PR DESCRIPTION
## Changes
- Create `config/opencode/tui.json` and `tui.tpl.json` with new `$schema` and `theme: tokyonight`
- Move `scroll_speed` from `opencode.jsonc` `tui` block into `tui.json`
- Remove `theme` and `tui` keys from `opencode.jsonc` and `opencode.tpl.jsonc`
- Update `default.nix` to symlink `tui.json` → `~/.config/opencode/tui.json`

## Technical Details
- opencode now reads UI theme from a separate `tui.json` file instead of `opencode.jsonc`

Generated with Claude Code by claude-sonnet-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move TUI settings into a dedicated tui.json and set the theme to tokyonight. This simplifies opencode config and aligns with the new TUI schema.

- **Refactors**
  - Add config/opencode/tui.json ($schema; theme: tokyonight; scroll_speed).
  - Remove theme/tui from opencode.jsonc and opencode.tpl.jsonc; drop tui.tpl.json.
  - Update default.nix to symlink ~/.config/opencode/tui.json.

- **Migration**
  - Home Manager: rebuild to apply.
  - Manual: create ~/.config/opencode/tui.json with the new schema.

<sup>Written for commit a44919cc07d5f83867889b43b6a99fb05cfe0c10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

