### PR TITLE
feat(openclaw): enable gateway allowRealIpFallback and allowTailscale identity

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -800,13 +800,15 @@
     },
     "auth": {
       "mode": "token",
-      "token": "__GATEWAY_TOKEN__"
+      "token": "__GATEWAY_TOKEN__",
+      "allowTailscale": true
     },
     "trustedProxies": [
       "10.0.0.0/8",
       "172.16.0.0/12",
       "192.168.0.0/16"
-    ]
+    ],
+    "allowRealIpFallback": true
   },
   "plugins": {
     "load": {

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -800,13 +800,15 @@
     },
     "auth": {
       "mode": "token",
-      "token": "__GATEWAY_TOKEN__"
+      "token": "__GATEWAY_TOKEN__",
+      "allowTailscale": true
     },
     "trustedProxies": [
       "10.0.0.0/8",
       "172.16.0.0/12",
       "192.168.0.0/16"
-    ]
+    ],
+    "allowRealIpFallback": true
   },
   "plugins": {
     "load": {


### PR DESCRIPTION
## Changes

Enables two gateway configuration options in both `openclaw.tpl.json` and `openclaw.template.json`:

### `gateway.allowRealIpFallback: true`
Enables `X-Real-IP` fallback when `X-Forwarded-For` is missing in proxy scenarios. Needed for ingress stacks that send `X-Real-IP` instead of `X-Forwarded-For`.

### `gateway.auth.allowTailscale: true`
Allows Tailscale Serve identity headers to satisfy Control UI/WebSocket auth checks (verified via `tailscale whois`). HTTP API endpoints still require token/password auth. Safe to enable given the tailnet identity posture here (Tailscale Serve mode is already configured).

## Notes
- `allowRealIpFallback` defaults to `false` (fail-closed) — explicitly enabling it here for proxy compatibility
- `allowTailscale` defaults to `true` when `tailscale.mode = "serve"` — making it explicit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable real IP fallback and Tailscale identity for the gateway to improve proxy compatibility and simplify Control UI/WebSocket auth. Applies to `config/openclaw/openclaw.template.json` and `config/openclaw/openclaw.tpl.json`.

- **New Features**
  - `gateway.allowRealIpFallback: true` — use `X-Real-IP` when `X-Forwarded-For` is missing (ingress that sends only `X-Real-IP`).
  - `gateway.auth.allowTailscale: true` — accept Tailscale Serve identity headers for Control UI/WebSocket; HTTP API remains token/password-only.

<sup>Written for commit 9673482aeed5e4e7ea643fbcd6492feb04facf8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

