### PR TITLE
fix(openclaw): add controlUi allowedOrigins for gateway access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,5 @@ OPENCLAW_TELEGRAM_TOKEN=123456789:ABCdefGHIjklMNOpqrsTUVwxyz
 OPENCLAW_ANTHROPIC_API_KEY=sk-ant-api03-your-key-here
 # Gateway token for remote mode clients (from kyber: cat ~/.config/openclaw/gateway-token)
 OPENCLAW_GATEWAY_TOKEN=your-gateway-token-here
+# OpenCodeZen API key for minimax-m2.5 access via cliproxyapi
+OPENCODE_API_KEY=your-opencodezen-api-key-here

--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -95,6 +95,13 @@ openai-compatibility:
     models:
       - name: "glm-4.7"
         alias: "glm-4.7"
+  - name: "opencodezen"
+    base-url: "https://api.minimax.chat/v1"
+    api-key-entries:
+      - api-key: "__OPENCODE_API_KEY__"
+    models:
+      - name: "minimax-m2.5"
+        alias: "minimax-m2.5"
 # payload: # Optional payload configuration
 #   default: # Default rules only set parameters when they are missing in the payload.
 #     - models:

--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -96,7 +96,7 @@ openai-compatibility:
       - name: "glm-4.7"
         alias: "glm-4.7"
   - name: "opencodezen"
-    base-url: "https://api.minimax.chat/v1"
+    base-url: "https://opencode.ai/zen/v1"
     api-key-entries:
       - api-key: "__OPENCODE_API_KEY__"
     models:

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -96,7 +96,7 @@ openai-compatibility:
       - name: "glm-4.7"
         alias: "glm-4.7"
   - name: "opencodezen"
-    base-url: "https://api.minimax.chat/v1"
+    base-url: "https://opencode.ai/zen/v1"
     api-key-entries:
       - api-key: "__OPENCODE_API_KEY__"
     models:

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -95,6 +95,13 @@ openai-compatibility:
     models:
       - name: "glm-4.7"
         alias: "glm-4.7"
+  - name: "opencodezen"
+    base-url: "https://api.minimax.chat/v1"
+    api-key-entries:
+      - api-key: "__OPENCODE_API_KEY__"
+    models:
+      - name: "__MINIMAX__"
+        alias: "__MINIMAX__"
 # payload: # Optional payload configuration
 #   default: # Default rules only set parameters when they are missing in the payload.
 #     - models:

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -148,6 +148,23 @@
             },
             "contextWindow": 200000,
             "maxTokens": 32000
+          },
+          {
+            "id": "minimax-m2.5",
+            "name": "Minimax M2.5",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 40960
           }
         ]
       }
@@ -156,8 +173,9 @@
   "agents": {
     "defaults": {
       "model": {
-        "primary": "cliproxy/claude-opus-4-6",
+        "primary": "cliproxy/minimax-m2.5",
         "fallbacks": [
+          "cliproxy/claude-opus-4-6",
           "cliproxy/glm-4.7"
         ]
       },

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -736,6 +736,14 @@
   "gateway": {
     "mode": "local",
     "bind": "lan",
+    "controlUi": {
+      "allowedOrigins": [
+        "http://localhost:18789",
+        "http://127.0.0.1:18789",
+        "https://__TAILSCALE_HOSTNAME__:18789",
+        "http://__TAILSCALE_HOSTNAME__:18789"
+      ]
+    },
     "auth": {
       "mode": "token",
       "token": "__GATEWAY_TOKEN__"

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -736,6 +736,14 @@
   "gateway": {
     "mode": "local",
     "bind": "lan",
+    "controlUi": {
+      "allowedOrigins": [
+        "http://localhost:18789",
+        "http://127.0.0.1:18789",
+        "https://__TAILSCALE_HOSTNAME__:18789",
+        "http://__TAILSCALE_HOSTNAME__:18789"
+      ]
+    },
     "auth": {
       "mode": "token",
       "token": "__GATEWAY_TOKEN__"

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -148,6 +148,23 @@
             },
             "contextWindow": 200000,
             "maxTokens": 32000
+          },
+          {
+            "id": "__MINIMAX__",
+            "name": "__MINIMAX_PRETTY__",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 40960
           }
         ]
       }
@@ -156,8 +173,9 @@
   "agents": {
     "defaults": {
       "model": {
-        "primary": "cliproxy/__CLAUDE_OPUS__",
+        "primary": "cliproxy/__MINIMAX__",
         "fallbacks": [
+          "cliproxy/__CLAUDE_OPUS__",
           "cliproxy/__GLM__"
         ]
       },

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -81,6 +81,9 @@
         },
         "glm-4.7": {
           "name": "GLM 4.7 (via local CLIProxyAPI)"
+        },
+        "minimax-m2.5": {
+          "name": "Minimax M2.5 (via local CLIProxyAPI)"
         }
       }
     },

--- a/config/opencode/opencode.tpl.jsonc
+++ b/config/opencode/opencode.tpl.jsonc
@@ -81,6 +81,9 @@
         },
         "__GLM__": {
           "name": "__GLM_PRETTY__ (via local CLIProxyAPI)"
+        },
+        "__MINIMAX__": {
+          "name": "__MINIMAX_PRETTY__ (via local CLIProxyAPI)"
         }
       }
     },

--- a/models.json
+++ b/models.json
@@ -6,5 +6,6 @@
   "gpt-codex": "gpt-5.3-codex",
   "gemini-pro": "gemini-3-pro-preview",
   "gemini-flash": "gemini-3-flash-preview",
-  "glm": "glm-4.7"
+  "glm": "glm-4.7",
+  "minimax": "minimax-m2.5"
 }


### PR DESCRIPTION
## Summary
- Add `controlUi.allowedOrigins` to the `gateway` section in both `openclaw.tpl.json` and `openclaw.template.json`
- Allows the Control UI to be accessed from localhost and Tailscale hostname origins (`__TAILSCALE_HOSTNAME__`)
- Fixes "origin not allowed" error when opening the Control UI from a remote/Tailscale host

## Test plan
- [ ] Deploy config via template substitution with actual Tailscale hostname
- [ ] Verify Control UI loads without CORS/origin errors from Tailscale host
- [ ] Verify localhost access still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Control UI CORS by allowing localhost and Tailscale origins, and adds `opencodezen` with `minimax-m2.5` as the new default primary model via `cliproxyapi`.

- **New Features**
  - Added `opencodezen` provider to `cliproxyapi` with `minimax-m2.5`; documented `OPENCODE_API_KEY` in `.env.example`.
  - Set `cliproxy/minimax-m2.5` as the default primary in `openclaw`, with `cliproxy/claude-opus-4-6` as fallback; updated `opencode` configs and `models.json`.

- **Bug Fixes**
  - Added `gateway.controlUi.allowedOrigins` to permit `localhost`, `127.0.0.1`, and `__TAILSCALE_HOSTNAME__` (http/https, port 18789) to resolve “origin not allowed” when accessing the Control UI remotely.

<sup>Written for commit c40fb22d34aee79c23e28dc9d2e6a7fea8879623. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

