### PR TITLE
fix(falcon): preserve AID across rebuilds

### DIFF
--- a/named-hosts/matic/falcon.nix
+++ b/named-hosts/matic/falcon.nix
@@ -22,11 +22,16 @@ let
       ${pkgs.e2fsprogs}/bin/chattr -i -R /opt/CrowdStrike 2>/dev/null || true
     fi
 
-    rm -rf /opt/CrowdStrike
     install -d -m 0770 /opt/CrowdStrike
 
-    # Copy real files so Falcon can write falconstore/CsConfig
-    cp -a ${falcon}/opt/CrowdStrike/. /opt/CrowdStrike/
+    # Update binaries from the nix store, but preserve runtime state files.
+    # falconstore contains the Agent ID (AID) — if lost, the sensor re-registers
+    # as a new host and consumes another license seat.
+    ${pkgs.rsync}/bin/rsync -a --delete \
+      --exclude=falconstore \
+      --exclude=falconstore.bak \
+      --exclude=CsConfig \
+      "${falcon}/opt/CrowdStrike/" /opt/CrowdStrike/
 
     chown -R root:root /opt/CrowdStrike
 


### PR DESCRIPTION
## Summary
- Replace destructive `rm -rf` + `cp -a` with `rsync --delete --exclude` in Falcon sensor init script
- Preserves `falconstore`, `falconstore.bak`, and `CsConfig` runtime state files across NixOS rebuilds
- Prevents the sensor from re-registering as a new host and consuming duplicate Kolide license seats

## Test plan
- [ ] `nixos-rebuild switch` completes successfully
- [ ] `sudo /opt/CrowdStrike/falconctl -g --aid` shows the same AID before and after rebuild
- [ ] No duplicate node appears in Kolide dashboard

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the CrowdStrike Falcon AID and runtime state across NixOS rebuilds to prevent sensor re-registration and duplicate Kolide seats. Switches the init script to `rsync -a --delete` with excludes for falconstore, falconstore.bak, and CsConfig under /opt/CrowdStrike.

<sup>Written for commit a52704c0d993eea7aa31dcc04b4204c5cdbba4a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

