### PR TITLE
chore: refresh llm configs for minimax m2.7

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,5 +11,5 @@ OPENCLAW_TELEGRAM_TOKEN=123456789:ABCdefGHIjklMNOpqrsTUVwxyz
 OPENCLAW_ANTHROPIC_API_KEY=sk-ant-api03-your-key-here
 # Gateway token for remote mode clients (from kyber: cat ~/.config/openclaw/gateway-token)
 OPENCLAW_GATEWAY_TOKEN=your-gateway-token-here
-# OpenCode API key for minimax-m2.7 access via cliproxyapi
+# OpenCode API key for OpenCode Go access via cliproxyapi
 OPENCODE_API_KEY=your-opencode-api-key-here

--- a/.env.example
+++ b/.env.example
@@ -11,5 +11,5 @@ OPENCLAW_TELEGRAM_TOKEN=123456789:ABCdefGHIjklMNOpqrsTUVwxyz
 OPENCLAW_ANTHROPIC_API_KEY=sk-ant-api03-your-key-here
 # Gateway token for remote mode clients (from kyber: cat ~/.config/openclaw/gateway-token)
 OPENCLAW_GATEWAY_TOKEN=your-gateway-token-here
-# OpenCode API key for minimax-m2.5 access via cliproxyapi
+# OpenCode API key for minimax-m2.7 access via cliproxyapi
 OPENCODE_API_KEY=your-opencode-api-key-here

--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -102,8 +102,8 @@ openai-compatibility:
     api-key-entries:
       - api-key: "__OPENCODE_API_KEY__"
     models:
-      - name: "minimax-m2.5"
-        alias: "minimax-m2.5"
+      - name: "minimax-m2.7"
+        alias: "minimax-m2.7"
 # payload: # Optional payload configuration
 #   default: # Default rules only set parameters when they are missing in the payload.
 #     - models:

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -150,8 +150,8 @@
             "maxTokens": 32000
           },
           {
-            "id": "minimax-m2.5",
-            "name": "Minimax M2.5",
+            "id": "minimax-m2.7",
+            "name": "Minimax M2.7",
             "reasoning": false,
             "input": [
               "text",
@@ -190,7 +190,7 @@
   "agents": {
     "defaults": {
       "model": {
-        "primary": "cliproxy/minimax-m2.5",
+        "primary": "cliproxy/minimax-m2.7",
         "fallbacks": [
           "cliproxy/claude-opus-4-6",
           "cliproxy/glm-4.7",

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -82,8 +82,8 @@
         "glm-4.7": {
           "name": "GLM 4.7 (via local CLIProxyAPI)"
         },
-        "minimax-m2.5": {
-          "name": "Minimax M2.5 (via local CLIProxyAPI)"
+        "minimax-m2.7": {
+          "name": "Minimax M2.7 (via local CLIProxyAPI)"
         }
       }
     },

--- a/config/pi/models.json
+++ b/config/pi/models.json
@@ -125,8 +125,8 @@
           "maxTokens": 8192
         },
         {
-          "id": "minimax-m2.5",
-          "name": "Minimax M2.5",
+          "id": "minimax-m2.7",
+          "name": "Minimax M2.7",
           "reasoning": true,
           "input": [
             "text",

--- a/models.json
+++ b/models.json
@@ -10,6 +10,6 @@
   "gemini-pro": "gemini-3.1-pro-preview",
   "gemini-flash": "gemini-3.1-flash-preview",
   "glm": "glm-4.7",
-  "minimax": "minimax-m2.5",
+  "minimax": "minimax-m2.7",
   "qwen-local": "qwen/qwen3.5-9b"
 }


### PR DESCRIPTION
$(cat <<'EOF'
Refresh the repo's canonical Minimax model entry from  to  and regenerate the configs that are derived from .

This keeps the generated CLIProxyAPI, OpenClaw, OpenCode, and Pi model definitions aligned with the source-of-truth model map instead of leaving those consumers on the previous version.

I also updated  so its OpenCode API key comment matches the configured Minimax model.
'EOF'
)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the canonical Minimax model from `minimax-m2.5` to `minimax-m2.7` and refresh all derived configs. This keeps `CLIProxyAPI`, `OpenClaw`, `OpenCode`, and `Pi` aligned with `models.json`.

- **Refactors**
  - Set `minimax` in `models.json` to `minimax-m2.7`.
  - Updated templates to use `minimax-m2.7` in `config/cliproxyapi`, `config/openclaw` (including default primary), `config/opencode`, and `config/pi`.
  - Clarified `.env.example` `OPENCODE_API_KEY` comment to reference OpenCode Go via `cliproxyapi`.

<sup>Written for commit 245dd91517c71a177bddc3d2f97819510a46f204. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

