### PR TITLE
feat(matic): improve power management for lid close and AC power

### DIFF
--- a/@matic/readme.md
+++ b/@matic/readme.md
@@ -1,0 +1,25 @@
+# NixOS (matic - Framework 13 AMD AI 300)
+
+## Full Disk Encryption (LUKS + TPM2)
+
+The root partition is encrypted with LUKS2. TPM2 auto-unlock is configured so no passphrase is needed on boot.
+
+After a fresh install or kernel update, enroll the TPM2 key:
+
+```bash
+sudo systemd-cryptenroll --tpm2-device=auto /dev/nvme0n1p2
+```
+
+If the boot chain changes (firmware/kernel update), TPM2 will refuse and fall back to the passphrase. Re-enroll after booting with the passphrase.
+
+## Building and Switching
+
+```bash
+make build HOST=matic && make switch HOST=matic
+```
+
+Or use `boot` instead of `switch` for major config changes (avoids dbus reload issues):
+
+```bash
+sudo nixos-rebuild boot --flake .#matic --impure && sudo reboot
+```

--- a/README.md
+++ b/README.md
@@ -8,32 +8,6 @@
 
 For troubleshooting and frequently asked questions, see [FAQ.md](./FAQ.md).
 
-## NixOS (matic - Framework 13 AMD AI 300)
-
-### Full Disk Encryption (LUKS + TPM2)
-
-The root partition is encrypted with LUKS2. TPM2 auto-unlock is configured so no passphrase is needed on boot.
-
-After a fresh install or kernel update, enroll the TPM2 key:
-
-```bash
-sudo systemd-cryptenroll --tpm2-device=auto /dev/nvme0n1p2
-```
-
-If the boot chain changes (firmware/kernel update), TPM2 will refuse and fall back to the passphrase. Re-enroll after booting with the passphrase.
-
-### Building and Switching
-
-```bash
-make build HOST=matic && make switch HOST=matic
-```
-
-Or use `boot` instead of `switch` for major config changes (avoids dbus reload issues):
-
-```bash
-sudo nixos-rebuild boot --flake .#matic --impure && sudo reboot
-```
-
 ## Credits
 
 See [REFERENCES.md](./REFERENCES.md) for more information.

--- a/config/hyprland/hypridle.conf
+++ b/config/hyprland/hypridle.conf
@@ -25,8 +25,8 @@ listener {
     on-resume = hyprctl dispatch dpms on
 }
 
-# Suspend after 30 minutes
+# Suspend after 30 minutes (only on battery)
 listener {
     timeout = 1800
-    on-timeout = systemctl suspend
+    on-timeout = bash -c 'cat /sys/class/power_supply/AC*/online | grep -q 1 || systemctl suspend'
 }

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -132,6 +132,9 @@ inputs.nixpkgs.lib.nixosSystem {
 
         # Power button behavior - lock screen instead of shutdown
         services.logind.settings.Login.HandlePowerKey = "lock";
+        # Ignore lid close — let hypridle's 30-min idle timer handle suspension
+        services.logind.settings.Login.HandleLidSwitch = "ignore";
+        services.logind.settings.Login.HandleLidSwitchExternalPower = "ignore";
 
         # Auto timezone (via geolocation)
         services.geoclue2.enable = true;


### PR DESCRIPTION
## Summary
- Ignore lid close via logind so hypridle's 30-min idle timer handles suspension instead of immediate suspend on lid close
- Skip auto-suspend in hypridle when connected to AC power

## Test plan
- [ ] Close lid while on battery — machine should stay on, then suspend after 30 min idle
- [ ] Close lid while plugged in — machine should not suspend
- [ ] Verify 30-min idle suspend still works on battery with screen open

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve power management on matic: ignore lid close in `logind` and only suspend after 30‑minute idle on battery; never auto‑suspend on AC. Also move matic NixOS docs from root `README.md` to `@matic/readme.md`.

- **New Features**
  - `services.logind`: set `HandleLidSwitch` and `HandleLidSwitchExternalPower` to `ignore` so `hypridle` controls suspend.
  - `hypridle`: suspend after 30 minutes only when `AC*/online` is 0; skip suspend on AC.

- **Refactors**
  - Moved matic NixOS setup docs from `README.md` to `@matic/readme.md`.

<sup>Written for commit 9e0a8f9e17195b0e68c9de017065e4c67d70fa76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

