### PR TITLE
fix(cliproxyapi): restart service on make switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -811,10 +811,11 @@ launchctl-tmux-session-logger: ## Restart tmux-session-logger launchd agent.
 systemctl: systemctl-cliproxyapi systemctl-cliproxyapi-backup systemctl-code-syncer systemctl-docker-postgres systemctl-dotfiles-updater systemctl-make-updater systemctl-neverssl-keepalive systemctl-ollama systemctl-openclaw systemctl-tmux-session-logger ## Restart all systemd user services.
 
 .PHONY: systemctl-cliproxyapi
-systemctl-cliproxyapi: ## Reload systemd units for cliproxyapi (home-manager handles restart).
-	@echo "🔄 Reloading cliproxyapi..."
+systemctl-cliproxyapi: ## Restart cliproxyapi systemd user service.
+	@echo "🔄 Restarting cliproxyapi..."
 	@systemctl --user daemon-reload
-	@echo "✅ cliproxyapi reloaded"
+	@systemctl --user restart cliproxyapi.service || true
+	@echo "✅ cliproxyapi restarted"
 
 .PHONY: systemctl-cliproxyapi-backup
 systemctl-cliproxyapi-backup: ## Restart cliproxyapi-backup systemd user service.


### PR DESCRIPTION
## Summary
- The `systemctl-cliproxyapi` Makefile target only ran `daemon-reload` without actually restarting the service
- Config/script changes were not picked up until a manual `systemctl --user restart cliproxyapi`
- Add explicit `restart` to match the pattern used by all other systemd service targets (e.g. `cliproxyapi-backup`)

## Test plan
- [ ] Run `make switch` and verify cliproxyapi restarts (check `systemctl --user status cliproxyapi` shows recent start time)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `make switch` restarts the `cliproxyapi` systemd user service so config and script changes take effect immediately. The `systemctl-cliproxyapi` Makefile target now runs `systemctl --user restart cliproxyapi.service` after `daemon-reload`, matching other service targets.

<sup>Written for commit 43c03dd6a0daa5b380e9774c61b352d5b4bb3e2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

