### PR TITLE
fix(make-updater): add missing build tools and nightly rust support

### DIFF
--- a/home-manager/services/make-updater/default.nix
+++ b/home-manager/services/make-updater/default.nix
@@ -1,6 +1,11 @@
-{ pkgs, ... }:
+{
+  config,
+  pkgs,
+  ...
+}:
 let
   inherit (pkgs) lib;
+  homeDir = config.home.homeDirectory;
 in
 {
   launchd.agents.make-updater = lib.mkIf pkgs.stdenv.isDarwin {
@@ -35,10 +40,13 @@ in
       Environment = [
         "PATH=${
           lib.makeBinPath [
+            pkgs.autoconf
             pkgs.bash
+            pkgs.binutils
             pkgs.cargo
             pkgs.coreutils
             pkgs.curl
+            pkgs.elixir
             pkgs.gawk
             pkgs.gcc
             pkgs.ghq
@@ -46,14 +54,18 @@ in
             pkgs.gnumake
             pkgs.gnused
             pkgs.go
+            pkgs.libtool
             pkgs.nix
             pkgs.openssl.dev
             pkgs.pkg-config
+            pkgs.rustup
             pkgs.sudo
             pkgs.which
           ]
         }"
         "AUTOMATED_UPDATE=true"
+        "RUSTUP_HOME=${homeDir}/.rustup"
+        "CARGO_HOME=${homeDir}/.cargo"
       ];
       ExecStart = "${./update.sh}";
     };


### PR DESCRIPTION
## Summary

- Add `pkgs.binutils` to fix `cannot find 'ld'` linker error in `coding_agent_session_search`
- Add `pkgs.rustup` + `RUSTUP_HOME`/`CARGO_HOME` env vars to support nightly Rust for `destructive_command_guard` (its dep `fsqlite-mvcc` uses `#![feature]`)
- Add `pkgs.autoconf` + `pkgs.libtool` to fix `tikv-jemalloc-sys` build failure in `pi_agent_rust`
- Add `pkgs.elixir` to fix `mix: No such file or directory` in `symphony`
- Use `config.home.homeDirectory` instead of hardcoded username for `RUSTUP_HOME`/`CARGO_HOME` paths

## Test plan

- [ ] Run `nixos-rebuild switch` to apply the updated service
- [ ] Manually trigger `systemctl --user start make-updater.service` and verify all 4 previously-failing projects now build successfully
- [ ] Confirm `systemctl --user status make-updater.service` exits with code 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes build failures in the `make-updater` service by adding missing build tools and Rust nightly support so all impacted projects build on macOS. Also switches Rust env paths to use the user’s home directory.

- **Bug Fixes**
  - `coding_agent_session_search`: add `pkgs.binutils` for `ld`.
  - `destructive_command_guard`: add `pkgs.rustup` and set `RUSTUP_HOME`/`CARGO_HOME` for nightly (dep `fsqlite-mvcc`).
  - `pi_agent_rust`: add `pkgs.autoconf` and `pkgs.libtool` for `tikv-jemalloc-sys`.
  - `symphony`: add `pkgs.elixir` for `mix`.

- **Refactors**
  - Use `config.home.homeDirectory` for `RUSTUP_HOME` and `CARGO_HOME` paths.

<sup>Written for commit 3cdf9a161c4eac7e07bb0ffc21736e77be35b2a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

