### PR TITLE
fix(fish): run claude binary directly instead of via node

### DIFF
--- a/home-manager/programs/fish/functions/_clrc_function.fish
+++ b/home-manager/programs/fish/functions/_clrc_function.fish
@@ -5,5 +5,5 @@ function _clrc_function --description "Run Claude Code remote-control with a sta
   # Usage: clrc [<claude remote-control args...>]
 
   set -l claude_real (realpath (which claude))
-  node $claude_real remote-control $argv
+  $claude_real remote-control $argv
 end

--- a/home-manager/programs/fish/functions/_clwrc_function.fish
+++ b/home-manager/programs/fish/functions/_clwrc_function.fish
@@ -5,5 +5,5 @@ function _clwrc_function --description "Run Claude Code remote-control with a st
   # Usage: clwrc [<claude remote-control args...>]
 
   set -l claude_real (realpath (which claude))
-  node $claude_real remote-control --worktree $argv
+  $claude_real remote-control --worktree $argv
 end

--- a/spec/fish/_clrc_function_test.fish
+++ b/spec/fish/_clrc_function_test.fish
@@ -1,22 +1,25 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
 source $fn/_clrc_function.fish
 
-# ── basic: resolves symlink and runs node with remote-control ──
+# ── basic: resolves symlink and runs binary with remote-control ──
 set log1 (mktemp)
 set fake_cli (mktemp)
+chmod +x $fake_cli
+echo '#!/bin/sh
+echo "$0" "$@" >> '$log1 > $fake_cli
 
 function which; echo $fake_cli; end
 function realpath; echo $argv[1]; end
-function node; echo "node" $argv >> $log1; end
 
 _clrc_function
 
-@test "calls node directly (not claude symlink)" (grep -c "^node" $log1) -ge 1
+@test "runs resolved binary directly" (grep -c $fake_cli $log1) -ge 1
 @test "passes remote-control subcommand" (grep -c "remote-control" $log1) -ge 1
 
 # ── with args: passes through extra args ──────────────────────
 set log2 (mktemp)
-function node; echo "node" $argv >> $log2; end
+echo '#!/bin/sh
+echo "$0" "$@" >> '$log2 > $fake_cli
 
 _clrc_function --name mysession
 

--- a/spec/fish/_clwrc_function_test.fish
+++ b/spec/fish/_clwrc_function_test.fish
@@ -1,23 +1,26 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
 source $fn/_clwrc_function.fish
 
-# ── basic: resolves symlink and runs node with remote-control --worktree ──
+# ── basic: resolves symlink and runs binary with remote-control --worktree ──
 set log1 (mktemp)
 set fake_cli (mktemp)
+chmod +x $fake_cli
+echo '#!/bin/sh
+echo "$0" "$@" >> '$log1 > $fake_cli
 
 function which; echo $fake_cli; end
 function realpath; echo $argv[1]; end
-function node; echo "node" $argv >> $log1; end
 
 _clwrc_function
 
-@test "calls node directly (not claude symlink)" (grep -c "^node" $log1) -ge 1
+@test "runs resolved binary directly" (grep -c $fake_cli $log1) -ge 1
 @test "passes remote-control subcommand" (grep -c "remote-control" $log1) -ge 1
 @test "passes --worktree flag" (grep -c -- "--worktree" $log1) -ge 1
 
 # ── with args: passes through extra args ──────────────────────
 set log2 (mktemp)
-function node; echo "node" $argv >> $log2; end
+echo '#!/bin/sh
+echo "$0" "$@" >> '$log2 > $fake_cli
 
 _clwrc_function --name mysession
 


### PR DESCRIPTION
## Summary
- Remove `node` wrapper from `_clrc_function` and `_clwrc_function` — the claude CLI is a compiled binary, not a Node.js script
- Execute the resolved binary directly (`$claude_real`) while keeping the `realpath` symlink-resolution trick for inode stability
- Update tests to use a shell script stub instead of mocking a `node` function

Closes #1216

## Test plan
- [x] `make fish-test` passes (all 65 tests ok)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Fish helpers to run the compiled `claude` CLI directly instead of through `node`. Fixes the SyntaxError and keeps `realpath` symlink resolution for inode stability.

- **Bug Fixes**
  - `_clrc_function` and `_clwrc_function` now execute `$claude_real ...` (no `node`).
  - Tests use a shell stub to capture argv and assert binary path and flags (`remote-control`, `--worktree`).

<sup>Written for commit 690ca4fb171125106469ff02c244a089b7841f16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

