### PR TITLE
chore: upgrade

### DIFF
--- a/config/omp/config.yml
+++ b/config/omp/config.yml
@@ -34,8 +34,7 @@ shellPath: null
 # extensions / enabledModels / disabledProviders / disabledExtensions
 #   Low-level capability and provider filters from the unified settings schema.
 #   Empty arrays keep upstream discovery behavior unchanged.
-extensions:
-  - "~/.omp/agent/extensions/swarm-extension"
+extensions: []
 enabledModels: []
 disabledProviders: []
 disabledExtensions: []


### PR DESCRIPTION
Automated upgrade

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `extensions: []` in `config/omp/config.yml` to remove the hardcoded `~/.omp/agent/extensions/swarm-extension`. This restores default extension discovery and avoids environment-specific path issues.

<sup>Written for commit ef05498d98fdad6ee455289926c3e3ed4c837c7c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

