### PR TITLE
fix(hyprland): restore Alt+Shift+T Telegram shortcut

### DIFF
--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -223,10 +223,10 @@ layerrule = blur on, match:namespace ^(rofi)$
 layerrule = ignore_alpha 0.3, match:namespace ^(rofi)$
 
 # =============================================================================
-# App Launch Hotkeys (Super + letter)
+# App Launch Hotkeys
 # =============================================================================
 bind = $mod, T, exec, ghostty
-bind = $mod SHIFT, T, exec, telegram-desktop
+bind = ALT SHIFT, T, exec, telegram-desktop
 bind = $mod, G, exec, hyprctl clients -j | grep -q '"class": "google-chrome"' && hyprctl dispatch focuswindow class:google-chrome || google-chrome-stable
 bind = $mod, S, exec, hyprctl clients -j | grep -q '"class": "Slack"' && hyprctl dispatch focuswindow class:Slack || slack
 bind = $mod, C, exec, cursor


### PR DESCRIPTION
Restore the Telegram launcher binding in Hyprland so it matches the expected Alt+Shift+T shortcut.

The config currently bound Telegram to Super+Shift+T because it reused ` SHIFT, T`, but `` is Super in this setup. That made the documented user workflow fail even though Telegram itself was installed correctly.

I considered keeping Telegram on a Super-based launcher and adding a second shortcut, but that would leave two competing representations of the intended hotkey. This change performs the full cutover to Alt+Shift+T and updates the section comment so it no longer implies every launcher in that block uses Super.

Validated with `DEVENV_ROOT="/home/skakinoki/dotfiles" make flake-check`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the Telegram launch hotkey in Hyprland to Alt+Shift+T so it matches the expected shortcut.

- **Bug Fixes**
  - Change `bind = $mod SHIFT, T` to `bind = ALT SHIFT, T` for `telegram-desktop`.
  - Update the app launcher section comment to not imply all bindings use Super.

<sup>Written for commit b506ec18355d415636e8310f49fb5bf0d96921ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

