### PR TITLE
feat(packages): add nvtop for GPU monitoring

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -114,6 +114,7 @@ with pkgs;
   gemini-cli
   keychain
   libiconv
+  nvtop
   opencode
   openssl
   openssl.dev


### PR DESCRIPTION
## Summary
- Adds `nvtop` to the default Linux packages in `home-manager/packages/default.nix`
- Placed alphabetically in the `stdenv.isLinux` section alongside other monitoring tools (`atop`, `below`, `powertop`)

## Test plan
- [ ] `nixos-rebuild switch` or `home-manager switch` to verify nvtop installs correctly
- [ ] Run `nvtop` to confirm GPU monitoring works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `nvtop` to the default Linux package set for GPU monitoring. This gives out‑of‑the‑box GPU usage visibility on Linux systems.

<sup>Written for commit dbfa559574bf4cfe126b68b76e43f128cb1ab234. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

