### PR TITLE
config: change preset to full and separator to pipe

### DIFF
--- a/config/omp/config.tpl.yml
+++ b/config/omp/config.tpl.yml
@@ -156,12 +156,12 @@ statusLine:
   #   Type: string
   #   Options: default | minimal | compact | full | nerd | ascii | custom
   #   Use "custom" when defining leftSegments/rightSegments below.
-  preset: "custom"
+  preset: "full"
   # separator
   #   Visual separator between status line segments.
   #   Type: string
   #   Options: powerline | powerline-thin | slash | pipe | block | none | ascii
-  separator: "powerline-thin"
+  separator: "pipe"
   # showHookStatus
   #   Display hook status messages below the status line.
   #   Type: boolean

--- a/config/omp/config.yml
+++ b/config/omp/config.yml
@@ -156,12 +156,12 @@ statusLine:
   #   Type: string
   #   Options: default | minimal | compact | full | nerd | ascii | custom
   #   Use "custom" when defining leftSegments/rightSegments below.
-  preset: "custom"
+  preset: "full"
   # separator
   #   Visual separator between status line segments.
   #   Type: string
   #   Options: powerline | powerline-thin | slash | pipe | block | none | ascii
-  separator: "powerline-thin"
+  separator: "pipe"
   # showHookStatus
   #   Display hook status messages below the status line.
   #   Type: boolean


### PR DESCRIPTION
Changes OMP config preset to "full" and separator to "pipe".

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the OMP status line to the built-in full preset and change the segment separator to pipe for a more informative, cleaner prompt. Updates both `config/omp/config.yml` and `config/omp/config.tpl.yml`.

<sup>Written for commit ea5795b5d9a731e8e8172c8d926d89d3ca276659. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

