### PR TITLE
fix(spec): add _clwrc test and remove stale SessionEnd tests

### DIFF
--- a/config/claude/pushover.sh
+++ b/config/claude/pushover.sh
@@ -39,6 +39,8 @@ send_notification() {
   [ -z "$message" ] && return
 
   curl -s \
+    --max-time 5 \
+    --connect-timeout 3 \
     --form-string "token=${PUSHOVER_API_TOKEN}" \
     --form-string "user=${PUSHOVER_USER_KEY}" \
     --form-string "message=${message}" \

--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -11,7 +11,7 @@ let
   docker = import ./docker { inherit lib pkgs; };
   dockerPostgres = import ./docker-postgres { inherit pkgs; };
   dotfilesUpdater = import ./dotfiles-updater { inherit pkgs; };
-  makeUpdater = import ./make-updater { inherit pkgs; };
+  makeUpdater = import ./make-updater { inherit config pkgs; };
   neversslKeepalive = import ./neverssl-keepalive { inherit pkgs; };
   ollama = import ./ollama { inherit pkgs; };
   sshAgent = import ./ssh-agent {

--- a/spec/fish/_clwrc_function_test.fish
+++ b/spec/fish/_clwrc_function_test.fish
@@ -1,0 +1,28 @@
+set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_clwrc_function.fish
+
+# ── basic: resolves symlink and runs node with remote-control --worktree ──
+set log1 (mktemp)
+set fake_cli (mktemp)
+
+function which; echo $fake_cli; end
+function realpath; echo $argv[1]; end
+function node; echo "node" $argv >> $log1; end
+
+_clwrc_function
+
+@test "calls node directly (not claude symlink)" (grep -c "^node" $log1) -ge 1
+@test "passes remote-control subcommand" (grep -c "remote-control" $log1) -ge 1
+@test "passes --worktree flag" (grep -c -- "--worktree" $log1) -ge 1
+
+# ── with args: passes through extra args ──────────────────────
+set log2 (mktemp)
+function node; echo "node" $argv >> $log2; end
+
+_clwrc_function --name mysession
+
+@test "passes extra args through" (grep -c -- "--name" $log2) -ge 1
+@test "still includes remote-control with args" (grep -c "remote-control" $log2) -ge 1
+@test "still includes --worktree with args" (grep -c -- "--worktree" $log2) -ge 1
+
+rm -f $log1 $log2 $fake_cli

--- a/spec/pushover_spec.sh
+++ b/spec/pushover_spec.sh
@@ -63,7 +63,6 @@ The output should eq ''
 End
 End
 
-
 Describe 'Notification hook'
 setup() {
   mock_bin_setup curl

--- a/spec/pushover_spec.sh
+++ b/spec/pushover_spec.sh
@@ -63,33 +63,6 @@ The output should eq ''
 End
 End
 
-Describe 'SessionEnd hook'
-setup() {
-  mock_bin_setup curl
-
-  # Set test credentials
-  export PUSHOVER_API_TOKEN="test_token"
-  export PUSHOVER_USER_KEY="test_user"
-}
-cleanup() {
-  mock_bin_cleanup
-}
-Before 'setup'
-After 'cleanup'
-
-It 'skips notification for "other" reason'
-When run bash -c 'echo "{\"reason\": \"other\"}" | bash '"$SCRIPT"'; cat "$MOCK_LOG"'
-The status should be success
-The output should eq ''
-End
-
-It 'processes notification for "user_exit" reason'
-When run bash -c 'echo "{\"reason\": \"user_exit\"}" | bash '"$SCRIPT"'; cat "$MOCK_LOG"'
-The status should be success
-The output should include 'priority=0'
-The output should include 'https://api.pushover.net/1/messages.json'
-End
-End
 
 Describe 'Notification hook'
 setup() {


### PR DESCRIPTION
## Summary

- Add `spec/fish/_clwrc_function_test.fish` to satisfy the fish function coverage spec for the recently added `_clwrc_function`
- Remove stale `SessionEnd` hook tests from `spec/pushover_spec.sh` — the hook was deleted so the tests were failing

## Test plan

- [x] `make shell-test` passes: 810 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Fish spec `spec/fish/_clwrc_function_test.fish` to verify `_clwrc_function` calls `node` with `remote-control --worktree` and forwards extra args, and remove stale `SessionEnd` tests in `spec/pushover_spec.sh` to fix `make shell-test` failures. Add curl timeouts in `config/claude/pushover.sh` to prevent hanging stop hooks, and pass `config` to the `make-updater` import in `home-manager/services/default.nix` to fix service wiring.

<sup>Written for commit 62d9f6e950e54c071167478b337fec22654f455f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

