### PR TITLE
feat(nix): add statix linting and fix all lint errors

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -100,6 +100,18 @@ jobs:
           NIX_CONFIG_TARGET: nixos
           HOST: matic
         run: make build
+  nix-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Lint Nix Files
+        run: make nix-lint
   nix-test:
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -118,6 +130,7 @@ jobs:
       - nix-darwin
       - nix-flake
       - nix-format
+      - nix-lint
       - nix-linux
       - nix-nixos
       - nix-test

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,7 @@ check: ## Run all validation checks (nix, format, lua).
 	@echo "🔍 Running all validation checks..."
 	@$(MAKE) nix-flake-check
 	@$(MAKE) nix-format-check
+	@$(MAKE) nix-lint
 	@$(MAKE) lua-check
 	@echo "✅ All checks passed"
 
@@ -396,6 +397,12 @@ nix-format-check: nix-format-clear-cache ## Check Nix file formatting.
 	@echo "🔍 Checking Nix file formatting..."
 	@$(NIX_EXEC) fmt -- --fail-on-change
 	@echo "✅ All Nix files are properly formatted"
+
+.PHONY: nix-lint
+nix-lint: ## Lint Nix files with statix.
+	@echo "🔍 Linting Nix files with statix..."
+	@$(NIX_EXEC) run nixpkgs#statix -- check .
+	@echo "✅ All Nix files pass lint checks"
 
 .PHONY: nix-switch
 nix-switch: ## Activate Nix configuration.

--- a/config/keyd/default.nix
+++ b/config/keyd/default.nix
@@ -1,4 +1,4 @@
-{ ... }:
+_:
 {
   services.keyd.enable = true;
 

--- a/config/keyd/default.nix
+++ b/config/keyd/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   services.keyd.enable = true;
 
   # Optional: silence the setgid warning (nice to have, not required for functionality)

--- a/config/rofi/default.nix
+++ b/config/rofi/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   xdg.configFile."rofi/config.rasi" = {
     source = ./config.rasi;
     force = true;

--- a/config/rofi/default.nix
+++ b/config/rofi/default.nix
@@ -1,4 +1,4 @@
-{ ... }:
+_:
 {
   xdg.configFile."rofi/config.rasi" = {
     source = ./config.rasi;

--- a/config/tmuxinator/default.nix
+++ b/config/tmuxinator/default.nix
@@ -1,4 +1,4 @@
-{ ... }:
+_:
 {
   xdg.configFile."tmuxinator/primary.yml".source = ./primary.yml;
   xdg.configFile."tmuxinator/mobile.yml".source = ./mobile.yml;

--- a/config/tmuxinator/default.nix
+++ b/config/tmuxinator/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   xdg.configFile."tmuxinator/primary.yml".source = ./primary.yml;
   xdg.configFile."tmuxinator/mobile.yml".source = ./mobile.yml;
   xdg.configFile."tmuxinator/work.yml".source = ./work.yml;

--- a/devenv.nix
+++ b/devenv.nix
@@ -14,7 +14,7 @@
     (pkgs.writeShellScriptBin "fishtape" (
       builtins.readFile (
         pkgs.replaceVars ./scripts/fishtape-wrapper.sh {
-          fish = pkgs.fish;
+          inherit (pkgs) fish;
           fishtape_3_src = pkgs.fishPlugins.fishtape_3.src;
         }
       )

--- a/home-manager/modules/cargo-globals/default.nix
+++ b/home-manager/modules/cargo-globals/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  isDarwin = pkgs.stdenv.isDarwin;
+  inherit (pkgs.stdenv) isDarwin;
   libiconvPkgConfigPath = lib.optionalString isDarwin ":${pkgs.libiconv.dev}/lib/pkgconfig";
   libiconvLibraryPath = lib.optionalString isDarwin "${pkgs.libiconv.out}/lib";
   libiconvCPath = lib.optionalString isDarwin "${pkgs.libiconv.dev}/include";

--- a/home-manager/modules/openclaw/default.nix
+++ b/home-manager/modules/openclaw/default.nix
@@ -9,7 +9,7 @@ let
   homeDir = config.home.homeDirectory;
 in
 # Only enable on kyber (gateway host)
-lib.mkIf (host.isKyber) {
+lib.mkIf host.isKyber {
   # Ensure OpenClaw directories exist with correct permissions
   home.activation.openclawSetup = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     mkdir -p /tmp/openclaw

--- a/home-manager/modules/yek/default.nix
+++ b/home-manager/modules/yek/default.nix
@@ -14,7 +14,7 @@ let
 
   # Install script with tool paths substituted
   installYekScript = pkgs.replaceVars ./install-yek.sh {
-    target = target;
+    inherit target;
     curl = "${pkgs.curl}/bin/curl";
     grep = "${pkgs.gnugrep}/bin/grep";
     cut = "${pkgs.coreutils}/bin/cut";
@@ -27,7 +27,7 @@ let
   installScript = pkgs.writeScriptBin "install-yek" (
     builtins.readFile (
       pkgs.replaceVars ./install-yek-shim.sh {
-        bash = pkgs.bash;
+        inherit (pkgs) bash;
         install_yek_script = installYekScript;
       }
     )
@@ -42,7 +42,7 @@ let
   yekWrapper = pkgs.writeScriptBin "yek" (
     builtins.readFile (
       pkgs.replaceVars ./yek-shim.sh {
-        bash = pkgs.bash;
+        inherit (pkgs) bash;
         yek_wrapper_script = yekWrapperScript;
       }
     )

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -141,35 +141,35 @@
     plugins = [
       {
         name = "autopair";
-        src = pkgs.fishPlugins.autopair-fish.src;
+        inherit (pkgs.fishPlugins.autopair-fish) src;
       }
       {
         name = "colored-man-pages";
-        src = pkgs.fishPlugins.colored-man-pages.src;
+        inherit (pkgs.fishPlugins.colored-man-pages) src;
       }
       {
         name = "done";
-        src = pkgs.fishPlugins.done.src;
+        inherit (pkgs.fishPlugins.done) src;
       }
       {
         name = "fzf";
-        src = pkgs.fishPlugins.fzf.src;
+        inherit (pkgs.fishPlugins.fzf) src;
       }
       {
         name = "fzf-fish";
-        src = pkgs.fishPlugins.fzf-fish.src;
+        inherit (pkgs.fishPlugins.fzf-fish) src;
       }
       {
         name = "grc";
-        src = pkgs.fishPlugins.grc.src;
+        inherit (pkgs.fishPlugins.grc) src;
       }
       {
         name = "puffer";
-        src = pkgs.fishPlugins.puffer.src;
+        inherit (pkgs.fishPlugins.puffer) src;
       }
       {
         name = "sponge";
-        src = pkgs.fishPlugins.sponge.src;
+        inherit (pkgs.fishPlugins.sponge) src;
       }
     ];
   };

--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -33,9 +33,9 @@ let
   dockerStartScript = pkgs.writeShellScript "cliproxyapi-docker-start" (
     builtins.readFile (
       pkgs.replaceVars ./scripts/docker-start.sh {
-        bash = pkgs.bash;
+        inherit (pkgs) bash;
         start_script = startScript;
-        docker = pkgs.docker;
+        inherit (pkgs) docker;
       }
     )
   );

--- a/home-manager/services/docker-postgres/default.nix
+++ b/home-manager/services/docker-postgres/default.nix
@@ -9,9 +9,9 @@ let
   startPostgresWrapper = pkgs.writeShellScript "start-postgres-wrapper" (
     builtins.readFile (
       pkgs.replaceVars ./start-postgres-wrapper.sh {
-        bash = pkgs.bash;
+        inherit (pkgs) bash;
         start_script = startScript;
-        docker = pkgs.docker;
+        inherit (pkgs) docker;
       }
     )
   );

--- a/home-manager/services/docker/default.nix
+++ b/home-manager/services/docker/default.nix
@@ -4,8 +4,7 @@ let
   dockerServiceFile = pkgs.writeText "docker.service" (
     builtins.readFile (
       pkgs.replaceVars ./docker.service {
-        docker = pkgs.docker;
-        coreutils = pkgs.coreutils;
+        inherit (pkgs) docker coreutils;
       }
     )
   );
@@ -14,10 +13,7 @@ let
   setupDockerScript = pkgs.writeShellScript "setup-docker" (
     builtins.readFile (
       pkgs.replaceVars ./setup-docker.sh {
-        shadow = pkgs.shadow;
-        gnugrep = pkgs.gnugrep;
-        systemd = pkgs.systemd;
-        coreutils = pkgs.coreutils;
+        inherit (pkgs) shadow gnugrep systemd coreutils;
         docker_service_file = dockerServiceFile;
       }
     )

--- a/home-manager/services/docker/default.nix
+++ b/home-manager/services/docker/default.nix
@@ -13,7 +13,12 @@ let
   setupDockerScript = pkgs.writeShellScript "setup-docker" (
     builtins.readFile (
       pkgs.replaceVars ./setup-docker.sh {
-        inherit (pkgs) shadow gnugrep systemd coreutils;
+        inherit (pkgs)
+          shadow
+          gnugrep
+          systemd
+          coreutils
+          ;
         docker_service_file = dockerServiceFile;
       }
     )

--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -19,13 +19,11 @@ let
     inherit system overlays;
     config = nixpkgsConfig;
   };
-  configuration =
-    _:
-    {
-      networking.hostName = hostname;
-      users.users.${username}.home = "/Users/${username}";
-      system.stateVersion = 4;
-    };
+  configuration = _: {
+    networking.hostName = hostname;
+    users.users.${username}.home = "/Users/${username}";
+    system.stateVersion = 4;
+  };
 in
 {
   specialArgs = {

--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -20,7 +20,7 @@ let
     config = nixpkgsConfig;
   };
   configuration =
-    { ... }:
+    _:
     {
       networking.hostName = hostname;
       users.users.${username}.home = "/Users/${username}";
@@ -55,7 +55,7 @@ in
       home-manager.useUserPackages = true;
       home-manager.users."${username}" = import ../../home-manager {
         inherit inputs username pkgs;
-        lib = pkgs.lib;
+        inherit (pkgs) lib;
         config = { };
       };
     }

--- a/hosts/linux/default.nix
+++ b/hosts/linux/default.nix
@@ -14,7 +14,7 @@ let
     inherit system overlays;
     config = nixpkgsConfig;
   };
-  lib = pkgs.lib;
+  inherit (pkgs) lib;
 in
 home-manager.lib.homeManagerConfiguration {
   inherit pkgs;
@@ -30,7 +30,7 @@ home-manager.lib.homeManagerConfiguration {
     ../../home-manager/default.nix
     {
       home = {
-        username = username;
+        inherit username;
         homeDirectory = lib.mkForce (if username == "root" then "/root" else "/home/${username}");
         activation.backupExistingFiles = lib.mkForce {
           before = [ "checkLinkTargets" ];

--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -99,7 +99,7 @@ let
 in
 nixpkgs.lib.nixosSystem {
   inherit system;
-  lib = nixpkgs.lib;
+  inherit (nixpkgs) lib;
   specialArgs = {
     inherit username isRunner;
   };
@@ -125,8 +125,8 @@ nixpkgs.lib.nixosSystem {
       home-manager.useUserPackages = true;
       home-manager.users."${username}" = import ../../home-manager {
         inherit inputs username;
-        lib = nixpkgs.lib;
-        pkgs = pkgs;
+        inherit (nixpkgs) lib;
+        inherit pkgs;
         config = { };
       };
     }

--- a/named-hosts/galactica/default.nix
+++ b/named-hosts/galactica/default.nix
@@ -8,11 +8,11 @@ let
 in
 inputs.nix-darwin.lib.darwinSystem {
   system = "aarch64-darwin";
-  specialArgs = darwin-modules.specialArgs;
+  inherit (darwin-modules) specialArgs;
   modules = darwin-modules.modules ++ [
     {
       age.identityPaths = [ "/Users/${username}/.ssh/id_ed25519" ];
-      age.secrets = builtins.mapAttrs (name: value: { file = value.file; }) (import ./secrets.nix);
+      age.secrets = builtins.mapAttrs (name: value: { inherit (value) file; }) (import ./secrets.nix);
       home-manager.users.${username} =
         { pkgs, config, ... }:
         {

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -14,7 +14,7 @@ let
     inherit system overlays;
     config = nixpkgsConfig;
   };
-  lib = pkgs.lib;
+  inherit (pkgs) lib;
 in
 home-manager.lib.homeManagerConfiguration {
   inherit pkgs;
@@ -28,7 +28,7 @@ home-manager.lib.homeManagerConfiguration {
       { config, lib, ... }:
       {
         home = {
-          username = username;
+          inherit username;
           homeDirectory = lib.mkForce "/home/${username}";
           activation.backupExistingFiles = lib.mkForce {
             before = [ "checkLinkTargets" ];
@@ -50,7 +50,7 @@ home-manager.lib.homeManagerConfiguration {
         age.secrets = builtins.mapAttrs (
           name: value:
           {
-            file = value.file;
+            inherit (value) file;
           }
           // (
             if name == "keys/id_github.age" then

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -156,7 +156,7 @@ inputs.nixpkgs.lib.nixosSystem {
                 unlockPy = pkgs.writeScript "unlock-gnome-keyring.py" (
                   builtins.readFile (
                     pkgs.replaceVars ./unlock-gnome-keyring.py {
-                      python3 = pkgs.python3;
+                      inherit (pkgs) python3;
                     }
                   )
                 );
@@ -393,8 +393,8 @@ inputs.nixpkgs.lib.nixosSystem {
                   isDesktop = true;
                 };
               };
-              lib = inputs.nixpkgs.lib;
-              pkgs = pkgs;
+              inherit (inputs.nixpkgs) lib;
+              inherit pkgs;
               config = { };
             })
           ];
@@ -419,7 +419,7 @@ inputs.nixpkgs.lib.nixosSystem {
           age.secrets = builtins.mapAttrs (
             name: value:
             {
-              file = value.file;
+              inherit (value) file;
             }
             // (
               if name == "keys/id_github.age" then

--- a/named-hosts/matic/falcon.nix
+++ b/named-hosts/matic/falcon.nix
@@ -16,9 +16,8 @@ let
   initScript = pkgs.writeScript "init-falcon" (
     builtins.readFile (
       pkgs.replaceVars ./falcon-init.sh {
-        e2fsprogs = pkgs.e2fsprogs;
-        rsync = pkgs.rsync;
-        falcon = falcon;
+        inherit (pkgs) e2fsprogs rsync;
+        inherit falcon;
       }
     )
   );

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -17,7 +17,7 @@
   })
   (final: prev: {
     # Provide non-deprecated alias so upstream modules using pkgs.system don't emit warnings.
-    system = prev.stdenv.hostPlatform.system;
+    inherit (prev.stdenv.hostPlatform) system;
   })
   (final: prev: {
     # Fix shellspec wrapper script that breaks when called via symlinks
@@ -51,15 +51,11 @@
   })
   (final: prev: {
     nightlyPkgs = import inputs.nixpkgs-nightly {
-      system = prev.system;
-      config = prev.config;
+      inherit (prev) system config;
       overlays = [ ];
     };
     # deno 2.6.10 on nixpkgs-unstable has broken check phase (integration_tests vs integration_test)
     # Use nightly (master) which has the fix and is in the binary cache
-    deno = final.nightlyPkgs.deno;
-    codex = final.nightlyPkgs.codex;
-    claude-code = final.nightlyPkgs.claude-code;
-    opencode = final.nightlyPkgs.opencode;
+    inherit (final.nightlyPkgs) deno codex claude-code opencode;
   })
 ]

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -56,6 +56,11 @@
     };
     # deno 2.6.10 on nixpkgs-unstable has broken check phase (integration_tests vs integration_test)
     # Use nightly (master) which has the fix and is in the binary cache
-    inherit (final.nightlyPkgs) deno codex claude-code opencode;
+    inherit (final.nightlyPkgs)
+      deno
+      codex
+      claude-code
+      opencode
+      ;
   })
 ]

--- a/statix.toml
+++ b/statix.toml
@@ -1,0 +1,3 @@
+disabled = ["repeated_keys"]
+nix_version = "2.4"
+ignore = [".direnv"]

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -61,7 +61,7 @@ in
 
   lib-nixpkgs-config = pkgs.runCommand "lib-nixpkgs-config" { } ''
     ${
-      if nixpkgsConfig ? allowUnfree && nixpkgsConfig.allowUnfree == true then
+      if nixpkgsConfig ? allowUnfree && nixpkgsConfig.allowUnfree then
         ''echo "lib/nixpkgs-config.nix: allowUnfree is true"''
       else
         ''echo "FAIL: allowUnfree must be true" && exit 1''


### PR DESCRIPTION
## Summary
- Add `statix` nix linter integration with `make nix-lint` target and `statix.toml` config (W20 `repeated_keys` disabled as it's idiomatic in NixOS/home-manager)
- Fix all statix lint errors across 20 nix files: use `inherit` instead of manual assignment (W03/W04), remove unnecessary boolean comparisons (W01), remove useless parentheses (W08), replace empty patterns with `_` (W10)
- Add `nix-lint` GitHub Actions job to the Nix workflow with gate check

## Test plan
- [x] `nix run nixpkgs#statix -- check .` passes clean (exit 0)
- [ ] `nix-lint` CI job passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `statix` linting with a `make nix-lint` target and a CI job, fixes all Nix lint issues, and applies the project formatter. This enforces consistent Nix style and adds a gate to prevent regressions.

- **New Features**
  - Added `make nix-lint` (runs `nixpkgs#statix`) and included it in `make check`.
  - Added `nix-lint` job to `.github/workflows/nix.yml` and included it in the workflow gate.
  - Introduced `statix.toml` (disables `repeated_keys`, sets `nix_version`, ignores `.direnv`).

- **Refactors**
  - Applied repository-wide Nix formatting.
  - Resolved all `statix` findings: use `inherit`/`inherit (scope)`, simplify booleans, remove extra parens, use `_:` for unused args, and replace empty patterns with `_`.
  - No functional changes intended.

<sup>Written for commit ddd8af5438c202b0cc6f10b74939bac28d999ae6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

