### PR TITLE
fix: openclaw tailscale serve mode and config permissions

### DIFF
--- a/config/openclaw/hydrate.sh
+++ b/config/openclaw/hydrate.sh
@@ -87,6 +87,7 @@ if [ "$MODE" = "gateway" ]; then
     -e "s|__WORKSPACE__|${WORKSPACE}|g" \
     -e "s|__HOME__|${HOME}|g" \
     "$TEMPLATE" >"$CONFIG"
+  chmod 600 "$CONFIG"
 
   echo "Generated openclaw gateway config at $CONFIG" >&2
 
@@ -97,19 +98,20 @@ if [ "$MODE" = "gateway" ]; then
   exec @openclaw@/bin/openclaw gateway --port 18789 "$@"
 
 else
-  # Client mode (macOS): generate remote config with gateway token
+  # Client mode (macOS): connect through kyber's Tailscale Serve endpoint
   cat >"$CONFIG" <<EOF
 {
   "gateway": {
     "mode": "remote",
     "remote": {
       "transport": "direct",
-      "url": "wss://kyber.tail950b36.ts.net:18789",
+      "url": "wss://kyber.tail950b36.ts.net",
       "token": "${GATEWAY_TOKEN}"
     }
   }
 }
 EOF
+  chmod 600 "$CONFIG"
 
   echo "Generated openclaw client config at $CONFIG" >&2
 fi

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -786,13 +786,16 @@
   },
   "gateway": {
     "mode": "local",
-    "bind": "lan",
+    "bind": "loopback",
+    "tailscale": {
+      "mode": "serve"
+    },
     "controlUi": {
       "allowedOrigins": [
         "http://localhost:18789",
         "http://127.0.0.1:18789",
         "https://openclaw.shunkakinoki.com",
-        "https://kyber.tail950b36.ts.net:18789"
+        "https://kyber.tail950b36.ts.net"
       ]
     },
     "auth": {

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -786,13 +786,16 @@
   },
   "gateway": {
     "mode": "local",
-    "bind": "lan",
+    "bind": "loopback",
+    "tailscale": {
+      "mode": "serve"
+    },
     "controlUi": {
       "allowedOrigins": [
         "http://localhost:18789",
         "http://127.0.0.1:18789",
         "https://openclaw.shunkakinoki.com",
-        "https://kyber.tail950b36.ts.net:18789"
+        "https://kyber.tail950b36.ts.net"
       ]
     },
     "auth": {

--- a/spec/openclaw_hydrate_spec.sh
+++ b/spec/openclaw_hydrate_spec.sh
@@ -134,6 +134,42 @@ The output should not include 'from-secret-file'
 End
 End
 
+Describe 'client config generation'
+setup_client() {
+  TEMP_HOME=$(mktemp -d)
+  mkdir -p "$TEMP_HOME/.config/openclaw"
+
+  cat >"$TEMP_HOME/.config/openclaw/gateway-token" <<'EOF'
+gateway-token
+EOF
+
+  PREPROCESSED_SCRIPT="$TEMP_HOME/hydrate.sh"
+  sed \
+    -e 's|@mode@|client|g' \
+    -e 's|@sed@|sed|g' \
+    -e 's|@template@|/unused|g' \
+    -e 's|@chromium@|/unused|g' \
+    -e 's|@openclaw@|/unused|g' \
+    "$SCRIPT" >"$PREPROCESSED_SCRIPT"
+  chmod +x "$PREPROCESSED_SCRIPT"
+}
+
+cleanup_client() {
+  rm -rf "$TEMP_HOME"
+}
+
+Before 'setup_client'
+After 'cleanup_client'
+
+It 'writes the Tailscale Serve URL without the gateway port'
+When run bash -c 'HOME="'"$TEMP_HOME"'" OPENCLAW_CONFIG_PATH="'"$TEMP_HOME"'/generated-openclaw.json" bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; cat "'"$TEMP_HOME"'/generated-openclaw.json"'
+The status should be success
+The output should include '"transport": "direct"'
+The output should include '"url": "wss://kyber.tail950b36.ts.net"'
+The output should not include '18789'
+End
+End
+
 Describe 'config generation'
 It 'uses sed to substitute values in template'
 When run bash -c "grep '@sed@' '$SCRIPT'"


### PR DESCRIPTION
## Changes
- Switch gateway bind from `lan` to `loopback` with Tailscale serve mode enabled
- Remove port 18789 from Tailscale URLs — Tailscale Serve handles routing
- Add `chmod 600` to secure generated config files in both gateway and client modes
- Add spec for client config URL asserting no port suffix

## Technical Details
- `openclaw.template.json` / `openclaw.tpl.json`: `bind: loopback` + `tailscale.mode: serve`
- `hydrate.sh`: client URL now `wss://kyber.tail950b36.ts.net` (no `:18789`)
- Config files restricted to owner-read/write only

## Testing
- New shellspec test verifies client config writes correct URL without port

Generated with [Claude Code](https://claude.ai/claude-code) by claude-sonnet-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Openclaw gateway to Tailscale Serve with a loopback bind, so traffic routes via Tailscale without exposing port 18789. Tightens security by setting 600 permissions on generated configs and updates the client URL to remove the port.

- **Bug Fixes**
  - Gateway now binds to loopback and uses Tailscale `serve` mode.
  - Removed `:18789` from Tailscale URLs and `allowedOrigins`; Serve handles routing.
  - Applied `chmod 600` to generated configs in gateway and client modes.
  - Added shellspec to assert the client config uses `wss://kyber.tail950b36.ts.net` without a port.

<sup>Written for commit b43725854ce46562d2b86aadfb9739c7d4108ae4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

