### PR TITLE
feat(programs): add lsp servers for 14 languages

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -151,7 +151,7 @@ with pkgs;
   swappy
   totem
   vlc
-  vscode
+  vscode-insiders
   wf-recorder
   wl-clip-persist
   wl-clipboard

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -155,8 +155,7 @@ with pkgs;
   swappy
   totem
   vlc
-  vscode
-  pkgs-nightly.vscode-insiders
+  pkgs-nightly.vscode
   wf-recorder
   wl-clip-persist
   wl-clipboard

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -4,6 +4,10 @@
 }:
 let
   inherit (inputs.host) isDesktop isDev;
+  pkgs-nightly = import inputs.nixpkgs-nightly {
+    inherit (pkgs) system;
+    config.allowUnfree = true;
+  };
 in
 with pkgs;
 [
@@ -151,7 +155,8 @@ with pkgs;
   swappy
   totem
   vlc
-  vscode-insiders
+  vscode
+  pkgs-nightly.vscode-insiders
   wf-recorder
   wl-clip-persist
   wl-clipboard

--- a/home-manager/programs/clang/default.nix
+++ b/home-manager/programs/clang/default.nix
@@ -1,7 +1,6 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    rustup
-    rust-analyzer
+    clang-tools
   ];
 }

--- a/home-manager/programs/dart/default.nix
+++ b/home-manager/programs/dart/default.nix
@@ -1,7 +1,6 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    rustup
-    rust-analyzer
+    dart
   ];
 }

--- a/home-manager/programs/default.nix
+++ b/home-manager/programs/default.nix
@@ -9,8 +9,11 @@ let
   bash = import ./bash { inherit lib pkgs; };
   bat = import ./bat;
   btop = import ./btop;
+  clang = import ./clang;
+  dart = import ./dart;
   delta = import ./delta;
   direnv = import ./direnv;
+  elixir = import ./elixir;
   fd = import ./fd;
   fish = import ./fish;
   fnm = import ./fnm;
@@ -19,18 +22,28 @@ let
   ghq = import ./ghq;
   git = import ./git;
   go = import ./go;
+  haskell = import ./haskell;
+  java = import ./java;
+  kotlin = import ./kotlin;
   lazydocker = import ./lazydocker;
   lazygit = import ./lazygit;
   lsd = import ./lsd;
+  lua = import ./lua;
   neovim = import ./neovim;
+  nix = import ./nix;
   node = import ./node;
+  ocaml = import ./ocaml;
   php = import ./php;
   python = import ./python;
+  ruby = import ./ruby;
   rust = import ./rust;
   ssh = import ./ssh;
   starship = import ./starship;
+  swift = import ./swift;
+  terraform = import ./terraform;
   tms = import ./tms;
   tmux = import ./tmux;
+  yaml = import ./yaml;
   zig = import ./zig;
   zoxide = import ./zoxide;
   zsh = import ./zsh;
@@ -40,8 +53,11 @@ in
   bash
   bat
   btop
+  clang
+  dart
   delta
   direnv
+  elixir
   fd
   fish
   fnm
@@ -50,19 +66,29 @@ in
   ghq
   git
   go
+  haskell
+  java
+  kotlin
   lazydocker
   lazygit
   lsd
+  lua
   neovim
+  nix
   node
+  ocaml
   php
   python
+  ruby
   rust
   ssh
-  zig
   starship
+  swift
+  terraform
   tms
   tmux
+  yaml
+  zig
   zoxide
   zsh
 ]

--- a/home-manager/programs/elixir/default.nix
+++ b/home-manager/programs/elixir/default.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    rustup
-    rust-analyzer
+    elixir
+    elixir-ls
   ];
 }

--- a/home-manager/programs/haskell/default.nix
+++ b/home-manager/programs/haskell/default.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    rustup
-    rust-analyzer
+    ghc
+    haskell-language-server
   ];
 }

--- a/home-manager/programs/java/default.nix
+++ b/home-manager/programs/java/default.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    rustup
-    rust-analyzer
+    jdk21
+    jdt-language-server
   ];
 }

--- a/home-manager/programs/kotlin/default.nix
+++ b/home-manager/programs/kotlin/default.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    rustup
-    rust-analyzer
+    kotlin
+    kotlin-language-server
   ];
 }

--- a/home-manager/programs/lua/default.nix
+++ b/home-manager/programs/lua/default.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    rustup
-    rust-analyzer
+    lua
+    lua-language-server
   ];
 }

--- a/home-manager/programs/nix/default.nix
+++ b/home-manager/programs/nix/default.nix
@@ -1,7 +1,6 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    rustup
-    rust-analyzer
+    nixd
   ];
 }

--- a/home-manager/programs/ocaml/default.nix
+++ b/home-manager/programs/ocaml/default.nix
@@ -2,6 +2,6 @@
 {
   home.packages = with pkgs; [
     ocaml
-    ocamlPackages.ocaml-lsp-server
+    ocamlPackages.ocaml-lsp
   ];
 }

--- a/home-manager/programs/ocaml/default.nix
+++ b/home-manager/programs/ocaml/default.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    rustup
-    rust-analyzer
+    ocaml
+    ocamlPackages.ocaml-lsp-server
   ];
 }

--- a/home-manager/programs/ruby/default.nix
+++ b/home-manager/programs/ruby/default.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    rustup
-    rust-analyzer
+    ruby
+    rubyPackages.ruby-lsp
   ];
 }

--- a/home-manager/programs/rust/default.nix
+++ b/home-manager/programs/rust/default.nix
@@ -2,6 +2,5 @@
 {
   home.packages = with pkgs; [
     rustup
-    rust-analyzer
   ];
 }

--- a/home-manager/programs/swift/default.nix
+++ b/home-manager/programs/swift/default.nix
@@ -1,7 +1,6 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    rustup
-    rust-analyzer
+    swift
   ];
 }

--- a/home-manager/programs/terraform/default.nix
+++ b/home-manager/programs/terraform/default.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    rustup
-    rust-analyzer
+    terraform
+    terraform-ls
   ];
 }

--- a/home-manager/programs/yaml/default.nix
+++ b/home-manager/programs/yaml/default.nix
@@ -1,7 +1,6 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    rustup
-    rust-analyzer
+    yaml-language-server
   ];
 }

--- a/lib/nixpkgs-config.nix
+++ b/lib/nixpkgs-config.nix
@@ -10,6 +10,7 @@
       "crush"
       "qwen-code"
       "slack"
+      "vscode-insiders"
     ];
   joypixels.acceptLicense = true;
 }

--- a/lib/nixpkgs-config.nix
+++ b/lib/nixpkgs-config.nix
@@ -10,7 +10,7 @@
       "crush"
       "qwen-code"
       "slack"
-      "vscode-insiders"
+      "vscode"
     ];
   joypixels.acceptLicense = true;
 }


### PR DESCRIPTION
## Changes
- Add 13 new language program modules: `clang`, `dart`, `elixir`, `haskell`, `java`, `kotlin`, `lua`, `nix`, `ocaml`, `ruby`, `swift`, `terraform`, `yaml`
- Add `rust-analyzer` to existing `rust` module
- Switch Linux desktop VSCode from `vscode` to `vscode-insiders` (nightly)
- Sort all imports and list entries in `programs/default.nix` alphabetically

## LSP Coverage
| Language | LSP Server |
|---|---|
| C/C++ | `clangd` via `clang-tools` |
| Dart | built-in (`dart`) |
| Elixir | `elixir-ls` |
| Haskell | `haskell-language-server` |
| Java | `jdt-language-server` |
| Kotlin | `kotlin-language-server` |
| Lua | `lua-language-server` |
| Nix | `nixd` |
| OCaml | `ocaml-lsp-server` |
| Ruby | `ruby-lsp` |
| Rust | `rust-analyzer` |
| Swift | `sourcekit-lsp` (built-in via `swift`) |
| Terraform | `terraform-ls` |
| YAML | `yaml-language-server` |

## Testing
- Apply with `home-manager switch` / `darwin-rebuild switch` / `nixos-rebuild switch`
- Verify binaries: `which rust-analyzer nixd lua-language-server clangd terraform-ls`

Generated with [Claude Code](https://claude.ai/claude-code) by claude-sonnet-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add LSP server coverage for 14 languages to improve out-of-the-box editor support. Switch VS Code to `pkgs-nightly.vscode` from `nixpkgs-nightly`.

- **New Features**
  - Added modules for 13 languages: `clang`, `dart`, `elixir`, `haskell`, `java`, `kotlin`, `lua`, `nix`, `ocaml`, `ruby`, `swift`, `terraform`, `yaml` (each installs its language’s LSP).

- **Refactors**
  - VS Code: use `pkgs-nightly.vscode`, allow unfree, and add to allowlist.
  - Rust: rely on `rustup` for `rust-analyzer` (remove standalone package).
  - Alphabetized imports and entries in `programs/default.nix`.
  - Use `ocamlPackages.ocaml-lsp` for OCaml.

<sup>Written for commit c13f66ad2fbd531874008cde48a7660e88f44bb0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

