### PR TITLE
ci: add shell-inline-check to enforce no inline scripts in Nix

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -10,6 +10,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 jobs:
+  shell-inline-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Check for inline scripts in Nix files
+        run: make shell-inline-check
   shell-lint:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -37,6 +45,7 @@ jobs:
   shell-check:
     if: always()
     needs:
+      - shell-inline-check
       - shell-lint
       - shell-test
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ dotagents-sync: ## Sync dotagents (commands, skills, MCP configuration).
 	@$(MAKE) -C dotagents sync
 
 .PHONY: test
-test: neovim-test nix-test shell-test python-test nix-inline-check ## Run all tests (neovim + nix + shell + python + nix-inline-check).
+test: neovim-test nix-test shell-test python-test shell-inline-check ## Run all tests (neovim + nix + shell + python + shell-inline-check).
 
 ##@ Update
 
@@ -876,8 +876,8 @@ shell-check-dev: ## Run ShellCheck inside the Nix dev shell (mirrors CI).
 .PHONY: shell-lint
 shell-lint: shell-check ## Lint shell scripts (alias for shell-check).
 
-.PHONY: nix-inline-check
-nix-inline-check: ## Fail if any .nix file contains inline write*Script* strings.
+.PHONY: shell-inline-check
+shell-inline-check: ## Fail if any .nix file contains inline shell or Python write*Script* strings.
 	@echo "🔍 Checking for inline scripts in Nix files..."
 	@bash scripts/check-nix-inline-scripts.sh
 

--- a/scripts/check-nix-inline-scripts.sh
+++ b/scripts/check-nix-inline-scripts.sh
@@ -3,21 +3,30 @@
 # All script content must live in external files referenced via builtins.readFile
 # or pkgs.replaceVars, not embedded as inline '' strings.
 #
-# Catches: writeScript, writeShellScript, writeShellScriptBin, writeScriptBin
+# Catches shell writers: writeScript, writeShellScript, writeShellScriptBin, writeScriptBin
+# Catches Python writers: writePython3, writePython3Bin
 # Does NOT flag: writeText (used for config files, not scripts)
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-violations=$(grep -rn \
+EXCLUDE_DIRS=(--exclude-dir='.git' --exclude-dir='result' --exclude-dir='.direnv' --exclude-dir='.worktrees')
+
+shell_violations=$(grep -rn \
   --include='*.nix' \
   -E 'write(Shell)?(Script|ScriptBin)[[:space:]]+"[^"]+"+[[:space:]]+'"''" \
   "$ROOT" \
-  --exclude-dir='.git' \
-  --exclude-dir='result' \
-  --exclude-dir='.direnv' \
-  --exclude-dir='.worktrees' |
+  "${EXCLUDE_DIRS[@]}" |
   grep -v "^Binary" || true)
+
+python_violations=$(grep -rn \
+  --include='*.nix' \
+  -E 'writePython3(Bin)?[[:space:]]+"[^"]+"+[[:space:]]+' \
+  "$ROOT" \
+  "${EXCLUDE_DIRS[@]}" |
+  grep -v "^Binary" || true)
+
+violations="${shell_violations}${python_violations}"
 
 if [ -n "$violations" ]; then
   echo "ERROR: Inline script strings found in Nix files." >&2
@@ -27,4 +36,4 @@ if [ -n "$violations" ]; then
   exit 1
 fi
 
-echo "✓ No inline scripts in Nix files"
+echo "✓ No inline shell or Python scripts in Nix files"


### PR DESCRIPTION
## Summary

- Add `shell-inline-check` CI job to `shell.yml`, blocked by the `shell-check` gate so PRs fail automatically if inline scripts are added
- Rename Makefile target `nix-inline-check` → `shell-inline-check` for consistency
- Extend `scripts/check-nix-inline-scripts.sh` to also catch inline Python scripts (`writePython3` / `writePython3Bin`) in addition to shell writers

## Test plan

- [ ] `make shell-inline-check` passes on a clean tree
- [ ] CI `shell-inline-check` job runs on PR and blocks merge if violations are found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `shell-inline-check` CI job to block inline shell and Python scripts in `.nix` files. Extends the checker to catch `writePython3*` usages and renames the Makefile target for consistency.

- New Features
  - Adds `shell-inline-check` job in CI; `shell-check` now depends on it to block merges on violations.
  - Updates `scripts/check-nix-inline-scripts.sh` to flag `writeScript*` and `writePython3*`, with better excludes and messages.

- Migration
  - Use `make shell-inline-check` (replaces `nix-inline-check`).

<sup>Written for commit 4a6cdd257a22aebb395a9ba56d57a3a27ec5b02d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

