### PR TITLE
feat: add minimax m2.5 via opencode zen to cliproxyapi

### DIFF
--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -102,13 +102,6 @@ openai-compatibility:
     models:
       - name: "minimax-m2.5"
         alias: "minimax-m2.5"
-  - name: "minimax"
-    base-url: "https://api.minimax.io/v1"
-    api-key-entries:
-      - api-key: "__MINIMAX_API_KEY__"
-    models:
-      - name: "MiniMax-M2.5"
-        alias: "minimax-m2.5"
 # payload: # Optional payload configuration
 #   default: # Default rules only set parameters when they are missing in the payload.
 #     - models:

--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -102,6 +102,13 @@ openai-compatibility:
     models:
       - name: "minimax-m2.5"
         alias: "minimax-m2.5"
+  - name: "minimax"
+    base-url: "https://api.minimax.io/v1"
+    api-key-entries:
+      - api-key: "__MINIMAX_API_KEY__"
+    models:
+      - name: "MiniMax-M2.5"
+        alias: "minimax-m2.5"
 # payload: # Optional payload configuration
 #   default: # Default rules only set parameters when they are missing in the payload.
 #     - models:

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -78,7 +78,7 @@ if [ -f "$TEMPLATE" ]; then
     -e "s|__OPENROUTER_API_KEY__|${OPENROUTER_API_KEY:-}|g" \
     -e "s|__CLIPROXY_MANAGEMENT_PASSWORD__|${CLIPROXY_MANAGEMENT_PASSWORD:-}|g" \
     -e "s|__ZAI_API_KEY__|${ZAI_API_KEY:-}|g" \
-    -e "s|__MINIMAX_API_KEY__|${MINIMAX_API_KEY:-}|g" \
+    -e "s|__OPENCODE_API_KEY__|${OPENCODE_API_KEY:-}|g" \
     -e "s|__AMP_UPSTREAM_API_KEY__|${AMP_UPSTREAM_API_KEY:-}|g" \
     "$TEMPLATE" >"$CONFIG"
 

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -78,6 +78,7 @@ if [ -f "$TEMPLATE" ]; then
     -e "s|__OPENROUTER_API_KEY__|${OPENROUTER_API_KEY:-}|g" \
     -e "s|__CLIPROXY_MANAGEMENT_PASSWORD__|${CLIPROXY_MANAGEMENT_PASSWORD:-}|g" \
     -e "s|__ZAI_API_KEY__|${ZAI_API_KEY:-}|g" \
+    -e "s|__MINIMAX_API_KEY__|${MINIMAX_API_KEY:-}|g" \
     -e "s|__AMP_UPSTREAM_API_KEY__|${AMP_UPSTREAM_API_KEY:-}|g" \
     "$TEMPLATE" >"$CONFIG"
 


### PR DESCRIPTION
## Summary
- Add MiniMax M2.5 as an OpenAI-compatible provider in cliproxyapi config template
- Routes through `https://opencode.ai/zen/v1` (opencode zen proxy)
- Model `MiniMax-M2.5` exposed with alias `minimax-m2.5`
- Uses `__OPENCODE_ZEN_API_KEY__` placeholder (requires `OPENCODE_ZEN_API_KEY` env var / Doppler secret)

## Test plan
- [ ] Ensure `OPENCODE_ZEN_API_KEY` is set in Doppler
- [ ] Run `make build && make switch` to apply and restart cliproxyapi
- [ ] Verify minimax provider appears in cliproxyapi management UI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add MiniMax M2.5 as an OpenAI-compatible provider in `cliproxyapi`, routed via `https://opencode.ai/zen/v1`, exposing `MiniMax-M2.5` as `minimax-m2.5`. Removed direct MiniMax API support and switched to `OPENCODE_API_KEY` for Zen.

- **Migration**
  - Set `OPENCODE_API_KEY` in Doppler.
  - Run `make build && make switch`, then verify `minimax-m2.5` appears in the management UI.

<sup>Written for commit 51ef25e51f63353128f255c9ff253f89f306ce51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

