### PR TITLE
feat(models): add minimax-m2.5 via opencodezen and set as openclaw default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,5 @@ OPENCLAW_TELEGRAM_TOKEN=123456789:ABCdefGHIjklMNOpqrsTUVwxyz
 OPENCLAW_ANTHROPIC_API_KEY=sk-ant-api03-your-key-here
 # Gateway token for remote mode clients (from kyber: cat ~/.config/openclaw/gateway-token)
 OPENCLAW_GATEWAY_TOKEN=your-gateway-token-here
+# OpenCodeZen API key for minimax-m2.5 access via cliproxyapi
+OPENCODE_API_KEY=your-opencodezen-api-key-here

--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -95,6 +95,13 @@ openai-compatibility:
     models:
       - name: "glm-4.7"
         alias: "glm-4.7"
+  - name: "opencodezen"
+    base-url: "https://api.minimax.chat/v1"
+    api-key-entries:
+      - api-key: "__OPENCODE_API_KEY__"
+    models:
+      - name: "minimax-m2.5"
+        alias: "minimax-m2.5"
 # payload: # Optional payload configuration
 #   default: # Default rules only set parameters when they are missing in the payload.
 #     - models:

--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -96,7 +96,7 @@ openai-compatibility:
       - name: "glm-4.7"
         alias: "glm-4.7"
   - name: "opencodezen"
-    base-url: "https://api.minimax.chat/v1"
+    base-url: "https://opencode.ai/zen/v1"
     api-key-entries:
       - api-key: "__OPENCODE_API_KEY__"
     models:

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -96,7 +96,7 @@ openai-compatibility:
       - name: "glm-4.7"
         alias: "glm-4.7"
   - name: "opencodezen"
-    base-url: "https://api.minimax.chat/v1"
+    base-url: "https://opencode.ai/zen/v1"
     api-key-entries:
       - api-key: "__OPENCODE_API_KEY__"
     models:

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -95,6 +95,13 @@ openai-compatibility:
     models:
       - name: "glm-4.7"
         alias: "glm-4.7"
+  - name: "opencodezen"
+    base-url: "https://api.minimax.chat/v1"
+    api-key-entries:
+      - api-key: "__OPENCODE_API_KEY__"
+    models:
+      - name: "__MINIMAX__"
+        alias: "__MINIMAX__"
 # payload: # Optional payload configuration
 #   default: # Default rules only set parameters when they are missing in the payload.
 #     - models:

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -148,6 +148,23 @@
             },
             "contextWindow": 200000,
             "maxTokens": 32000
+          },
+          {
+            "id": "minimax-m2.5",
+            "name": "Minimax M2.5",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 40960
           }
         ]
       }
@@ -156,8 +173,9 @@
   "agents": {
     "defaults": {
       "model": {
-        "primary": "cliproxy/claude-opus-4-6",
+        "primary": "cliproxy/minimax-m2.5",
         "fallbacks": [
+          "cliproxy/claude-opus-4-6",
           "cliproxy/glm-4.7"
         ]
       },

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -148,6 +148,23 @@
             },
             "contextWindow": 200000,
             "maxTokens": 32000
+          },
+          {
+            "id": "__MINIMAX__",
+            "name": "__MINIMAX_PRETTY__",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 40960
           }
         ]
       }
@@ -156,8 +173,9 @@
   "agents": {
     "defaults": {
       "model": {
-        "primary": "cliproxy/__CLAUDE_OPUS__",
+        "primary": "cliproxy/__MINIMAX__",
         "fallbacks": [
+          "cliproxy/__CLAUDE_OPUS__",
           "cliproxy/__GLM__"
         ]
       },

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -81,6 +81,9 @@
         },
         "glm-4.7": {
           "name": "GLM 4.7 (via local CLIProxyAPI)"
+        },
+        "minimax-m2.5": {
+          "name": "Minimax M2.5 (via local CLIProxyAPI)"
         }
       }
     },

--- a/config/opencode/opencode.tpl.jsonc
+++ b/config/opencode/opencode.tpl.jsonc
@@ -81,6 +81,9 @@
         },
         "__GLM__": {
           "name": "__GLM_PRETTY__ (via local CLIProxyAPI)"
+        },
+        "__MINIMAX__": {
+          "name": "__MINIMAX_PRETTY__ (via local CLIProxyAPI)"
         }
       }
     },

--- a/models.json
+++ b/models.json
@@ -6,5 +6,6 @@
   "gpt-codex": "gpt-5.3-codex",
   "gemini-pro": "gemini-3-pro-preview",
   "gemini-flash": "gemini-3-flash-preview",
-  "glm": "glm-4.7"
+  "glm": "glm-4.7",
+  "minimax": "minimax-m2.5"
 }


### PR DESCRIPTION
## Changes
- Add \`minimax-m2.5\` to \`models.json\`
- Configure \`opencodezen\` provider in cliproxyapi with \`OPENCODE_API_KEY\` pointing to \`https://opencode.ai/zen/v1\`
- Add \`minimax-m2.5\` model entry to openclaw's cliproxy provider list (1M context window, 40960 max tokens)
- Set \`cliproxy/minimax-m2.5\` as the default primary model in openclaw agents, with \`claude-opus-4-6\` as first fallback
- Add \`minimax-m2.5\` to opencode's cliproxyapi provider models
- Document \`OPENCODE_API_KEY\` in \`.env.example\`

## Technical Details
- Template files (\`*.tpl.*\`) updated with \`__MINIMAX__\` / \`__MINIMAX_PRETTY__\` placeholders
- Generated files updated via \`scripts/llm-update.sh\`
- openclaw default primary: \`cliproxy/claude-opus-4-6\` → \`cliproxy/minimax-m2.5\` (opus moved to fallback)
- OpenCode Zen base URL: \`https://opencode.ai/zen/v1\` (OpenAI-compatible gateway)

## Testing
- \`scripts/llm-update.sh\` runs cleanly
- All template substitutions verified in generated output files

Generated with [Claude Code](https://claude.ai/claude-code) by claude-sonnet-4-6