### PR TITLE
feat: add minimax m2.5 openai-compatibility provider to cliproxyapi

### DIFF
--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -95,6 +95,13 @@ openai-compatibility:
     models:
       - name: "glm-4.7"
         alias: "glm-4.7"
+  - name: "minimax"
+    base-url: "https://api.minimax.io/v1"
+    api-key-entries:
+      - api-key: "__MINIMAX_API_KEY__"
+    models:
+      - name: "MiniMax-M2.5"
+        alias: "minimax-m2.5"
 # payload: # Optional payload configuration
 #   default: # Default rules only set parameters when they are missing in the payload.
 #     - models:

--- a/home-manager/modules/cargo-globals/default.nix
+++ b/home-manager/modules/cargo-globals/default.nix
@@ -17,8 +17,8 @@ in
   home.activation.installCargoGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     export PATH=${pkgs.rustup}/bin:${pkgs.cargo}/bin:${pkgs.rustc}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:$PATH
     export CARGO_HOME="$HOME/.cargo"
-    $DRY_RUN_CMD ${pkgs.rustup}/bin/rustup toolchain install stable
-    $DRY_RUN_CMD ${pkgs.rustup}/bin/rustup default stable
+    $DRY_RUN_CMD ${pkgs.rustup}/bin/rustup toolchain install stable --no-self-update || true
+    $DRY_RUN_CMD ${pkgs.rustup}/bin/rustup default stable || true
     export PKG_CONFIG_PATH="${pkgs.openssl.dev}/lib/pkgconfig${libiconvPkgConfigPath}''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
     export OPENSSL_DIR="${pkgs.openssl.dev}"
     export OPENSSL_LIB_DIR="${pkgs.openssl.out}/lib"

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -78,6 +78,7 @@ if [ -f "$TEMPLATE" ]; then
     -e "s|__OPENROUTER_API_KEY__|${OPENROUTER_API_KEY:-}|g" \
     -e "s|__CLIPROXY_MANAGEMENT_PASSWORD__|${CLIPROXY_MANAGEMENT_PASSWORD:-}|g" \
     -e "s|__ZAI_API_KEY__|${ZAI_API_KEY:-}|g" \
+    -e "s|__MINIMAX_API_KEY__|${MINIMAX_API_KEY:-}|g" \
     -e "s|__AMP_UPSTREAM_API_KEY__|${AMP_UPSTREAM_API_KEY:-}|g" \
     "$TEMPLATE" >"$CONFIG"
 

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -33,6 +33,25 @@
     });
   })
   (final: prev: {
+    # Hide empty action bar in hyprpanel notifications when no valid actions exist.
+    # Notifications with empty action IDs (e.g. from Claude Code) bypass the length
+    # guard and render a blank bar. Filter them out before the guard and the map.
+    hyprpanel = prev.hyprpanel.overrideAttrs (oldAttrs: {
+      postPatch =
+        (oldAttrs.postPatch or "")
+        + ''
+          substituteInPlace src/components/notifications/Notification/index.tsx \
+            --replace-fail \
+            'notification.get_actions().length' \
+            'notification.get_actions().filter((a) => a.id !== "").length'
+          substituteInPlace src/components/notifications/Actions/index.tsx \
+            --replace-fail \
+            'notification.get_actions().map' \
+            'notification.get_actions().filter((a) => a.id !== "").map'
+        '';
+    });
+  })
+  (final: prev: {
     nightlyPkgs = import inputs.nixpkgs-nightly {
       system = prev.system;
       config = prev.config;

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -37,18 +37,16 @@
     # Notifications with empty action IDs (e.g. from Claude Code) bypass the length
     # guard and render a blank bar. Filter them out before the guard and the map.
     hyprpanel = prev.hyprpanel.overrideAttrs (oldAttrs: {
-      postPatch =
-        (oldAttrs.postPatch or "")
-        + ''
-          substituteInPlace src/components/notifications/Notification/index.tsx \
-            --replace-fail \
-            'notification.get_actions().length' \
-            'notification.get_actions().filter((a) => a.id !== "").length'
-          substituteInPlace src/components/notifications/Actions/index.tsx \
-            --replace-fail \
-            'notification.get_actions().map' \
-            'notification.get_actions().filter((a) => a.id !== "").map'
-        '';
+      postPatch = (oldAttrs.postPatch or "") + ''
+        substituteInPlace src/components/notifications/Notification/index.tsx \
+          --replace-fail \
+          'notification.get_actions().length' \
+          'notification.get_actions().filter((a) => a.id !== "").length'
+        substituteInPlace src/components/notifications/Actions/index.tsx \
+          --replace-fail \
+          'notification.get_actions().map' \
+          'notification.get_actions().filter((a) => a.id !== "").map'
+      '';
     });
   })
   (final: prev: {

--- a/spec/fish/_cltxe_function_test.fish
+++ b/spec/fish/_cltxe_function_test.fish
@@ -1,11 +1,11 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
-source $fn/_clxte_function.fish
+source $fn/_cltxe_function.fish
 
 # ── no args: interactive mode ─────────────────────────────
 set log1 (mktemp)
 function claude; echo $argv >> $log1; end
 
-_clxte_function
+_cltxe_function
 
 @test "no args uses --worktree --tmux flags" (grep -c -- "--worktree" $log1) -ge 1
 @test "no args skips --print flag" (grep -c -- "--print" $log1) -eq 0
@@ -14,7 +14,7 @@ _clxte_function
 set log2 (mktemp)
 function claude; echo $argv >> $log2; end
 
-_clxte_function hello world
+_cltxe_function hello world
 
 @test "with args uses --print flag" (grep -c -- "--print" $log2) -ge 1
 @test "with args uses --tmux flag" (grep -c -- "--tmux" $log2) -ge 1

--- a/spec/fish/_cltxeh_function_test.fish
+++ b/spec/fish/_cltxeh_function_test.fish
@@ -1,5 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
-source $fn/_clxteh_function.fish
+source $fn/_cltxeh_function.fish
 
-@test "empty prompt rejects" (echo "" | _clxteh_function 2>&1) = "No prompt provided, aborting."
-@test "empty prompt returns 1" (echo "" | _clxteh_function 2>/dev/null; echo $status) = 1
+@test "empty prompt rejects" (echo "" | _cltxeh_function 2>&1) = "No prompt provided, aborting."
+@test "empty prompt returns 1" (echo "" | _cltxeh_function 2>/dev/null; echo $status) = 1

--- a/spec/fish/_clwxe_function_test.fish
+++ b/spec/fish/_clwxe_function_test.fish
@@ -1,11 +1,11 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
-source $fn/_clxwe_function.fish
+source $fn/_clwxe_function.fish
 
 # ── no args: interactive mode ─────────────────────────────
 set log1 (mktemp)
 function claude; echo $argv >> $log1; end
 
-_clxwe_function
+_clwxe_function
 
 @test "no args uses --worktree flag" (grep -c -- "--worktree" $log1) -ge 1
 @test "no args skips --print flag" (grep -c -- "--print" $log1) -eq 0
@@ -14,7 +14,7 @@ _clxwe_function
 set log2 (mktemp)
 function claude; echo $argv >> $log2; end
 
-_clxwe_function hello world
+_clwxe_function hello world
 
 @test "with args uses --print flag" (grep -c -- "--print" $log2) -ge 1
 @test "with args uses --worktree flag" (grep -c -- "--worktree" $log2) -ge 1

--- a/spec/fish/_clwxeh_function_test.fish
+++ b/spec/fish/_clwxeh_function_test.fish
@@ -1,5 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
-source $fn/_clxweh_function.fish
+source $fn/_clwxeh_function.fish
 
-@test "empty prompt rejects" (echo "" | _clxweh_function 2>&1) = "No prompt provided, aborting."
-@test "empty prompt returns 1" (echo "" | _clxweh_function 2>/dev/null; echo $status) = 1
+@test "empty prompt rejects" (echo "" | _clwxeh_function 2>&1) = "No prompt provided, aborting."
+@test "empty prompt returns 1" (echo "" | _clwxeh_function 2>/dev/null; echo $status) = 1


### PR DESCRIPTION
## Summary
- Add MiniMax M2.5 as an OpenAI-compatible provider in cliproxyapi config template
- Add `__MINIMAX_API_KEY__` substitution in start.sh (reads from `MINIMAX_API_KEY` env var)
- Provider routes to `https://api.minimax.io/v1` with model alias `minimax-m2.5`

## Test plan
- [ ] Run `make build && make switch` to apply and restart cliproxyapi
- [ ] Verify minimax provider appears in cliproxyapi management UI under OpenAI Compatible Providers
- [ ] Set `MINIMAX_API_KEY` in `.env` / Doppler for the key to be injected at service start

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MiniMax M2.5 as an OpenAI-compatible provider in `cliproxyapi`. Injects `MINIMAX_API_KEY` at startup and includes small fixes to `hyprpanel` and tests.

- **New Features**
  - Add `minimax` provider to `cliproxyapi` with base URL `https://api.minimax.io/v1` and model alias `minimax-m2.5`.
  - Add `__MINIMAX_API_KEY__` substitution in `start.sh` to read from `MINIMAX_API_KEY`.

- **Bug Fixes**
  - `hyprpanel`: hide empty notification action bars by filtering actions with empty IDs.
  - Make `rustup` toolchain setup more resilient with `--no-self-update` and non-fatal defaults.
  - Update fish tests to source and call the corrected `_cltxe*` and `_clwxe*` function names.

<sup>Written for commit 375cde925800eeda8984a1c8dac0ab91e386bcfd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

