### PR TITLE
feat(fish): add clrc command for stable claude remote-control

### DIFF
--- a/config/openclaw/default.nix
+++ b/config/openclaw/default.nix
@@ -11,25 +11,33 @@ let
 
   mode = if host.isKyber then "gateway" else "client";
 
-  hydrateScript = pkgs.replaceVars ./hydrate.sh (
-    {
-      sed = "${pkgs.gnused}/bin/sed";
-      template = ./openclaw.template.json;
-      inherit mode;
-    }
-    // (
-      if host.isKyber then
-        {
-          chromium = pkgs.chromium;
-          openclaw = "${homeDir}/.bun";
-        }
-      else
-        {
-          chromium = "/unused";
-          openclaw = "/unused";
-        }
-    )
-  );
+  # Use writeText instead of replaceVars to avoid builtins.toFile context warnings
+  hydrateScript =
+    let
+      vars = {
+        sed = "${pkgs.gnused}/bin/sed";
+        template = "${./openclaw.template.json}";
+        inherit mode;
+      }
+      // (
+        if host.isKyber then
+          {
+            chromium = "${pkgs.chromium}";
+            openclaw = "${homeDir}/.bun";
+          }
+        else
+          {
+            chromium = "/unused";
+            openclaw = "/unused";
+          }
+      );
+      names = builtins.attrNames vars;
+    in
+    pkgs.writeText "hydrate.sh" (
+      builtins.replaceStrings (map (n: "@${n}@") names) (map (n: builtins.toString vars.${n}) names) (
+        builtins.readFile ./hydrate.sh
+      )
+    );
 in
 {
   # Hydrate OpenClaw config from .env secrets

--- a/home-manager/programs/fish/functions/_clrc_function.fish
+++ b/home-manager/programs/fish/functions/_clrc_function.fish
@@ -1,0 +1,9 @@
+function _clrc_function --description "Run Claude Code remote-control with a stable binary, immune to bun updates while running"
+  # Resolve the symlink to the real inode before starting.
+  # When bun replaces the file (creates a new inode), the running node process
+  # keeps its reference to the old inode and is unaffected.
+  # Usage: clrc [<claude remote-control args...>]
+
+  set -l claude_real (realpath (which claude))
+  node $claude_real remote-control $argv
+end

--- a/spec/fish/_clrc_function_test.fish
+++ b/spec/fish/_clrc_function_test.fish
@@ -1,0 +1,26 @@
+set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_clrc_function.fish
+
+# ── basic: resolves symlink and runs node with remote-control ──
+set log1 (mktemp)
+set fake_cli (mktemp)
+
+function which; echo $fake_cli; end
+function realpath; echo $argv[1]; end
+function node; echo "node" $argv >> $log1; end
+
+_clrc_function
+
+@test "calls node directly (not claude symlink)" (grep -c "^node" $log1) -ge 1
+@test "passes remote-control subcommand" (grep -c "remote-control" $log1) -ge 1
+
+# ── with args: passes through extra args ──────────────────────
+set log2 (mktemp)
+function node; echo "node" $argv >> $log2; end
+
+_clrc_function --name mysession
+
+@test "passes extra args through" (grep -c -- "--name" $log2) -ge 1
+@test "still includes remote-control with args" (grep -c "remote-control" $log2) -ge 1
+
+rm -f $log1 $log2 $fake_cli

--- a/spec/fish/_ssh_add_github_test.fish
+++ b/spec/fish/_ssh_add_github_test.fish
@@ -11,10 +11,11 @@ set -x HOME $tmpdir
 # ── key exists but keychain missing ───────────────────────
 mkdir -p $tmpdir/.ssh
 touch $tmpdir/.ssh/id_ed25519_github
-function keychain; end
-# Remove keychain from PATH by shadowing with non-existent command
-functions -e keychain
+# Filter keychain binary out of PATH so command -v keychain fails
+set -l old_PATH $PATH
+set -x PATH (for p in $PATH; if not test -x $p/keychain; echo $p; end; end)
 
 @test "no keychain prints error" (string match -q "*keychain not found*" (_ssh_add_github 2>&1); echo $status) = 0
 
+set -x PATH $old_PATH
 rm -rf $tmpdir


### PR DESCRIPTION
## Summary

- Adds `clrc` fish abbreviation that runs `claude remote-control` by invoking `node` directly on the resolved `cli.js` inode (via `realpath $(which claude)`)
- When bun updates the claude package and writes a new file (new inode), the already-running session keeps its reference to the old inode and is unaffected
- Fixes a pre-existing test failure in `_ssh_add_github_test.fish` where `keychain` was shadowed by erasing a fish function, but the real binary on PATH was still found by `command -v`; fix uses PATH filtering instead

## Test plan

- [x] `make fish-test` passes 202/202
- `clrc` — runs remote-control with a stable binary handle
- `clrc --name mysession --spawn worktree` — args pass through correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `clrc` fish command that runs `claude remote-control` via `node` on the resolved `claude` path to keep sessions stable across `bun` upgrades. Also updates the OpenClaw Nix hydrate script to avoid context warnings and formats for `treefmt`.

- **New Features**
  - `clrc`: runs `node (realpath (which claude)) remote-control ...` for stability; tests cover basic run and arg passthrough.

- **Bug Fixes**
  - `_ssh_add_github_test.fish`: filter `PATH` so `keychain` is correctly treated as missing.
  - `config/openclaw/default.nix`: rewrite hydrate script with `writeText`/`replaceStrings` to avoid Nix context warnings; apply `treefmt` formatting.

<sup>Written for commit 44ad1a8fd427f59d797b632c4e730c9dba2072cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

