### PR TITLE
fix(tmux): disable auto-restore, keep manual restore in work session only

### DIFF
--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -1,5 +1,9 @@
 { lib, pkgs, ... }:
 {
+  home.packages = with pkgs; [
+    nodePackages.bash-language-server
+  ];
+
   programs.bash = {
     enable = true;
     enableCompletion = true;

--- a/home-manager/programs/default.nix
+++ b/home-manager/programs/default.nix
@@ -24,6 +24,7 @@ let
   lsd = import ./lsd;
   neovim = import ./neovim;
   node = import ./node;
+  php = import ./php;
   python = import ./python;
   rust = import ./rust;
   ssh = import ./ssh;
@@ -53,6 +54,8 @@ in
   lazygit
   lsd
   neovim
+  node
+  php
   python
   rust
   ssh

--- a/home-manager/programs/node/default.nix
+++ b/home-manager/programs/node/default.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    node
+    nodejs
     nodePackages.typescript-language-server
   ];
 }

--- a/home-manager/programs/node/default.nix
+++ b/home-manager/programs/node/default.nix
@@ -2,5 +2,6 @@
 {
   home.packages = with pkgs; [
     node
+    nodePackages.typescript-language-server
   ];
 }

--- a/home-manager/programs/php/default.nix
+++ b/home-manager/programs/php/default.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    go
-    gopls
+    php
+    nodePackages.intelephense
   ];
 }

--- a/home-manager/programs/python/default.nix
+++ b/home-manager/programs/python/default.nix
@@ -2,6 +2,7 @@
 {
   home.packages = with pkgs; [
     python3
+    pyright
   ];
 
   programs.fish.interactiveShellInit = ''

--- a/home-manager/programs/rust/default.nix
+++ b/home-manager/programs/rust/default.nix
@@ -2,5 +2,6 @@
 {
   home.packages = with pkgs; [
     rustup
+    rust-analyzer
   ];
 }

--- a/home-manager/programs/rust/default.nix
+++ b/home-manager/programs/rust/default.nix
@@ -2,6 +2,5 @@
 {
   home.packages = with pkgs; [
     rustup
-    rust-analyzer
   ];
 }

--- a/home-manager/programs/tmux/tmux.conf
+++ b/home-manager/programs/tmux/tmux.conf
@@ -128,7 +128,7 @@ set -g message-style "bg=colour28,fg=colour255"
 # Resurrect + Continuum (session persistence)
 set -g @resurrect-capture-pane-contents 'on'
 set -g @resurrect-processes 'btop fish git'
-set -g @continuum-restore 'on'
+set -g @continuum-restore 'off'
 set -g @continuum-save-interval '3'
 
 # Tmux-thumbs (quick text copy)

--- a/home-manager/programs/zig/default.nix
+++ b/home-manager/programs/zig/default.nix
@@ -2,5 +2,6 @@
 {
   home.packages = with pkgs; [
     zig
+    zls
   ];
 }


### PR DESCRIPTION
## Summary

- Disable `@continuum-restore 'on'` globally so tmux does not auto-restore sessions on every server start
- Manual restore in `_two_function.fish` (work session) is preserved — resurrect only triggers when attaching to the `work` session
- `_tpo_function.fish` (primary session) is unaffected

## Test plan

- [ ] Start a new tmux server — sessions should NOT auto-restore
- [ ] Run `_tpo` — attaches to primary without restoring
- [ ] Run `_two` — triggers resurrect restore before attaching to work session

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable tmux auto-restore so sessions don’t come back on every server start; keep manual restore when attaching to the `work` session via `_two`. Also add language servers and a PHP program for better editor support.

- **Bug Fixes**
  - Set `@continuum-restore` to `off` to stop automatic restores.
  - `_two` still triggers Resurrect before attaching to `work`; `_tpo` is unchanged.

- **New Features**
  - Add language servers: `nodePackages.bash-language-server`, `gopls`, `nodePackages.typescript-language-server`, `pyright`, `zls`.
  - Switch `node` to `nodejs`.
  - Add PHP program with `php` and `nodePackages.intelephense`.

<sup>Written for commit 43c31727a91a4ce7d8164a9cf2ab4f5c5d8a9e75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

