### PR TITLE
fix(cliproxyapi): update opencode base URL and remove redundant open-inference configs

### DIFF
--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -98,7 +98,7 @@ openai-compatibility:
       - name: "glm-4.7"
         alias: "glm-4.7"
   - name: "opencode"
-    base-url: "https://opencode.ai/go/v1"
+    base-url: "https://opencode.ai/zen/go/v1"
     api-key-entries:
       - api-key: "__OPENCODE_API_KEY__"
     models:

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -98,7 +98,7 @@ openai-compatibility:
       - name: "glm-4.7"
         alias: "glm-4.7"
   - name: "opencode"
-    base-url: "https://opencode.ai/go/v1"
+    base-url: "https://opencode.ai/zen/go/v1"
     api-key-entries:
       - api-key: "__OPENCODE_API_KEY__"
     models:

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -187,58 +187,6 @@
         }
       }
     },
-    "openrouter": {
-      "models": {
-        "deepseek/deepseek-chat-v3.1:free": {
-          "name": "DeepSeek Chat V3.1 (via OpenRouter)",
-          "options": {
-            "provider": {
-              "order": ["open-inference"],
-              "allow_fallbacks": false
-            }
-          }
-        },
-        "moonshotai/kimi-k2": {
-          "name": "Kimi K2 (via OpenRouter)",
-          "options": {
-            "provider": {
-              "order": ["open-inference"],
-              "allow_fallbacks": false
-            }
-          }
-        },
-        "moonshotai/kimi-k2:free": {
-          "name": "Kimi K2 Free (via OpenRouter)",
-          "options": {
-            "provider": {
-              "order": ["open-inference"],
-              "allow_fallbacks": false
-            }
-          }
-        },
-        "openai/gpt-oss-120b:free": {
-          "name": "GPT-OSS 120B Free (via OpenRouter)",
-          "options": {
-            "provider": {
-              "order": ["open-inference"],
-              "allow_fallbacks": false
-            }
-          }
-        },
-        "qwen/qwen3-coder:free": {
-          "name": "Qwen3 Coder Free (via OpenRouter)",
-          "options": {
-            "provider": {
-              "order": ["open-inference"],
-              "allow_fallbacks": false
-            }
-          }
-        }
-      },
-      "options": {
-        "apiKey": "{env:OPENROUTER_API_KEY}"
-      }
-    },
     "zai-coding-plan": {
       "models": {
         "glm-4.7": {

--- a/config/opencode/opencode.tpl.jsonc
+++ b/config/opencode/opencode.tpl.jsonc
@@ -187,58 +187,6 @@
         }
       }
     },
-    "openrouter": {
-      "models": {
-        "deepseek/deepseek-chat-v3.1:free": {
-          "name": "DeepSeek Chat V3.1 (via OpenRouter)",
-          "options": {
-            "provider": {
-              "order": ["open-inference"],
-              "allow_fallbacks": false
-            }
-          }
-        },
-        "moonshotai/kimi-k2": {
-          "name": "Kimi K2 (via OpenRouter)",
-          "options": {
-            "provider": {
-              "order": ["open-inference"],
-              "allow_fallbacks": false
-            }
-          }
-        },
-        "moonshotai/kimi-k2:free": {
-          "name": "Kimi K2 Free (via OpenRouter)",
-          "options": {
-            "provider": {
-              "order": ["open-inference"],
-              "allow_fallbacks": false
-            }
-          }
-        },
-        "openai/gpt-oss-120b:free": {
-          "name": "GPT-OSS 120B Free (via OpenRouter)",
-          "options": {
-            "provider": {
-              "order": ["open-inference"],
-              "allow_fallbacks": false
-            }
-          }
-        },
-        "qwen/qwen3-coder:free": {
-          "name": "Qwen3 Coder Free (via OpenRouter)",
-          "options": {
-            "provider": {
-              "order": ["open-inference"],
-              "allow_fallbacks": false
-            }
-          }
-        }
-      },
-      "options": {
-        "apiKey": "{env:OPENROUTER_API_KEY}"
-      }
-    },
     "zai-coding-plan": {
       "models": {
         "glm-4.7": {


### PR DESCRIPTION
## Summary
- Update cliproxyapi opencode base URL from `https://opencode.ai/go/v1` to `https://opencode.ai/zen/go/v1`
- Remove redundant `openrouter` open-inference provider configs from opencode since these models are now served through cliproxyapi's opencode endpoint

## Test plan
- [ ] Verify cliproxyapi connects to the new `zen/go/v1` endpoint
- [ ] Verify opencode still works without the removed openrouter open-inference models

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `cliproxyapi` to use the new OpenCode base URL `https://opencode.ai/zen/go/v1`. Removed redundant `openrouter` open-inference model configs from `opencode` since those models are now served through the `cliproxyapi` OpenCode endpoint.

<sup>Written for commit 6a0ebe6959c0fd93acb262eff8f51c11d3c5254b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

