### PR TITLE
feat: add llm-upgrade and gitalias-upgrade to make upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,19 @@ update-local-binaries: ## Update and rebuild local binaries from .local-binaries
 ##@ Upgrade
 
 .PHONY: upgrade
-upgrade: nix-upgrade overlays-upgrade neovim-upgrade ## Upgrade Nix flake, overlays, Neovim plugins
+upgrade: nix-upgrade overlays-upgrade neovim-upgrade llm-upgrade gitalias-upgrade ## Upgrade Nix flake, overlays, Neovim plugins, LLM configs, and gitalias
+
+.PHONY: llm-upgrade
+llm-upgrade: ## Regenerate tool configs from models.json.
+	@echo "🤖 Updating LLM tool configs..."
+	@./scripts/llm-update.sh
+	@echo "✅ LLM configs updated"
+
+.PHONY: gitalias-upgrade
+gitalias-upgrade: ## Download latest gitalias.txt from upstream.
+	@echo "📥 Updating gitalias.txt..."
+	@./scripts/update-gitalias.sh
+	@echo "✅ gitalias.txt updated"
 
 .PHONY: upgrade-dev
 upgrade-dev: ## Upgrade inside the Nix dev shell (mirrors CI).
@@ -594,6 +606,9 @@ neovim-dev: ## Set up local Neovim development environment.
 .PHONY: neovim-upgrade
 neovim-upgrade: ## Update Neovim plugins.
 	@echo "📦 Updating neovim plugins..."
+	@mkdir -p ~/.config/nvim
+	@ln -sf "$(PWD)/home-manager/programs/neovim/init.lua" ~/.config/nvim/init.lua
+	@ln -sf "$(PWD)/home-manager/programs/neovim/nvim-pack-lock.json" ~/.config/nvim/nvim-pack-lock.json
 	@nvim --headless +"lua vim.pack.update()" +qa
 	@echo "✅ Neovim plugins updated"
 

--- a/config/ccs/gemini.settings.template.json
+++ b/config/ccs/gemini.settings.template.json
@@ -2,9 +2,9 @@
   "env": {
     "ANTHROPIC_BASE_URL": "http://127.0.0.1:8317/api/provider/gemini",
     "ANTHROPIC_AUTH_TOKEN": "__CLIPROXY_API_KEY__",
-    "ANTHROPIC_MODEL": "gemini-3-pro-preview",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "gemini-3-pro-preview",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "gemini-3-pro-preview",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gemini-3-flash-preview"
+    "ANTHROPIC_MODEL": "gemini-3.1-pro-preview",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "gemini-3.1-pro-preview",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "gemini-3.1-pro-preview",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gemini-3.1-flash-preview"
   }
 }

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -86,6 +86,7 @@
         "hooks": [
           {
             "command": "git-ai checkpoint claude --hook-input stdin",
+            "timeout": 10,
             "type": "command"
           }
         ],
@@ -147,6 +148,7 @@
         "hooks": [
           {
             "command": "git-ai checkpoint claude --hook-input stdin",
+            "timeout": 10,
             "type": "command"
           }
         ],

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -65,8 +65,8 @@
             "maxTokens": 32000
           },
           {
-            "id": "gpt-5.2",
-            "name": "GPT 5.2",
+            "id": "gpt-5.4",
+            "name": "GPT 5.4",
             "reasoning": false,
             "input": [
               "text",
@@ -99,8 +99,8 @@
             "maxTokens": 32000
           },
           {
-            "id": "gemini-3-pro-preview",
-            "name": "Gemini 3 Pro",
+            "id": "gemini-3.1-pro-preview",
+            "name": "Gemini 3.1 Pro",
             "reasoning": false,
             "input": [
               "text",
@@ -116,8 +116,8 @@
             "maxTokens": 32000
           },
           {
-            "id": "gemini-3-flash-preview",
-            "name": "Gemini 3 Flash",
+            "id": "gemini-3.1-flash-preview",
+            "name": "Gemini 3.1 Flash",
             "reasoning": false,
             "input": [
               "text",
@@ -285,7 +285,7 @@
         "name": "Code Reviewer (Gemini Pro)",
         "workspace": "__WORKSPACE__/agents/code-review",
         "model": {
-          "primary": "cliproxy/gemini-3-pro-preview",
+          "primary": "cliproxy/gemini-3.1-pro-preview",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"
@@ -391,7 +391,7 @@
         "name": "Sales Agent",
         "workspace": "__WORKSPACE__/agents/sales",
         "model": {
-          "primary": "cliproxy/gpt-5.2",
+          "primary": "cliproxy/gpt-5.4",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"
@@ -409,7 +409,7 @@
         "name": "Twitter (Gemini)",
         "workspace": "__WORKSPACE__/agents/twitter",
         "model": {
-          "primary": "cliproxy/gemini-3-pro-preview",
+          "primary": "cliproxy/gemini-3.1-pro-preview",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"
@@ -521,7 +521,7 @@
         "name": "Product Manager",
         "workspace": "__WORKSPACE__/agents/product",
         "model": {
-          "primary": "cliproxy/gemini-3-pro-preview",
+          "primary": "cliproxy/gemini-3.1-pro-preview",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"
@@ -557,7 +557,7 @@
         "name": "Strategy (GPT)",
         "workspace": "__WORKSPACE__/agents/strategy",
         "model": {
-          "primary": "cliproxy/gpt-5.2",
+          "primary": "cliproxy/gpt-5.4",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"
@@ -575,7 +575,7 @@
         "name": "Strategy (Gemini)",
         "workspace": "__WORKSPACE__/agents/strategy",
         "model": {
-          "primary": "cliproxy/gemini-3-pro-preview",
+          "primary": "cliproxy/gemini-3.1-pro-preview",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -33,17 +33,17 @@
         "claude-haiku-4-5-20251001": {
           "name": "Claude Haiku 4.5 (via shunkakinoki's CLIProxy)"
         },
-        "gpt-5.2": {
-          "name": "GPT 5.2 (via shunkakinoki's CLIProxy)"
+        "gpt-5.4": {
+          "name": "GPT 5.4 (via shunkakinoki's CLIProxy)"
         },
         "gpt-5.3-codex": {
           "name": "GPT 5.3 Codex (via shunkakinoki's CLIProxy)"
         },
-        "gemini-3-pro-preview": {
-          "name": "Gemini 3 Pro (via shunkakinoki's CLIProxy)"
+        "gemini-3.1-pro-preview": {
+          "name": "Gemini 3.1 Pro (via shunkakinoki's CLIProxy)"
         },
-        "gemini-3-flash-preview": {
-          "name": "Gemini 3 Flash (via shunkakinoki's CLIProxy)"
+        "gemini-3.1-flash-preview": {
+          "name": "Gemini 3.1 Flash (via shunkakinoki's CLIProxy)"
         },
         "z-ai/glm-4.7": {
           "name": "GLM 4.7 (via shunkakinoki's CLIProxy)"
@@ -67,17 +67,17 @@
         "claude-haiku-4-5-20251001": {
           "name": "Claude Haiku 4.5 (via local CLIProxyAPI)"
         },
-        "gpt-5.2": {
-          "name": "GPT 5.2 (via local CLIProxyAPI)"
+        "gpt-5.4": {
+          "name": "GPT 5.4 (via local CLIProxyAPI)"
         },
         "gpt-5.3-codex": {
           "name": "GPT 5.3 Codex (via local CLIProxyAPI)"
         },
-        "gemini-3-pro-preview": {
-          "name": "Gemini 3 Pro (via local CLIProxyAPI)"
+        "gemini-3.1-pro-preview": {
+          "name": "Gemini 3.1 Pro (via local CLIProxyAPI)"
         },
-        "gemini-3-flash-preview": {
-          "name": "Gemini 3 Flash (via local CLIProxyAPI)"
+        "gemini-3.1-flash-preview": {
+          "name": "Gemini 3.1 Flash (via local CLIProxyAPI)"
         },
         "glm-4.7": {
           "name": "GLM 4.7 (via local CLIProxyAPI)"

--- a/config/pi/models.json
+++ b/config/pi/models.json
@@ -23,8 +23,8 @@
           "maxTokens": 128000
         },
         {
-          "id": "gpt-5.2",
-          "name": "GPT 5.2 [ChatGPT Pro]",
+          "id": "gpt-5.4",
+          "name": "GPT 5.4 [ChatGPT Pro]",
           "reasoning": true,
           "input": [
             "text",
@@ -40,8 +40,8 @@
           "maxTokens": 128000
         },
         {
-          "id": "gemini-3-pro-preview",
-          "name": "Gemini 3 Pro",
+          "id": "gemini-3.1-pro-preview",
+          "name": "Gemini 3.1 Pro",
           "reasoning": true,
           "input": [
             "text",
@@ -57,8 +57,8 @@
           "maxTokens": 65536
         },
         {
-          "id": "gemini-3-flash-preview",
-          "name": "Gemini 3 Flash",
+          "id": "gemini-3.1-flash-preview",
+          "name": "Gemini 3.1 Flash",
           "reasoning": false,
           "input": [
             "text",

--- a/home-manager/programs/fish/functions/_coxe_function.fish
+++ b/home-manager/programs/fish/functions/_coxe_function.fish
@@ -3,9 +3,9 @@ function _coxe_function --description "Run Codex with a free-form prompt"
   # Usage: cxe [<prompt words...>]
 
   if test (count $argv) -eq 0
-    codex --model 'gpt-5.3-codex' --full-auto -c model_reasoning_summary_format=experimental
+    codex --model 'gpt-5.4' --full-auto -c model_reasoning_summary_format=experimental
   else
     set -l prompt (string join " " -- $argv)
-    codex exec --model 'gpt-5.3-codex' --full-auto -c model_reasoning_summary_format=experimental -- "$prompt"
+    codex exec --model 'gpt-5.4' --full-auto -c model_reasoning_summary_format=experimental -- "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_coxe_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_coxe_function.tpl.fish
@@ -3,9 +3,9 @@ function _coxe_function --description "Run Codex with a free-form prompt"
   # Usage: cxe [<prompt words...>]
 
   if test (count $argv) -eq 0
-    codex --model '__GPT_CODEX__' --full-auto -c model_reasoning_summary_format=experimental
+    codex --model '__GPT__' --full-auto -c model_reasoning_summary_format=experimental
   else
     set -l prompt (string join " " -- $argv)
-    codex exec --model '__GPT_CODEX__' --full-auto -c model_reasoning_summary_format=experimental -- "$prompt"
+    codex exec --model '__GPT__' --full-auto -c model_reasoning_summary_format=experimental -- "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_coxeh_function.fish
+++ b/home-manager/programs/fish/functions/_coxeh_function.fish
@@ -8,5 +8,5 @@ function _coxeh_function --description "Run Codex headlessly with a prompted inp
     return 1
   end
 
-  codex exec --model 'gpt-5.3-codex' --full-auto -c model_reasoning_summary_format=experimental -- "$prompt"
+  codex exec --model 'gpt-5.4' --full-auto -c model_reasoning_summary_format=experimental -- "$prompt"
 end

--- a/home-manager/programs/fish/functions/_coxeh_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_coxeh_function.tpl.fish
@@ -8,5 +8,5 @@ function _coxeh_function --description "Run Codex headlessly with a prompted inp
     return 1
   end
 
-  codex exec --model '__GPT_CODEX__' --full-auto -c model_reasoning_summary_format=experimental -- "$prompt"
+  codex exec --model '__GPT__' --full-auto -c model_reasoning_summary_format=experimental -- "$prompt"
 end

--- a/home-manager/programs/git/gitalias.txt
+++ b/home-manager/programs/git/gitalias.txt
@@ -1718,8 +1718,8 @@
     fi; \
   };f"
 
-  topic-end = topic-finish
-  
+  topic-finish = topic-end
+
   # Update the current topic branch by synchronizing changes.
   #
   # Example:


### PR DESCRIPTION
## Changes
- Add `llm-upgrade` target: runs `scripts/llm-update.sh` to regenerate tool configs from `models.json`
- Add `gitalias-upgrade` target: downloads latest `gitalias.txt` from upstream
- Fix `neovim-upgrade`: symlink `nvim-pack-lock.json` into repo before running `vim.pack.update()` so changes persist
- Run upgrade locally to apply generated file changes

## Technical Details
These targets are now wired into `make upgrade`, which means the daily scheduled upgrade workflow will produce actual file diffs and create PRs instead of being a no-op.

Generated with [Claude Code](https://claude.com/claude-code) by claude-sonnet-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `llm-upgrade` and `gitalias-upgrade` to `make upgrade` so scheduled upgrades regenerate LLM configs and refresh `gitalias.txt`. Also fixes Neovim plugin upgrades and updates Codex defaults to `gpt-5.4`.

- **New Features**
  - `llm-upgrade`: regenerate tool configs from `models.json` via `scripts/llm-update.sh` (bumps Gemini to `3.1` and GPT to `5.4` across configs).
  - `gitalias-upgrade`: fetch latest `gitalias.txt` via `scripts/update-gitalias.sh`.
  - Upgrade Codex default model for `cxe`/`cxeh` to `gpt-5.4`; switch templates from `__GPT_CODEX__` to `__GPT__`.

- **Bug Fixes**
  - Persist Neovim plugin updates by symlinking `init.lua` and `nvim-pack-lock.json` before running `vim.pack.update()`.
  - Add 10s timeouts to `git-ai` commit hooks to prevent hangs.

<sup>Written for commit b10cf2ea027d7ec502f238ce4cc3567117c08529. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

