### PR TITLE
chore: upgrade

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -38,6 +38,14 @@ personality = true
 name = "CLIProxyAPI"
 base_url = "http://localhost:8317/v1"
 
+[model_providers.lmstudio]
+name = "LMStudio"
+base_url = "http://127.0.0.1:1234/v1"
+
+[model_providers.ollama]
+name = "Ollama"
+base_url = "http://127.0.0.1:11434/v1"
+
 [model_providers.openrouter]
 name = "OpenRouter"
 base_url = "https://openrouter.ai/api/v1"


### PR DESCRIPTION
Automated upgrade

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added LMStudio and Ollama as model providers in Codex config to enable local LLM endpoints. Defaults to http://127.0.0.1:1234/v1 (LMStudio) and http://127.0.0.1:11434/v1 (Ollama).

<sup>Written for commit 16726ff86e99f627a0e000b1408df0cf27fb7015. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

