### PR TITLE
feat(ghostty): add ctrl+enter keybind via kitty keyboard protocol

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -23,6 +23,7 @@ keybind = ctrl+shift+c=copy_to_clipboard
 keybind = ctrl+shift+v=paste_from_clipboard
 keybind = alt+backspace=text:\x1b\x7f
 keybind = shift+enter=text:\n
+keybind = ctrl+enter=text:\x1b[13;5u
 keybind = super+alt+left=previous_tab
 keybind = super+alt+right=next_tab
 keybind = super+shift+left=move_tab:-1


### PR DESCRIPTION
## Summary
- Add `ctrl+enter` keybind to Ghostty config that sends `\x1b[13;5u` (kitty keyboard protocol)
- Allows applications like Neovim, Zellij, etc. to distinguish `ctrl+enter` from plain Enter

## Test plan
- [ ] Reload Ghostty config and verify `ctrl+enter` is detected in target applications

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `ctrl+enter` keybind to the Ghostty config that emits the kitty keyboard protocol sequence `\x1b[13;5u`. This lets apps like `Neovim` and `Zellij` distinguish Ctrl+Enter from Enter.

<sup>Written for commit acad301b29c286b34ea96be9eb89b45ea49187b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

