### PR TITLE
feat(perl): add perl home-manager program with PLS language server

### DIFF
--- a/home-manager/programs/default.nix
+++ b/home-manager/programs/default.nix
@@ -33,6 +33,7 @@ let
   nix = import ./nix;
   node = import ./node;
   ocaml = import ./ocaml;
+  perl = import ./perl;
   php = import ./php;
   python = import ./python;
   ruby = import ./ruby;
@@ -77,6 +78,7 @@ in
   nix
   node
   ocaml
+  perl
   php
   python
   ruby

--- a/home-manager/programs/neovim/lua/config/lsp.lua
+++ b/home-manager/programs/neovim/lua/config/lsp.lua
@@ -44,6 +44,7 @@ local function configure_servers()
 		jsonls = {},
 		bashls = {},
 		dockerls = {},
+		perlpls = {},
 		yamlls = {},
 	}
 

--- a/home-manager/programs/neovim/lua/config/treesitter.lua
+++ b/home-manager/programs/neovim/lua/config/treesitter.lua
@@ -63,6 +63,7 @@ require("nvim-treesitter.configs").setup({
 		"markdown_inline",
 		"mermaid",
 		"nix",
+		"perl",
 		"python",
 		"query",
 		"regex",

--- a/home-manager/programs/perl/default.nix
+++ b/home-manager/programs/perl/default.nix
@@ -1,0 +1,7 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [
+    perl
+    perlPackages.PLS
+  ];
+}


### PR DESCRIPTION
## Summary
- Add home-manager/programs/perl/default.nix with perl runtime and perlPackages.PLS language server
- Register the module in home-manager/programs/default.nix
- Add perlpls to Neovim LSP servers in lsp.lua
- Add perl parser to Treesitter ensure_installed list in treesitter.lua

## Test plan
- nix flake check passes
- perl available after rebuild
- pls binary available after rebuild
- Neovim LSP attaches to .pl/.pm files via perlpls
- Treesitter syntax highlighting works for Perl files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Perl Home Manager program with `perl` and `perlPackages.PLS`, and integrates `perlpls` with Neovim LSP and Treesitter for Perl files.

- **New Features**
  - New module `home-manager/programs/perl/default.nix` installing `perl` and `perlPackages.PLS`.
  - Registered the Perl module in `home-manager/programs/default.nix`.
  - Enabled `perlpls` in Neovim LSP config.
  - Added `perl` parser to Treesitter `ensure_installed`.

<sup>Written for commit d8a2a85c8113898c62ecc691d34a2a3e98263309. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

