### PR TITLE
fix(tmux): replace pbcopy with cross-platform clipboard command

### DIFF
--- a/home-manager/programs/tmux/tmux.conf
+++ b/home-manager/programs/tmux/tmux.conf
@@ -25,7 +25,7 @@ set-option -g automatic-rename-format '#{b:pane_current_path}'
 set-window-option -g mode-keys vi
 bind-key -T copy-mode-vi v send-keys -X begin-selection
 bind-key -T copy-mode-vi r send-keys -X rectangle-toggle
-bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel 'pbcopy'
+bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel '#{@clipboard_cmd}'
 
 # Open splits and windows in the current folder
 bind u split-window -l 30% -v -c "#{pane_current_path}"
@@ -37,6 +37,7 @@ set-option -g repeat-time 1000
 
 # Clipboard
 set -g set-clipboard on
+set -g @clipboard_cmd "command -v pbcopy >/dev/null 2>&1 && pbcopy || { [ -n \"$WAYLAND_DISPLAY\" ] && wl-copy || xclip -selection clipboard; }"
 
 # Status bar
 set -g status "on"
@@ -59,7 +60,7 @@ bind r command-prompt -I "#{window_name}" "rename-window '%%'"
 bind R command-prompt -I "#{session_name}" "rename-session '%%'"
 
 # Copy text on select
-bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel '#{@clipboard_cmd}'
 
 # Switch window
 bind , previous-window
@@ -90,8 +91,8 @@ bind-key "%" split-window -h -c "#{pane_current_path}"
 bind-key '"' split-window -v -c "#{pane_current_path}"
 
 # Yank pane history to clipboard
-bind y run-shell 'tmux capture-pane -pS - | pbcopy && tmux display-message "Full pane history copied to clipboard"'
-bind v run-shell 'tmux capture-pane -p | pbcopy && tmux display-message "Visible pane copied to clipboard"'
+bind y run-shell 'tmux capture-pane -pS - | #{@clipboard_cmd} && tmux display-message "Full pane history copied to clipboard"'
+bind v run-shell 'tmux capture-pane -p | #{@clipboard_cmd} && tmux display-message "Visible pane copied to clipboard"'
 
 # Pane number indicator
 set -g display-panes-colour colour233


### PR DESCRIPTION
## Summary
- Replaces hardcoded `pbcopy` (macOS-only) with a portable clipboard command defined once as `@clipboard_cmd`
- Detects environment at runtime: `pbcopy` on macOS, `wl-copy` on Wayland, `xclip` on X11
- Applied to vi copy-mode yank, mouse drag copy, and pane history yank bindings

## Test plan
- [ ] On macOS: yank in copy-mode copies to clipboard via `pbcopy`
- [ ] On Linux Wayland: yank copies via `wl-copy`
- [ ] On Linux X11: yank copies via `xclip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace macOS-only `pbcopy` in tmux with a cross‑platform clipboard command defined as `@clipboard_cmd`. It auto-detects the environment (`pbcopy` on macOS, `wl-copy` on Wayland, `xclip -selection clipboard` on X11) and is used for vi copy-mode yank, mouse drag copy, and pane history yanks.

<sup>Written for commit 15029e9b936153740901970d1d5acc8f61a656ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

