### PR TITLE
fix(hyprland): remove hyprexpo plugin

### DIFF
--- a/config/hyprland/default.nix
+++ b/config/hyprland/default.nix
@@ -4,16 +4,12 @@
   pkgs,
   ...
 }:
-let
-  hyprexpoPlugin = pkgs.hyprlandPlugins.hyprexpo;
-in
 {
   wayland.windowManager.hyprland = {
     enable = true;
     package = pkgs.hyprland;
     systemd.enable = false;
     extraConfig = ''
-      plugin = ${hyprexpoPlugin}/lib/libhyprexpo.so
       exec-once = ${pkgs.hyprpanel}/bin/hyprpanel
       exec-once = ${pkgs.hyprshell}/bin/hyprshell run &
     ''

--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -431,17 +431,3 @@ bind = CTRL ALT SHIFT SUPER, L, exec, hyprlock
 # =============================================================================
 bind = $mod SHIFT, D, exec, hyprpanel toggleWindow notifications-center
 
-# =============================================================================
-# Plugins
-# =============================================================================
-plugin {
-    hyprexpo {
-        columns = 3
-        gap_size = 5
-        bg_col = rgb(282a36)
-        workspace_method = first 1
-        gesture_fingers = 3
-        gesture_distance = 300
-        gesture_positive = false
-    }
-}


### PR DESCRIPTION
## Summary

- Remove `hyprexpo` plugin: incompatible with `hyprland 0.54.1` in nixpkgs-unstable due to API changes (`HookSystemManager` removed in Hyprland 0.54.x)
- Remove plugin config block from `hyprland.conf`

## Test plan

- [x] `make build` succeeds
- [x] `make switch` applied successfully