### PR TITLE
fix(xremap): use unconditional global remap to prevent Hyper event leaks

### DIFF
--- a/home-manager/modules/xremap/default.nix
+++ b/home-manager/modules/xremap/default.nix
@@ -100,16 +100,17 @@ in
         # Only intercept keyd output — SUPER (CapsLock/RightAlt) goes straight to Hyprland
         deviceNames = [ "keyd virtual keyboard" ];
         config = {
-          virtual_modifiers = [ "Alt-Shift-Super" ];
           keymap = [
             {
+              # Ghostty: Framework+C/V → Ctrl+Shift+C/V (terminal convention: Ctrl+C = SIGINT)
               name = "Framework Command (Ghostty)";
               application.only = [ "com.mitchellh.ghostty" ];
               remap = ghosttyRemap;
             }
             {
+              # Global: no application filter — applies unconditionally so window detection
+              # failures don't cause raw Hyper events to leak through to apps (e.g. Slack).
               name = "Framework Command (Global)";
-              application.not = [ "com.mitchellh.ghostty" ];
               remap = globalRemap;
             }
           ];


### PR DESCRIPTION
## Summary
- Remove `application.not` filter from the global xremap keymap rule, making it unconditional
- Remove incorrect `virtual_modifiers` usage (wrong tool for the job — it makes non-modifier keys act as modifiers, not suppresses modifier leaks)
- Ghostty rule remains filtered and evaluated first, so it still wins for terminal copy/paste

## Why
When xremap can't detect the focused window (timing race, Electron quirks), filtered rules are skipped and the raw `Ctrl+Alt+Shift+Super+C` chord leaks through to apps like Slack — triggering unintended shortcuts (e.g. "mark as unread"). An unconditional global rule always fires, preventing any leak.

## Test plan
- [ ] Rebuild and restart xremap: `make build && systemctl --user restart xremap`
- [ ] Framework+C/V copies/pastes correctly in browser, VS Code, Slack
- [ ] Framework+C/V in Ghostty uses Ctrl+Shift+C/V (terminal convention)
- [ ] No "mark as unread" side effect in Slack when copying

Generated with Claude Code by claude-opus-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the global `xremap` remap unconditional to stop Hyper chord leaks when window detection fails, preventing unintended shortcuts (e.g., in Slack). Keep the `Ghostty`-only mapping first so terminal copy/paste still uses Ctrl+Shift+C/V, and remove the incorrect `virtual_modifiers` setting.

<sup>Written for commit 9ff72faee8d9def56eae12af5da6f0f10f2c0a63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

