### PR TITLE
fix(matic): suspend immediately on battery when lid closed

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -132,9 +132,44 @@ inputs.nixpkgs.lib.nixosSystem {
 
         # Power button behavior - lock screen instead of shutdown
         services.logind.settings.Login.HandlePowerKey = "lock";
-        # Ignore lid close — let hypridle's 30-min idle timer handle suspension
+        # On battery: let lid-battery-suspend.service handle it (3-min delay then suspend)
+        # On AC: ignore lid close — let hypridle's 30-min idle timer handle suspension
         services.logind.settings.Login.HandleLidSwitch = "ignore";
         services.logind.settings.Login.HandleLidSwitchExternalPower = "ignore";
+
+        # Suspend after 3 minutes on battery when lid is closed
+        systemd.services.lid-battery-suspend = {
+          description = "Suspend after lid closed on battery for 3 minutes";
+          serviceConfig = {
+            Type = "oneshot";
+            ExecStart = pkgs.writeShellScript "lid-battery-suspend" ''
+              # Only proceed if on battery (AC not online)
+              if cat /sys/class/power_supply/AC*/online 2>/dev/null | grep -q 1; then
+                exit 0
+              fi
+              # Wait 3 minutes
+              sleep 180
+              # Re-check: still on battery?
+              if cat /sys/class/power_supply/AC*/online 2>/dev/null | grep -q 1; then
+                exit 0
+              fi
+              # Re-check: lid still closed?
+              if grep -q open /proc/acpi/button/lid/*/state 2>/dev/null; then
+                exit 0
+              fi
+              systemctl suspend
+            '';
+          };
+        };
+
+        # Trigger lid-battery-suspend service on lid close via acpid
+        services.acpid = {
+          enable = true;
+          handlers.lid-close = {
+            event = "button/lid LID close";
+            action = "systemctl start lid-battery-suspend.service";
+          };
+        };
 
         # Auto timezone (via geolocation)
         services.geoclue2.enable = true;

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -132,44 +132,10 @@ inputs.nixpkgs.lib.nixosSystem {
 
         # Power button behavior - lock screen instead of shutdown
         services.logind.settings.Login.HandlePowerKey = "lock";
-        # On battery: let lid-battery-suspend.service handle it (3-min delay then suspend)
+        # On battery: suspend immediately when lid closed
         # On AC: ignore lid close — let hypridle's 30-min idle timer handle suspension
-        services.logind.settings.Login.HandleLidSwitch = "ignore";
+        services.logind.settings.Login.HandleLidSwitch = "suspend";
         services.logind.settings.Login.HandleLidSwitchExternalPower = "ignore";
-
-        # Suspend after 3 minutes on battery when lid is closed
-        systemd.services.lid-battery-suspend = {
-          description = "Suspend after lid closed on battery for 3 minutes";
-          serviceConfig = {
-            Type = "oneshot";
-            ExecStart = pkgs.writeShellScript "lid-battery-suspend" ''
-              # Only proceed if on battery (AC not online)
-              if cat /sys/class/power_supply/AC*/online 2>/dev/null | grep -q 1; then
-                exit 0
-              fi
-              # Wait 3 minutes
-              sleep 180
-              # Re-check: still on battery?
-              if cat /sys/class/power_supply/AC*/online 2>/dev/null | grep -q 1; then
-                exit 0
-              fi
-              # Re-check: lid still closed?
-              if grep -q open /proc/acpi/button/lid/*/state 2>/dev/null; then
-                exit 0
-              fi
-              systemctl suspend
-            '';
-          };
-        };
-
-        # Trigger lid-battery-suspend service on lid close via acpid
-        services.acpid = {
-          enable = true;
-          handlers.lid-close = {
-            event = "button/lid LID close";
-            action = "systemctl start lid-battery-suspend.service";
-          };
-        };
 
         # Auto timezone (via geolocation)
         services.geoclue2.enable = true;


### PR DESCRIPTION
## Summary

- Added `services.acpid` to detect lid-close ACPI events
- Added `lid-battery-suspend` systemd oneshot service that waits 3 minutes then suspends if still on battery and lid still closed
- On AC power, lid close continues to be ignored indefinitely (unchanged)

## Test plan

- [ ] Close lid while on battery → laptop suspends after ~3 minutes
- [ ] Close lid while on AC → laptop stays on indefinitely
- [ ] Close lid on battery, plug in AC within 3 min → no suspend
- [ ] Close lid on battery, reopen within 3 min → no suspend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Immediately suspend on lid close when on battery using `logind`; lid close on AC is still ignored so hypridle manages idle. Replaces the old 3-minute delay and removes the `acpid` + oneshot service.

- **Refactors**
  - Set `services.logind.settings.Login.HandleLidSwitch` to `suspend`.
  - Keep `services.logind.settings.Login.HandleLidSwitchExternalPower` as `ignore`.

<sup>Written for commit 6a38ef3f7316675c2ac20450dc45519276179121. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

