### PR TITLE
feat: add make reset command to restore clean git state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,12 @@ clean: ## Clean up old Nix generations and garbage collect.
 	@$(SUDO) nix-collect-garbage -d
 	@echo "✅ Cleanup complete"
 
+.PHONY: reset
+reset: git-submodule-sync ## Reset git status to clean (restore all changes and reinitialize submodules).
+	@echo "🔄 Resetting git status to clean..."
+	@git checkout -- .
+	@echo "✅ Git status reset to clean"
+
 .PHONY: services
 services: ## Restart platform-specific services (launchd on macOS, systemd on Linux).
 	@if [ "$(OS)" = "Darwin" ]; then \


### PR DESCRIPTION
## Changes
- Added `make reset` target to the `##@ General` section
- Depends on existing `git-submodule-sync` to reinitialize submodules
- Restores all tracked file changes via git checkout

## Testing
- Run `make reset` to verify it clears modified files and resyncs submodules

Generated with Claude Code by claude-sonnet-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a make reset command to quickly restore a clean git working tree and resync submodules. This makes it easy to discard local changes and fix submodule drift.

- **New Features**
  - New make reset target depends on git-submodule-sync to reinitialize submodules.
  - Restores tracked files using git checkout -- . to return to a clean state.

<sup>Written for commit 53d42eca999be622f4c0912d76630d1c0fa64173. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

