### PR TITLE
fix(make): set SHELL := bash to fix declare -A on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 ##@ Variables
 
+SHELL := bash
+
 # Include dotagents from submodule but keep the local help target authoritative.
 DOTAGENTS_SKIP_HELP := 1
 -include dotagents/Makefile


### PR DESCRIPTION
## Changes
- Set `SHELL := bash` at the top of the Makefile

## Problem
The `make-updater` launchd service was failing with:
```
declare: -A: invalid option
declare: usage: declare [-afFirtx] [-p] [name[=value] ...]
```

GNU make defaults `SHELL` to `/bin/sh`, which on macOS is bash 3.2. The script `scripts/update-local-binaries.sh` uses `declare -A` (associative arrays), which requires bash 4+.

## Fix
Setting `SHELL := bash` makes GNU make use the `bash` found in PATH (nix's bash 5.x, which the launchd service puts first) for all recipe execution, enabling `declare -A` to work correctly.

Generated with [Claude Code](https://claude.ai/claude-code) by claude-sonnet-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `SHELL := bash` in the Makefile so GNU make runs recipes with the PATH’s `bash` (5.x), enabling `declare -A` in scripts. Fixes macOS `make-updater` launchd failures caused by the default `/bin/sh` (bash 3.2) not supporting associative arrays.

<sup>Written for commit ee31750fa90e6a78897f27daed4de29a80fb4282. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

