### PR TITLE
Add Foundry nightly warning suppression to Fish shell config

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -22,6 +22,9 @@
       # Go configuration
       set -gx GOPATH $HOME/go
 
+      # Foundry configuration
+      set -gx FOUNDRY_DISABLE_NIGHTLY_WARNING 1
+
       direnv hook fish | source
     '';
     loginShellInit = ''


### PR DESCRIPTION
## Summary
Added Foundry environment variable configuration to the Fish shell initialization to suppress nightly build warnings.

## Changes
- Added `FOUNDRY_DISABLE_NIGHTLY_WARNING` environment variable set to `1` in Fish shell's `interactiveShellInit`
- Placed the configuration in the appropriate section alongside other tool configurations (Go)

## Details
This change disables Foundry's nightly version warnings by setting the environment variable during Fish shell initialization. The configuration is added to the interactive shell init section, ensuring it's available in all Fish shell sessions.

https://claude.ai/code/session_01WpfBrBGCVbJuAcHkRBjas7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress Foundry nightly build warnings in Fish by exporting FOUNDRY_DISABLE_NIGHTLY_WARNING=1 during interactive shell init. This reduces noise in interactive sessions.

<sup>Written for commit 6236cf92222bd57a24fcf0d2de7c4cc8be73cbba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

