### PR TITLE
feat(nvtop): add GPU monitoring with Linux and macOS support

### DIFF
--- a/home-manager/programs/default.nix
+++ b/home-manager/programs/default.nix
@@ -30,6 +30,7 @@ let
   lsd = import ./lsd;
   lua = import ./lua;
   neovim = import ./neovim;
+  nvtop = import ./nvtop;
   nix = import ./nix;
   node = import ./node;
   ocaml = import ./ocaml;
@@ -75,6 +76,7 @@ in
   lsd
   lua
   neovim
+  nvtop
   nix
   node
   ocaml

--- a/home-manager/programs/nvtop/default.nix
+++ b/home-manager/programs/nvtop/default.nix
@@ -1,0 +1,6 @@
+{ pkgs, ... }:
+{
+  home.packages = [
+    (if pkgs.stdenv.isDarwin then pkgs.nvtopPackages.apple else pkgs.nvtopPackages.full)
+  ];
+}


### PR DESCRIPTION
## Summary
- Adds `nvtop` GPU process monitor as a home-manager program
- Uses `nvtopPackages.full` on Linux (covers NVIDIA, AMD, Intel GPUs)
- Uses `nvtopPackages.apple` on macOS (Apple GPU support)

## Test plan
- [ ] Verify `nvtop` is available after `home-manager switch` on Linux
- [ ] Verify `nvtop` is available after `home-manager switch` on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GPU monitoring via `nvtop` to Home Manager. Installs `nvtopPackages.full` on Linux (NVIDIA, AMD, Intel) and `nvtopPackages.apple` on macOS.

<sup>Written for commit 14faaa213a2a34d5a12943077c29cf3df506faa5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

