### PR TITLE
chore: upgrade

### DIFF
--- a/config/omp/config.yml
+++ b/config/omp/config.yml
@@ -34,8 +34,7 @@ shellPath: null
 # extensions / enabledModels / disabledProviders / disabledExtensions
 #   Low-level capability and provider filters from the unified settings schema.
 #   Empty arrays keep upstream discovery behavior unchanged.
-extensions:
-  - "~/.omp/agent/extensions/swarm-extension"
+extensions: []
 enabledModels: []
 disabledProviders: []
 disabledExtensions: []


### PR DESCRIPTION
Automated upgrade

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable local extensions by default in `config/omp/config.yml` by setting `extensions: []`. This removes the hardcoded `~/.omp/agent/extensions/swarm-extension` to avoid environment-specific behavior.

- **Migration**
  - If you use the swarm extension, add its path back to `extensions` in your local or project config.

<sup>Written for commit b2f4fd415f381c207ef78cf2068f94a53763d879. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

