### PR TITLE
feat(claude): replace SessionEnd with PermissionRequest notifications

### DIFF
--- a/config/claude/notify.sh
+++ b/config/claude/notify.sh
@@ -54,10 +54,10 @@ if echo "$input" | jq -e '.message' >/dev/null 2>&1; then
   exit 0
 fi
 
-# Handle SessionEnd hook
-if echo "$input" | jq -e '.reason' >/dev/null 2>&1; then
-  REASON=$(echo "$input" | jq -r '.reason')
-  notify "Session ended: ${REASON}"
+# Handle PermissionRequest hook
+if echo "$input" | jq -e '.hook_event_name == "PermissionRequest"' >/dev/null 2>&1; then
+  TOOL_NAME=$(echo "$input" | jq -r '.tool_name // "unknown"')
+  notify "Approval required: ${TOOL_NAME}" "Basso"
   exit 0
 fi
 

--- a/config/claude/pushover.sh
+++ b/config/claude/pushover.sh
@@ -2,7 +2,7 @@
 
 # Claude Code Pushover Notification Script
 # Sends notifications to your smartwatch/phone when Claude needs attention
-# Supports: Notification, Stop, SessionEnd, PreCompact, SubagentStop hooks
+# Supports: Notification, Stop, PermissionRequest, PreCompact, SubagentStop hooks
 
 # Source credentials from dotfiles/.env if environment variables aren't set
 # This is needed because Claude Code hooks run in a subprocess that may not
@@ -117,14 +117,12 @@ if echo "$input" | jq -e '.message' >/dev/null 2>&1; then
   exit 0
 fi
 
-# Handle SessionEnd hook (priority 0 = normal)
-# Skip "other" reason - it's a generic/unknown reason that's noisy
-if echo "$input" | jq -e '.reason' >/dev/null 2>&1; then
-  REASON=$(echo "$input" | jq -r '.reason')
-  if [ "$REASON" = "other" ]; then
-    exit 0
-  fi
-  send_notification "👋 Session ended: ${REASON}" 0
+# Handle PermissionRequest hook (priority 1 = high - needs immediate attention)
+if echo "$input" | jq -e '.hook_event_name == "PermissionRequest"' >/dev/null 2>&1; then
+  TOOL_NAME=$(echo "$input" | jq -r '.tool_name // "unknown"')
+  CWD=$(echo "$input" | jq -r '.cwd // empty' | sed "s|$HOME|~|")
+  send_notification "🔐 [${HOSTNAME}] Approval required: ${TOOL_NAME}
+📂 ${CWD}" 1
   exit 0
 fi
 

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -165,7 +165,7 @@
         "matcher": "Write|Edit|MultiEdit"
       }
     ],
-    "SessionEnd": [
+    "PermissionRequest": [
       {
         "hooks": [
           {


### PR DESCRIPTION
## Changes
- Replace `SessionEnd` hook with `PermissionRequest` hook in `settings.json`
- Update `notify.sh` to handle `PermissionRequest` events (plays Basso sound)
- Update `pushover.sh` to handle `PermissionRequest` events (high priority notification with tool name and cwd)

## Technical Details
- `PermissionRequest` fires when Claude needs approval before executing a tool, making it useful for remote control (`clrc`) instances where you need to know when approval is pending
- Both scripts detect the event via `hook_event_name == "PermissionRequest"` and extract `tool_name` for context

Generated with [Claude Code](https://claude.ai/claude-code) by claude-sonnet-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace SessionEnd notifications with PermissionRequest alerts to signal when tool approval is needed. Adds a clear sound cue and a high-priority Pushover message with context for faster responses.

- **New Features**
  - Switched `settings.json` hook from SessionEnd to PermissionRequest.
  - `notify.sh`: detects PermissionRequest, plays Basso, shows “Approval required: <tool>”.
  - `pushover.sh`: sends high-priority alert with host, tool name, and cwd.

<sup>Written for commit 3493e5f77270504c5c0a11cc2cac1446f35b4a72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

