### PR TITLE
feat(home-manager): added telegram-desktop to desktop package list

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -165,6 +165,7 @@ with pkgs;
   slack
   slurp
   swappy
+  telegram-desktop
   totem
   vlc
   pkgs-nightly.vscode


### PR DESCRIPTION
- Included Telegram in the desktop package set for Home Manager profiles.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `telegram-desktop` to the default desktop package set in Home Manager so Telegram is installed by default on all profiles.

<sup>Written for commit b8b36f59422478eef936ebd5857501fe60b7df18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

