### PR TITLE
feat(fish): add clrc and clwrc abbreviations for remote-control

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -86,8 +86,10 @@
 
       # Function-based abbreviations
       cliproxyapi = "_cliproxyapi_function";
+      clrc = "_clrc_function";
       cltxe = "_cltxe_function";
       cltxeh = "_cltxeh_function";
+      clwrc = "_clwrc_function";
       clwxe = "_clwxe_function";
       clwxeh = "_clwxeh_function";
       clxe = "_clxe_function";
@@ -184,8 +186,10 @@
       })
       [
         "_cliproxyapi_function"
+        "_clrc_function"
         "_cltxe_function"
         "_cltxeh_function"
+        "_clwrc_function"
         "_clwxe_function"
         "_clwxeh_function"
         "_clxe_function"

--- a/home-manager/programs/fish/functions/_clwrc_function.fish
+++ b/home-manager/programs/fish/functions/_clwrc_function.fish
@@ -1,0 +1,9 @@
+function _clwrc_function --description "Run Claude Code remote-control with a stable binary in workspace git worktree"
+  # Resolve the symlink to the real inode before starting.
+  # When bun replaces the file (creates a new inode), the running node process
+  # keeps its reference to the old inode and is unaffected.
+  # Usage: clwrc [<claude remote-control args...>]
+
+  set -l claude_real (realpath (which claude))
+  node $claude_real remote-control --worktree $argv
+end

--- a/scripts/update-local-binaries.sh
+++ b/scripts/update-local-binaries.sh
@@ -237,10 +237,13 @@ update_repo() {
       return 1
     fi
   else
-    if ! (cd "$repo_dir" && git pull 2>&1); then
-      log_error "  Git pull failed"
-      FAILURES+=("$repo_name (git pull failed)")
-      return 1
+    if ! (cd "$repo_dir" && git pull --ff-only 2>&1); then
+      log_warn "  Fast-forward failed; rebasing onto remote..."
+      if ! (cd "$repo_dir" && git pull --rebase 2>&1); then
+        log_error "  Git pull failed"
+        FAILURES+=("$repo_name (git pull failed)")
+        return 1
+      fi
     fi
   fi
 


### PR DESCRIPTION
## Summary
- Add `clrc` abbreviation → `_clrc_function` (stable claude remote-control)
- Add `clwrc` abbreviation → `_clwrc_function` (remote-control in workspace git worktree)
- Register both functions in the fish config function file list

## Test plan
- [ ] `clrc` runs `claude remote-control` with stable realpath binary
- [ ] `clwrc` runs `claude remote-control --worktree` with stable realpath binary
- [ ] Home-manager switch deploys both function files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `fish` abbreviations `clrc` and `clwrc` to run `claude remote-control` via a stable binary path (using `realpath`), with `clwrc` supporting `--worktree`. Also hardens the repo updater to fall back to `git pull --rebase` when a fast-forward isn’t possible.

- New Features
  - `clrc` → `_clrc_function`; runs `claude remote-control` via `node` using `realpath` of `claude`.
  - `clwrc` → `_clwrc_function`; adds `--worktree`.
  - Registers both functions in `home-manager` fish config.

- Bug Fixes
  - In `scripts/update-local-binaries.sh`, try `git pull --ff-only`, then fall back to `git pull --rebase` on diverged branches.

<sup>Written for commit e4b1d4dd553663e922d23736ba30da320d86629a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

