### PR TITLE
chore(omp): manage config via dotfiles templates

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -23,6 +23,7 @@ in
   ./karabiner
   ./llm
   ./openclaw
+  ./omp
   ./opencode
   ./pi
   ./serena

--- a/config/omp/config.tpl.yml
+++ b/config/omp/config.tpl.yml
@@ -8,5 +8,6 @@ theme:
 steeringMode: all
 followUpMode: all
 interruptMode: immediate
+doubleEscapeAction: none
 startup:
   quiet: true

--- a/config/omp/config.tpl.yml
+++ b/config/omp/config.tpl.yml
@@ -1,0 +1,12 @@
+lastChangelogVersion: 13.13.2
+modelRoles:
+  default: codex/__GPT__
+display:
+  showTokenUsage: true
+theme:
+  dark: dark-dracula
+steeringMode: all
+followUpMode: all
+interruptMode: immediate
+startup:
+  quiet: true

--- a/config/omp/config.yml
+++ b/config/omp/config.yml
@@ -8,5 +8,6 @@ theme:
 steeringMode: all
 followUpMode: all
 interruptMode: immediate
+doubleEscapeAction: none
 startup:
   quiet: true

--- a/config/omp/config.yml
+++ b/config/omp/config.yml
@@ -1,0 +1,12 @@
+lastChangelogVersion: 13.13.2
+modelRoles:
+  default: codex/gpt-5.4
+display:
+  showTokenUsage: true
+theme:
+  dark: dark-dracula
+steeringMode: all
+followUpMode: all
+interruptMode: immediate
+startup:
+  quiet: true

--- a/config/omp/default.nix
+++ b/config/omp/default.nix
@@ -1,0 +1,10 @@
+{ lib, ... }:
+{
+  # Use activation script instead of home.file symlink.
+  # Keep only the tracked config.yml in dotfiles and leave runtime state untouched.
+  home.activation.ompConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    $DRY_RUN_CMD mkdir -p ~/.omp/agent
+    $DRY_RUN_CMD cp -f ${./config.yml} ~/.omp/agent/config.yml
+    $DRY_RUN_CMD chmod 644 ~/.omp/agent/config.yml
+  '';
+}

--- a/scripts/llm-update.sh
+++ b/scripts/llm-update.sh
@@ -56,6 +56,7 @@ declare -A TEMPLATES=(
   ["config/ccs/glm.settings.tpl.json"]=config/ccs/glm.settings.template.json
   ["config/codex/config.tpl.toml"]=config/codex/config.toml
   ["config/cliproxyapi/config.tpl.yaml"]=config/cliproxyapi/config.template.yaml
+  ["config/omp/config.tpl.yml"]=config/omp/config.yml
   ["config/pi/models.tpl.json"]=config/pi/models.json
   ["config/pi/settings.tpl.json"]=config/pi/settings.json
   ["home-manager/programs/fish/functions/_coxe_function.tpl.fish"]=home-manager/programs/fish/functions/_coxe_function.fish


### PR DESCRIPTION
Add dotfiles-managed OMP config under config/omp and wire it into the existing Nix config module list.

This keeps only ~/.omp/agent/config.yml under dotfiles control while leaving OMP runtime state such as databases and session files untouched. The Home Manager module uses copy semantics instead of symlinks so the tracked config behaves like other mutable CLI configs in this repo.

The OMP config also follows the existing models.json template convention by introducing config/omp/config.tpl.yml and adding it to scripts/llm-update.sh. The generated config keeps the default role on codex/__GPT__.

Additional context:
- only the tracked config file is managed
- runtime files under ~/.omp/agent remain unmanaged
- config/default.nix now imports ./omp

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Manage `omp` config via dotfiles using a Home Manager activation step that copies the tracked config to `~/.omp/agent/config.yml` without touching runtime state. Adds a template wired to `scripts/llm-update.sh` for automatic regeneration.

- **New Features**
  - Import `./omp` in `config/default.nix`.
  - Copy `config/omp/config.yml` to `~/.omp/agent/config.yml` on activation (no symlink); leave runtime files unmanaged; chmod 644.
  - Add `config/omp/config.tpl.yml` and map it in `scripts/llm-update.sh`; template keeps default role on `codex/__GPT__`.
  - Set `doubleEscapeAction: none`.

<sup>Written for commit 96842af7a2726d95217eb4cfadfd7dc5aa788750. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

