### PR TITLE
feat(atuin): set filter_mode to global for cross-machine history

### DIFF
--- a/home-manager/programs/atuin/default.nix
+++ b/home-manager/programs/atuin/default.nix
@@ -9,6 +9,7 @@
       sync_frequency = "3m";
       sync_address = "https://api.atuin.sh";
       search_mode = "fuzzy";
+      filter_mode = "global";
     };
   };
 }


### PR DESCRIPTION
## Summary
- Add `filter_mode = "global"` to atuin settings so shell history search shows commands from all machines by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `filter_mode = "global"` in `atuin` settings so shell history search includes commands from all machines by default.

<sup>Written for commit af05cc7243b6e54b487137ca232e4ec9603bcb65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

