### PR TITLE
feat(elixir): pin to elixir_1_19

### DIFF
--- a/home-manager/programs/elixir/default.nix
+++ b/home-manager/programs/elixir/default.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    elixir
+    elixir_1_19
     elixir-ls
   ];
 }


### PR DESCRIPTION
## Changes
- Pin Elixir to `elixir_1_19` (1.19.5) from `nixpkgs-unstable`

## Technical Details
- Previously using unversioned `elixir` package (resolved to 1.18.4)
- `elixir_1_19` is available via `nixpkgs-unstable` which the flake already follows

Generated with [Claude Code](https://claude.ai/claude-code) by claude-sonnet-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin Elixir to `elixir_1_19` (1.19.5) to ensure consistent local tooling across machines. Replaces the unversioned `elixir` that previously resolved to 1.18.4.

- **Migration**
  - Run `home-manager switch` to apply the change (rebuild your flake profile if applicable).

<sup>Written for commit 78392ed32f145064a7cba88fa1dae7592e1f51f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

