### PR TITLE
feat(perl): add perl home-manager program with PLS language server

### DIFF
--- a/home-manager/programs/default.nix
+++ b/home-manager/programs/default.nix
@@ -33,6 +33,7 @@ let
   nix = import ./nix;
   node = import ./node;
   ocaml = import ./ocaml;
+  perl = import ./perl;
   php = import ./php;
   python = import ./python;
   ruby = import ./ruby;
@@ -77,6 +78,7 @@ in
   nix
   node
   ocaml
+  perl
   php
   python
   ruby

--- a/home-manager/programs/neovim/lua/config/lsp.lua
+++ b/home-manager/programs/neovim/lua/config/lsp.lua
@@ -44,6 +44,7 @@ local function configure_servers()
 		jsonls = {},
 		bashls = {},
 		dockerls = {},
+		perlpls = {},
 		yamlls = {},
 	}
 

--- a/home-manager/programs/neovim/lua/config/treesitter.lua
+++ b/home-manager/programs/neovim/lua/config/treesitter.lua
@@ -63,6 +63,7 @@ require("nvim-treesitter.configs").setup({
 		"markdown_inline",
 		"mermaid",
 		"nix",
+		"perl",
 		"python",
 		"query",
 		"regex",

--- a/home-manager/programs/perl/default.nix
+++ b/home-manager/programs/perl/default.nix
@@ -1,0 +1,7 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [
+    perl
+    perlPackages.PLS
+  ];
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a Perl home-manager program that installs `perl` and the PLS language server, and enable Perl LSP and Treesitter support in Neovim.

- **New Features**
  - Add `perl` home-manager module that installs `perl` and `perlPackages.PLS`, and register it in the programs list.
  - Enable `perlpls` in Neovim LSP config.
  - Add `perl` parser to Treesitter setup for syntax highlighting.

<sup>Written for commit d8a2a85c8113898c62ecc691d34a2a3e98263309. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

