### PR TITLE
feat(packages): add GNOME desktop apps for isDesktop

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -125,19 +125,26 @@ with pkgs;
 ]
 ++ lib.optionals (stdenv.isLinux && isDesktop) [
   _1password-gui
+  baobab
   brightnessctl
+  celluloid
+  cheese
   chromium
   clickup
   cliphist
   code-cursor
   discord
+  eog
   evince
   ffmpeg
+  file-roller
+  gedit
   ghostty
   github-desktop
   gnome-disk-utility
   google-chrome
   grim
+  gthumb
   hypridle
   hyprlock
   hyprpicker
@@ -146,11 +153,14 @@ with pkgs;
   hyprsunset
   libnotify
   linux-wallpaperengine
+  loupe
   nautilus
   pavucontrol
   playerctl
   rofi
   rofimoji
+  seahorse
+  shotwell
   signal-desktop
   slack
   slurp

--- a/named-hosts/matic/README.md
+++ b/named-hosts/matic/README.md
@@ -1,0 +1,37 @@
+# matic
+
+Setup and operational notes for the `matic` NixOS host.
+
+---
+
+## GNOME Keyring Auto-Unlock via TPM2
+
+The system unlocks the GNOME Keyring automatically at login — including when using fingerprint auth — by storing the keyring password as a `systemd-creds` credential encrypted with the machine's TPM2 + host key. The credential can only be decrypted on this machine.
+
+### One-time setup
+
+After first running `make switch`, create the credential:
+
+```bash
+mkdir -p ~/.config/credstore.encrypted
+systemd-ask-password "Keyring password:" | systemd-creds encrypt \
+  --name=gnome-keyring --with-key=tpm2+host \
+  - ~/.config/credstore.encrypted/gnome-keyring.cred
+```
+
+Then restart the service:
+
+```bash
+systemctl --user restart gnome-keyring-unlock.service
+```
+
+### How it works
+
+1. `services.gnome.gnome-keyring.enable` starts the keyring daemon at login.
+2. `security.pam.services.greetd.enableGnomeKeyring` hooks into PAM (works for password login).
+3. `systemd.user.services.gnome-keyring-unlock` decrypts the TPM2-bound credential and pipes it to `gnome-keyring-daemon --unlock` — this handles fingerprint login where PAM has no password to forward.
+4. The service skips silently if the credential file does not exist yet.
+
+### Re-encrypting after keyring password change
+
+If you change your keyring password (via seahorse), re-run the setup command above to update the credential.

--- a/named-hosts/matic/README.md
+++ b/named-hosts/matic/README.md
@@ -10,27 +10,29 @@ The system unlocks the GNOME Keyring automatically at login — including when u
 
 ### One-time setup
 
-After first running `make switch`, create the credential:
+After first running `make switch`, create the credential (requires sudo for TPM access):
 
 ```bash
-mkdir -p ~/.config/credstore.encrypted
-systemd-ask-password "Keyring password:" | systemd-creds encrypt \
-  --name=gnome-keyring --with-key=tpm2+host \
-  - ~/.config/credstore.encrypted/gnome-keyring.cred
+sudo bash -c 'mkdir -p /etc/credstore.encrypted && \
+  systemd-ask-password "Keyring password:" | \
+  systemd-creds encrypt --name=gnome-keyring --with-key=tpm2+host \
+  - /etc/credstore.encrypted/gnome-keyring.cred'
 ```
 
 Then restart the service:
 
 ```bash
-systemctl --user restart gnome-keyring-unlock.service
+sudo systemctl restart gnome-keyring-unlock.service
 ```
 
 ### How it works
 
-1. `services.gnome.gnome-keyring.enable` starts the keyring daemon at login.
-2. `security.pam.services.greetd.enableGnomeKeyring` hooks into PAM (works for password login).
-3. `systemd.user.services.gnome-keyring-unlock` decrypts the TPM2-bound credential and pipes it to `gnome-keyring-daemon --unlock` — this handles fingerprint login where PAM has no password to forward.
+1. `services.gnome.gnome-keyring.enable` starts the keyring daemon at login via PAM.
+2. `security.pam.services.greetd.enableGnomeKeyring` auto-unlocks for password logins.
+3. `systemd.services.gnome-keyring-unlock` runs as a **system service** (so the system manager can access the TPM) with `User=skakinoki`. It decrypts the credential and pipes it to `gnome-keyring-daemon --unlock` — covering fingerprint logins where PAM has no password to forward.
 4. The service skips silently if the credential file does not exist yet.
+
+> **Note:** The credential must be at the system path `/etc/credstore.encrypted/gnome-keyring.cred` (not in `~/.config`). User-level systemd services cannot access TPM/host keys — only the system manager can.
 
 ### Re-encrypting after keyring password change
 

--- a/named-hosts/matic/README.md
+++ b/named-hosts/matic/README.md
@@ -29,10 +29,12 @@ sudo systemctl restart gnome-keyring-unlock.service
 
 1. `services.gnome.gnome-keyring.enable` starts the keyring daemon at login via PAM.
 2. `security.pam.services.greetd.enableGnomeKeyring` auto-unlocks for password logins.
-3. `systemd.services.gnome-keyring-unlock` runs as a **system service** (so the system manager can access the TPM) with `User=skakinoki`. It decrypts the credential and pipes it to `gnome-keyring-daemon --unlock` — covering fingerprint logins where PAM has no password to forward.
+3. `systemd.services.gnome-keyring-unlock` runs as a **system service** with `User=skakinoki` so the system manager handles TPM decryption. It then speaks the gnome-keyring **control socket protocol** directly to unlock the running daemon — covering fingerprint logins where PAM has no password to forward.
 4. The service skips silently if the credential file does not exist yet.
 
-> **Note:** The credential must be at the system path `/etc/credstore.encrypted/gnome-keyring.cred` (not in `~/.config`). User-level systemd services cannot access TPM/host keys — only the system manager can.
+> **Note:** `gnome-keyring-daemon --unlock` (v48+) ignores `GNOME_KEYRING_CONTROL` and always starts a fresh instance. The service works around this by writing directly to `$XDG_RUNTIME_DIR/keyring/control` using the binary protocol: credentials byte + big-endian `[oplen][op=1][pwlen][password]`, reads `[8][result]`.
+>
+> **Note:** The credential must be at `/etc/credstore.encrypted/gnome-keyring.cred` (not `~/.config`). User-level systemd services cannot access TPM/host keys — only the system manager can.
 
 ### Re-encrypting after keyring password change
 

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -434,13 +434,17 @@ inputs.nixpkgs.lib.nixosSystem {
             };
           };
 
+          # GNOME Keyring - auto-unlocks GPG key on login via PAM
+          services.gnome.gnome-keyring.enable = true;
+          security.pam.services.greetd.enableGnomeKeyring = true;
+
           # GPG agent configuration
           services.gpg-agent = {
             enable = true;
             enableSshSupport = false;
-            pinentry.package = pkgs.pinentry-tty;
-            defaultCacheTtl = 94608000; # 3 years
-            maxCacheTtl = 94608000; # 3 years
+            pinentry.package = pkgs.pinentry-gnome3;
+            defaultCacheTtl = 2147483647; # max (effectively forever)
+            maxCacheTtl = 2147483647; # max (effectively forever)
           };
 
           # GPG_TTY is set in fish shell init instead of sessionVariables

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -438,6 +438,32 @@ inputs.nixpkgs.lib.nixosSystem {
             };
           };
 
+          # Auto-unlock GNOME Keyring on login via TPM2-backed credential
+          # Setup (run once):
+          #   mkdir -p ~/.config/credstore.encrypted
+          #   echo -n "your-keyring-password" | systemd-creds encrypt \
+          #     --name=gnome-keyring --with-key=tpm2+host \
+          #     - ~/.config/credstore.encrypted/gnome-keyring.cred
+          systemd.user.services.gnome-keyring-unlock = {
+            Unit = {
+              Description = "Unlock GNOME Keyring via TPM2 credential";
+              After = [ "graphical-session-pre.target" ];
+              PartOf = [ "graphical-session-pre.target" ];
+            };
+            Service = {
+              Type = "oneshot";
+              LoadCredentialEncrypted = "gnome-keyring:%h/.config/credstore.encrypted/gnome-keyring.cred";
+              ExecStart = "${pkgs.writeShellScript "unlock-keyring" ''
+                cat "$CREDENTIALS_DIRECTORY/gnome-keyring" | \
+                  ${pkgs.gnome-keyring}/bin/gnome-keyring-daemon --unlock
+              ''}";
+              RemainAfterExit = "yes";
+            };
+            Install = {
+              WantedBy = [ "graphical-session-pre.target" ];
+            };
+          };
+
           # GPG agent configuration
           services.gpg-agent = {
             enable = true;

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -137,12 +137,53 @@ inputs.nixpkgs.lib.nixosSystem {
             Type = "oneshot";
             User = username;
             LoadCredentialEncrypted = "gnome-keyring:/etc/credstore.encrypted/gnome-keyring.cred";
-            ExecStart = pkgs.writeShellScript "unlock-keyring" ''
-              export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$(id -u)/bus"
-              export GNOME_KEYRING_CONTROL="/run/user/$(id -u)/keyring"
-              cat "$CREDENTIALS_DIRECTORY/gnome-keyring" | \
-                ${pkgs.gnome-keyring}/bin/gnome-keyring-daemon --unlock
-            '';
+            ExecStart =
+              let
+                # Speaks the gnome-keyring control socket protocol directly.
+                # gnome-keyring-daemon --unlock (v48) ignores GNOME_KEYRING_CONTROL
+                # and always starts a new instance, so we bypass it entirely.
+                #
+                # Protocol (all big-endian):
+                #   1. connect to $XDG_RUNTIME_DIR/keyring/control (UNIX stream)
+                #   2. send \x00 — daemon reads our UID via SO_PEERCRED
+                #   3. send [oplen:4][op=1:4][pwlen:4][password bytes]
+                #          where oplen = 8 + 4 + len(password)
+                #   4. read [8:4][result:4] — result 0 = OK
+                unlockPy = pkgs.writeScript "unlock-gnome-keyring.py" ''
+                  #!${pkgs.python3}/bin/python3
+                  import os, socket, struct, stat, sys
+
+                  def unlock(password):
+                      uid = os.getuid()
+                      xdg = os.environ.get("XDG_RUNTIME_DIR", f"/run/user/{uid}")
+                      sock_path = os.path.join(xdg, "keyring", "control")
+                      st = os.lstat(sock_path)
+                      if not stat.S_ISSOCK(st.st_mode) or st.st_uid != uid:
+                          raise RuntimeError(f"bad socket: {sock_path}")
+                      pw = password.encode()
+                      oplen = 8 + 4 + len(pw)
+                      pkt = struct.pack(">II", oplen, 1) + struct.pack(">I", len(pw)) + pw
+                      with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+                          s.connect(sock_path)
+                          s.sendall(b"\x00")
+                          s.sendall(pkt)
+                          resp = b""
+                          while len(resp) < 8:
+                              resp += s.recv(8 - len(resp))
+                      _, result = struct.unpack(">II", resp)
+                      return result
+
+                  pw = sys.stdin.readline().rstrip("\n")
+                  result = unlock(pw)
+                  codes = {0: "OK", 1: "DENIED", 2: "FAILED", 3: "NO_DAEMON"}
+                  print(f"gnome-keyring unlock: {codes.get(result, result)}", flush=True)
+                  sys.exit(0 if result == 0 else 1)
+                '';
+              in
+                pkgs.writeShellScript "unlock-keyring" ''
+                  export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+                  cat "$CREDENTIALS_DIRECTORY/gnome-keyring" | ${unlockPy}
+                '';
             RemainAfterExit = "yes";
           };
         };

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -449,6 +449,7 @@ inputs.nixpkgs.lib.nixosSystem {
               Description = "Unlock GNOME Keyring via TPM2 credential";
               After = [ "graphical-session-pre.target" ];
               PartOf = [ "graphical-session-pre.target" ];
+              ConditionPathExists = "%h/.config/credstore.encrypted/gnome-keyring.cred";
             };
             Service = {
               Type = "oneshot";

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -121,6 +121,31 @@ inputs.nixpkgs.lib.nixosSystem {
         # GNOME Keyring - auto-unlocks GPG key on login via PAM
         services.gnome.gnome-keyring.enable = true;
 
+        # Unlock GNOME Keyring via TPM2 credential at login.
+        # System service so the system manager (not user manager) handles TPM decryption.
+        # Credential stored at /etc/credstore.encrypted/gnome-keyring.cred — create once with:
+        #   sudo bash -c 'mkdir -p /etc/credstore.encrypted && \
+        #     systemd-ask-password "Keyring password:" | \
+        #     systemd-creds encrypt --name=gnome-keyring --with-key=tpm2+host \
+        #     - /etc/credstore.encrypted/gnome-keyring.cred'
+        systemd.services.gnome-keyring-unlock = {
+          description = "Unlock GNOME Keyring via TPM2 credential";
+          after = [ "user@${toString 1000}.service" ];
+          wantedBy = [ "user@${toString 1000}.service" ];
+          unitConfig.ConditionPathExists = "/etc/credstore.encrypted/gnome-keyring.cred";
+          serviceConfig = {
+            Type = "oneshot";
+            User = username;
+            LoadCredentialEncrypted = "gnome-keyring:/etc/credstore.encrypted/gnome-keyring.cred";
+            ExecStart = pkgs.writeShellScript "unlock-keyring" ''
+              export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$(id -u)/bus"
+              cat "$CREDENTIALS_DIRECTORY/gnome-keyring" | \
+                ${pkgs.gnome-keyring}/bin/gnome-keyring-daemon --unlock
+            '';
+            RemainAfterExit = "yes";
+          };
+        };
+
         # Fingerprint authentication
         services.fprintd.enable = true;
         security.pam.services.greetd = {
@@ -435,33 +460,6 @@ inputs.nixpkgs.lib.nixosSystem {
             enable = true;
             settings = {
               default-key = "shunkakinoki@gmail.com";
-            };
-          };
-
-          # Auto-unlock GNOME Keyring on login via TPM2-backed credential
-          # Setup (run once):
-          #   mkdir -p ~/.config/credstore.encrypted
-          #   echo -n "your-keyring-password" | systemd-creds encrypt \
-          #     --name=gnome-keyring --with-key=tpm2+host \
-          #     - ~/.config/credstore.encrypted/gnome-keyring.cred
-          systemd.user.services.gnome-keyring-unlock = {
-            Unit = {
-              Description = "Unlock GNOME Keyring via TPM2 credential";
-              After = [ "graphical-session-pre.target" ];
-              PartOf = [ "graphical-session-pre.target" ];
-              ConditionPathExists = "%h/.config/credstore.encrypted/gnome-keyring.cred";
-            };
-            Service = {
-              Type = "oneshot";
-              LoadCredentialEncrypted = "gnome-keyring:%h/.config/credstore.encrypted/gnome-keyring.cred";
-              ExecStart = "${pkgs.writeShellScript "unlock-keyring" ''
-                cat "$CREDENTIALS_DIRECTORY/gnome-keyring" | \
-                  ${pkgs.gnome-keyring}/bin/gnome-keyring-daemon --unlock
-              ''}";
-              RemainAfterExit = "yes";
-            };
-            Install = {
-              WantedBy = [ "graphical-session-pre.target" ];
             };
           };
 

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -139,6 +139,7 @@ inputs.nixpkgs.lib.nixosSystem {
             LoadCredentialEncrypted = "gnome-keyring:/etc/credstore.encrypted/gnome-keyring.cred";
             ExecStart = pkgs.writeShellScript "unlock-keyring" ''
               export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$(id -u)/bus"
+              export GNOME_KEYRING_CONTROL="/run/user/$(id -u)/keyring"
               cat "$CREDENTIALS_DIRECTORY/gnome-keyring" | \
                 ${pkgs.gnome-keyring}/bin/gnome-keyring-daemon --unlock
             '';

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -118,10 +118,14 @@ inputs.nixpkgs.lib.nixosSystem {
         # Thunderbolt support
         services.hardware.bolt.enable = true;
 
+        # GNOME Keyring - auto-unlocks GPG key on login via PAM
+        services.gnome.gnome-keyring.enable = true;
+
         # Fingerprint authentication
         services.fprintd.enable = true;
         security.pam.services.greetd = {
           fprintAuth = true;
+          enableGnomeKeyring = true;
         };
         security.pam.services.hyprlock = {
           fprintAuth = true;
@@ -433,10 +437,6 @@ inputs.nixpkgs.lib.nixosSystem {
               default-key = "shunkakinoki@gmail.com";
             };
           };
-
-          # GNOME Keyring - auto-unlocks GPG key on login via PAM
-          services.gnome.gnome-keyring.enable = true;
-          security.pam.services.greetd.enableGnomeKeyring = true;
 
           # GPG agent configuration
           services.gpg-agent = {

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -136,6 +136,7 @@ inputs.nixpkgs.lib.nixosSystem {
           serviceConfig = {
             Type = "oneshot";
             User = username;
+            TimeoutStartSec = 60;
             LoadCredentialEncrypted = "gnome-keyring:/etc/credstore.encrypted/gnome-keyring.cred";
             ExecStart =
               let
@@ -173,11 +174,28 @@ inputs.nixpkgs.lib.nixosSystem {
                       _, result = struct.unpack(">II", resp)
                       return result
 
-                  pw = sys.stdin.readline().rstrip("\n")
-                  result = unlock(pw)
+                  import time
+
+                  pw = sys.stdin.read().rstrip("\n")
                   codes = {0: "OK", 1: "DENIED", 2: "FAILED", 3: "NO_DAEMON"}
-                  print(f"gnome-keyring unlock: {codes.get(result, result)}", flush=True)
-                  sys.exit(0 if result == 0 else 1)
+                  uid = os.getuid()
+                  sock_path = f"/run/user/{uid}/keyring/control"
+
+                  for attempt in range(10):
+                      # Wait for the control socket to appear (keyring daemon to start)
+                      if not os.path.exists(sock_path):
+                          print(f"attempt {attempt+1}: waiting for control socket...", flush=True)
+                          time.sleep(3)
+                          continue
+                      result = unlock(pw)
+                      print(f"attempt {attempt+1}: gnome-keyring unlock: {codes.get(result, result)}", flush=True)
+                      if result == 0:
+                          sys.exit(0)
+                      # DENIED might mean daemon not fully ready yet, retry
+                      time.sleep(3)
+
+                  print("gnome-keyring unlock: gave up after 10 attempts", flush=True)
+                  sys.exit(1)
                 '';
               in
                 pkgs.writeShellScript "unlock-keyring" ''


### PR DESCRIPTION
## Summary

### GNOME desktop apps
Adds 10 GNOME desktop apps to the `isDesktop` package list:
`baobab`, `celluloid`, `cheese`, `eog`, `file-roller`, `gedit`, `gthumb`, `loupe`, `seahorse`, `shotwell`

### GNOME Keyring auto-unlock via TPM2 (fingerprint-compatible)
Enables fully automatic GNOME Keyring unlock at login — including fingerprint auth — using a TPM2+host-bound `systemd-creds` credential.

**Why not `gnome-keyring-daemon --unlock`?** In v48+ it ignores `GNOME_KEYRING_CONTROL` and always spawns a fresh instance. Instead, a Python script speaks the control socket protocol directly (`$XDG_RUNTIME_DIR/keyring/control`): credentials byte + big-endian `[oplen][op=1][pwlen][password]`, reads `[8][result]`.

**Architecture:**
- System service (`systemd.services`) with `User=skakinoki` — system manager handles TPM decryption, then drops to user
- `LoadCredentialEncrypted` from `/etc/credstore.encrypted/gnome-keyring.cred`
- `pam_gnome_keyring` still handles password logins via PAM; this service covers fingerprint logins

**One-time setup** (see `named-hosts/matic/README.md`):
```bash
sudo bash -c 'mkdir -p /etc/credstore.encrypted && \
  systemd-ask-password "Keyring password:" | \
  systemd-creds encrypt --name=gnome-keyring --with-key=tpm2+host \
  - /etc/credstore.encrypted/gnome-keyring.cred'
```

## Test plan

- [ ] `make build && make switch` succeeds
- [ ] GNOME apps launch correctly on desktop
- [ ] After setup: `sudo systemctl restart gnome-keyring-unlock.service` logs `gnome-keyring unlock: OK`
- [ ] After reboot with fingerprint login: no keyring password prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)