### PR TITLE
feat(matic): improve battery and CPU power management

### DIFF
--- a/config/hyprland/hypridle.conf
+++ b/config/hyprland/hypridle.conf
@@ -5,9 +5,9 @@ general {
     inhibit_sleep = 3
 }
 
-# Dim screen after 15 minutes
+# Dim screen after 3 minutes
 listener {
-    timeout = 900
+    timeout = 180
     on-timeout = brightnessctl -s set 10
     on-resume = brightnessctl -r
 }

--- a/config/hyprland/hypridle.conf
+++ b/config/hyprland/hypridle.conf
@@ -5,10 +5,17 @@ general {
     inhibit_sleep = 3
 }
 
-# Dim screen after 3 minutes
+# Dim screen after 3 minutes (only on battery)
 listener {
     timeout = 180
-    on-timeout = brightnessctl -s set 10
+    on-timeout = bash -c 'cat /sys/class/power_supply/AC*/online | grep -q 0 && brightnessctl -s set 10'
+    on-resume = brightnessctl -r
+}
+
+# Dim screen after 30 minutes (only on AC)
+listener {
+    timeout = 1800
+    on-timeout = bash -c 'cat /sys/class/power_supply/AC*/online | grep -q 1 && brightnessctl -s set 10'
     on-resume = brightnessctl -r
 }
 
@@ -28,5 +35,5 @@ listener {
 # Suspend after 30 minutes (only on battery)
 listener {
     timeout = 1800
-    on-timeout = bash -c 'cat /sys/class/power_supply/AC*/online | grep -q 1 || systemctl suspend'
+    on-timeout = bash -c 'cat /sys/class/power_supply/AC*/online | grep -q 0 && systemctl suspend'
 }

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -134,6 +134,8 @@ inputs.nixpkgs.lib.nixosSystem {
         services.fwupd.enable = true;
 
         # Power management
+        powerManagement.enable = true;
+        powerManagement.powertop.enable = true;
         services.upower.enable = true;
         services.power-profiles-daemon.enable = false;
         services.auto-cpufreq = {

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -53,10 +53,17 @@ inputs.nixpkgs.lib.nixosSystem {
         # Pin kernel to 6.18 for CrowdStrike Falcon compatibility (RFM on 6.19)
         boot.kernelPackages = pkgs.linuxPackages_6_18;
 
+        # AMD power management kernel params
+        boot.kernelParams = [
+          "amdgpu.abmlevel=3" # auto backlight management
+          "amdgpu.runpm=1" # runtime power management for GPU
+          "amd_pstate=active" # AMD P-state driver (better than acpi-cpufreq)
+        ];
+
         # Networking
         networking.hostName = "matic";
         networking.networkmanager.enable = true;
-        networking.networkmanager.wifi.powersave = false;
+        networking.networkmanager.wifi.powersave = true;
 
         # Enable fish shell
         programs.fish.enable = true;
@@ -128,7 +135,20 @@ inputs.nixpkgs.lib.nixosSystem {
 
         # Power management
         services.upower.enable = true;
-        services.power-profiles-daemon.enable = true;
+        services.power-profiles-daemon.enable = false;
+        services.auto-cpufreq = {
+          enable = true;
+          settings = {
+            battery = {
+              governor = "powersave";
+              turbo = "never";
+            };
+            charger = {
+              governor = "performance";
+              turbo = "auto";
+            };
+          };
+        };
 
         # Power button behavior - lock screen instead of shutdown
         services.logind.settings.Login.HandlePowerKey = "lock";


### PR DESCRIPTION
## Summary

- Enable `powerManagement.enable` for PCIe runtime power management
- Enable `powerManagement.powertop.enable` for automatic boot-time power tuning (~50+ optimizations: USB autosuspend, PCIe ASPM, NIC wake-on-LAN, etc.)
- Fix hypridle screen dim to fire before lock (3min on battery, 30min on AC) — previously 15min fired after display was already off

## Test plan

- [ ] Rebuild NixOS: `make build HOST=matic && make switch HOST=matic`
- [ ] Verify powertop autotune ran on boot: `journalctl -u powertop`
- [ ] Confirm screen dims after ~3min idle on battery before locking
- [ ] Confirm screen dims after ~30min idle on AC

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve battery life and lower fan usage on matic by enabling runtime power tuning, dynamic CPU scaling, and fixing screen dim behavior on battery vs AC. Also adds AMD kernel power params for better CPU/GPU efficiency.

- **New Features**
  - Enable `powerManagement.enable` and `powerManagement.powertop.enable` for PCIe runtime PM and boot-time `powertop` autotune.
  - Replace `power-profiles-daemon` with `auto-cpufreq` (battery: powersave + no turbo; AC: performance).
  - Turn on Wi‑Fi powersave in `NetworkManager`.
  - Add AMD kernel params: `amd_pstate=active`, `amdgpu.runpm=1`, `amdgpu.abmlevel=3`.
  - Fix `hypridle` timeouts: dim at 3 min on battery and 30 min on AC; suspend after 30 min on battery; dim happens before lock.

- **Migration**
  - Rebuild and switch on matic: `make build HOST=matic && make switch HOST=matic`.
  - Verify: `journalctl -u powertop` shows autotune ran; confirm dim timings on battery and AC.

<sup>Written for commit 0b9fc0cc0b5b97365465efc087484671479dea1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

