### PR TITLE
chore: upgrade

### DIFF
--- a/config/omp/config.yml
+++ b/config/omp/config.yml
@@ -34,8 +34,7 @@ shellPath: null
 # extensions / enabledModels / disabledProviders / disabledExtensions
 #   Low-level capability and provider filters from the unified settings schema.
 #   Empty arrays keep upstream discovery behavior unchanged.
-extensions:
-  - "~/.omp/agent/extensions/swarm-extension"
+extensions: []
 enabledModels: []
 disabledProviders: []
 disabledExtensions: []


### PR DESCRIPTION
Automated upgrade

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `extensions: []` in `config/omp/config.yml` to remove the local `~/.omp/agent/extensions/swarm-extension` and use default extension discovery. This prevents loading a deprecated path during upgrades.

<sup>Written for commit c04755dd938757284f89ae1c918a98d27ccf66a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

