### PR TITLE
fix(fish): update test files to match renamed function files

### DIFF
--- a/spec/fish/_cltxe_function_test.fish
+++ b/spec/fish/_cltxe_function_test.fish
@@ -1,11 +1,11 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
-source $fn/_clxte_function.fish
+source $fn/_cltxe_function.fish
 
 # ── no args: interactive mode ─────────────────────────────
 set log1 (mktemp)
 function claude; echo $argv >> $log1; end
 
-_clxte_function
+_cltxe_function
 
 @test "no args uses --worktree --tmux flags" (grep -c -- "--worktree" $log1) -ge 1
 @test "no args skips --print flag" (grep -c -- "--print" $log1) -eq 0
@@ -14,7 +14,7 @@ _clxte_function
 set log2 (mktemp)
 function claude; echo $argv >> $log2; end
 
-_clxte_function hello world
+_cltxe_function hello world
 
 @test "with args uses --print flag" (grep -c -- "--print" $log2) -ge 1
 @test "with args uses --tmux flag" (grep -c -- "--tmux" $log2) -ge 1

--- a/spec/fish/_cltxeh_function_test.fish
+++ b/spec/fish/_cltxeh_function_test.fish
@@ -1,5 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
-source $fn/_clxteh_function.fish
+source $fn/_cltxeh_function.fish
 
-@test "empty prompt rejects" (echo "" | _clxteh_function 2>&1) = "No prompt provided, aborting."
-@test "empty prompt returns 1" (echo "" | _clxteh_function 2>/dev/null; echo $status) = 1
+@test "empty prompt rejects" (echo "" | _cltxeh_function 2>&1) = "No prompt provided, aborting."
+@test "empty prompt returns 1" (echo "" | _cltxeh_function 2>/dev/null; echo $status) = 1

--- a/spec/fish/_clwxe_function_test.fish
+++ b/spec/fish/_clwxe_function_test.fish
@@ -1,11 +1,11 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
-source $fn/_clxwe_function.fish
+source $fn/_clwxe_function.fish
 
 # ── no args: interactive mode ─────────────────────────────
 set log1 (mktemp)
 function claude; echo $argv >> $log1; end
 
-_clxwe_function
+_clwxe_function
 
 @test "no args uses --worktree flag" (grep -c -- "--worktree" $log1) -ge 1
 @test "no args skips --print flag" (grep -c -- "--print" $log1) -eq 0
@@ -14,7 +14,7 @@ _clxwe_function
 set log2 (mktemp)
 function claude; echo $argv >> $log2; end
 
-_clxwe_function hello world
+_clwxe_function hello world
 
 @test "with args uses --print flag" (grep -c -- "--print" $log2) -ge 1
 @test "with args uses --worktree flag" (grep -c -- "--worktree" $log2) -ge 1

--- a/spec/fish/_clwxeh_function_test.fish
+++ b/spec/fish/_clwxeh_function_test.fish
@@ -1,5 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
-source $fn/_clxweh_function.fish
+source $fn/_clwxeh_function.fish
 
-@test "empty prompt rejects" (echo "" | _clxweh_function 2>&1) = "No prompt provided, aborting."
-@test "empty prompt returns 1" (echo "" | _clxweh_function 2>/dev/null; echo $status) = 1
+@test "empty prompt rejects" (echo "" | _clwxeh_function 2>&1) = "No prompt provided, aborting."
+@test "empty prompt returns 1" (echo "" | _clwxeh_function 2>/dev/null; echo $status) = 1


### PR DESCRIPTION
## Summary
- Renames `spec/fish/_clxte_function_test.fish` → `_cltxe_function_test.fish`
- Renames `spec/fish/_clxteh_function_test.fish` → `_cltxeh_function_test.fish`
- Renames `spec/fish/_clxwe_function_test.fish` → `_clwxe_function_test.fish`
- Renames `spec/fish/_clxweh_function_test.fish` → `_clwxeh_function_test.fish`
- Updates internal `source` paths and function call names in each test file

## Context
The abbreviation naming refactor (#1057) renamed the function files in `home-manager/programs/fish/functions/` but did not update the corresponding test files in `spec/fish/`, causing CI `fish-test` failures with "No such file or directory" errors.

## Test plan
- [ ] CI `fish-test` passes for all four affected test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns fish spec tests with renamed function files from the abbreviation naming refactor (#1057). Fixes CI `fish-test` “No such file or directory” errors.

- **Bug Fixes**
  - Renamed tests to match functions: `_clxte`→`_cltxe`, `_clxteh`→`_cltxeh`, `_clxwe`→`_clwxe`, `_clxweh`→`_clwxeh`.
  - Updated `source` paths and function calls; interactive flag checks and empty-prompt assertions remain unchanged (rejects and returns 1).

<sup>Written for commit 6de5ddc03eb53eb2ce07534d119b4a7b6ef3530d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

