### PR TITLE
feat(claude): enable gopls-lsp plugin for Go LSP support

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -16,6 +16,7 @@
     "safety-net@cc-marketplace": true,
     "serena@claude-plugins-official": true,
     "skill-codex@skill-codex": true,
+    "gopls-lsp@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
     "worktrunk@worktrunk": true
   },


### PR DESCRIPTION
## Summary
- Enable `gopls-lsp@claude-plugins-official` in Claude Code settings
- Provides Go language server features (go-to-definition, hover docs, references, etc.) within Claude Code sessions

## Test plan
- [ ] Reload Claude Code and verify `gopls-lsp` is active
- [ ] Open a `.go` file and test LSP operations (goToDefinition, hover, findReferences)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `gopls-lsp@claude-plugins-official` in Claude Code. Adds Go LSP features (go to definition, hover docs, references) for .go files.

<sup>Written for commit 2955f2b68e1399a2f334648c2db0307dac0bf83c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

