### PR TITLE
feat(homebrew): add cmux cask from manaflow-ai tap

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -20,6 +20,7 @@
       "oven-sh/bun"
       "paradigmxyz/brew"
       "entireio/tap"
+      "manaflow-ai/cmux"
       "sst/tap"
       "steipete/tap"
     ];
@@ -74,6 +75,7 @@
       "blender"
       "block-goose"
       "chatgpt"
+      "cmux"
       "claude-code"
       "claude"
       "codex-app"


### PR DESCRIPTION
## Summary
- Adds `manaflow-ai/cmux` to Homebrew taps
- Adds `cmux` cask to Homebrew casks

## Test plan
- [ ] Verify `brew tap manaflow-ai/cmux` succeeds
- [ ] Verify `brew install --cask cmux` installs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `manaflow-ai/cmux` Homebrew tap and the `cmux` cask to the nix-darwin Homebrew config so `brew install --cask cmux` works out of the box.

- **New Features**
  - Add `manaflow-ai/cmux` to Homebrew taps.
  - Add `cmux` to Homebrew casks.

<sup>Written for commit 8d097821de9e279b26bd6e3cbd0e18210e5511b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

