### PR TITLE
chore: upgrade

### DIFF
--- a/config/pi/settings.json
+++ b/config/pi/settings.json
@@ -24,8 +24,7 @@
     "keepRecentTokens": 20000
   },
   "packages": [
-    "https://github.com/davebcn87/pi-autoresearch",
-    "https://github.com/cagdotin/agents"
+    "https://github.com/davebcn87/pi-autoresearch"
   ],
   "skills": [],
   "retry": {


### PR DESCRIPTION
Automated upgrade

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `https://github.com/cagdotin/agents` from the `packages` array in `config/pi/settings.json`, keeping only `https://github.com/davebcn87/pi-autoresearch` to simplify the config.

<sup>Written for commit 0a96c54e4b9d334f91cc4043451d6008d1a4b0fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

