### PR TITLE
fix(makefile): add daemon-reload before cliproxyapi restart on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -765,6 +765,7 @@ systemctl: systemctl-cliproxyapi systemctl-code-syncer systemctl-docker-postgres
 .PHONY: systemctl-cliproxyapi
 systemctl-cliproxyapi: ## Pull latest image and restart cliproxyapi systemd user service.
 	@echo "🔄 Restarting cliproxyapi..."
+	@systemctl --user daemon-reload
 	@systemctl --user restart cliproxyapi.service || true
 	@echo "✅ cliproxyapi restarted"
 


### PR DESCRIPTION
## Problem

After `make build` + `make switch`, cliproxyapi would not pick up the new service definition on Linux. `nix-switch` writes a new `cliproxyapi.service` unit to the nix store, but systemd still has the old unit loaded in memory. Without `daemon-reload`, the subsequent `systemctl --user restart` would restart the process using the **stale** `ExecStart` path (old nix derivation).

On macOS this is not an issue — launchctl `unload` + `load` always reads the fresh plist from disk.

## Fix

Add `systemctl --user daemon-reload` before `systemctl --user restart cliproxyapi.service` in the `systemctl-cliproxyapi` Makefile target.

## Testing
- Run `make switch` after a nix rebuild and verify cliproxyapi picks up the new binary/config

Generated with [Claude Code](https://claude.ai/claude-code) by claude-sonnet-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add systemd `daemon-reload` before restarting the `cliproxyapi` user service so Linux picks up the updated unit after `make switch`. Prevents restarts from using a stale ExecStart path after a nix rebuild.

<sup>Written for commit 55b62d66122d2ec7b3860ddda77f39350457deb3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

