### PR TITLE
tailscale dns configuration

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -1,5 +1,11 @@
-{ isRunner }:
+{ isRunner, lib }:
 {
+  # Prepend `set +e` so individual brew bundle failures don't abort
+  # the entire darwin-rebuild activation. Errors are printed but ignored.
+  system.activationScripts.homebrew.text = lib.mkBefore ''
+    set +e
+  '';
+
   homebrew = {
     enable = !isRunner && (builtins.getEnv "NIX_OFFLINE" != "1");
     onActivation = {

--- a/nix-darwin/config/networking.nix
+++ b/nix-darwin/config/networking.nix
@@ -6,4 +6,15 @@
       "Thunderbolt Ethernet"
     ];
   };
+
+  # Split DNS: route only Tailscale domains through Tailscale's DNS proxy.
+  # Regular DNS (internet, local router) is unaffected, so WiFi stays
+  # connectable even when the Tailscale tunnel is unreachable.
+  # Requires Tailscale's DNS proxy (100.100.100.100) to be active —
+  # ensure accept-dns=true in the Tailscale app (default).
+  environment.etc = {
+    "resolver/ts.net".text = ''
+      nameserver 100.100.100.100
+    '';
+  };
 }

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -10,7 +10,7 @@ let
   inherit (inputs) env host;
   dock = import ./config/dock.nix;
   fonts = import ./config/fonts.nix { inherit pkgs; };
-  homebrew = import ./config/homebrew.nix { inherit isRunner; };
+  homebrew = import ./config/homebrew.nix { inherit isRunner lib; };
   networking = import ./config/networking.nix;
   nix = import ./config/nix.nix;
   security = import ./config/security.nix { inherit username; };


### PR DESCRIPTION
- **feat(networking): add Tailscale DNS proxy configuration**
- **fix(homebrew): include lib in homebrew configuration for proper script execution**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Split DNS for Tailscale so only ts.net resolves via 100.100.100.100, leaving normal DNS untouched. Also prevents Homebrew activation from aborting when a bundle step fails.

- **New Features**
  - Route ts.net through Tailscale DNS proxy (100.100.100.100) via an /etc/resolver entry.

- **Bug Fixes**
  - Prepend set +e to the Homebrew activation script using `lib.mkBefore`, and pass `lib` from `default.nix` to `homebrew.nix` so the script runs correctly.

<sup>Written for commit 143a648f6e5a42cb4d6bd5b4a16f244e08d5fd55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

