### PR TITLE
chore: add handy cask

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -102,6 +102,7 @@
       "google-chrome"
       "google-drive"
       "hammerspoon"
+      "handy"
       "iina"
       "iterm2"
       "karabiner-elements"


### PR DESCRIPTION
Add the Handy Homebrew cask to the darwin Homebrew configuration.

This keeps Handy managed alongside the rest of the machine bootstrap applications in `nix-darwin/config/homebrew.nix`, so it is installed through the same declarative setup as the other GUI tools.

Validated with a targeted `nix eval` that confirms `homebrew.casks` contains `"handy"`. I also ran `make check`, but the full flake check fails locally on `aarch64-darwin` because some Linux dev-shell checks require unsupported systems/features in this environment, which appears unrelated to this one-line cask addition.