### PR TITLE
fix(make): detect nix in Docker where profile path differs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ NIX_USERNAME := $(shell \
 	else \
 		echo "$(shell whoami)"; \
 	fi)
-NIX_ENV := $(shell . ~/.nix-profile/etc/profile.d/nix.sh 2>/dev/null || echo "not_found")
+NIX_ENV := $(shell . ~/.nix-profile/etc/profile.d/nix.sh 2>/dev/null || . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh 2>/dev/null || command -v nix >/dev/null 2>&1 || echo "not_found")
 NIX_FLAGS := --extra-experimental-features 'flakes nix-command' --no-pure-eval --impure
 # Only add cache options when user is trusted or on Darwin/CI (avoids "ignoring untrusted substituter" warnings)
 ifeq ($(OS),Darwin)


### PR DESCRIPTION
## Summary
- `NIX_ENV` only sourced `~/.nix-profile/etc/profile.d/nix.sh`, which doesn't exist in the Docker CI image where nix is pre-installed at `/usr/bin`
- Add fallbacks: Determinate Systems daemon profile path (`/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh`) and `command -v nix`
- Prevents the installer from re-running and failing with "nix is already a valid command"

## Test plan
- [ ] Docker CI build passes without `make: *** [Makefile:301: nix-install] Error 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Nix detection in Docker/CI by adding daemon profile and command-based fallbacks, so the installer skips when `nix` is already available. Prevents `make nix-install` failures in images where `nix` lives at `/usr/bin`.

- **Bug Fixes**
  - Update `NIX_ENV` to source `~/.nix-profile/...`, or `/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh`, or use `command -v nix` as a final check.

<sup>Written for commit cb8bba464b089a2243fad15cee560f22b54d7c20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

