### PR TITLE
fix(scripts): fallback to git pull --rebase on diverged branches

### DIFF
--- a/scripts/update-local-binaries.sh
+++ b/scripts/update-local-binaries.sh
@@ -237,10 +237,13 @@ update_repo() {
       return 1
     fi
   else
-    if ! (cd "$repo_dir" && git pull 2>&1); then
-      log_error "  Git pull failed"
-      FAILURES+=("$repo_name (git pull failed)")
-      return 1
+    if ! (cd "$repo_dir" && git pull --ff-only 2>&1); then
+      log_warn "  Fast-forward failed; rebasing onto remote..."
+      if ! (cd "$repo_dir" && git pull --rebase 2>&1); then
+        log_error "  Git pull failed"
+        FAILURES+=("$repo_name (git pull failed)")
+        return 1
+      fi
     fi
   fi
 


### PR DESCRIPTION
## Changes
- In `update-local-binaries.sh`, replace plain `git pull` (clean tree path) with `git pull --ff-only` + `git pull --rebase` fallback

## Problem
Global git config has `pull.ff = only`, so `git pull` fails with `fatal: Not possible to fast-forward, aborting.` when a repo's local branch has diverged from the remote (e.g. local commits not on upstream).

The `make-updater` service was reporting `coding_agent_session_search (git pull failed)` every run as a result.

## Fix
Try `--ff-only` first (respects the global config intent). If that fails due to diverged branches, fall back to `--rebase` to cleanly bring the branch up to date.

Generated with [Claude Code](https://claude.ai/claude-code) by claude-sonnet-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `update-local-binaries.sh` to use fast-forward-only pulls with a rebase fallback to handle diverged branches. This respects `pull.ff=only` and stops updater failures on repos with local commits.

- **Bug Fixes**
  - Try `git pull --ff-only` first; on failure, log a warning and run `git pull --rebase`.
  - Prevents repeated "coding_agent_session_search (git pull failed)" errors in `make-updater`.

<sup>Written for commit 7cc6d1a0ae3b44b901c8abff54ccc8b5271977ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

