### PR TITLE
fix: replace shazow/foundry.nix with nixpkgs foundry to fix nightly URL failures

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -472,42 +472,6 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "foundry": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773646257,
-        "narHash": "sha256-oNel9H4AWSqLEuK51UWICmOEG0CShbVDwOqfYhedZjE=",
-        "owner": "shazow",
-        "repo": "foundry.nix",
-        "rev": "c3aea6faee9fd2fadebccd37c35376bf85d4e524",
-        "type": "github"
-      },
-      "original": {
-        "owner": "shazow",
-        "repo": "foundry.nix",
-        "type": "github"
-      }
-    },
     "git-hooks": {
       "inputs": {
         "flake-compat": [
@@ -1151,7 +1115,6 @@
         "agenix": "agenix",
         "devenv": "devenv",
         "flake-parts": "flake-parts_4",
-        "foundry": "foundry",
         "home-manager": "home-manager",
         "mk-shell-bin": "mk-shell-bin",
         "neovim-nightly-overlay": "neovim-nightly-overlay",

--- a/flake.nix
+++ b/flake.nix
@@ -46,10 +46,6 @@
       url = "github:cachix/devenv";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    foundry = {
-      url = "github:shazow/foundry.nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
     mk-shell-bin = {
       url = "github:rrbutani/nix-mk-shell-bin";
     };

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -2,7 +2,11 @@
 [
   inputs.nur.overlays.default
   inputs.neovim-nightly-overlay.overlays.default
-  inputs.foundry.overlay
+  (final: prev: {
+    # Use stable nixpkgs foundry instead of shazow/foundry.nix nightly overlay
+    # to avoid unreliable nightly binary downloads.
+    foundry-bin = prev.foundry;
+  })
   (final: prev: {
     # Ensure neovim-unwrapped exposes a lua attribute for wrapper consumers (e.g., home-manager)
     neovim-unwrapped =


### PR DESCRIPTION
## Summary

- The foundry nightly binary downloads were causing intermittent CI failures — either hash mismatches or HTTP 500 errors from GitHub release URLs
- The locked revision of `shazow/foundry.nix` (`c3aea6faee9fd2fadebccd37c35376bf85d4e524`) references `nightly-d055c0999b23e2b045acba0e402f83d1e1e20496` binaries that are unreliable
- Replace with stable `pkgs.foundry` from nixpkgs (v1.5.1) via a local overlay alias (`foundry-bin = prev.foundry`)
- Remove the `foundry` flake input entirely

## Test plan

- [ ] `nix-linux` CI job passes (no more foundry download failures)
- [ ] `nix-nixos` CI job passes
- [ ] `nix-darwin` CI job passes (was failing with curl 500 on `foundry_nightly_darwin_arm64.tar.gz`)
- [ ] `foundry-bin` package resolves to nixpkgs foundry 1.5.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Foundry from `shazow/foundry.nix` nightly builds to the stable `nixpkgs` `foundry` (v1.5.1). This stabilizes CI by avoiding unreliable nightly URLs.

- **Bug Fixes**
  - Alias `foundry-bin` to `prev.foundry` via a local overlay.
  - Remove the `foundry` flake input and its entries from `flake.lock`.

<sup>Written for commit 17075556d854e21cd578ca8cc98a5bdf1409132a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

