### PR TITLE
fix: resolve fish test path correctly with fishtape

### DIFF
--- a/home-manager/programs/elixir/default.nix
+++ b/home-manager/programs/elixir/default.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    elixir
+    elixir_1_19
     elixir-ls
   ];
 }

--- a/spec/fish/_cliproxyapi_function_test.fish
+++ b/spec/fish/_cliproxyapi_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_cliproxyapi_function.fish
 
 set call_log (mktemp)

--- a/spec/fish/_cltxe_function_test.fish
+++ b/spec/fish/_cltxe_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_cltxe_function.fish
 
 # ── no args: interactive mode ─────────────────────────────

--- a/spec/fish/_cltxeh_function_test.fish
+++ b/spec/fish/_cltxeh_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_cltxeh_function.fish
 
 @test "empty prompt rejects" (echo "" | _cltxeh_function 2>&1) = "No prompt provided, aborting."

--- a/spec/fish/_clwxe_function_test.fish
+++ b/spec/fish/_clwxe_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_clwxe_function.fish
 
 # ── no args: interactive mode ─────────────────────────────

--- a/spec/fish/_clwxeh_function_test.fish
+++ b/spec/fish/_clwxeh_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_clwxeh_function.fish
 
 @test "empty prompt rejects" (echo "" | _clwxeh_function 2>&1) = "No prompt provided, aborting."

--- a/spec/fish/_clxe_function_test.fish
+++ b/spec/fish/_clxe_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_clxe_function.fish
 
 # ── no args: interactive mode ─────────────────────────────

--- a/spec/fish/_clxeh_function_test.fish
+++ b/spec/fish/_clxeh_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_clxeh_function.fish
 
 @test "empty prompt rejects" (echo "" | _clxeh_function 2>&1) = "No prompt provided, aborting."

--- a/spec/fish/_coxe_function_test.fish
+++ b/spec/fish/_coxe_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_coxe_function.fish
 
 # ── no args: interactive mode ─────────────────────────────

--- a/spec/fish/_coxeh_function_test.fish
+++ b/spec/fish/_coxeh_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_coxeh_function.fish
 
 @test "empty prompt rejects" (echo "" | _coxeh_function 2>&1) = "No prompt provided, aborting."

--- a/spec/fish/_coxel_function_test.fish
+++ b/spec/fish/_coxel_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_coxel_function.fish
 
 # ── no args: interactive mode ─────────────────────────────

--- a/spec/fish/_coxelh_function_test.fish
+++ b/spec/fish/_coxelh_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_coxelh_function.fish
 
 @test "empty prompt rejects" (echo "" | _coxelh_function 2>&1) = "No prompt provided, aborting."

--- a/spec/fish/_dev_function_test.fish
+++ b/spec/fish/_dev_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_dev_function.fish
 
 set tmpdir (mktemp -d)

--- a/spec/fish/_fish_shortcuts_test.fish
+++ b/spec/fish/_fish_shortcuts_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_fish_shortcuts.fish
 
 @test "function is defined after sourcing" (functions -q _fish_shortcuts; echo $status) = 0

--- a/spec/fish/_fzf_chrome_history_test.fish
+++ b/spec/fish/_fzf_chrome_history_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_fzf_chrome_history.fish
 
 set tmpdir (mktemp -d)

--- a/spec/fish/_fzf_directory_picker_test.fish
+++ b/spec/fish/_fzf_directory_picker_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_fzf_preview_name.fish
 source $fn/_fzf_directory_picker.fish
 

--- a/spec/fish/_fzf_file_picker_test.fish
+++ b/spec/fish/_fzf_file_picker_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_fzf_preview_name.fish
 source $fn/_fzf_file_picker.fish
 

--- a/spec/fish/_fzf_ghq_picker_test.fish
+++ b/spec/fish/_fzf_ghq_picker_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_fzf_preview_name.fish
 source $fn/_fzf_ghq_picker.fish
 

--- a/spec/fish/_fzf_git_branch_test.fish
+++ b/spec/fish/_fzf_git_branch_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_fzf_git_branch.fish
 
 function git; end

--- a/spec/fish/_fzf_git_worktree_test.fish
+++ b/spec/fish/_fzf_git_worktree_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_fzf_git_worktree.fish
 
 function git; end

--- a/spec/fish/_fzf_preview_cmd_test.fish
+++ b/spec/fish/_fzf_preview_cmd_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_fzf_preview_cmd.fish
 
 set tmpdir (mktemp -d)

--- a/spec/fish/_fzf_preview_name_test.fish
+++ b/spec/fish/_fzf_preview_name_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_fzf_preview_name.fish
 
 @test "with arg includes arg name" (string match -q "*Files*" (_fzf_preview_name "Files"); echo $status) = 0

--- a/spec/fish/_fzf_shell_history_test.fish
+++ b/spec/fish/_fzf_shell_history_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_fzf_preview_name.fish
 source $fn/_fzf_shell_history.fish
 

--- a/spec/fish/_gco_function_test.fish
+++ b/spec/fish/_gco_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_gco_function.fish
 
 set call_log (mktemp)

--- a/spec/fish/_grco_function_test.fish
+++ b/spec/fish/_grco_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_grco_function.fish
 
 set call_log (mktemp)

--- a/spec/fish/_grcr_function_test.fish
+++ b/spec/fish/_grcr_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_grcr_function.fish
 
 # ── detached HEAD → error ─────────────────────────────────

--- a/spec/fish/_hm_load_env_file_test.fish
+++ b/spec/fish/_hm_load_env_file_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_hm_load_env_file.fish
 
 set tmpdir (mktemp -d)

--- a/spec/fish/_kyber_function_test.fish
+++ b/spec/fish/_kyber_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_kyber_function.fish
 
 set log (mktemp)

--- a/spec/fish/_kyberd_function_test.fish
+++ b/spec/fish/_kyberd_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_kyberd_function.fish
 
 set log (mktemp)

--- a/spec/fish/_kyberm_function_test.fish
+++ b/spec/fish/_kyberm_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_kyberm_function.fish
 
 set log (mktemp)

--- a/spec/fish/_ocxe_function_test.fish
+++ b/spec/fish/_ocxe_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_ocxe_function.fish
 
 # ── no args: interactive mode ─────────────────────────────

--- a/spec/fish/_ocxeh_function_test.fish
+++ b/spec/fish/_ocxeh_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_ocxeh_function.fish
 
 @test "empty prompt rejects" (echo "" | _ocxeh_function 2>&1) = "No prompt provided, aborting."

--- a/spec/fish/_pixe_function_test.fish
+++ b/spec/fish/_pixe_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_pixe_function.fish
 
 # ── no args: interactive mode ─────────────────────────────

--- a/spec/fish/_pixeh_function_test.fish
+++ b/spec/fish/_pixeh_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_pixeh_function.fish
 
 @test "empty prompt rejects" (echo "" | _pixeh_function 2>&1) = "No prompt provided, aborting."

--- a/spec/fish/_ssh_add_github_test.fish
+++ b/spec/fish/_ssh_add_github_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_ssh_add_github.fish
 
 set tmpdir (mktemp -d)

--- a/spec/fish/_tdo_function_test.fish
+++ b/spec/fish/_tdo_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_tdo_function.fish
 
 # ── session missing → tmuxinator start desktop ────────────

--- a/spec/fish/_tmo_function_test.fish
+++ b/spec/fish/_tmo_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_tmo_function.fish
 
 # ── session missing → tmuxinator start mobile ─────────────

--- a/spec/fish/_tpo_function_test.fish
+++ b/spec/fish/_tpo_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_tpo_function.fish
 
 # ── session missing → tmuxinator start primary ────────────

--- a/spec/fish/_tsh_function_test.fish
+++ b/spec/fish/_tsh_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_tsh_function.fish
 
 set tmpdir (mktemp -d)

--- a/spec/fish/_tsk_function_test.fish
+++ b/spec/fish/_tsk_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_tsk_function.fish
 
 function tmux; end

--- a/spec/fish/_tss_function_test.fish
+++ b/spec/fish/_tss_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_tss_function.fish
 
 set tmpdir (mktemp -d)

--- a/spec/fish/_tsw_function_test.fish
+++ b/spec/fish/_tsw_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_tsw_function.fish
 
 set tmpdir (mktemp -d)

--- a/spec/fish/_two_function_test.fish
+++ b/spec/fish/_two_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_two_function.fish
 
 # ── no resurrect, no work session → tmuxinator start work ─

--- a/spec/fish/_zdo_function_test.fish
+++ b/spec/fish/_zdo_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_zdo_function.fish
 
 set log (mktemp)

--- a/spec/fish/_zmo_function_test.fish
+++ b/spec/fish/_zmo_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_zmo_function.fish
 
 set log (mktemp)

--- a/spec/fish/_zpo_function_test.fish
+++ b/spec/fish/_zpo_function_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/_zpo_function.fish
 
 set log (mktemp)

--- a/spec/fish/fish_user_key_bindings_test.fish
+++ b/spec/fish/fish_user_key_bindings_test.fish
@@ -1,4 +1,4 @@
-set fn (status dirname)/../../home-manager/programs/fish/functions
+set fn ../../home-manager/programs/fish/functions
 source $fn/fish_user_key_bindings.fish
 
 function bind; end


### PR DESCRIPTION
The issue was that (status dirname) returns unexpected values when fish test files are run via fishtape in CI. This caused the path resolution to fail, resulting in 'Unknown command' errors.

Fix: Use relative path ../../home-manager/programs/fish/functions directly instead of relying on status dirname, since fishtape runs with the test file's directory as the current working directory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes fishtape path resolution in fish tests to stop "Unknown command" errors in CI. Also pins Elixir to `elixir_1_19` for consistent builds.

- **Bug Fixes**
  - Load fish functions via `../../home-manager/programs/fish/functions` instead of `(status dirname)`.
  - Aligns with fishtape running tests from the test file’s directory, restoring CI reliability.

- **Dependencies**
  - Switch `elixir` to `elixir_1_19` in Home Manager for a stable toolchain.

<sup>Written for commit eed18e292659fb165b4ebb732664f50c4ec8dd42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

