### PR TITLE
fix: add missing build tools to make-updater service

### DIFF
--- a/home-manager/services/make-updater/default.nix
+++ b/home-manager/services/make-updater/default.nix
@@ -40,11 +40,15 @@ in
             pkgs.coreutils
             pkgs.curl
             pkgs.gawk
+            pkgs.gcc
+            pkgs.ghq
             pkgs.git
             pkgs.gnumake
             pkgs.gnused
             pkgs.go
             pkgs.nix
+            pkgs.openssl.dev
+            pkgs.pkg-config
             pkgs.sudo
             pkgs.which
           ]

--- a/scripts/update-local-binaries.sh
+++ b/scripts/update-local-binaries.sh
@@ -205,6 +205,12 @@ update_repo() {
     fi
   fi
 
+  # Remove stale lock files left by crashed git processes
+  if [ -f "$repo_dir/.git/index.lock" ]; then
+    log_warn "  Removing stale .git/index.lock..."
+    rm -f "$repo_dir/.git/index.lock"
+  fi
+
   # Git pull
   log_step "  Pulling latest changes..."
   if (cd "$repo_dir" && [ -n "$(git status --porcelain)" ]); then


### PR DESCRIPTION
## Summary
- Add `gcc`, `ghq`, `pkg-config`, and `openssl.dev` to the systemd make-updater service PATH, fixing build failures for Rust (linker `cc` not found) and Go (CGo compiler `gcc` not found) projects
- Add automatic cleanup of stale `.git/index.lock` files before `git pull`, preventing failures from crashed git processes
- `ghq` in PATH enables auto-cloning of missing repos listed in `.local-binaries.txt`

## Test plan
- [ ] `home-manager switch` succeeds
- [ ] `systemctl --user restart make-updater.service` completes without build failures
- [ ] `journalctl --user -u make-updater.service` shows successful builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix make-updater service builds by adding missing build tools to the PATH and cleaning stale Git locks. Rust and Go projects now build in the service, and missing repos auto-clone via `ghq`.

- **Bug Fixes**
  - Add `gcc`, `ghq`, `pkg-config`, and `openssl.dev` to the service PATH.
  - Remove stale `.git/index.lock` before `git pull` to avoid failures.
  - Enable `ghq` auto-clone for repos listed in `.local-binaries.txt`.

<sup>Written for commit 94ab5ee1604e7c78840131fc3586901ca91fe22a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

