### PR TITLE
Feat/pi local qwen wrappers

### DIFF
--- a/config/opencode/opencode.tpl.jsonc
+++ b/config/opencode/opencode.tpl.jsonc
@@ -182,7 +182,7 @@
       },
       "models": {
         "glm-4.7": {
-          "id": "@preset/glm-4-7",
+          "id": "@preset/__GLM_NONDOT__",
           "name": "Preset GLM-4.7 (via OpenRouter)"
         }
       }

--- a/config/pi/models.json
+++ b/config/pi/models.json
@@ -181,6 +181,29 @@
           "maxTokens": 16384
         }
       ]
+    },
+    "lmstudio": {
+      "baseUrl": "http://127.0.0.1:1234/v1",
+      "api": "openai-responses",
+      "models": [
+        {
+          "id": "qwen/qwen3.5-9b",
+          "name": "Qwen 3.5 9B (LM Studio)",
+          "reasoning": true,
+          "input": [
+            "text",
+            "image"
+          ],
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          },
+          "contextWindow": 262144,
+          "maxTokens": 32768
+        }
+      ]
     }
   }
 }

--- a/config/pi/models.json
+++ b/config/pi/models.json
@@ -1,6 +1,6 @@
 {
   "providers": {
-    "cli-proxy-api": {
+    "cliproxyapi": {
       "baseUrl": "http://localhost:8317/v1",
       "apiKey": "CLIPROXY_API_KEY",
       "api": "openai-responses",
@@ -184,6 +184,7 @@
     },
     "lmstudio": {
       "baseUrl": "http://127.0.0.1:1234/v1",
+      "apiKey": "LM_API_TOKEN",
       "api": "openai-responses",
       "models": [
         {

--- a/config/pi/models.tpl.json
+++ b/config/pi/models.tpl.json
@@ -165,7 +165,7 @@
       "api": "openai-completions",
       "models": [
         {
-          "id": "@preset/glm-4-7",
+          "id": "@preset/__GLM_NONDOT__",
           "name": "GLM-4.7 (Z-AI)",
           "reasoning": false,
           "input": [

--- a/config/pi/models.tpl.json
+++ b/config/pi/models.tpl.json
@@ -1,6 +1,6 @@
 {
   "providers": {
-    "cli-proxy-api": {
+    "cliproxyapi": {
       "baseUrl": "http://localhost:8317/v1",
       "apiKey": "CLIPROXY_API_KEY",
       "api": "openai-responses",
@@ -184,6 +184,7 @@
     },
     "lmstudio": {
       "baseUrl": "http://127.0.0.1:1234/v1",
+      "apiKey": "LM_API_TOKEN",
       "api": "openai-responses",
       "models": [
         {

--- a/config/pi/models.tpl.json
+++ b/config/pi/models.tpl.json
@@ -181,6 +181,29 @@
           "maxTokens": 16384
         }
       ]
+    },
+    "lmstudio": {
+      "baseUrl": "http://127.0.0.1:1234/v1",
+      "api": "openai-responses",
+      "models": [
+        {
+          "id": "__QWEN_LOCAL__",
+          "name": "Qwen 3.5 9B (LM Studio)",
+          "reasoning": true,
+          "input": [
+            "text",
+            "image"
+          ],
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          },
+          "contextWindow": 262144,
+          "maxTokens": 32768
+        }
+      ]
     }
   }
 }

--- a/config/pi/settings.json
+++ b/config/pi/settings.json
@@ -6,10 +6,12 @@
   "defaultThinkingLevel": "medium",
   "enabledModels": [
     "cli-proxy-api/*",
+    "lmstudio/*",
     "*gpt-5*",
     "*gemini*",
     "*claude*",
     "*glm*",
+    "*qwen*",
     "*kimi*"
   ],
   "steeringMode": "one-at-a-time",

--- a/config/pi/settings.json
+++ b/config/pi/settings.json
@@ -1,11 +1,11 @@
 {
   "theme": "dark",
   "quietStartup": true,
-  "defaultProvider": "cli-proxy-api",
+  "defaultProvider": "cliproxyapi",
   "defaultModel": "glm-4.7",
   "defaultThinkingLevel": "medium",
   "enabledModels": [
-    "cli-proxy-api/*",
+    "cliproxyapi/*",
     "lmstudio/*",
     "*gpt-5*",
     "*gemini*",

--- a/config/pi/settings.tpl.json
+++ b/config/pi/settings.tpl.json
@@ -6,10 +6,12 @@
   "defaultThinkingLevel": "medium",
   "enabledModels": [
     "cli-proxy-api/*",
+    "lmstudio/*",
     "*gpt-5*",
     "*gemini*",
     "*claude*",
     "*glm*",
+    "*qwen*",
     "*kimi*"
   ],
   "steeringMode": "one-at-a-time",

--- a/config/pi/settings.tpl.json
+++ b/config/pi/settings.tpl.json
@@ -1,11 +1,11 @@
 {
   "theme": "dark",
   "quietStartup": true,
-  "defaultProvider": "cli-proxy-api",
+  "defaultProvider": "cliproxyapi",
   "defaultModel": "__GLM__",
   "defaultThinkingLevel": "medium",
   "enabledModels": [
-    "cli-proxy-api/*",
+    "cliproxyapi/*",
     "lmstudio/*",
     "*gpt-5*",
     "*gemini*",

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -119,6 +119,8 @@
       ocxeh = "_ocxeh_function";
       ocxelh = "_ocxelh_function";
       pixe = "_pixe_function";
+      pixel = "_pixel_function";
+      pixelh = "_pixelh_function";
       pixeh = "_pixeh_function";
       sag = "_ssh_add_github";
       shortcuts = "_fish_shortcuts";
@@ -215,6 +217,8 @@
         "_ocxeh_function"
         "_ocxelh_function"
         "_pixe_function"
+        "_pixel_function"
+        "_pixelh_function"
         "_pixeh_function"
         "_ssh_add_github"
         "_tdo_function"

--- a/home-manager/programs/fish/functions/_pixe_function.fish
+++ b/home-manager/programs/fish/functions/_pixe_function.fish
@@ -1,11 +1,11 @@
-function _pixe_function --description "Run Pi agent with a free-form prompt using the local Qwen model"
-  # Run Pi agent with a free-form prompt (spaces allowed) using the local Qwen model
+function _pixe_function --description "Run Pi agent with a free-form prompt"
+  # Run Pi agent with a free-form prompt (spaces allowed)
   # Usage: pixe [<prompt words...>]
 
   if test (count $argv) -eq 0
-    pi-agent -m 'lmstudio/qwen/qwen3.5-9b'
+    pi-agent -m 'openrouter-preset/@preset/glm-4-7'
   else
     set -l prompt (string join " " -- $argv)
-    pi-agent "$prompt" -m 'lmstudio/qwen/qwen3.5-9b'
+    pi-agent "$prompt" -m 'openrouter-preset/@preset/glm-4-7'
   end
 end

--- a/home-manager/programs/fish/functions/_pixe_function.fish
+++ b/home-manager/programs/fish/functions/_pixe_function.fish
@@ -1,11 +1,11 @@
-function _pixe_function --description "Run Pi agent with a free-form prompt"
-  # Run Pi agent with a free-form prompt (spaces allowed)
+function _pixe_function --description "Run Pi with a free-form prompt"
+  # Run Pi with a free-form prompt (spaces allowed)
   # Usage: pixe [<prompt words...>]
 
   if test (count $argv) -eq 0
-    pi-agent -m 'openrouter-preset/@preset/glm-4-7'
+    pi --model 'cliproxyapi/glm-4.7'
   else
     set -l prompt (string join " " -- $argv)
-    pi-agent "$prompt" -m 'openrouter-preset/@preset/glm-4-7'
+    pi --model 'cliproxyapi/glm-4.7' "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_pixe_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_pixe_function.tpl.fish
@@ -1,11 +1,11 @@
-function _pixe_function --description "Run Pi agent with a free-form prompt"
-  # Run Pi agent with a free-form prompt (spaces allowed)
+function _pixe_function --description "Run Pi with a free-form prompt"
+  # Run Pi with a free-form prompt (spaces allowed)
   # Usage: pixe [<prompt words...>]
 
   if test (count $argv) -eq 0
-    pi-agent -m 'openrouter-preset/@preset/__GLM_NONDOT__'
+    pi --model 'cliproxyapi/__GLM__'
   else
     set -l prompt (string join " " -- $argv)
-    pi-agent "$prompt" -m 'openrouter-preset/@preset/__GLM_NONDOT__'
+    pi --model 'cliproxyapi/__GLM__' "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_pixe_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_pixe_function.tpl.fish
@@ -1,11 +1,11 @@
-function _pixe_function --description "Run Pi agent with a free-form prompt using the local Qwen model"
-  # Run Pi agent with a free-form prompt (spaces allowed) using the local Qwen model
+function _pixe_function --description "Run Pi agent with a free-form prompt"
+  # Run Pi agent with a free-form prompt (spaces allowed)
   # Usage: pixe [<prompt words...>]
 
   if test (count $argv) -eq 0
-    pi-agent -m 'lmstudio/__QWEN_LOCAL__'
+    pi-agent -m 'openrouter-preset/@preset/__GLM_NONDOT__'
   else
     set -l prompt (string join " " -- $argv)
-    pi-agent "$prompt" -m 'lmstudio/__QWEN_LOCAL__'
+    pi-agent "$prompt" -m 'openrouter-preset/@preset/__GLM_NONDOT__'
   end
 end

--- a/home-manager/programs/fish/functions/_pixeh_function.fish
+++ b/home-manager/programs/fish/functions/_pixeh_function.fish
@@ -1,5 +1,5 @@
-function _pixeh_function --description "Run Pi agent headlessly with a prompted input"
-  # Prompt for input and run Pi agent
+function _pixeh_function --description "Run Pi headlessly with a prompted input"
+  # Prompt for input and run Pi in print mode
   # Usage: pixeh
 
   read -P "Prompt: " prompt
@@ -8,5 +8,5 @@ function _pixeh_function --description "Run Pi agent headlessly with a prompted 
     return 1
   end
 
-  pi-agent "$prompt" -m 'openrouter-preset/@preset/glm-4-7'
+  pi --model 'cliproxyapi/glm-4.7' -p "$prompt"
 end

--- a/home-manager/programs/fish/functions/_pixeh_function.fish
+++ b/home-manager/programs/fish/functions/_pixeh_function.fish
@@ -1,5 +1,5 @@
-function _pixeh_function --description "Run Pi agent headlessly with the local Qwen model"
-  # Prompt for input and run Pi agent with the local Qwen model
+function _pixeh_function --description "Run Pi agent headlessly with a prompted input"
+  # Prompt for input and run Pi agent
   # Usage: pixeh
 
   read -P "Prompt: " prompt
@@ -8,5 +8,5 @@ function _pixeh_function --description "Run Pi agent headlessly with the local Q
     return 1
   end
 
-  pi-agent "$prompt" -m 'lmstudio/qwen/qwen3.5-9b'
+  pi-agent "$prompt" -m 'openrouter-preset/@preset/glm-4-7'
 end

--- a/home-manager/programs/fish/functions/_pixeh_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_pixeh_function.tpl.fish
@@ -1,5 +1,5 @@
-function _pixeh_function --description "Run Pi agent headlessly with a prompted input"
-  # Prompt for input and run Pi agent
+function _pixeh_function --description "Run Pi agent headlessly with the local Qwen model"
+  # Prompt for input and run Pi agent with the local Qwen model
   # Usage: pixeh
 
   read -P "Prompt: " prompt
@@ -8,5 +8,5 @@ function _pixeh_function --description "Run Pi agent headlessly with a prompted 
     return 1
   end
 
-  pi-agent "$prompt" -m 'openrouter-preset/@preset/__GLM_NONDOT__'
+  pi-agent "$prompt" -m 'lmstudio/__QWEN_LOCAL__'
 end

--- a/home-manager/programs/fish/functions/_pixeh_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_pixeh_function.tpl.fish
@@ -1,5 +1,5 @@
-function _pixeh_function --description "Run Pi agent headlessly with the local Qwen model"
-  # Prompt for input and run Pi agent with the local Qwen model
+function _pixeh_function --description "Run Pi agent headlessly with a prompted input"
+  # Prompt for input and run Pi agent
   # Usage: pixeh
 
   read -P "Prompt: " prompt
@@ -8,5 +8,5 @@ function _pixeh_function --description "Run Pi agent headlessly with the local Q
     return 1
   end
 
-  pi-agent "$prompt" -m 'lmstudio/__QWEN_LOCAL__'
+  pi-agent "$prompt" -m 'openrouter-preset/@preset/__GLM_NONDOT__'
 end

--- a/home-manager/programs/fish/functions/_pixeh_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_pixeh_function.tpl.fish
@@ -1,5 +1,5 @@
-function _pixeh_function --description "Run Pi agent headlessly with a prompted input"
-  # Prompt for input and run Pi agent
+function _pixeh_function --description "Run Pi headlessly with a prompted input"
+  # Prompt for input and run Pi in print mode
   # Usage: pixeh
 
   read -P "Prompt: " prompt
@@ -8,5 +8,5 @@ function _pixeh_function --description "Run Pi agent headlessly with a prompted 
     return 1
   end
 
-  pi-agent "$prompt" -m 'openrouter-preset/@preset/__GLM_NONDOT__'
+  pi --model 'cliproxyapi/__GLM__' -p "$prompt"
 end

--- a/home-manager/programs/fish/functions/_pixel_function.fish
+++ b/home-manager/programs/fish/functions/_pixel_function.fish
@@ -1,11 +1,11 @@
-function _pixel_function --description "Run Pi agent with a free-form prompt using the local Qwen model"
-  # Run Pi agent with a free-form prompt (spaces allowed) using the local Qwen model
+function _pixel_function --description "Run Pi with a free-form prompt using the local Qwen model"
+  # Run Pi with a free-form prompt (spaces allowed) using the local Qwen model
   # Usage: pixel [<prompt words...>]
 
   if test (count $argv) -eq 0
-    pi-agent -m 'lmstudio/qwen/qwen3.5-9b'
+    pi --model 'lmstudio/qwen/qwen3.5-9b'
   else
     set -l prompt (string join " " -- $argv)
-    pi-agent "$prompt" -m 'lmstudio/qwen/qwen3.5-9b'
+    pi --model 'lmstudio/qwen/qwen3.5-9b' "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_pixel_function.fish
+++ b/home-manager/programs/fish/functions/_pixel_function.fish
@@ -1,6 +1,6 @@
-function _pixe_function --description "Run Pi agent with a free-form prompt using the local Qwen model"
+function _pixel_function --description "Run Pi agent with a free-form prompt using the local Qwen model"
   # Run Pi agent with a free-form prompt (spaces allowed) using the local Qwen model
-  # Usage: pixe [<prompt words...>]
+  # Usage: pixel [<prompt words...>]
 
   if test (count $argv) -eq 0
     pi-agent -m 'lmstudio/qwen/qwen3.5-9b'

--- a/home-manager/programs/fish/functions/_pixel_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_pixel_function.tpl.fish
@@ -1,11 +1,11 @@
-function _pixel_function --description "Run Pi agent with a free-form prompt using the local Qwen model"
-  # Run Pi agent with a free-form prompt (spaces allowed) using the local Qwen model
+function _pixel_function --description "Run Pi with a free-form prompt using the local Qwen model"
+  # Run Pi with a free-form prompt (spaces allowed) using the local Qwen model
   # Usage: pixel [<prompt words...>]
 
   if test (count $argv) -eq 0
-    pi-agent -m 'lmstudio/__QWEN_LOCAL__'
+    pi --model 'lmstudio/__QWEN_LOCAL__'
   else
     set -l prompt (string join " " -- $argv)
-    pi-agent "$prompt" -m 'lmstudio/__QWEN_LOCAL__'
+    pi --model 'lmstudio/__QWEN_LOCAL__' "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_pixel_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_pixel_function.tpl.fish
@@ -1,6 +1,6 @@
-function _pixe_function --description "Run Pi agent with a free-form prompt using the local Qwen model"
+function _pixel_function --description "Run Pi agent with a free-form prompt using the local Qwen model"
   # Run Pi agent with a free-form prompt (spaces allowed) using the local Qwen model
-  # Usage: pixe [<prompt words...>]
+  # Usage: pixel [<prompt words...>]
 
   if test (count $argv) -eq 0
     pi-agent -m 'lmstudio/__QWEN_LOCAL__'

--- a/home-manager/programs/fish/functions/_pixelh_function.fish
+++ b/home-manager/programs/fish/functions/_pixelh_function.fish
@@ -1,6 +1,6 @@
-function _pixeh_function --description "Run Pi agent headlessly with the local Qwen model"
+function _pixelh_function --description "Run Pi agent headlessly with the local Qwen model"
   # Prompt for input and run Pi agent with the local Qwen model
-  # Usage: pixeh
+  # Usage: pixelh
 
   read -P "Prompt: " prompt
   if test -z "$prompt"

--- a/home-manager/programs/fish/functions/_pixelh_function.fish
+++ b/home-manager/programs/fish/functions/_pixelh_function.fish
@@ -1,5 +1,5 @@
-function _pixelh_function --description "Run Pi agent headlessly with the local Qwen model"
-  # Prompt for input and run Pi agent with the local Qwen model
+function _pixelh_function --description "Run Pi headlessly with the local Qwen model"
+  # Prompt for input and run Pi in print mode with the local Qwen model
   # Usage: pixelh
 
   read -P "Prompt: " prompt
@@ -8,5 +8,5 @@ function _pixelh_function --description "Run Pi agent headlessly with the local 
     return 1
   end
 
-  pi-agent "$prompt" -m 'lmstudio/qwen/qwen3.5-9b'
+  pi --model 'lmstudio/qwen/qwen3.5-9b' -p "$prompt"
 end

--- a/home-manager/programs/fish/functions/_pixelh_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_pixelh_function.tpl.fish
@@ -1,6 +1,6 @@
-function _pixeh_function --description "Run Pi agent headlessly with the local Qwen model"
+function _pixelh_function --description "Run Pi agent headlessly with the local Qwen model"
   # Prompt for input and run Pi agent with the local Qwen model
-  # Usage: pixeh
+  # Usage: pixelh
 
   read -P "Prompt: " prompt
   if test -z "$prompt"
@@ -8,5 +8,5 @@ function _pixeh_function --description "Run Pi agent headlessly with the local Q
     return 1
   end
 
-  pi-agent "$prompt" -m 'lmstudio/qwen/qwen3.5-9b'
+  pi-agent "$prompt" -m 'lmstudio/__QWEN_LOCAL__'
 end

--- a/home-manager/programs/fish/functions/_pixelh_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_pixelh_function.tpl.fish
@@ -1,5 +1,5 @@
-function _pixelh_function --description "Run Pi agent headlessly with the local Qwen model"
-  # Prompt for input and run Pi agent with the local Qwen model
+function _pixelh_function --description "Run Pi headlessly with the local Qwen model"
+  # Prompt for input and run Pi in print mode with the local Qwen model
   # Usage: pixelh
 
   read -P "Prompt: " prompt
@@ -8,5 +8,5 @@ function _pixelh_function --description "Run Pi agent headlessly with the local 
     return 1
   end
 
-  pi-agent "$prompt" -m 'lmstudio/__QWEN_LOCAL__'
+  pi --model 'lmstudio/__QWEN_LOCAL__' -p "$prompt"
 end

--- a/scripts/llm-update.sh
+++ b/scripts/llm-update.sh
@@ -67,6 +67,8 @@ declare -A TEMPLATES=(
   ["home-manager/programs/fish/functions/_ocxeh_function.tpl.fish"]=home-manager/programs/fish/functions/_ocxeh_function.fish
   ["home-manager/programs/fish/functions/_ocxelh_function.tpl.fish"]=home-manager/programs/fish/functions/_ocxelh_function.fish
   ["home-manager/programs/fish/functions/_pixe_function.tpl.fish"]=home-manager/programs/fish/functions/_pixe_function.fish
+  ["home-manager/programs/fish/functions/_pixel_function.tpl.fish"]=home-manager/programs/fish/functions/_pixel_function.fish
+  ["home-manager/programs/fish/functions/_pixelh_function.tpl.fish"]=home-manager/programs/fish/functions/_pixelh_function.fish
   ["home-manager/programs/fish/functions/_pixeh_function.tpl.fish"]=home-manager/programs/fish/functions/_pixeh_function.fish
 )
 

--- a/spec/fish/_pixe_function.tpl_test.fish
+++ b/spec/fish/_pixe_function.tpl_test.fish
@@ -3,15 +3,15 @@ source $fn/_pixe_function.tpl.fish
 
 # ── no args: interactive mode ─────────────────────────────
 set log1 (mktemp)
-function pi-agent; echo $argv >> $log1; end
+function pi; echo $argv >> $log1; end
 
 _pixe_function
 
-@test "no args calls pi-agent with templated cliproxyapi model" (grep -c "cliproxyapi/__GLM__" $log1) -ge 1
+@test "no args calls pi with templated cliproxyapi model" (grep -c "cliproxyapi/__GLM__" $log1) -ge 1
 
 # ── with args: builds prompt ──────────────────────────────
 set log2 (mktemp)
-function pi-agent; echo $argv >> $log2; end
+function pi; echo $argv >> $log2; end
 
 _pixe_function hello world
 

--- a/spec/fish/_pixe_function.tpl_test.fish
+++ b/spec/fish/_pixe_function.tpl_test.fish
@@ -7,7 +7,7 @@ function pi-agent; echo $argv >> $log1; end
 
 _pixe_function
 
-@test "no args calls pi-agent with templated local Qwen model" (grep -c "lmstudio/__QWEN_LOCAL__" $log1) -ge 1
+@test "no args calls pi-agent with templated preset" (grep -c "openrouter-preset/@preset/__GLM_NONDOT__" $log1) -ge 1
 
 # ── with args: builds prompt ──────────────────────────────
 set log2 (mktemp)
@@ -16,6 +16,6 @@ function pi-agent; echo $argv >> $log2; end
 _pixe_function hello world
 
 @test "with args builds prompt" (grep -c "hello world" $log2) -ge 1
-@test "with args uses templated local Qwen model" (grep -c "lmstudio/__QWEN_LOCAL__" $log2) -ge 1
+@test "with args uses templated preset" (grep -c "openrouter-preset/@preset/__GLM_NONDOT__" $log2) -ge 1
 
 rm -f $log1 $log2

--- a/spec/fish/_pixe_function.tpl_test.fish
+++ b/spec/fish/_pixe_function.tpl_test.fish
@@ -7,7 +7,7 @@ function pi-agent; echo $argv >> $log1; end
 
 _pixe_function
 
-@test "no args calls pi-agent with templated preset" (grep -c "openrouter-preset/@preset/__GLM_NONDOT__" $log1) -ge 1
+@test "no args calls pi-agent with templated local Qwen model" (grep -c "lmstudio/__QWEN_LOCAL__" $log1) -ge 1
 
 # ── with args: builds prompt ──────────────────────────────
 set log2 (mktemp)
@@ -16,5 +16,6 @@ function pi-agent; echo $argv >> $log2; end
 _pixe_function hello world
 
 @test "with args builds prompt" (grep -c "hello world" $log2) -ge 1
+@test "with args uses templated local Qwen model" (grep -c "lmstudio/__QWEN_LOCAL__" $log2) -ge 1
 
 rm -f $log1 $log2

--- a/spec/fish/_pixe_function.tpl_test.fish
+++ b/spec/fish/_pixe_function.tpl_test.fish
@@ -7,7 +7,7 @@ function pi-agent; echo $argv >> $log1; end
 
 _pixe_function
 
-@test "no args calls pi-agent with templated preset" (grep -c "openrouter-preset/@preset/__GLM_NONDOT__" $log1) -ge 1
+@test "no args calls pi-agent with templated cliproxyapi model" (grep -c "cliproxyapi/__GLM__" $log1) -ge 1
 
 # ── with args: builds prompt ──────────────────────────────
 set log2 (mktemp)
@@ -16,6 +16,6 @@ function pi-agent; echo $argv >> $log2; end
 _pixe_function hello world
 
 @test "with args builds prompt" (grep -c "hello world" $log2) -ge 1
-@test "with args uses templated preset" (grep -c "openrouter-preset/@preset/__GLM_NONDOT__" $log2) -ge 1
+@test "with args uses templated cliproxyapi model" (grep -c "cliproxyapi/__GLM__" $log2) -ge 1
 
 rm -f $log1 $log2

--- a/spec/fish/_pixe_function_test.fish
+++ b/spec/fish/_pixe_function_test.fish
@@ -7,7 +7,7 @@ function pi-agent; echo $argv >> $log1; end
 
 _pixe_function
 
-@test "no args calls pi-agent with preset model" (grep -c "openrouter-preset/@preset/glm-4-7" $log1) -ge 1
+@test "no args calls pi-agent with cliproxyapi model" (grep -c "cliproxyapi/glm-4.7" $log1) -ge 1
 
 # ── with args: builds prompt ──────────────────────────────
 set log2 (mktemp)
@@ -16,6 +16,6 @@ function pi-agent; echo $argv >> $log2; end
 _pixe_function hello world
 
 @test "with args builds prompt" (grep -c "hello world" $log2) -ge 1
-@test "with args uses preset model" (grep -c "openrouter-preset/@preset/glm-4-7" $log2) -ge 1
+@test "with args uses cliproxyapi model" (grep -c "cliproxyapi/glm-4.7" $log2) -ge 1
 
 rm -f $log1 $log2

--- a/spec/fish/_pixe_function_test.fish
+++ b/spec/fish/_pixe_function_test.fish
@@ -3,15 +3,15 @@ source $fn/_pixe_function.fish
 
 # ── no args: interactive mode ─────────────────────────────
 set log1 (mktemp)
-function pi-agent; echo $argv >> $log1; end
+function pi; echo $argv >> $log1; end
 
 _pixe_function
 
-@test "no args calls pi-agent with cliproxyapi model" (grep -c "cliproxyapi/glm-4.7" $log1) -ge 1
+@test "no args calls pi with cliproxyapi model" (grep -c "cliproxyapi/glm-4.7" $log1) -ge 1
 
 # ── with args: builds prompt ──────────────────────────────
 set log2 (mktemp)
-function pi-agent; echo $argv >> $log2; end
+function pi; echo $argv >> $log2; end
 
 _pixe_function hello world
 

--- a/spec/fish/_pixe_function_test.fish
+++ b/spec/fish/_pixe_function_test.fish
@@ -7,7 +7,7 @@ function pi-agent; echo $argv >> $log1; end
 
 _pixe_function
 
-@test "no args calls pi-agent with local Qwen model" (grep -c "lmstudio/qwen/qwen3.5-9b" $log1) -ge 1
+@test "no args calls pi-agent with preset model" (grep -c "openrouter-preset/@preset/glm-4-7" $log1) -ge 1
 
 # ── with args: builds prompt ──────────────────────────────
 set log2 (mktemp)
@@ -16,6 +16,6 @@ function pi-agent; echo $argv >> $log2; end
 _pixe_function hello world
 
 @test "with args builds prompt" (grep -c "hello world" $log2) -ge 1
-@test "with args uses local Qwen model" (grep -c "lmstudio/qwen/qwen3.5-9b" $log2) -ge 1
+@test "with args uses preset model" (grep -c "openrouter-preset/@preset/glm-4-7" $log2) -ge 1
 
 rm -f $log1 $log2

--- a/spec/fish/_pixeh_function.tpl_test.fish
+++ b/spec/fish/_pixeh_function.tpl_test.fish
@@ -10,6 +10,6 @@ function pi-agent; echo $argv >> $log1; end
 echo "hello world" | _pixeh_function
 
 @test "non-empty prompt builds prompt" (grep -c "hello world" $log1) -ge 1
-@test "non-empty prompt uses templated preset" (grep -c "openrouter-preset/@preset/__GLM_NONDOT__" $log1) -ge 1
+@test "non-empty prompt uses templated cliproxyapi model" (grep -c "cliproxyapi/__GLM__" $log1) -ge 1
 
 rm -f $log1

--- a/spec/fish/_pixeh_function.tpl_test.fish
+++ b/spec/fish/_pixeh_function.tpl_test.fish
@@ -10,6 +10,6 @@ function pi-agent; echo $argv >> $log1; end
 echo "hello world" | _pixeh_function
 
 @test "non-empty prompt builds prompt" (grep -c "hello world" $log1) -ge 1
-@test "non-empty prompt uses templated local Qwen model" (grep -c "lmstudio/__QWEN_LOCAL__" $log1) -ge 1
+@test "non-empty prompt uses templated preset" (grep -c "openrouter-preset/@preset/__GLM_NONDOT__" $log1) -ge 1
 
 rm -f $log1

--- a/spec/fish/_pixeh_function.tpl_test.fish
+++ b/spec/fish/_pixeh_function.tpl_test.fish
@@ -5,11 +5,12 @@ source $fn/_pixeh_function.tpl.fish
 @test "empty prompt returns 1" (echo "" | _pixeh_function 2>/dev/null; echo $status) = 1
 
 set log1 (mktemp)
-function pi-agent; echo $argv >> $log1; end
+function pi; echo $argv >> $log1; end
 
 echo "hello world" | _pixeh_function
 
 @test "non-empty prompt builds prompt" (grep -c "hello world" $log1) -ge 1
 @test "non-empty prompt uses templated cliproxyapi model" (grep -c "cliproxyapi/__GLM__" $log1) -ge 1
+@test "non-empty prompt uses print mode" (grep -c -- "-p" $log1) -ge 1
 
 rm -f $log1

--- a/spec/fish/_pixeh_function_test.fish
+++ b/spec/fish/_pixeh_function_test.fish
@@ -5,11 +5,12 @@ source $fn/_pixeh_function.fish
 @test "empty prompt returns 1" (echo "" | _pixeh_function 2>/dev/null; echo $status) = 1
 
 set log1 (mktemp)
-function pi-agent; echo $argv >> $log1; end
+function pi; echo $argv >> $log1; end
 
 echo "hello world" | _pixeh_function
 
 @test "non-empty prompt builds prompt" (grep -c "hello world" $log1) -ge 1
 @test "non-empty prompt uses cliproxyapi model" (grep -c "cliproxyapi/glm-4.7" $log1) -ge 1
+@test "non-empty prompt uses print mode" (grep -c -- "-p" $log1) -ge 1
 
 rm -f $log1

--- a/spec/fish/_pixeh_function_test.fish
+++ b/spec/fish/_pixeh_function_test.fish
@@ -10,6 +10,6 @@ function pi-agent; echo $argv >> $log1; end
 echo "hello world" | _pixeh_function
 
 @test "non-empty prompt builds prompt" (grep -c "hello world" $log1) -ge 1
-@test "non-empty prompt uses preset model" (grep -c "openrouter-preset/@preset/glm-4-7" $log1) -ge 1
+@test "non-empty prompt uses cliproxyapi model" (grep -c "cliproxyapi/glm-4.7" $log1) -ge 1
 
 rm -f $log1

--- a/spec/fish/_pixeh_function_test.fish
+++ b/spec/fish/_pixeh_function_test.fish
@@ -10,6 +10,6 @@ function pi-agent; echo $argv >> $log1; end
 echo "hello world" | _pixeh_function
 
 @test "non-empty prompt builds prompt" (grep -c "hello world" $log1) -ge 1
-@test "non-empty prompt uses local Qwen model" (grep -c "lmstudio/qwen/qwen3.5-9b" $log1) -ge 1
+@test "non-empty prompt uses preset model" (grep -c "openrouter-preset/@preset/glm-4-7" $log1) -ge 1
 
 rm -f $log1

--- a/spec/fish/_pixel_function.tpl_test.fish
+++ b/spec/fish/_pixel_function.tpl_test.fish
@@ -3,15 +3,15 @@ source $fn/_pixel_function.tpl.fish
 
 # ── no args: interactive mode ─────────────────────────────
 set log1 (mktemp)
-function pi-agent; echo $argv >> $log1; end
+function pi; echo $argv >> $log1; end
 
 _pixel_function
 
-@test "no args calls pi-agent with templated local Qwen model" (grep -c "lmstudio/__QWEN_LOCAL__" $log1) -ge 1
+@test "no args calls pi with templated local Qwen model" (grep -c "lmstudio/__QWEN_LOCAL__" $log1) -ge 1
 
 # ── with args: builds prompt ──────────────────────────────
 set log2 (mktemp)
-function pi-agent; echo $argv >> $log2; end
+function pi; echo $argv >> $log2; end
 
 _pixel_function hello world
 

--- a/spec/fish/_pixel_function.tpl_test.fish
+++ b/spec/fish/_pixel_function.tpl_test.fish
@@ -1,21 +1,21 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
-source $fn/_pixe_function.fish
+source $fn/_pixel_function.tpl.fish
 
 # ── no args: interactive mode ─────────────────────────────
 set log1 (mktemp)
 function pi-agent; echo $argv >> $log1; end
 
-_pixe_function
+_pixel_function
 
-@test "no args calls pi-agent with local Qwen model" (grep -c "lmstudio/qwen/qwen3.5-9b" $log1) -ge 1
+@test "no args calls pi-agent with templated local Qwen model" (grep -c "lmstudio/__QWEN_LOCAL__" $log1) -ge 1
 
 # ── with args: builds prompt ──────────────────────────────
 set log2 (mktemp)
 function pi-agent; echo $argv >> $log2; end
 
-_pixe_function hello world
+_pixel_function hello world
 
 @test "with args builds prompt" (grep -c "hello world" $log2) -ge 1
-@test "with args uses local Qwen model" (grep -c "lmstudio/qwen/qwen3.5-9b" $log2) -ge 1
+@test "with args uses templated local Qwen model" (grep -c "lmstudio/__QWEN_LOCAL__" $log2) -ge 1
 
 rm -f $log1 $log2

--- a/spec/fish/_pixel_function_test.fish
+++ b/spec/fish/_pixel_function_test.fish
@@ -3,15 +3,15 @@ source $fn/_pixel_function.fish
 
 # ── no args: interactive mode ─────────────────────────────
 set log1 (mktemp)
-function pi-agent; echo $argv >> $log1; end
+function pi; echo $argv >> $log1; end
 
 _pixel_function
 
-@test "no args calls pi-agent with local Qwen model" (grep -c "lmstudio/qwen/qwen3.5-9b" $log1) -ge 1
+@test "no args calls pi with local Qwen model" (grep -c "lmstudio/qwen/qwen3.5-9b" $log1) -ge 1
 
 # ── with args: builds prompt ──────────────────────────────
 set log2 (mktemp)
-function pi-agent; echo $argv >> $log2; end
+function pi; echo $argv >> $log2; end
 
 _pixel_function hello world
 

--- a/spec/fish/_pixel_function_test.fish
+++ b/spec/fish/_pixel_function_test.fish
@@ -1,11 +1,11 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
-source $fn/_pixe_function.fish
+source $fn/_pixel_function.fish
 
 # ── no args: interactive mode ─────────────────────────────
 set log1 (mktemp)
 function pi-agent; echo $argv >> $log1; end
 
-_pixe_function
+_pixel_function
 
 @test "no args calls pi-agent with local Qwen model" (grep -c "lmstudio/qwen/qwen3.5-9b" $log1) -ge 1
 
@@ -13,7 +13,7 @@ _pixe_function
 set log2 (mktemp)
 function pi-agent; echo $argv >> $log2; end
 
-_pixe_function hello world
+_pixel_function hello world
 
 @test "with args builds prompt" (grep -c "hello world" $log2) -ge 1
 @test "with args uses local Qwen model" (grep -c "lmstudio/qwen/qwen3.5-9b" $log2) -ge 1

--- a/spec/fish/_pixelh_function.tpl_test.fish
+++ b/spec/fish/_pixelh_function.tpl_test.fish
@@ -5,11 +5,12 @@ source $fn/_pixelh_function.tpl.fish
 @test "empty prompt returns 1" (echo "" | _pixelh_function 2>/dev/null; echo $status) = 1
 
 set log1 (mktemp)
-function pi-agent; echo $argv >> $log1; end
+function pi; echo $argv >> $log1; end
 
 echo "hello world" | _pixelh_function
 
 @test "non-empty prompt builds prompt" (grep -c "hello world" $log1) -ge 1
 @test "non-empty prompt uses templated local Qwen model" (grep -c "lmstudio/__QWEN_LOCAL__" $log1) -ge 1
+@test "non-empty prompt uses print mode" (grep -c -- "-p" $log1) -ge 1
 
 rm -f $log1

--- a/spec/fish/_pixelh_function.tpl_test.fish
+++ b/spec/fish/_pixelh_function.tpl_test.fish
@@ -1,13 +1,13 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
-source $fn/_pixeh_function.tpl.fish
+source $fn/_pixelh_function.tpl.fish
 
-@test "empty prompt rejects" (echo "" | _pixeh_function 2>&1) = "No prompt provided, aborting."
-@test "empty prompt returns 1" (echo "" | _pixeh_function 2>/dev/null; echo $status) = 1
+@test "empty prompt rejects" (echo "" | _pixelh_function 2>&1) = "No prompt provided, aborting."
+@test "empty prompt returns 1" (echo "" | _pixelh_function 2>/dev/null; echo $status) = 1
 
 set log1 (mktemp)
 function pi-agent; echo $argv >> $log1; end
 
-echo "hello world" | _pixeh_function
+echo "hello world" | _pixelh_function
 
 @test "non-empty prompt builds prompt" (grep -c "hello world" $log1) -ge 1
 @test "non-empty prompt uses templated local Qwen model" (grep -c "lmstudio/__QWEN_LOCAL__" $log1) -ge 1

--- a/spec/fish/_pixelh_function_test.fish
+++ b/spec/fish/_pixelh_function_test.fish
@@ -1,13 +1,13 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
-source $fn/_pixeh_function.fish
+source $fn/_pixelh_function.fish
 
-@test "empty prompt rejects" (echo "" | _pixeh_function 2>&1) = "No prompt provided, aborting."
-@test "empty prompt returns 1" (echo "" | _pixeh_function 2>/dev/null; echo $status) = 1
+@test "empty prompt rejects" (echo "" | _pixelh_function 2>&1) = "No prompt provided, aborting."
+@test "empty prompt returns 1" (echo "" | _pixelh_function 2>/dev/null; echo $status) = 1
 
 set log1 (mktemp)
 function pi-agent; echo $argv >> $log1; end
 
-echo "hello world" | _pixeh_function
+echo "hello world" | _pixelh_function
 
 @test "non-empty prompt builds prompt" (grep -c "hello world" $log1) -ge 1
 @test "non-empty prompt uses local Qwen model" (grep -c "lmstudio/qwen/qwen3.5-9b" $log1) -ge 1

--- a/spec/fish/_pixelh_function_test.fish
+++ b/spec/fish/_pixelh_function_test.fish
@@ -5,11 +5,12 @@ source $fn/_pixelh_function.fish
 @test "empty prompt returns 1" (echo "" | _pixelh_function 2>/dev/null; echo $status) = 1
 
 set log1 (mktemp)
-function pi-agent; echo $argv >> $log1; end
+function pi; echo $argv >> $log1; end
 
 echo "hello world" | _pixelh_function
 
 @test "non-empty prompt builds prompt" (grep -c "hello world" $log1) -ge 1
 @test "non-empty prompt uses local Qwen model" (grep -c "lmstudio/qwen/qwen3.5-9b" $log1) -ge 1
+@test "non-empty prompt uses print mode" (grep -c -- "-p" $log1) -ge 1
 
 rm -f $log1

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -62,9 +62,10 @@ The output should include 'config/llm/default_model.tpl.txt'
 End
 
 It 'includes fish wrapper templates in template mappings'
-When run bash -c "grep '_ocxe_function.tpl.fish' '$SCRIPT' && grep '_pixe_function.tpl.fish' '$SCRIPT'"
+When run bash -c "grep '_ocxe_function.tpl.fish' '$SCRIPT' && grep '_pixe_function.tpl.fish' '$SCRIPT' && grep '_pixel_function.tpl.fish' '$SCRIPT'"
 The output should include '_ocxe_function.tpl.fish'
 The output should include '_pixe_function.tpl.fish'
+The output should include '_pixel_function.tpl.fish'
 End
 End
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds local Qwen 3.5 9B support via LM Studio and new fish commands pixel/pixelh for Pi. Also switches Pi wrappers to the `cliproxyapi` provider and updates configs and tests.

- **New Features**
  - Added `lmstudio` provider (OpenAI-compatible at 127.0.0.1:1234) with Qwen 3.5 9B.
  - New fish wrappers: `pixel` (interactive) and `pixelh` (print mode) to run Pi on the local Qwen model.

- **Refactors**
  - Renamed provider key `cli-proxy-api` to `cliproxyapi`; set as default and enabled `lmstudio/*` and `*qwen*` in settings.
  - Replaced `pi-agent` with `pi` and switched models from presets to `cliproxyapi/glm-4.7` (templated `__GLM__`).
  - Updated GLM preset placeholders to `@preset/__GLM_NONDOT__`.
  - Mapped new wrapper templates in `scripts/llm-update.sh`.
  - Updated and added fish specs for new models, wrappers, and print mode.

<sup>Written for commit d98f8c1973b3066fe08bc944b3d0fb707909b457. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

