### PR TITLE
feat(programs): add language servers and php program

### DIFF
--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -1,5 +1,9 @@
 { lib, pkgs, ... }:
 {
+  home.packages = with pkgs; [
+    nodePackages.bash-language-server
+  ];
+
   programs.bash = {
     enable = true;
     enableCompletion = true;

--- a/home-manager/programs/default.nix
+++ b/home-manager/programs/default.nix
@@ -24,6 +24,7 @@ let
   lsd = import ./lsd;
   neovim = import ./neovim;
   node = import ./node;
+  php = import ./php;
   python = import ./python;
   rust = import ./rust;
   ssh = import ./ssh;
@@ -53,6 +54,8 @@ in
   lazygit
   lsd
   neovim
+  node
+  php
   python
   rust
   ssh

--- a/home-manager/programs/node/default.nix
+++ b/home-manager/programs/node/default.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    node
+    nodejs
     nodePackages.typescript-language-server
   ];
 }

--- a/home-manager/programs/node/default.nix
+++ b/home-manager/programs/node/default.nix
@@ -2,5 +2,6 @@
 {
   home.packages = with pkgs; [
     node
+    nodePackages.typescript-language-server
   ];
 }

--- a/home-manager/programs/php/default.nix
+++ b/home-manager/programs/php/default.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    go
-    gopls
+    php
+    nodePackages.intelephense
   ];
 }

--- a/home-manager/programs/python/default.nix
+++ b/home-manager/programs/python/default.nix
@@ -2,6 +2,7 @@
 {
   home.packages = with pkgs; [
     python3
+    pyright
   ];
 
   programs.fish.interactiveShellInit = ''

--- a/home-manager/programs/rust/default.nix
+++ b/home-manager/programs/rust/default.nix
@@ -2,5 +2,6 @@
 {
   home.packages = with pkgs; [
     rustup
+    rust-analyzer
   ];
 }

--- a/home-manager/programs/rust/default.nix
+++ b/home-manager/programs/rust/default.nix
@@ -2,6 +2,5 @@
 {
   home.packages = with pkgs; [
     rustup
-    rust-analyzer
   ];
 }

--- a/home-manager/programs/zig/default.nix
+++ b/home-manager/programs/zig/default.nix
@@ -2,5 +2,6 @@
 {
   home.packages = with pkgs; [
     zig
+    zls
   ];
 }


### PR DESCRIPTION
## Summary
- Add PHP program directory (`home-manager/programs/php/`) with `php` and `nodePackages.intelephense` (PHP Intelephense LSP)
- Add language servers to existing program directories: `bash-language-server`, `typescript-language-server`, `pyright`, `rust-analyzer`, `zls`
- Wire `php` and `node` into the programs list in `default.nix`

## Test plan
- [ ] Run `home-manager switch` to verify all packages build and install correctly
- [ ] Confirm LSP servers are available in `$PATH` after switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add built-in LSP support for Bash, TypeScript, Python, Go, and Zig, and add a PHP program with Intelephense. Also register `php` and `node` in the programs list and switch Node to `nodejs`.

- **New Features**
  - New PHP program with `php` and `nodePackages.intelephense`.
  - Added LSPs: `nodePackages.bash-language-server`, `nodePackages.typescript-language-server`, `pyright`, `gopls`, `zls`.
  - Wired into `home-manager/programs/default.nix`: import `php`; include `node` and `php`.

- **Bug Fixes**
  - Use `nodejs` package name for Node.
  - Drop standalone `rust-analyzer`.

<sup>Written for commit a1b6220dffb55851bf78047dc0c7efefaea8b1ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

