### PR TITLE
perf: move copy-ignored to post-start hook

### DIFF
--- a/config/worktrunk/config.toml
+++ b/config/worktrunk/config.toml
@@ -1,6 +1,6 @@
 worktree-path = "{{ repo_path }}/.worktrees/{{ branch | sanitize }}"
 
-[post-create]
+[post-start]
 copy = "wt step copy-ignored"
 
 [commit]

--- a/config/worktrunk/config.toml
+++ b/config/worktrunk/config.toml
@@ -1,7 +1,7 @@
 worktree-path = "{{ repo_path }}/.worktrees/{{ branch | sanitize }}"
 
 [post-start]
-copy = "wt step copy-ignored"
+copy = "bash -c 'created=0; [ ! -f .worktreeinclude ] && printf \".env*\\nnode_modules/\\n\" > .worktreeinclude && created=1; wt step copy-ignored; [ $created -eq 1 ] && rm -f .worktreeinclude; exit 0'"
 
 [commit]
 stage = "all"

--- a/config/worktrunk/config.toml
+++ b/config/worktrunk/config.toml
@@ -1,7 +1,7 @@
 worktree-path = "{{ repo_path }}/.worktrees/{{ branch | sanitize }}"
 
 [post-start]
-copy = "bash -c 'created=0; [ ! -f .worktreeinclude ] && printf \".env*\\nnode_modules/\\n\" > .worktreeinclude && created=1; wt step copy-ignored; [ $created -eq 1 ] && rm -f .worktreeinclude; exit 0'"
+copy = "wt step copy-ignored"
 
 [commit]
 stage = "all"


### PR DESCRIPTION
## Summary
- Move `copy = "wt step copy-ignored"` from `[post-create]` to `[post-start]` in worktrunk config
- `post-create` runs synchronously and blocks worktree creation; `post-start` runs in the background
- Fixes slow `clwxe` startup caused by copying gitignored files (node_modules, .env, etc.) synchronously on every worktree creation

## Test plan
- [ ] Run `clwxe` and verify worktree creation is fast
- [ ] Verify node_modules and .env are still copied (just async)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the worktrunk copy step from `[post-create]` to `[post-start]` so worktree creation isn’t blocked and `clwxe` starts faster. `post-start` now runs `wt step copy-ignored` as-is (no temporary `.worktreeinclude`), performing the copy in the background.

<sup>Written for commit 093e27b3a8b37d20411f04a67f914d0e0657e707. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

