### PR TITLE
feat(hyprland): add Telegram shortcut

### DIFF
--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -226,6 +226,7 @@ layerrule = ignore_alpha 0.3, match:namespace ^(rofi)$
 # App Launch Hotkeys (Super + letter)
 # =============================================================================
 bind = $mod, T, exec, ghostty
+bind = $mod SHIFT, T, exec, telegram-desktop
 bind = $mod, G, exec, hyprctl clients -j | grep -q '"class": "google-chrome"' && hyprctl dispatch focuswindow class:google-chrome || google-chrome-stable
 bind = $mod, S, exec, hyprctl clients -j | grep -q '"class": "Slack"' && hyprctl dispatch focuswindow class:Slack || slack
 bind = $mod, C, exec, cursor


### PR DESCRIPTION
Add a Super+Shift+T Hyprland binding to launch Telegram.

This keeps the existing Super+T Ghostty launcher intact while giving Telegram a dedicated shortcut in the same app-launch section of the config.

Validated locally with `make flake-check`.

Generated with Oh My Pi by Claude.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Hyprland binding to launch `telegram-desktop` with Super+Shift+T, keeping Super+T for `ghostty`. Provides a dedicated, fast shortcut for Telegram in the app-launch section.

<sup>Written for commit 066328614fec3cd30b4b6aa3fbe936d1e9021eb6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

