### PR TITLE
change

### DIFF
--- a/config/omp/config.tpl.yml
+++ b/config/omp/config.tpl.yml
@@ -34,7 +34,8 @@ shellPath: null
 # extensions / enabledModels / disabledProviders / disabledExtensions
 #   Low-level capability and provider filters from the unified settings schema.
 #   Empty arrays keep upstream discovery behavior unchanged.
-extensions: []
+extensions:
+  - "~/.omp/agent/extensions/swarm-extension"
 enabledModels: []
 disabledProviders: []
 disabledExtensions: []


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable the swarm extension by default in the OMP config template so swarm capabilities work out of the box. Adds `~/.omp/agent/extensions/swarm-extension` to the `extensions` list.

<sup>Written for commit 1b409740a1e42142bb68e82e0858c6bb7d55defb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

