### PR TITLE
fix(xremap): suppress enable=false warning on non-desktop hosts

### DIFF
--- a/home-manager/modules/xremap/default.nix
+++ b/home-manager/modules/xremap/default.nix
@@ -90,33 +90,36 @@ let
   };
 in
 {
-  config = lib.mkIf (isDesktop && isLinux) {
-    services.xremap = {
-      enable = true;
-      withWlroots = true;
-      watch = true;
-      # Only intercept keyd output — SUPER (CapsLock/RightAlt) goes straight to Hyprland
-      deviceNames = [ "keyd virtual keyboard" ];
-      config = {
-        keymap = [
-          {
-            name = "Framework Command (Ghostty)";
-            application.only = [ "com.mitchellh.ghostty" ];
-            remap = ghosttyRemap;
-          }
-          {
-            name = "Framework Command (Global)";
-            application.not = [ "com.mitchellh.ghostty" ];
-            remap = globalRemap;
-          }
-        ];
+  config = lib.mkMerge [
+    { services.xremap.enable = lib.mkDefault false; }
+    (lib.mkIf (isDesktop && isLinux) {
+      services.xremap = {
+        enable = true;
+        withWlroots = true;
+        watch = true;
+        # Only intercept keyd output — SUPER (CapsLock/RightAlt) goes straight to Hyprland
+        deviceNames = [ "keyd virtual keyboard" ];
+        config = {
+          keymap = [
+            {
+              name = "Framework Command (Ghostty)";
+              application.only = [ "com.mitchellh.ghostty" ];
+              remap = ghosttyRemap;
+            }
+            {
+              name = "Framework Command (Global)";
+              application.not = [ "com.mitchellh.ghostty" ];
+              remap = globalRemap;
+            }
+          ];
+        };
       };
-    };
 
-    # Upstream module already sets After/PartOf/Restart; only add extras.
-    systemd.user.services.xremap = {
-      Unit.StartLimitIntervalSec = 0;
-      Service.RestartSec = 3;
-    };
-  };
+      # Upstream module already sets After/PartOf/Restart; only add extras.
+      systemd.user.services.xremap = {
+        Unit.StartLimitIntervalSec = 0;
+        Service.RestartSec = 3;
+      };
+    })
+  ];
 }


### PR DESCRIPTION
## Summary

- Wraps the xremap config in `lib.mkMerge` to explicitly set `services.xremap.enable = lib.mkDefault false`
- Suppresses the upstream module warning emitted when `enable` is left at its implicit default on non-desktop hosts (e.g. `ubuntu`)
- On desktop Linux, the `lib.mkIf` block's `enable = true` still takes precedence via NixOS module priority

## Test plan

- [ ] `make build` on a non-desktop host (e.g. `ubuntu`) produces no xremap evaluation warning
- [ ] `make build` on a desktop host (e.g. `kyber`) still enables and activates xremap correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress the xremap warning on non-desktop hosts by explicitly defaulting enable=false, while keeping desktop Linux behavior unchanged.

- **Bug Fixes**
  - Wrapped config in lib.mkMerge and set services.xremap.enable = lib.mkDefault false to silence the upstream warning on non-desktop hosts.
  - Preserved desktop Linux behavior with lib.mkIf (isDesktop && isLinux) where enable = true still wins via module priority, keeping systemd tweaks intact.

<sup>Written for commit 99a5b68920b6d8a66727506f0a526d0362af97f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

