### PR TITLE
feat(local-binaries): add alias support, mise integration, and fish-test fallback

### DIFF
--- a/.local-binaries.txt
+++ b/.local-binaries.txt
@@ -1,12 +1,15 @@
 # Local development binaries
 # Add one binary path per line
 # Lines starting with # are comments
+# Use path:alias to create a symlink with a custom name (e.g., ~/path/to/pi:pir)
 
 ~/ghq/github.com/Dicklesworthstone/beads_viewer/bv
 ~/ghq/github.com/Dicklesworthstone/coding_agent_session_search/target/release/cass
 ~/ghq/github.com/Dicklesworthstone/cross_agent_sessions_resumer/target/release/casr
 ~/ghq/github.com/Dicklesworthstone/destructive_command_guard/target/release/dcg
+~/ghq/github.com/Dicklesworthstone/pi_agent_rust/target/release/pi:pir
 ~/ghq/github.com/Dicklesworthstone/ultimate_bug_scanner/ubs
 ~/ghq/github.com/nwiizo/ccswarm/target/release/ccswarm
+~/ghq/github.com/openai/symphony/elixir/bin/symphony
 ~/ghq/github.com/steveyegge/beads/bd
 ~/ghq/github.com/steveyegge/gastown/gt

--- a/Makefile
+++ b/Makefile
@@ -827,13 +827,18 @@ shell-test-dev: ## Run shell tests inside the Nix dev shell (mirrors CI).
 .PHONY: fish-test
 fish-test: ## Run fish function tests using fishtape.
 	@echo "🐟 Running fish function tests..."
-	@fish_errors=$$(mktemp); \
+	@if ! command -v fishtape >/dev/null 2>&1; then \
+	  echo "  fishtape not found, running inside Nix dev shell..."; \
+	  $(MAKE) fish-test-dev; \
+	else \
+	  fish_errors=$$(mktemp); \
 	  fishtape spec/fish/*_test.fish 2>"$$fish_errors"; \
 	  rc=$$?; \
 	  if [ -s "$$fish_errors" ]; then \
 	    echo "fish test stderr (failing):"; cat "$$fish_errors"; rm -f "$$fish_errors"; exit 1; \
 	  fi; \
-	  rm -f "$$fish_errors"; exit $$rc
+	  rm -f "$$fish_errors"; exit $$rc; \
+	fi
 
 .PHONY: fish-test-dev
 fish-test-dev: ## Run fish tests inside the Nix dev shell (mirrors CI).

--- a/config/pi/settings.json
+++ b/config/pi/settings.json
@@ -21,9 +21,7 @@
     "reserveTokens": 16384,
     "keepRecentTokens": 20000
   },
-  "skills": {
-    "enabled": true
-  },
+  "skills": [],
   "retry": {
     "enabled": true,
     "maxRetries": 3,

--- a/home-manager/modules/local-binaries/sync-local-binaries.sh
+++ b/home-manager/modules/local-binaries/sync-local-binaries.sh
@@ -32,6 +32,12 @@ while IFS= read -r line || [ -n "$line" ]; do
   \#*) continue ;;
   esac
 
+  # Parse optional alias (path:alias)
+  alias_name=""
+  case "$line" in
+  *:*) alias_name="${line##*:}"; line="${line%:*}" ;;
+  esac
+
   # Expand ~ to $HOME
   line="${line/#\~/$HOME}"
 
@@ -41,10 +47,31 @@ while IFS= read -r line || [ -n "$line" ]; do
     continue
   fi
 
-  # Get binary name and create symlink
-  bin_name="$(basename "$line")"
+  # Get binary name and target path (use alias if provided)
+  bin_name="${alias_name:-$(basename "$line")}"
   target="$BIN_DIR/$bin_name"
 
-  ln -sf "$line" "$target"
-  echo "Linked: $bin_name -> $line"
+  # Walk up from binary to find a mise.toml (stops at $HOME)
+  mise_dir=""
+  walk="$(dirname "$line")"
+  while [ "$walk" != "$HOME" ] && [ "$walk" != "/" ]; do
+    if [ -f "$walk/mise.toml" ]; then
+      mise_dir="$walk"
+      break
+    fi
+    walk="$(dirname "$walk")"
+  done
+
+  # If a mise.toml was found and mise is available, create a wrapper script
+  if [ -n "$mise_dir" ] && command -v mise >/dev/null 2>&1; then
+    cat >"$target" <<WRAPPER
+#!/usr/bin/env bash
+exec mise exec -C "$mise_dir" -- "$line" "\$@"
+WRAPPER
+    chmod +x "$target"
+    echo "Wrapped (mise): $bin_name -> $line (via $mise_dir/mise.toml)"
+  else
+    ln -sf "$line" "$target"
+    echo "Linked: $bin_name -> $line"
+  fi
 done <"$BINARIES_FILE"

--- a/scripts/update-local-binaries.sh
+++ b/scripts/update-local-binaries.sh
@@ -88,36 +88,82 @@ get_repo_name() {
   basename "$repo_dir"
 }
 
+# Find closest ancestor directory (from binary up to repo root) that has a build file
+find_build_dir() {
+  local repo_dir="$1"
+  local binary_path="$2"
+  # Expand ~
+  binary_path="${binary_path/#\~/$HOME}"
+
+  local dir
+  dir="$(dirname "$binary_path")"
+
+  # Walk up from binary dir to repo root (inclusive)
+  while true; do
+    if [ -f "$dir/Makefile" ] || [ -f "$dir/Cargo.toml" ] || [ -f "$dir/go.mod" ] || [ -f "$dir/mix.exs" ]; then
+      echo "$dir"
+      return 0
+    fi
+    [ "$dir" = "$repo_dir" ] && break
+    dir="$(dirname "$dir")"
+  done
+
+  # Fallback to repo root
+  echo "$repo_dir"
+}
+
 # Detect and run build command
 build_repo() {
   local repo_dir="$1"
+  local binary_path="${2:-}"
   local repo_name
   repo_name="$(get_repo_name "$repo_dir")"
 
   log_step "  Building $repo_name..."
 
-  if [ -f "$repo_dir/Makefile" ]; then
-    if make -C "$repo_dir" build 2>&1; then
+  # Use subdirectory build dir if binary path provided
+  local build_dir="$repo_dir"
+  if [ -n "$binary_path" ]; then
+    build_dir="$(find_build_dir "$repo_dir" "$binary_path")"
+  fi
+
+  # Install tools via mise if mise.toml is present
+  if [ -f "$build_dir/mise.toml" ] && command -v mise >/dev/null 2>&1; then
+    log_step "  Installing tools via mise..."
+    (cd "$build_dir" && mise install 2>&1) || true
+  fi
+
+  if [ -f "$build_dir/Makefile" ]; then
+    # Use mise exec if mise.toml present to ensure correct tool versions
+    local make_cmd="make"
+    if [ -f "$build_dir/mise.toml" ] && command -v mise >/dev/null 2>&1; then
+      make_cmd="mise exec -- make"
+    fi
+    # Run deps target first if the Makefile defines it
+    if (cd "$build_dir" && $make_cmd -n deps >/dev/null 2>&1); then
+      (cd "$build_dir" && $make_cmd deps 2>&1) || true
+    fi
+    if (cd "$build_dir" && $make_cmd build 2>&1); then
       return 0
     else
       return 1
     fi
-  elif [ -f "$repo_dir/Cargo.toml" ]; then
-    if (cd "$repo_dir" && cargo build --release 2>&1); then
+  elif [ -f "$build_dir/Cargo.toml" ]; then
+    if (cd "$build_dir" && cargo build --release 2>&1); then
       return 0
     else
       return 1
     fi
-  elif [ -f "$repo_dir/go.mod" ]; then
+  elif [ -f "$build_dir/go.mod" ]; then
     # Go project: build ./cmd/{repo_name} if it exists, otherwise build root
-    if [ -d "$repo_dir/cmd/$repo_name" ]; then
-      if (cd "$repo_dir" && go build "./cmd/$repo_name" 2>&1); then
+    if [ -d "$build_dir/cmd/$repo_name" ]; then
+      if (cd "$build_dir" && go build "./cmd/$repo_name" 2>&1); then
         return 0
       else
         return 1
       fi
     else
-      if (cd "$repo_dir" && go build 2>&1); then
+      if (cd "$build_dir" && go build 2>&1); then
         return 0
       else
         return 1
@@ -193,7 +239,7 @@ update_repo() {
   fi
 
   # Build
-  if build_repo "$repo_dir"; then
+  if build_repo "$repo_dir" "$binary_path"; then
     log_info "  ✅ $repo_name updated successfully"
     SUCCESSES+=("$repo_name")
   else
@@ -266,6 +312,11 @@ main() {
     if [ -n "$filter" ] && [[ ! $line =~ $filter ]]; then
       continue
     fi
+
+    # Strip optional alias suffix (path:alias)
+    case "$line" in
+    *:*) line="${line%:*}" ;;
+    esac
 
     # Get repo directory and check if already processed
     local repo_dir


### PR DESCRIPTION
## Summary
- Support `path:alias` syntax in `.local-binaries.txt` for custom symlink names (e.g., `~/path/to/pi:pir`)
- Auto-detect `mise.toml` and create wrapper scripts using `mise exec` for correct tool versions
- Build from closest ancestor directory with a build file instead of always repo root
- `fish-test` Makefile target falls back to nix dev shell when `fishtape` not found
- Add `pir` (pi_agent_rust) and `symphony` binaries
- Fix pi `settings.json` skills config

## Test plan
- [ ] Verify `path:alias` creates symlink with alias name
- [ ] Verify mise wrapper scripts work for repos with `mise.toml`
- [ ] Verify `make fish-test` falls back to dev shell without fishtape
- [ ] Verify `make update-local-binaries` builds from correct subdirectory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds alias support and `mise` integration to local binaries, improves build detection, and updates test fallback behavior. Also adds `pir`/`symphony` binaries and fixes PI skills config.

- **New Features**
  - Support `path:alias` in `.local-binaries.txt` to set custom symlink names.
  - Auto-wrap binaries with `mise exec` when a `mise.toml` is found.
  - Build from the nearest directory with a build file (`Makefile`, `Cargo.toml`, `go.mod`, `mix.exs`).
  - `fish-test` falls back to the Nix dev shell when `fishtape` is missing.
  - Add `pir` (from `pi_agent_rust`) and `symphony` binaries.

- **Bug Fixes**
  - Fix PI `settings.json` by setting `"skills": []`.

<sup>Written for commit 0fd8321a292cd3edb6566eb76f13aeac12e2c0a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

