### PR TITLE
fix(matic): wait for fprintd before starting greetd

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -253,6 +253,9 @@ inputs.nixpkgs.lib.nixosSystem {
             };
           };
         };
+        # Ensure fprintd is ready before greetd starts to avoid PAM fingerprint timeout
+        systemd.services.greetd.after = [ "fprintd.service" ];
+        systemd.services.greetd.wants = [ "fprintd.service" ];
 
         # Disk management
         services.gvfs.enable = true; # For automounting external drives in Nautilus and managing disk permissions


### PR DESCRIPTION
## Summary
- Adds `after` and `wants` systemd dependencies so `greetd` waits for `fprintd.service` to be active before starting
- Prevents the PAM fingerprint authentication timeout at the login screen

## Test plan
- [ ] Boot machine and verify no fprintd timeout error in greetd
- [ ] Fingerprint login works at the greeter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `greetd` waits for `fprintd.service` before starting to prevent PAM fingerprint timeouts on the login screen. Adds `systemd` `after` and `wants` dependencies in `named-hosts/matic/default.nix`.

<sup>Written for commit 1dabb0266461f9bb67047061fe8efe7e4e265b3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

