### PR TITLE
fix(fish): update clrc/clwrc for new remote-control CLI flags

### DIFF
--- a/home-manager/programs/fish/functions/_clrc_function.fish
+++ b/home-manager/programs/fish/functions/_clrc_function.fish
@@ -5,5 +5,5 @@ function _clrc_function --description "Run Claude Code remote-control with a sta
   # Usage: clrc [<claude remote-control args...>]
 
   set -l claude_real (realpath (which claude))
-  $claude_real remote-control $argv
+  $claude_real remote-control --permission-mode bypassPermissions $argv
 end

--- a/home-manager/programs/fish/functions/_clwrc_function.fish
+++ b/home-manager/programs/fish/functions/_clwrc_function.fish
@@ -5,5 +5,5 @@ function _clwrc_function --description "Run Claude Code remote-control with a st
   # Usage: clwrc [<claude remote-control args...>]
 
   set -l claude_real (realpath (which claude))
-  $claude_real remote-control --worktree $argv
+  $claude_real remote-control --spawn worktree --permission-mode bypassPermissions $argv
 end

--- a/spec/fish/_clrc_function_test.fish
+++ b/spec/fish/_clrc_function_test.fish
@@ -15,6 +15,7 @@ _clrc_function
 
 @test "runs resolved binary directly" (grep -c $fake_cli $log1) -ge 1
 @test "passes remote-control subcommand" (grep -c "remote-control" $log1) -ge 1
+@test "passes --permission-mode bypassPermissions" (grep -c -- "bypassPermissions" $log1) -ge 1
 
 # ── with args: passes through extra args ──────────────────────
 set log2 (mktemp)
@@ -25,5 +26,6 @@ _clrc_function --name mysession
 
 @test "passes extra args through" (grep -c -- "--name" $log2) -ge 1
 @test "still includes remote-control with args" (grep -c "remote-control" $log2) -ge 1
+@test "still includes bypassPermissions with args" (grep -c -- "bypassPermissions" $log2) -ge 1
 
 rm -f $log1 $log2 $fake_cli

--- a/spec/fish/_clwrc_function_test.fish
+++ b/spec/fish/_clwrc_function_test.fish
@@ -1,7 +1,7 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
 source $fn/_clwrc_function.fish
 
-# ── basic: resolves symlink and runs binary with remote-control --worktree ──
+# ── basic: resolves symlink and runs binary with remote-control --spawn worktree ──
 set log1 (mktemp)
 set fake_cli (mktemp)
 chmod +x $fake_cli
@@ -15,7 +15,8 @@ _clwrc_function
 
 @test "runs resolved binary directly" (grep -c $fake_cli $log1) -ge 1
 @test "passes remote-control subcommand" (grep -c "remote-control" $log1) -ge 1
-@test "passes --worktree flag" (grep -c -- "--worktree" $log1) -ge 1
+@test "passes --spawn worktree flags" (grep -c -- "--spawn" $log1) -ge 1
+@test "passes --permission-mode bypassPermissions" (grep -c -- "bypassPermissions" $log1) -ge 1
 
 # ── with args: passes through extra args ──────────────────────
 set log2 (mktemp)
@@ -26,6 +27,7 @@ _clwrc_function --name mysession
 
 @test "passes extra args through" (grep -c -- "--name" $log2) -ge 1
 @test "still includes remote-control with args" (grep -c "remote-control" $log2) -ge 1
-@test "still includes --worktree with args" (grep -c -- "--worktree" $log2) -ge 1
+@test "still includes --spawn worktree with args" (grep -c -- "--spawn" $log2) -ge 1
+@test "still includes bypassPermissions with args" (grep -c -- "bypassPermissions" $log2) -ge 1
 
 rm -f $log1 $log2 $fake_cli


### PR DESCRIPTION
## Summary
- Replace deprecated `--worktree` with `--spawn worktree` in `clwrc`
- Add `--permission-mode bypassPermissions` to both `clrc` and `clwrc`
- Update tests to match new flags

## Test plan
- [ ] Verify `clrc` runs with `bypassPermissions` mode
- [ ] Verify `clwrc` uses `--spawn worktree` and `bypassPermissions`
- [ ] Run fish spec tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update fish `clrc` and `clwrc` to match the latest `claude remote-control` flags and default permissions. Keeps the wrappers working with the new CLI and updates tests to match.

- **Bug Fixes**
  - `clwrc`: replace deprecated `--worktree` with `--spawn worktree`.
  - `clrc` and `clwrc`: add `--permission-mode bypassPermissions`.
  - Update fish specs to assert the new flags.

<sup>Written for commit c29b47f6705a045f19c74b9b49f92690732a248c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

