### PR TITLE
feat: add openrouter/free via cliproxyapi as openclaw fallback

### DIFF
--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -87,7 +87,7 @@ openai-compatibility:
       - api-key: "__OPENROUTER_API_KEY__"
     models:
       - name: "openrouter/free"
-        alias: "cliproxy/free"
+        alias: "free"
       - name: "@preset/glm-4-7"
         alias: "glm-4.7"
   - name: "z-ai"

--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -86,6 +86,8 @@ openai-compatibility:
     api-key-entries:
       - api-key: "__OPENROUTER_API_KEY__"
     models:
+      - name: "openrouter/free"
+        alias: "cliproxy/free"
       - name: "@preset/glm-4-7"
         alias: "glm-4.7"
   - name: "z-ai"

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -87,7 +87,7 @@ openai-compatibility:
       - api-key: "__OPENROUTER_API_KEY__"
     models:
       - name: "openrouter/free"
-        alias: "cliproxy/free"
+        alias: "free"
       - name: "@preset/glm-4-7"
         alias: "glm-4.7"
   - name: "z-ai"

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -86,6 +86,8 @@ openai-compatibility:
     api-key-entries:
       - api-key: "__OPENROUTER_API_KEY__"
     models:
+      - name: "openrouter/free"
+        alias: "cliproxy/free"
       - name: "@preset/glm-4-7"
         alias: "glm-4.7"
   - name: "z-ai"

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -165,6 +165,23 @@
             },
             "contextWindow": 1000000,
             "maxTokens": 40960
+          },
+          {
+            "id": "cliproxy/free",
+            "name": "CliProxy Free",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 200000,
+            "maxTokens": 32000
           }
         ]
       }
@@ -176,7 +193,8 @@
         "primary": "cliproxy/minimax-m2.5",
         "fallbacks": [
           "cliproxy/claude-opus-4-6",
-          "cliproxy/glm-4.7"
+          "cliproxy/glm-4.7",
+          "cliproxy/free"
         ]
       },
       "workspace": "__HOME__/.openclaw/workspace",
@@ -198,7 +216,8 @@
         "model": {
           "primary": "cliproxy/claude-opus-4-6",
           "fallbacks": [
-            "cliproxy/glm-4.7"
+            "cliproxy/glm-4.7",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -215,7 +234,8 @@
         "model": {
           "primary": "cliproxy/claude-sonnet-4-6",
           "fallbacks": [
-            "cliproxy/glm-4.7"
+            "cliproxy/glm-4.7",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -230,7 +250,10 @@
         "name": "Code Reviewer (GLM)",
         "workspace": "__WORKSPACE__/agents/code-review",
         "model": {
-          "primary": "cliproxy/glm-4.7"
+          "primary": "cliproxy/glm-4.7",
+          "fallbacks": [
+            "cliproxy/free"
+          ]
         },
         "tools": {
           "allow": [
@@ -246,7 +269,8 @@
         "model": {
           "primary": "cliproxy/gpt-5.3-codex",
           "fallbacks": [
-            "cliproxy/glm-4.7"
+            "cliproxy/glm-4.7",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -263,7 +287,8 @@
         "model": {
           "primary": "cliproxy/gemini-3-pro-preview",
           "fallbacks": [
-            "cliproxy/glm-4.7"
+            "cliproxy/glm-4.7",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -278,7 +303,10 @@
         "name": "Code Formatter",
         "workspace": "__WORKSPACE__/agents/formatter",
         "model": {
-          "primary": "cliproxy/glm-4.7"
+          "primary": "cliproxy/glm-4.7",
+          "fallbacks": [
+            "cliproxy/free"
+          ]
         },
         "tools": {
           "allow": [
@@ -294,7 +322,8 @@
         "model": {
           "primary": "cliproxy/claude-opus-4-6",
           "fallbacks": [
-            "cliproxy/claude-sonnet-4-6"
+            "cliproxy/claude-sonnet-4-6",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -309,7 +338,10 @@
         "name": "Test Coverage",
         "workspace": "__WORKSPACE__/agents/testing",
         "model": {
-          "primary": "cliproxy/glm-4.7"
+          "primary": "cliproxy/glm-4.7",
+          "fallbacks": [
+            "cliproxy/free"
+          ]
         },
         "tools": {
           "allow": [
@@ -325,7 +357,8 @@
         "model": {
           "primary": "cliproxy/claude-sonnet-4-6",
           "fallbacks": [
-            "cliproxy/glm-4.7"
+            "cliproxy/glm-4.7",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -339,7 +372,10 @@
         "name": "CI/CD Fixer",
         "workspace": "__WORKSPACE__/agents/cicd",
         "model": {
-          "primary": "cliproxy/glm-4.7"
+          "primary": "cliproxy/glm-4.7",
+          "fallbacks": [
+            "cliproxy/free"
+          ]
         },
         "tools": {
           "allow": [
@@ -357,7 +393,8 @@
         "model": {
           "primary": "cliproxy/gpt-5.2",
           "fallbacks": [
-            "cliproxy/glm-4.7"
+            "cliproxy/glm-4.7",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -374,7 +411,8 @@
         "model": {
           "primary": "cliproxy/gemini-3-pro-preview",
           "fallbacks": [
-            "cliproxy/glm-4.7"
+            "cliproxy/glm-4.7",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -391,7 +429,8 @@
         "model": {
           "primary": "cliproxy/claude-opus-4-6",
           "fallbacks": [
-            "cliproxy/glm-4.7"
+            "cliproxy/glm-4.7",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -408,7 +447,8 @@
         "model": {
           "primary": "cliproxy/claude-opus-4-6",
           "fallbacks": [
-            "cliproxy/glm-4.7"
+            "cliproxy/glm-4.7",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -425,7 +465,8 @@
         "model": {
           "primary": "cliproxy/claude-sonnet-4-6",
           "fallbacks": [
-            "cliproxy/glm-4.7"
+            "cliproxy/glm-4.7",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -442,7 +483,8 @@
         "model": {
           "primary": "cliproxy/claude-opus-4-6",
           "fallbacks": [
-            "cliproxy/glm-4.7"
+            "cliproxy/glm-4.7",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -461,7 +503,8 @@
         "model": {
           "primary": "cliproxy/gpt-5.3-codex",
           "fallbacks": [
-            "cliproxy/glm-4.7"
+            "cliproxy/glm-4.7",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -480,7 +523,8 @@
         "model": {
           "primary": "cliproxy/gemini-3-pro-preview",
           "fallbacks": [
-            "cliproxy/glm-4.7"
+            "cliproxy/glm-4.7",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -497,7 +541,8 @@
         "model": {
           "primary": "cliproxy/claude-opus-4-6",
           "fallbacks": [
-            "cliproxy/glm-4.7"
+            "cliproxy/glm-4.7",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -514,7 +559,8 @@
         "model": {
           "primary": "cliproxy/gpt-5.2",
           "fallbacks": [
-            "cliproxy/glm-4.7"
+            "cliproxy/glm-4.7",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -531,7 +577,8 @@
         "model": {
           "primary": "cliproxy/gemini-3-pro-preview",
           "fallbacks": [
-            "cliproxy/glm-4.7"
+            "cliproxy/glm-4.7",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -548,7 +595,8 @@
         "model": {
           "primary": "cliproxy/claude-sonnet-4-6",
           "fallbacks": [
-            "cliproxy/glm-4.7"
+            "cliproxy/glm-4.7",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -563,7 +611,10 @@
         "name": "DevOps Engineer",
         "workspace": "__WORKSPACE__/agents/devops",
         "model": {
-          "primary": "cliproxy/glm-4.7"
+          "primary": "cliproxy/glm-4.7",
+          "fallbacks": [
+            "cliproxy/free"
+          ]
         },
         "tools": {
           "allow": [

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -165,6 +165,23 @@
             },
             "contextWindow": 1000000,
             "maxTokens": 40960
+          },
+          {
+            "id": "cliproxy/free",
+            "name": "CliProxy Free",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 200000,
+            "maxTokens": 32000
           }
         ]
       }
@@ -176,7 +193,8 @@
         "primary": "cliproxy/__MINIMAX__",
         "fallbacks": [
           "cliproxy/__CLAUDE_OPUS__",
-          "cliproxy/__GLM__"
+          "cliproxy/__GLM__",
+          "cliproxy/free"
         ]
       },
       "workspace": "__HOME__/.openclaw/workspace",
@@ -198,7 +216,8 @@
         "model": {
           "primary": "cliproxy/__CLAUDE_OPUS__",
           "fallbacks": [
-            "cliproxy/__GLM__"
+            "cliproxy/__GLM__",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -215,7 +234,8 @@
         "model": {
           "primary": "cliproxy/__CLAUDE_SONNET__",
           "fallbacks": [
-            "cliproxy/__GLM__"
+            "cliproxy/__GLM__",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -230,7 +250,10 @@
         "name": "Code Reviewer (GLM)",
         "workspace": "__WORKSPACE__/agents/code-review",
         "model": {
-          "primary": "cliproxy/__GLM__"
+          "primary": "cliproxy/__GLM__",
+          "fallbacks": [
+            "cliproxy/free"
+          ]
         },
         "tools": {
           "allow": [
@@ -246,7 +269,8 @@
         "model": {
           "primary": "cliproxy/__GPT_CODEX__",
           "fallbacks": [
-            "cliproxy/__GLM__"
+            "cliproxy/__GLM__",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -263,7 +287,8 @@
         "model": {
           "primary": "cliproxy/__GEMINI_PRO__",
           "fallbacks": [
-            "cliproxy/__GLM__"
+            "cliproxy/__GLM__",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -278,7 +303,10 @@
         "name": "Code Formatter",
         "workspace": "__WORKSPACE__/agents/formatter",
         "model": {
-          "primary": "cliproxy/__GLM__"
+          "primary": "cliproxy/__GLM__",
+          "fallbacks": [
+            "cliproxy/free"
+          ]
         },
         "tools": {
           "allow": [
@@ -294,7 +322,8 @@
         "model": {
           "primary": "cliproxy/__CLAUDE_OPUS__",
           "fallbacks": [
-            "cliproxy/__CLAUDE_SONNET__"
+            "cliproxy/__CLAUDE_SONNET__",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -309,7 +338,10 @@
         "name": "Test Coverage",
         "workspace": "__WORKSPACE__/agents/testing",
         "model": {
-          "primary": "cliproxy/__GLM__"
+          "primary": "cliproxy/__GLM__",
+          "fallbacks": [
+            "cliproxy/free"
+          ]
         },
         "tools": {
           "allow": [
@@ -325,7 +357,8 @@
         "model": {
           "primary": "cliproxy/__CLAUDE_SONNET__",
           "fallbacks": [
-            "cliproxy/__GLM__"
+            "cliproxy/__GLM__",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -339,7 +372,10 @@
         "name": "CI/CD Fixer",
         "workspace": "__WORKSPACE__/agents/cicd",
         "model": {
-          "primary": "cliproxy/__GLM__"
+          "primary": "cliproxy/__GLM__",
+          "fallbacks": [
+            "cliproxy/free"
+          ]
         },
         "tools": {
           "allow": [
@@ -357,7 +393,8 @@
         "model": {
           "primary": "cliproxy/__GPT__",
           "fallbacks": [
-            "cliproxy/__GLM__"
+            "cliproxy/__GLM__",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -374,7 +411,8 @@
         "model": {
           "primary": "cliproxy/__GEMINI_PRO__",
           "fallbacks": [
-            "cliproxy/__GLM__"
+            "cliproxy/__GLM__",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -391,7 +429,8 @@
         "model": {
           "primary": "cliproxy/__CLAUDE_OPUS__",
           "fallbacks": [
-            "cliproxy/__GLM__"
+            "cliproxy/__GLM__",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -408,7 +447,8 @@
         "model": {
           "primary": "cliproxy/__CLAUDE_OPUS__",
           "fallbacks": [
-            "cliproxy/__GLM__"
+            "cliproxy/__GLM__",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -425,7 +465,8 @@
         "model": {
           "primary": "cliproxy/__CLAUDE_SONNET__",
           "fallbacks": [
-            "cliproxy/__GLM__"
+            "cliproxy/__GLM__",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -442,7 +483,8 @@
         "model": {
           "primary": "cliproxy/__CLAUDE_OPUS__",
           "fallbacks": [
-            "cliproxy/__GLM__"
+            "cliproxy/__GLM__",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -461,7 +503,8 @@
         "model": {
           "primary": "cliproxy/__GPT_CODEX__",
           "fallbacks": [
-            "cliproxy/__GLM__"
+            "cliproxy/__GLM__",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -480,7 +523,8 @@
         "model": {
           "primary": "cliproxy/__GEMINI_PRO__",
           "fallbacks": [
-            "cliproxy/__GLM__"
+            "cliproxy/__GLM__",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -497,7 +541,8 @@
         "model": {
           "primary": "cliproxy/__CLAUDE_OPUS__",
           "fallbacks": [
-            "cliproxy/__GLM__"
+            "cliproxy/__GLM__",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -514,7 +559,8 @@
         "model": {
           "primary": "cliproxy/__GPT__",
           "fallbacks": [
-            "cliproxy/__GLM__"
+            "cliproxy/__GLM__",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -531,7 +577,8 @@
         "model": {
           "primary": "cliproxy/__GEMINI_PRO__",
           "fallbacks": [
-            "cliproxy/__GLM__"
+            "cliproxy/__GLM__",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -548,7 +595,8 @@
         "model": {
           "primary": "cliproxy/__CLAUDE_SONNET__",
           "fallbacks": [
-            "cliproxy/__GLM__"
+            "cliproxy/__GLM__",
+            "cliproxy/free"
           ]
         },
         "tools": {
@@ -563,7 +611,10 @@
         "name": "DevOps Engineer",
         "workspace": "__WORKSPACE__/agents/devops",
         "model": {
-          "primary": "cliproxy/__GLM__"
+          "primary": "cliproxy/__GLM__",
+          "fallbacks": [
+            "cliproxy/free"
+          ]
         },
         "tools": {
           "allow": [


### PR DESCRIPTION
## Summary
- Add `openrouter/free` model to cliproxyapi's openrouter provider (aliased as `cliproxy/free`)
- Add `cliproxy/free` as a last-resort fallback for all openclaw agents
- Agents with no fallbacks (glm-4.7 primary) now also get `cliproxy/free` as fallback

## Test plan
- [ ] Verify cliproxyapi resolves `cliproxy/free` -> `openrouter/free` upstream
- [ ] Verify openclaw agents fall back to `cliproxy/free` when other models fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `openrouter/free` to `cliproxyapi` with alias `free`, exposed as `cliproxy/free` and used as a last-resort fallback across all `openclaw` agents. Improves reliability with a zero-cost backup when primaries fail.

- **New Features**
  - Register `openrouter/free` in `cliproxyapi` with alias `free`; expose as `cliproxy/free` in the model registry.
  - Add `cliproxy/free` as the final fallback across agent configs (e.g., after `glm-4.7`).

- **Migration**
  - No changes required. Ensure `__OPENROUTER_API_KEY__` is configured.

<sup>Written for commit 8051c988f67b73898db63c1d6f6ddbc9148c825e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

