### PR TITLE
fix: openclaw client gateway port and pi agents package

### DIFF
--- a/config/openclaw/hydrate.sh
+++ b/config/openclaw/hydrate.sh
@@ -104,7 +104,7 @@ else
     "mode": "remote",
     "remote": {
       "transport": "direct",
-      "url": "wss://kyber.tail950b36.ts.net",
+      "url": "wss://kyber.tail950b36.ts.net:18789",
       "token": "${GATEWAY_TOKEN}"
     }
   }

--- a/config/pi/settings.tpl.json
+++ b/config/pi/settings.tpl.json
@@ -24,7 +24,8 @@
     "keepRecentTokens": 20000
   },
   "packages": [
-    "https://github.com/davebcn87/pi-autoresearch"
+    "https://github.com/davebcn87/pi-autoresearch",
+    "https://github.com/cagdotin/agents"
   ],
   "skills": [],
   "retry": {


### PR DESCRIPTION
## Changes
- Fix openclaw macOS client config: WSS URL was missing `:18789` port, causing connections to hit port 443 (WSS default) instead of the actual gateway port
- Add `cagdotin/agents` package to pi settings template

## Technical Details
- `config/openclaw/hydrate.sh`: client mode URL changed from `wss://kyber.tail950b36.ts.net` → `wss://kyber.tail950b36.ts.net:18789`
- `config/pi/settings.tpl.json`: added second entry to `packages` array

## Testing
- Port 18789 on kyber is reachable via Tailscale IP
- Generated with [Claude Code](https://claude.ai/claude-code) by claude-sonnet-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OpenClaw client WSS URL to use port :18789 so connections hit the correct gateway instead of defaulting to 443. Adds `cagdotin/agents` to the Pi settings template.

<sup>Written for commit bbe3188ade9fd88f5dc435aac880109523200f4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

