### PR TITLE
chore: remove unused model provider configurations

### DIFF
--- a/config/codex/config.tpl.toml
+++ b/config/codex/config.tpl.toml
@@ -38,14 +38,6 @@ personality = true
 name = "CLIProxyAPI"
 base_url = "http://localhost:8317/v1"
 
-[model_providers.lmstudio]
-name = "LMStudio"
-base_url = "http://127.0.0.1:1234/v1"
-
-[model_providers.ollama]
-name = "Ollama"
-base_url = "http://127.0.0.1:11434/v1"
-
 [model_providers.openrouter]
 name = "OpenRouter"
 base_url = "https://openrouter.ai/api/v1"


### PR DESCRIPTION
Entire-Checkpoint: d90487ac9315


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused model provider configs (`LMStudio`, `Ollama`) from `config/codex/config.tpl.toml` to simplify the default setup and avoid confusion. Updated the `dotagents` submodule reference.

<sup>Written for commit 0a92a0365ee2e930e2269f03a09f1b8aae4f8ae8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

