### PR TITLE
fix(openclaw): address doctor essentials

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -740,8 +740,7 @@
       "allowedOrigins": [
         "http://localhost:18789",
         "http://127.0.0.1:18789",
-        "https://__TAILSCALE_HOSTNAME__:18789",
-        "http://__TAILSCALE_HOSTNAME__:18789"
+        "https://openclaw.shunkakinoki.com"
       ]
     },
     "auth": {

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -741,7 +741,7 @@
         "http://localhost:18789",
         "http://127.0.0.1:18789",
         "https://openclaw.shunkakinoki.com",
-        "https://__TAILSCALE_HOSTNAME__:18789"
+        "https://kyber.tail950b36.ts.net:18789"
       ]
     },
     "auth": {

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -740,7 +740,8 @@
       "allowedOrigins": [
         "http://localhost:18789",
         "http://127.0.0.1:18789",
-        "https://openclaw.shunkakinoki.com"
+        "https://openclaw.shunkakinoki.com",
+        "https://__TAILSCALE_HOSTNAME__:18789"
       ]
     },
     "auth": {

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -740,8 +740,7 @@
       "allowedOrigins": [
         "http://localhost:18789",
         "http://127.0.0.1:18789",
-        "https://__TAILSCALE_HOSTNAME__:18789",
-        "http://__TAILSCALE_HOSTNAME__:18789"
+        "https://openclaw.shunkakinoki.com"
       ]
     },
     "auth": {

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -741,7 +741,7 @@
         "http://localhost:18789",
         "http://127.0.0.1:18789",
         "https://openclaw.shunkakinoki.com",
-        "https://__TAILSCALE_HOSTNAME__:18789"
+        "https://kyber.tail950b36.ts.net:18789"
       ]
     },
     "auth": {

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -740,7 +740,8 @@
       "allowedOrigins": [
         "http://localhost:18789",
         "http://127.0.0.1:18789",
-        "https://openclaw.shunkakinoki.com"
+        "https://openclaw.shunkakinoki.com",
+        "https://__TAILSCALE_HOSTNAME__:18789"
       ]
     },
     "auth": {

--- a/home-manager/modules/openclaw/default.nix
+++ b/home-manager/modules/openclaw/default.nix
@@ -10,17 +10,19 @@ let
 in
 # Only enable on kyber (gateway host)
 lib.mkIf (host.isKyber) {
-  # Ensure OpenClaw directories exist
+  # Ensure OpenClaw directories exist with correct permissions
   home.activation.openclawSetup = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     mkdir -p /tmp/openclaw
     mkdir -p ${homeDir}/.openclaw
+    chmod 700 ${homeDir}/.openclaw
   '';
 
   # Systemd service for OpenClaw gateway
   systemd.user.services.openclaw-gateway = {
     Unit = {
       Description = "OpenClaw gateway";
-      After = [ "network.target" ];
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
     };
     Service = {
       Type = "simple";


### PR DESCRIPTION
## Summary
Fixes essential issues found by `openclaw doctor`.

- **systemd**: `After`/`Wants` changed from `network.target` → `network-online.target` so gateway waits for full network before starting
- **state dir**: `chmod 700 ~/.openclaw` added to home-manager activation to enforce correct permissions
- **deprecated env vars**: removed `CLAWDBOT_*` vars from `.env` (superseded by `OPENCLAW_*` equivalents)

## Applied live
- `chmod 700 ~/.openclaw` ✓
- `loginctl enable-linger ubuntu` ✓ (gateway survives logout)

## Related
Follows up on #1064

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `minimax-m2.5` via `opencodezen` to `cliproxyapi` and makes it the default model. Also fixes `openclaw doctor` findings to improve gateway startup, security, and Control UI access.

- **New Features**
  - Add `opencodezen` provider to `cliproxyapi` (https://opencode.ai/zen/v1) with `minimax-m2.5`; include mappings in `models.json` and `opencode` configs; document `OPENCODE_API_KEY` in `.env.example`.
  - Set `cliproxy/minimax-m2.5` as the default model with `cliproxy/claude-opus-4-6` fallback; add the model to `openclaw` provider lists.

- **Bug Fixes**
  - Ensure gateway waits for full network: switch `systemd` `After`/`Wants` to `network-online.target`.
  - Enforce secure state dir perms: run `chmod 700 ~/.openclaw` during home-manager activation.
  - Update `gateway.controlUi.allowedOrigins`: use Cloudflare tunnel `https://openclaw.shunkakinoki.com` and Tailscale `https://kyber.tail950b36.ts.net:18789`; remove templated `__TAILSCALE_HOSTNAME__`.

<sup>Written for commit 1babf1f5083b409bbbe35b08a3a46923606b4325. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

