### PR TITLE
fix(fish): rename internal function name in _cltxe_function.fish

### DIFF
--- a/home-manager/programs/fish/functions/_cltxe_function.fish
+++ b/home-manager/programs/fish/functions/_cltxe_function.fish
@@ -1,6 +1,6 @@
-function _clxte_function --description "Run Claude Code with a free-form prompt while skipping permissions with tmux integration"
+function _cltxe_function --description "Run Claude Code with a free-form prompt while skipping permissions with tmux integration"
   # Run Claude Code with a free-form prompt (spaces allowed) and bypass permission checks
-  # Usage: clxte [<prompt words...>]
+  # Usage: cltxe [<prompt words...>]
 
   if test (count $argv) -eq 0
     claude --dangerously-skip-permissions --worktree --tmux

--- a/spec/fish/_cltxe_function_test.fish
+++ b/spec/fish/_cltxe_function_test.fish
@@ -1,11 +1,11 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
-source $fn/_clxte_function.fish
+source $fn/_cltxe_function.fish
 
 # ── no args: interactive mode ─────────────────────────────
 set log1 (mktemp)
 function claude; echo $argv >> $log1; end
 
-_clxte_function
+_cltxe_function
 
 @test "no args uses --worktree --tmux flags" (grep -c -- "--worktree" $log1) -ge 1
 @test "no args skips --print flag" (grep -c -- "--print" $log1) -eq 0
@@ -14,7 +14,7 @@ _clxte_function
 set log2 (mktemp)
 function claude; echo $argv >> $log2; end
 
-_clxte_function hello world
+_cltxe_function hello world
 
 @test "with args uses --print flag" (grep -c -- "--print" $log2) -ge 1
 @test "with args uses --tmux flag" (grep -c -- "--tmux" $log2) -ge 1

--- a/spec/fish/_cltxeh_function_test.fish
+++ b/spec/fish/_cltxeh_function_test.fish
@@ -1,5 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
-source $fn/_clxteh_function.fish
+source $fn/_cltxeh_function.fish
 
-@test "empty prompt rejects" (echo "" | _clxteh_function 2>&1) = "No prompt provided, aborting."
-@test "empty prompt returns 1" (echo "" | _clxteh_function 2>/dev/null; echo $status) = 1
+@test "empty prompt rejects" (echo "" | _cltxeh_function 2>&1) = "No prompt provided, aborting."
+@test "empty prompt returns 1" (echo "" | _cltxeh_function 2>/dev/null; echo $status) = 1

--- a/spec/fish/_clwxe_function_test.fish
+++ b/spec/fish/_clwxe_function_test.fish
@@ -1,11 +1,11 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
-source $fn/_clxwe_function.fish
+source $fn/_clwxe_function.fish
 
 # ── no args: interactive mode ─────────────────────────────
 set log1 (mktemp)
 function claude; echo $argv >> $log1; end
 
-_clxwe_function
+_clwxe_function
 
 @test "no args uses --worktree flag" (grep -c -- "--worktree" $log1) -ge 1
 @test "no args skips --print flag" (grep -c -- "--print" $log1) -eq 0
@@ -14,7 +14,7 @@ _clxwe_function
 set log2 (mktemp)
 function claude; echo $argv >> $log2; end
 
-_clxwe_function hello world
+_clwxe_function hello world
 
 @test "with args uses --print flag" (grep -c -- "--print" $log2) -ge 1
 @test "with args uses --worktree flag" (grep -c -- "--worktree" $log2) -ge 1

--- a/spec/fish/_clwxeh_function_test.fish
+++ b/spec/fish/_clwxeh_function_test.fish
@@ -1,5 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
-source $fn/_clxweh_function.fish
+source $fn/_clwxeh_function.fish
 
-@test "empty prompt rejects" (echo "" | _clxweh_function 2>&1) = "No prompt provided, aborting."
-@test "empty prompt returns 1" (echo "" | _clxweh_function 2>/dev/null; echo $status) = 1
+@test "empty prompt rejects" (echo "" | _clwxeh_function 2>&1) = "No prompt provided, aborting."
+@test "empty prompt returns 1" (echo "" | _clwxeh_function 2>/dev/null; echo $status) = 1


### PR DESCRIPTION
## Summary
- Fixes the internal function name in `_cltxe_function.fish` from `_clxte_function` to `_cltxe_function`

## Context
The file rename in #1057 updated the filename but left the function declaration using the old name `_clxte_function`. This caused 4 test failures where `_cltxe_function` was an unknown command.

## Test plan
- [ ] CI `fish-test` passes (was `# pass 104 # fail 4`, should now be `# pass 108 # fail 0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the internal function from `_clxte_function` to `_cltxe_function` and updated related fish specs to source/call the correct names. This aligns with the earlier file rename and restores `fish-test` from 4 failures to passing.

<sup>Written for commit dead8cee3edd762dc795ff48578625fe07a5dcd1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

