### PR TITLE
chore: sort nix package lists alphabetically

### DIFF
--- a/home-manager/programs/php/default.nix
+++ b/home-manager/programs/php/default.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    php
     nodePackages.intelephense
+    php
   ];
 }

--- a/home-manager/programs/tmux/default.nix
+++ b/home-manager/programs/tmux/default.nix
@@ -9,15 +9,15 @@
     enable = true;
     extraConfig = builtins.readFile ./tmux.conf;
     plugins = with pkgs.tmuxPlugins; [
-      sensible
-      yank
-      tmux-fzf
-      resurrect
       continuum
+      extrakto
+      open
+      resurrect
+      sensible
+      tmux-fzf
       tmux-sessionx
       tmux-thumbs
-      open
-      extrakto
+      yank
     ];
   };
 }

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -304,12 +304,12 @@ inputs.nixpkgs.lib.nixosSystem {
         programs.nix-ld.enable = true;
         programs.nix-ld.libraries = with pkgs; [
           # Common libraries needed by security tools
-          glibc
-          zlib
-          openssl
           curl
-          libnl
+          glibc
           libgcc
+          libnl
+          openssl
+          zlib
         ];
 
         # Nix settings

--- a/named-hosts/matic/falcon/default.nix
+++ b/named-hosts/matic/falcon/default.nix
@@ -30,9 +30,9 @@ let
     inherit version arch src;
 
     buildInputs = [
+      autoPatchelfHook
       dpkg
       zlib
-      autoPatchelfHook
     ];
     sourceRoot = ".";
 


### PR DESCRIPTION
## Summary
- Sort tmux plugins alphabetically in `home-manager/programs/tmux/default.nix`
- Sort `nix-ld.libraries` alphabetically in `named-hosts/matic/default.nix`
- Sort `buildInputs` alphabetically in `named-hosts/matic/falcon/default.nix`
- Sort `home.packages` alphabetically in `home-manager/programs/php/default.nix`

## Test plan
- [ ] Verify `nix flake check` passes
- [ ] Verify no functional changes (pure reordering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sorted package and plugin lists alphabetically across Nix modules for consistency and easier diffs. No functional changes.

Sorted `tmux` plugins, `nix-ld.libraries`, Falcon `buildInputs`, and PHP `home.packages`.

<sup>Written for commit 2c3d6463b98669b4d9a72ca96ce646a163fde1c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

