### PR TITLE
fix: openclaw gateway stability and security hardening

### DIFF
--- a/config/openclaw/hydrate.sh
+++ b/config/openclaw/hydrate.sh
@@ -76,15 +76,12 @@ if [ "$MODE" = "gateway" ]; then
   ANTHROPIC_API_KEY="${OPENCLAW_ANTHROPIC_API_KEY:-${ANTHROPIC_API_KEY:-$(read_secret "${SECRETS_DIR}/anthropic-key")}}"
   CHROMIUM_PATH="@chromium@/bin/chromium"
 
-  WORKSPACE="${HOME}/ghq/github.com/shunkakinoki/openclaw"
-
   @sed@ \
     -e "s|__CLIPROXY_API_KEY__|${CLIPROXY_API_KEY}|g" \
     -e "s|__TELEGRAM_TOKEN__|${TELEGRAM_TOKEN}|g" \
     -e "s|__WHATSAPP_ALLOW_FROM__|${WHATSAPP_ALLOW_FROM}|g" \
     -e "s|__GATEWAY_TOKEN__|${GATEWAY_TOKEN}|g" \
     -e "s|__CHROMIUM_PATH__|${CHROMIUM_PATH}|g" \
-    -e "s|__WORKSPACE__|${WORKSPACE}|g" \
     -e "s|__HOME__|${HOME}|g" \
     "$TEMPLATE" >"$CONFIG"
   chmod 600 "$CONFIG"

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -212,7 +212,7 @@
       {
         "id": "code-reviewer-opus",
         "name": "Code Reviewer (Opus)",
-        "workspace": "__WORKSPACE__/agents/code-review",
+        "workspace": "__HOME__/.openclaw/workspace/agents/code-review",
         "model": {
           "primary": "cliproxy/claude-opus-4-6",
           "fallbacks": [
@@ -230,7 +230,7 @@
       {
         "id": "code-reviewer-sonnet",
         "name": "Code Reviewer (Sonnet)",
-        "workspace": "__WORKSPACE__/agents/code-review",
+        "workspace": "__HOME__/.openclaw/workspace/agents/code-review",
         "model": {
           "primary": "cliproxy/claude-sonnet-4-6",
           "fallbacks": [
@@ -248,7 +248,7 @@
       {
         "id": "code-reviewer-glm",
         "name": "Code Reviewer (GLM)",
-        "workspace": "__WORKSPACE__/agents/code-review",
+        "workspace": "__HOME__/.openclaw/workspace/agents/code-review",
         "model": {
           "primary": "cliproxy/glm-4.7",
           "fallbacks": [
@@ -265,7 +265,7 @@
       {
         "id": "code-reviewer-gpt-codex",
         "name": "Code Reviewer (GPT Codex)",
-        "workspace": "__WORKSPACE__/agents/code-review",
+        "workspace": "__HOME__/.openclaw/workspace/agents/code-review",
         "model": {
           "primary": "cliproxy/gpt-5.3-codex",
           "fallbacks": [
@@ -283,7 +283,7 @@
       {
         "id": "code-reviewer-gemini",
         "name": "Code Reviewer (Gemini Pro)",
-        "workspace": "__WORKSPACE__/agents/code-review",
+        "workspace": "__HOME__/.openclaw/workspace/agents/code-review",
         "model": {
           "primary": "cliproxy/gemini-3.1-pro-preview",
           "fallbacks": [
@@ -301,7 +301,7 @@
       {
         "id": "code-formatter",
         "name": "Code Formatter",
-        "workspace": "__WORKSPACE__/agents/formatter",
+        "workspace": "__HOME__/.openclaw/workspace/agents/formatter",
         "model": {
           "primary": "cliproxy/glm-4.7",
           "fallbacks": [
@@ -318,7 +318,7 @@
       {
         "id": "security-scanner",
         "name": "Security Scanner",
-        "workspace": "__WORKSPACE__/agents/security",
+        "workspace": "__HOME__/.openclaw/workspace/agents/security",
         "model": {
           "primary": "cliproxy/claude-opus-4-6",
           "fallbacks": [
@@ -336,7 +336,7 @@
       {
         "id": "test-coverage",
         "name": "Test Coverage",
-        "workspace": "__WORKSPACE__/agents/testing",
+        "workspace": "__HOME__/.openclaw/workspace/agents/testing",
         "model": {
           "primary": "cliproxy/glm-4.7",
           "fallbacks": [
@@ -353,7 +353,7 @@
       {
         "id": "docs-checker",
         "name": "Docs Checker",
-        "workspace": "__WORKSPACE__/agents/docs",
+        "workspace": "__HOME__/.openclaw/workspace/agents/docs",
         "model": {
           "primary": "cliproxy/claude-sonnet-4-6",
           "fallbacks": [
@@ -370,7 +370,7 @@
       {
         "id": "cicd-fixer",
         "name": "CI/CD Fixer",
-        "workspace": "__WORKSPACE__/agents/cicd",
+        "workspace": "__HOME__/.openclaw/workspace/agents/cicd",
         "model": {
           "primary": "cliproxy/glm-4.7",
           "fallbacks": [
@@ -389,7 +389,7 @@
       {
         "id": "sales",
         "name": "Sales Agent",
-        "workspace": "__WORKSPACE__/agents/sales",
+        "workspace": "__HOME__/.openclaw/workspace/agents/sales",
         "model": {
           "primary": "cliproxy/gpt-5.4",
           "fallbacks": [
@@ -407,7 +407,7 @@
       {
         "id": "twitter-gemini",
         "name": "Twitter (Gemini)",
-        "workspace": "__WORKSPACE__/agents/twitter",
+        "workspace": "__HOME__/.openclaw/workspace/agents/twitter",
         "model": {
           "primary": "cliproxy/gemini-3.1-pro-preview",
           "fallbacks": [
@@ -425,7 +425,7 @@
       {
         "id": "twitter-opus",
         "name": "Twitter (Opus)",
-        "workspace": "__WORKSPACE__/agents/twitter",
+        "workspace": "__HOME__/.openclaw/workspace/agents/twitter",
         "model": {
           "primary": "cliproxy/claude-opus-4-6",
           "fallbacks": [
@@ -443,7 +443,7 @@
       {
         "id": "mindset",
         "name": "Mindset Coach",
-        "workspace": "__WORKSPACE__/agents/mindset",
+        "workspace": "__HOME__/.openclaw/workspace/agents/mindset",
         "model": {
           "primary": "cliproxy/claude-opus-4-6",
           "fallbacks": [
@@ -461,7 +461,7 @@
       {
         "id": "routine",
         "name": "Routine Manager",
-        "workspace": "__WORKSPACE__/agents/routine",
+        "workspace": "__HOME__/.openclaw/workspace/agents/routine",
         "model": {
           "primary": "cliproxy/claude-sonnet-4-6",
           "fallbacks": [
@@ -479,7 +479,7 @@
       {
         "id": "dev-opus",
         "name": "Dev (Opus)",
-        "workspace": "__WORKSPACE__/agents/dev",
+        "workspace": "__HOME__/.openclaw/workspace/agents/dev",
         "model": {
           "primary": "cliproxy/claude-opus-4-6",
           "fallbacks": [
@@ -499,7 +499,7 @@
       {
         "id": "dev-gpt-codex",
         "name": "Dev (GPT Codex)",
-        "workspace": "__WORKSPACE__/agents/dev",
+        "workspace": "__HOME__/.openclaw/workspace/agents/dev",
         "model": {
           "primary": "cliproxy/gpt-5.3-codex",
           "fallbacks": [
@@ -519,7 +519,7 @@
       {
         "id": "product",
         "name": "Product Manager",
-        "workspace": "__WORKSPACE__/agents/product",
+        "workspace": "__HOME__/.openclaw/workspace/agents/product",
         "model": {
           "primary": "cliproxy/gemini-3.1-pro-preview",
           "fallbacks": [
@@ -537,7 +537,7 @@
       {
         "id": "strategy-opus",
         "name": "Strategy (Opus)",
-        "workspace": "__WORKSPACE__/agents/strategy",
+        "workspace": "__HOME__/.openclaw/workspace/agents/strategy",
         "model": {
           "primary": "cliproxy/claude-opus-4-6",
           "fallbacks": [
@@ -555,7 +555,7 @@
       {
         "id": "strategy-gpt",
         "name": "Strategy (GPT)",
-        "workspace": "__WORKSPACE__/agents/strategy",
+        "workspace": "__HOME__/.openclaw/workspace/agents/strategy",
         "model": {
           "primary": "cliproxy/gpt-5.4",
           "fallbacks": [
@@ -573,7 +573,7 @@
       {
         "id": "strategy-gemini",
         "name": "Strategy (Gemini)",
-        "workspace": "__WORKSPACE__/agents/strategy",
+        "workspace": "__HOME__/.openclaw/workspace/agents/strategy",
         "model": {
           "primary": "cliproxy/gemini-3.1-pro-preview",
           "fallbacks": [
@@ -591,7 +591,7 @@
       {
         "id": "communication",
         "name": "Communication Specialist",
-        "workspace": "__WORKSPACE__/agents/communication",
+        "workspace": "__HOME__/.openclaw/workspace/agents/communication",
         "model": {
           "primary": "cliproxy/claude-sonnet-4-6",
           "fallbacks": [
@@ -609,7 +609,7 @@
       {
         "id": "devops",
         "name": "DevOps Engineer",
-        "workspace": "__WORKSPACE__/agents/devops",
+        "workspace": "__HOME__/.openclaw/workspace/agents/devops",
         "model": {
           "primary": "cliproxy/glm-4.7",
           "fallbacks": [
@@ -726,6 +726,9 @@
       "strategy-gemini"
     ]
   },
+  "session": {
+    "dmScope": "per-channel-peer"
+  },
   "messages": {
     "queue": {
       "mode": "interrupt"
@@ -801,7 +804,12 @@
     "auth": {
       "mode": "token",
       "token": "__GATEWAY_TOKEN__",
-      "allowTailscale": true
+      "allowTailscale": true,
+      "rateLimit": {
+        "maxAttempts": 10,
+        "windowMs": 60000,
+        "lockoutMs": 300000
+      }
     },
     "trustedProxies": [
       "10.0.0.0/8",

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -212,7 +212,7 @@
       {
         "id": "code-reviewer-opus",
         "name": "Code Reviewer (Opus)",
-        "workspace": "__WORKSPACE__/agents/code-review",
+        "workspace": "__HOME__/.openclaw/workspace/agents/code-review",
         "model": {
           "primary": "cliproxy/__CLAUDE_OPUS__",
           "fallbacks": [
@@ -230,7 +230,7 @@
       {
         "id": "code-reviewer-sonnet",
         "name": "Code Reviewer (Sonnet)",
-        "workspace": "__WORKSPACE__/agents/code-review",
+        "workspace": "__HOME__/.openclaw/workspace/agents/code-review",
         "model": {
           "primary": "cliproxy/__CLAUDE_SONNET__",
           "fallbacks": [
@@ -248,7 +248,7 @@
       {
         "id": "code-reviewer-glm",
         "name": "Code Reviewer (GLM)",
-        "workspace": "__WORKSPACE__/agents/code-review",
+        "workspace": "__HOME__/.openclaw/workspace/agents/code-review",
         "model": {
           "primary": "cliproxy/__GLM__",
           "fallbacks": [
@@ -265,7 +265,7 @@
       {
         "id": "code-reviewer-gpt-codex",
         "name": "Code Reviewer (GPT Codex)",
-        "workspace": "__WORKSPACE__/agents/code-review",
+        "workspace": "__HOME__/.openclaw/workspace/agents/code-review",
         "model": {
           "primary": "cliproxy/__GPT_CODEX__",
           "fallbacks": [
@@ -283,7 +283,7 @@
       {
         "id": "code-reviewer-gemini",
         "name": "Code Reviewer (Gemini Pro)",
-        "workspace": "__WORKSPACE__/agents/code-review",
+        "workspace": "__HOME__/.openclaw/workspace/agents/code-review",
         "model": {
           "primary": "cliproxy/__GEMINI_PRO__",
           "fallbacks": [
@@ -301,7 +301,7 @@
       {
         "id": "code-formatter",
         "name": "Code Formatter",
-        "workspace": "__WORKSPACE__/agents/formatter",
+        "workspace": "__HOME__/.openclaw/workspace/agents/formatter",
         "model": {
           "primary": "cliproxy/__GLM__",
           "fallbacks": [
@@ -318,7 +318,7 @@
       {
         "id": "security-scanner",
         "name": "Security Scanner",
-        "workspace": "__WORKSPACE__/agents/security",
+        "workspace": "__HOME__/.openclaw/workspace/agents/security",
         "model": {
           "primary": "cliproxy/__CLAUDE_OPUS__",
           "fallbacks": [
@@ -336,7 +336,7 @@
       {
         "id": "test-coverage",
         "name": "Test Coverage",
-        "workspace": "__WORKSPACE__/agents/testing",
+        "workspace": "__HOME__/.openclaw/workspace/agents/testing",
         "model": {
           "primary": "cliproxy/__GLM__",
           "fallbacks": [
@@ -353,7 +353,7 @@
       {
         "id": "docs-checker",
         "name": "Docs Checker",
-        "workspace": "__WORKSPACE__/agents/docs",
+        "workspace": "__HOME__/.openclaw/workspace/agents/docs",
         "model": {
           "primary": "cliproxy/__CLAUDE_SONNET__",
           "fallbacks": [
@@ -370,7 +370,7 @@
       {
         "id": "cicd-fixer",
         "name": "CI/CD Fixer",
-        "workspace": "__WORKSPACE__/agents/cicd",
+        "workspace": "__HOME__/.openclaw/workspace/agents/cicd",
         "model": {
           "primary": "cliproxy/__GLM__",
           "fallbacks": [
@@ -389,7 +389,7 @@
       {
         "id": "sales",
         "name": "Sales Agent",
-        "workspace": "__WORKSPACE__/agents/sales",
+        "workspace": "__HOME__/.openclaw/workspace/agents/sales",
         "model": {
           "primary": "cliproxy/__GPT__",
           "fallbacks": [
@@ -407,7 +407,7 @@
       {
         "id": "twitter-gemini",
         "name": "Twitter (Gemini)",
-        "workspace": "__WORKSPACE__/agents/twitter",
+        "workspace": "__HOME__/.openclaw/workspace/agents/twitter",
         "model": {
           "primary": "cliproxy/__GEMINI_PRO__",
           "fallbacks": [
@@ -425,7 +425,7 @@
       {
         "id": "twitter-opus",
         "name": "Twitter (Opus)",
-        "workspace": "__WORKSPACE__/agents/twitter",
+        "workspace": "__HOME__/.openclaw/workspace/agents/twitter",
         "model": {
           "primary": "cliproxy/__CLAUDE_OPUS__",
           "fallbacks": [
@@ -443,7 +443,7 @@
       {
         "id": "mindset",
         "name": "Mindset Coach",
-        "workspace": "__WORKSPACE__/agents/mindset",
+        "workspace": "__HOME__/.openclaw/workspace/agents/mindset",
         "model": {
           "primary": "cliproxy/__CLAUDE_OPUS__",
           "fallbacks": [
@@ -461,7 +461,7 @@
       {
         "id": "routine",
         "name": "Routine Manager",
-        "workspace": "__WORKSPACE__/agents/routine",
+        "workspace": "__HOME__/.openclaw/workspace/agents/routine",
         "model": {
           "primary": "cliproxy/__CLAUDE_SONNET__",
           "fallbacks": [
@@ -479,7 +479,7 @@
       {
         "id": "dev-opus",
         "name": "Dev (Opus)",
-        "workspace": "__WORKSPACE__/agents/dev",
+        "workspace": "__HOME__/.openclaw/workspace/agents/dev",
         "model": {
           "primary": "cliproxy/__CLAUDE_OPUS__",
           "fallbacks": [
@@ -499,7 +499,7 @@
       {
         "id": "dev-gpt-codex",
         "name": "Dev (GPT Codex)",
-        "workspace": "__WORKSPACE__/agents/dev",
+        "workspace": "__HOME__/.openclaw/workspace/agents/dev",
         "model": {
           "primary": "cliproxy/__GPT_CODEX__",
           "fallbacks": [
@@ -519,7 +519,7 @@
       {
         "id": "product",
         "name": "Product Manager",
-        "workspace": "__WORKSPACE__/agents/product",
+        "workspace": "__HOME__/.openclaw/workspace/agents/product",
         "model": {
           "primary": "cliproxy/__GEMINI_PRO__",
           "fallbacks": [
@@ -537,7 +537,7 @@
       {
         "id": "strategy-opus",
         "name": "Strategy (Opus)",
-        "workspace": "__WORKSPACE__/agents/strategy",
+        "workspace": "__HOME__/.openclaw/workspace/agents/strategy",
         "model": {
           "primary": "cliproxy/__CLAUDE_OPUS__",
           "fallbacks": [
@@ -555,7 +555,7 @@
       {
         "id": "strategy-gpt",
         "name": "Strategy (GPT)",
-        "workspace": "__WORKSPACE__/agents/strategy",
+        "workspace": "__HOME__/.openclaw/workspace/agents/strategy",
         "model": {
           "primary": "cliproxy/__GPT__",
           "fallbacks": [
@@ -573,7 +573,7 @@
       {
         "id": "strategy-gemini",
         "name": "Strategy (Gemini)",
-        "workspace": "__WORKSPACE__/agents/strategy",
+        "workspace": "__HOME__/.openclaw/workspace/agents/strategy",
         "model": {
           "primary": "cliproxy/__GEMINI_PRO__",
           "fallbacks": [
@@ -591,7 +591,7 @@
       {
         "id": "communication",
         "name": "Communication Specialist",
-        "workspace": "__WORKSPACE__/agents/communication",
+        "workspace": "__HOME__/.openclaw/workspace/agents/communication",
         "model": {
           "primary": "cliproxy/__CLAUDE_SONNET__",
           "fallbacks": [
@@ -609,7 +609,7 @@
       {
         "id": "devops",
         "name": "DevOps Engineer",
-        "workspace": "__WORKSPACE__/agents/devops",
+        "workspace": "__HOME__/.openclaw/workspace/agents/devops",
         "model": {
           "primary": "cliproxy/__GLM__",
           "fallbacks": [
@@ -726,6 +726,9 @@
       "strategy-gemini"
     ]
   },
+  "session": {
+    "dmScope": "per-channel-peer"
+  },
   "messages": {
     "queue": {
       "mode": "interrupt"
@@ -801,7 +804,12 @@
     "auth": {
       "mode": "token",
       "token": "__GATEWAY_TOKEN__",
-      "allowTailscale": true
+      "allowTailscale": true,
+      "rateLimit": {
+        "maxAttempts": 10,
+        "windowMs": 60000,
+        "lockoutMs": 300000
+      }
     },
     "trustedProxies": [
       "10.0.0.0/8",

--- a/home-manager/modules/openclaw/default.nix
+++ b/home-manager/modules/openclaw/default.nix
@@ -31,7 +31,7 @@ lib.mkIf host.isKyber {
       RestartSec = "5s";
       Environment = [
         "HOME=${homeDir}"
-        "PATH=${homeDir}/.local/bin:${homeDir}/.bun/bin:${homeDir}/.nix-profile/bin:/usr/local/bin:/usr/bin:/bin"
+        "PATH=${homeDir}/.local/bin:${homeDir}/.bun/bin:${homeDir}/.nix-profile/bin:${homeDir}/.local/share/pnpm:${homeDir}/.local/share/fnm/current/bin:${homeDir}/.npm-global/bin:/usr/local/bin:/usr/bin:/bin"
       ];
       WorkingDirectory = "${homeDir}/.openclaw";
       StandardOutput = "append:/tmp/openclaw/openclaw-gateway.log";


### PR DESCRIPTION
## Summary

- **Root cause fix**: Agent workspaces pointed to the openclaw source repo (`~/ghq/.../openclaw/agents/`), causing the skill scanner to traverse the entire repo tree on every startup. This saturated disk I/O, put the gateway worker into `D` (uninterruptible disk sleep) state, and triggered the "Gateway is draining for restart" error.
- **Security**: Add auth rate limiting (10 attempts/60s, 5min lockout) to mitigate brute-force on the LAN-bound gateway
- **Privacy**: Isolate DM sessions per sender (`session.dmScope: per-channel-peer`) so Telegram DM users don't leak context to each other
- **Systemd**: Expand service PATH with pnpm, fnm, npm-global dirs (fixes `doctor` warnings about missing PATH entries)

## What changed

| File | Change |
|------|--------|
| `openclaw.template.json` / `openclaw.tpl.json` | Agent workspaces → `~/.openclaw/workspace/agents/...`, add `rateLimit`, add `session.dmScope` |
| `hydrate.sh` | Remove unused `WORKSPACE` var and `__WORKSPACE__` sed substitution |
| `home-manager/modules/openclaw/default.nix` | Expand systemd service PATH |

## Test plan

- [x] Killed stuck gateway processes, systemd auto-restarted
- [x] Applied fixes to runtime config, restarted gateway
- [x] Gateway responding on `http://127.0.0.1:18789` (HTTP 200)
- [ ] Run `home-manager switch` to apply nix changes persistently
- [ ] Verify `openclaw doctor` no longer shows PATH or workspace warnings
- [ ] Verify skill scanner no longer spams "Skipping skill path" on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the Openclaw gateway by moving agent workspaces out of the source repo to stop disk I/O stalls. Adds auth rate limiting, per-DM isolation, and fixes the systemd PATH.

- **Bug Fixes**
  - Point all agent `workspace` paths to `~/.openclaw/workspace/agents/...` to prevent repo-wide scans and the drain/restart loop.
  - Remove unused `__WORKSPACE__` template var and related `hydrate.sh` substitution.
  - Expand systemd service `PATH` to include pnpm, fnm, and npm-global bins to resolve PATH warnings.

- **New Features**
  - Add `auth.rateLimit` (10 attempts/60s; 5 min lockout).
  - Isolate DMs with `session.dmScope: per-channel-peer`.

<sup>Written for commit d432481295ce147ee26b6f4c43067b82e4507bdc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

