### PR TITLE
fix(make-updater): restore nix build evaluation

### DIFF
--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -11,7 +11,7 @@ let
   docker = import ./docker { inherit lib pkgs; };
   dockerPostgres = import ./docker-postgres { inherit pkgs; };
   dotfilesUpdater = import ./dotfiles-updater { inherit pkgs; };
-  makeUpdater = import ./make-updater { inherit config pkgs; };
+  makeUpdater = import ./make-updater { inherit pkgs; };
   neversslKeepalive = import ./neverssl-keepalive { inherit pkgs; };
   ollama = import ./ollama { inherit pkgs; };
   sshAgent = import ./ssh-agent {

--- a/home-manager/services/make-updater/default.nix
+++ b/home-manager/services/make-updater/default.nix
@@ -1,11 +1,6 @@
-{
-  config,
-  pkgs,
-  ...
-}:
+{ pkgs, ... }:
 let
   inherit (pkgs) lib;
-  homeDir = config.home.homeDirectory;
 in
 {
   launchd.agents.make-updater = lib.mkIf pkgs.stdenv.isDarwin {
@@ -64,8 +59,8 @@ in
           ]
         }"
         "AUTOMATED_UPDATE=true"
-        "RUSTUP_HOME=${homeDir}/.rustup"
-        "CARGO_HOME=${homeDir}/.cargo"
+        "RUSTUP_HOME=%h/.rustup"
+        "CARGO_HOME=%h/.cargo"
       ];
       ExecStart = "${./update.sh}";
     };


### PR DESCRIPTION
Restore make build after the recent make-updater regression.

The service module started reading config.home.homeDirectory during evaluation. In the NixOS plus Home Manager path used by make build, that attribute is not available at that point, so evaluation fails before the system configuration can build.

This switches RUSTUP_HOME and CARGO_HOME to systemd %h runtime expansion and removes the now-unused config wiring from the parent service import. I considered recomputing the path from the username again, but %h keeps the module runtime-scoped and avoids reintroducing evaluation-time coupling.

Verified by rerunning make build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `make build` evaluation errors by removing eval-time use of `config.home.homeDirectory` in the `make-updater` service. Uses systemd `%h` for `RUSTUP_HOME` and `CARGO_HOME` and stops passing `config` into the module import.

- **Bug Fixes**
  - Removed `config` from `make-updater` import to avoid reading `config.home.homeDirectory` during evaluation.
  - Set `RUSTUP_HOME` and `CARGO_HOME` to `%h/...` so paths resolve at runtime; `make build` works again.

<sup>Written for commit 40a4e09f83caa2833e4e414f6208f27836b59ebe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

