### PR TITLE
fix(nvim): update nvim-treesitter module name from configs to config

### DIFF
--- a/home-manager/programs/neovim/lua/config/treesitter.lua
+++ b/home-manager/programs/neovim/lua/config/treesitter.lua
@@ -29,7 +29,7 @@ require("treesitter-context").setup()
 -- Configures Treesitter language parsers, highlighting, and textobjects.
 -- From: https://github.com/nvim-treesitter/nvim-treesitter
 ---@diagnostic disable-next-line: missing-fields
-require("nvim-treesitter.configs").setup({
+require("nvim-treesitter.config").setup({
 	ensure_installed = {
 		"arduino",
 		"awk",


### PR DESCRIPTION
## Changes
- Rename `require("nvim-treesitter.configs")` to `require("nvim-treesitter.config")` in treesitter config

## Technical Details
nvim-treesitter renamed its Lua module from `nvim-treesitter.configs` to `nvim-treesitter.config` in a recent update. This caused Neovim to fail on startup with `module 'nvim-treesitter.configs' not found`.

## Testing
- Neovim starts without the E5113 Lua chunk error

Generated with [Claude Code](https://claude.ai/claude-code) by claude-sonnet-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Neovim startup by updating the `nvim-treesitter` require path from `nvim-treesitter.configs` to `nvim-treesitter.config`. Matches the plugin rename and prevents the E5113 module-not-found error on launch.

<sup>Written for commit cff246bb595baa6ad90e6035c3b0c4a05fcc5012. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

