### PR TITLE
feat(matic): add filesystem hardening and immutable root protection

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -53,6 +53,14 @@ inputs.nixpkgs.lib.nixosSystem {
         # Pin kernel to 6.18 for CrowdStrike Falcon compatibility (RFM on 6.19)
         boot.kernelPackages = pkgs.linuxPackages_6_18;
 
+        # Filesystem hardening
+        boot.kernel.sysctl = {
+          "fs.protected_regular" = 2;
+          "fs.protected_fifos" = 2;
+          "fs.protected_symlinks" = 1;
+          "fs.protected_hardlinks" = 1;
+        };
+
         # AMD power management kernel params
         boot.kernelParams = [
           "amdgpu.abmlevel=3" # auto backlight management
@@ -88,6 +96,18 @@ inputs.nixpkgs.lib.nixosSystem {
         virtualisation.docker.enable = true;
 
         security.sudo.wheelNeedsPassword = false;
+
+        # Immutable root — prevents rm -rf / by blocking top-level entry removal
+        systemd.services.immutable-root = {
+          description = "Set immutable flag on /";
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStart = "${pkgs.e2fsprogs}/bin/chattr +i /";
+            ExecStop = "${pkgs.e2fsprogs}/bin/chattr -i /";
+          };
+        };
         # Keyd configuration (Linux desktop only)
         services.keyd.enable = true;
         users.groups.keyd = { };


### PR DESCRIPTION
## Summary
- Adds kernel sysctl hardening (`fs.protected_regular`, `fs.protected_fifos`, `fs.protected_symlinks`, `fs.protected_hardlinks`) to prevent symlink/hardlink attacks and unsafe file creation in sticky directories
- Adds a systemd oneshot service that sets `chattr +i /` at boot, preventing `rm -rf /` by blocking creation/removal of top-level entries without affecting normal operations within subdirectories

## Test plan
- [ ] `nixos-rebuild switch` completes without errors
- [ ] `lsattr -d /` shows immutable flag (`i`) after boot
- [ ] `rm -rf /` is blocked (Permission denied on top-level entries)
- [ ] Normal file operations within subdirectories work as expected
- [ ] `systemctl stop immutable-root` removes the flag when needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds filesystem hardening and immutable root protection for the matic host. Symlink/hardlink defenses are enabled, and `/` is set immutable at boot to block rm -rf / while normal subdirectory operations continue to work.

- **New Features**
  - Enable kernel sysctls: fs.protected_regular=2, fs.protected_fifos=2, fs.protected_symlinks=1, fs.protected_hardlinks=1.
  - Add `immutable-root` systemd oneshot service that runs `chattr +i /` at boot and supports `ExecStop` with `chattr -i /` (via `e2fsprogs`).

<sup>Written for commit 41230ba9be6075d5c9430c86e7f5c304227e088f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

