### PR TITLE
fix(xremap): prevent modifier leak to Slack with virtual_modifiers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -399,9 +399,9 @@ nix-format-check: nix-format-clear-cache ## Check Nix file formatting.
 	@echo "✅ All Nix files are properly formatted"
 
 .PHONY: nix-lint
-nix-lint: ## Lint Nix files with statix.
+nix-lint: ## Lint Nix files with statix from the flake/dev shell.
 	@echo "🔍 Linting Nix files with statix..."
-	@$(NIX_EXEC) run nixpkgs#statix -- check .
+	@DEVENV_ROOT=$(CURDIR) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) develop $(NIX_FLAGS) .# --command statix check .
 	@echo "✅ All Nix files pass lint checks"
 
 .PHONY: nix-switch

--- a/docs/HYPRLAND.md
+++ b/docs/HYPRLAND.md
@@ -1,0 +1,119 @@
+# Hyprland Keybindings
+
+`$mod` = Super (Win key)
+
+## App Launch
+
+| Shortcut | Action |
+|---|---|
+| `Super + T` | Terminal (ghostty) |
+| `Super + G` | Chrome (focus or launch) |
+| `Super + S` | Slack (focus or launch) |
+| `Super + C` | Cursor |
+| `Super + V` | VS Code |
+| `Super + P` | 1Password |
+| `Super + M` | Signal |
+| `Super + D` | Discord (focus or launch) |
+| `Super + F` | File manager (yazi) |
+| `Hyper + Space` | App launcher (rofi) |
+
+## Window Focus
+
+| Shortcut | Action |
+|---|---|
+| `Super + H/J/K/L` | Focus left/down/up/right |
+| `Super + ←/↓/↑/→` | Focus left/down/up/right |
+| `Super + Tab` | Switch window (hyprshell) |
+| `Super + \`` | Toggle previous window |
+
+## Window Management
+
+| Shortcut | Action |
+|---|---|
+| `Super + Q` | Close window |
+| `Super + Shift + F` | Toggle floating |
+| `Super Ctrl + F` | Fullscreen (maximize) |
+| `Hyper + F` | Move to empty workspace + fullscreen |
+| `Super + W` | Minimize (send to special:minimized) |
+| `Super + Shift + W` | Restore all minimized windows |
+
+## Move Window (within workspace)
+
+| Shortcut | Action |
+|---|---|
+| `Super + Shift + K/J` | Move window up/down |
+| `Super + Shift + ↑/↓` | Move window up/down |
+| `Super + Alt + H/J/K/L` | Swap window left/down/up/right |
+| `Super + Alt + Shift + ←/↓/↑/→` | Swap window left/down/up/right |
+| `Super + left click drag` | Freely drag window |
+
+## Resize Window
+
+| Shortcut | Action |
+|---|---|
+| `Super + Ctrl + ←/↓/↑/→` | Resize window |
+| `Super + ;` / `Super + '` | Resize narrower/wider |
+| `Super + Ctrl + ;` / `Super + Ctrl + '` | Resize shorter/taller |
+| `Super + right click drag` | Freely resize window |
+
+## Workspaces
+
+| Shortcut | Action |
+|---|---|
+| `Super + 1-9` | Go to workspace 1-9 |
+| `Ctrl + ←/→` | Previous/next workspace |
+| `Super + scroll` | Scroll through workspaces |
+| `Super + N` | Go to empty workspace |
+| `Super + Shift + 1-9` | Move window to workspace 1-9 |
+| `Super + Shift + H/L` | Move window to prev/next workspace |
+| `Super + Shift + ←/→` | Move window to empty workspace |
+
+## Scratchpad
+
+| Shortcut | Action |
+|---|---|
+| `Super + Ctrl + T` | Toggle scratchpad terminal |
+
+## Screenshot
+
+| Shortcut | Action |
+|---|---|
+| `Super + Shift + S` | Region screenshot (annotate) |
+| `Print` | Region screenshot (quick) |
+| `Shift + Print` | Window screenshot |
+| `Ctrl + Print` | Full screen screenshot |
+| `Hyper + 3` | Full screen screenshot |
+| `Hyper + 4` | Region screenshot |
+| `Hyper + 5` | Record screen |
+| `Super + Print` | Color picker |
+
+## Clipboard
+
+| Shortcut | Action |
+|---|---|
+| `Super + Shift + V` | Clipboard history (rofi, auto-paste) |
+| `Super + E` | Emoji picker (auto-paste) |
+
+## System
+
+| Shortcut | Action |
+|---|---|
+| `Super + I` | Network menu |
+| `Super + B` | Bluetooth manager |
+| `Super + A` | Audio (pavucontrol) |
+| `Super + Shift + Q` | Power menu |
+| `Hyper + L` | Lock screen |
+
+## Media Keys (Framework 13)
+
+| Key | Action |
+|---|---|
+| `F1` | Mute |
+| `F2 / F3` | Volume down/up |
+| `F4 / F5` | Previous/next track |
+| `F6` | Play/pause |
+| `F7 / F8` | Brightness down/up |
+| `F9` | Toggle display scale (1.0x ↔ 1.567x) |
+| `F10` | Airplane mode |
+| `F11` | Full screen screenshot |
+| `Hyper + -` / `Hyper + =` | Zoom display out/in |

--- a/home-manager/modules/xremap/default.nix
+++ b/home-manager/modules/xremap/default.nix
@@ -100,6 +100,7 @@ in
         # Only intercept keyd output — SUPER (CapsLock/RightAlt) goes straight to Hyprland
         deviceNames = [ "keyd virtual keyboard" ];
         config = {
+          virtual_modifiers = [ "Alt-Shift-Super" ];
           keymap = [
             {
               name = "Framework Command (Ghostty)";

--- a/home-manager/programs/git/.gitignore.global
+++ b/home-manager/programs/git/.gitignore.global
@@ -35,6 +35,11 @@ Temporary Items
 tmp
 .tmp*
 tmp*
+
+# AI
+.cursor/
+.entire/
+.serena/
  
 # Ignore deprecated files
 *.deprecated

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -58,6 +58,7 @@ inputs.nixpkgs.lib.nixosSystem {
           "amdgpu.abmlevel=3" # auto backlight management
           "amdgpu.runpm=1" # runtime power management for GPU
           "amd_pstate=active" # AMD P-state driver (better than acpi-cpufreq)
+          "amdgpu.dcdebugmask=0x410" # disable PSR and REPLAY to fix screen flickering
         ];
 
         # Networking


### PR DESCRIPTION
## Summary
- Add `virtual_modifiers` to xremap config to treat `Alt+Shift+Super` as an atomic virtual modifier
- Prevents intermediate modifier events from leaking to Electron apps (Slack), which caused Framework+C to trigger "mark as unread" alongside copy
- Also includes: hyprland keybindings docs, amdgpu PSR fix, gitignore AI dirs, statix lint fix

## Test plan
- [ ] Rebuild NixOS config and restart xremap
- [ ] Verify Framework+C in Slack copies without triggering mark-as-unread
- [ ] Verify Framework+C/V still works in browser, Ghostty, and other apps

Generated with Claude Code by claude-opus-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat Alt+Shift+Super as a virtual modifier in `xremap` to stop modifier events leaking into Electron apps (Slack), so Framework+C copies without toggling mark‑as‑unread. Also fixes Framework 13 screen flicker by disabling AMDGPU PSR/REPLAY.

- **Bug Fixes**
  - `xremap`: Add virtual_modifiers Alt‑Shift‑Super to suppress intermediate events in Electron apps; Framework+C now sends only Ctrl+C in Slack.
  - `matic`: Set amdgpu.dcdebugmask=0x410 to disable PSR/REPLAY and eliminate flicker.

- **Refactors**
  - Run `statix` from the flake dev shell in the Makefile.
  - Add Hyprland keybindings docs.
  - Ignore local AI tool directories in global gitignore.

<sup>Written for commit 8d42b0813c34d25a303b1e7556be12dbcd4108aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

