### PR TITLE
fix(docker): update service file when Nix store paths change

### DIFF
--- a/home-manager/services/docker/default.nix
+++ b/home-manager/services/docker/default.nix
@@ -18,6 +18,7 @@ let
           gnugrep
           systemd
           coreutils
+          diffutils
           ;
         docker_service_file = dockerServiceFile;
       }

--- a/home-manager/services/docker/setup-docker.sh
+++ b/home-manager/services/docker/setup-docker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Ensures the user is in the docker group and the system Docker daemon is running.
-# @shadow@, @gnugrep@, @systemd@, @coreutils@, @docker_service_file@
+# @shadow@, @gnugrep@, @systemd@, @coreutils@, @docker_service_file@, @diffutils@
 # are substituted by pkgs.replaceVars.
 set -euo pipefail
 
@@ -10,7 +10,9 @@ GREP=@gnugrep@/bin/grep
 USERMOD=@shadow@/bin/usermod
 SYSTEMCTL=@systemd@/bin/systemctl
 TEE=@coreutils@/bin/tee
+DIFF=@diffutils@/bin/diff
 DOCKER_SERVICE_FILE=@docker_service_file@
+SYSTEM_SERVICE=/etc/systemd/system/docker.service
 
 # Check if docker group exists and user is in it
 if ! "$GROUPS_CMD" | "$GREP" -q docker; then
@@ -19,18 +21,34 @@ if ! "$GROUPS_CMD" | "$GREP" -q docker; then
   echo "Added to docker group. Please log out and back in, or run: newgrp docker"
 fi
 
-# Check if system docker service exists and is running
+# Always ensure the service file is up to date (Nix GC can invalidate store paths)
+NEEDS_RELOAD=false
+if [ ! -f "$SYSTEM_SERVICE" ]; then
+  echo "Installing Docker systemd service..."
+  # shellcheck disable=SC2024
+  sudo "$TEE" "$SYSTEM_SERVICE" >/dev/null <"$DOCKER_SERVICE_FILE"
+  sudo "$SYSTEMCTL" enable docker
+  NEEDS_RELOAD=true
+elif ! "$DIFF" -q "$DOCKER_SERVICE_FILE" "$SYSTEM_SERVICE" >/dev/null 2>&1; then
+  echo "Updating Docker systemd service (Nix store paths changed)..."
+  # shellcheck disable=SC2024
+  sudo "$TEE" "$SYSTEM_SERVICE" >/dev/null <"$DOCKER_SERVICE_FILE"
+  NEEDS_RELOAD=true
+fi
+
+if [ "$NEEDS_RELOAD" = true ]; then
+  sudo "$SYSTEMCTL" daemon-reload
+fi
+
+# Start or restart Docker as needed
 if ! "$SYSTEMCTL" is-active --quiet docker 2>/dev/null; then
   echo "Starting Docker daemon..."
-  if [ ! -f /etc/systemd/system/docker.service ]; then
-    echo "Installing Docker systemd service..."
-    # shellcheck disable=SC2024
-    sudo "$TEE" /etc/systemd/system/docker.service >/dev/null <"$DOCKER_SERVICE_FILE"
-    sudo "$SYSTEMCTL" daemon-reload
-    sudo "$SYSTEMCTL" enable docker
-  fi
   sudo "$SYSTEMCTL" start docker
   echo "Docker daemon started"
+elif [ "$NEEDS_RELOAD" = true ]; then
+  echo "Restarting Docker daemon (service file updated)..."
+  sudo "$SYSTEMCTL" restart docker
+  echo "Docker daemon restarted"
 else
   echo "Docker daemon is already running"
 fi


### PR DESCRIPTION
## Summary
- `docker-setup` now always compares the installed service file against the desired one
- If Nix store paths have changed (e.g. after `nix-collect-garbage`), the service file is updated and Docker is restarted
- Previously, the service file was only installed when missing — a stale file with GC'd paths would persist and prevent Docker from starting

## Test plan
- [ ] Run `make build && make switch` to get new `docker-setup` script
- [ ] Run `docker-setup` — should say "Docker daemon is already running" if paths match
- [ ] Run `nix-collect-garbage -d`, then `docker-setup` — should detect stale paths and update the service file

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the Docker systemd service in sync with current Nix store paths to prevent daemon startup failures after `nix-collect-garbage`. The setup script now updates the service file when paths change, reloads systemd, and restarts Docker if needed.

- **Bug Fixes**
  - Compare desired service file with `/etc/systemd/system/docker.service`; install or update when different.
  - Reload systemd when the service file changes; start or restart Docker accordingly.
  - Add `diffutils` for reliable file comparison.

<sup>Written for commit a8ac711fd53e6f04101cc318f817d7e7565fba46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

