### PR TITLE
refactor(git): reorganize .gitignore.global entries for clarity

### DIFF
--- a/home-manager/programs/git/.gitignore.global
+++ b/home-manager/programs/git/.gitignore.global
@@ -1,3 +1,29 @@
+# AI
+.conductor/
+.cursor/
+.entire/
+.pi/
+.serena/
+.worktrees/
+
+# Env files
+.env.*
+.env.local
+.envrc
+
+# Other
+.cache/
+.devenv/
+.jj/
+
+# Tmp files
+tmp
+.tmp*
+tmp*
+
+# Ignore deprecated files
+*.deprecated
+
 # General
 .DS_Store
 .AppleDouble
@@ -25,21 +51,3 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
-
-# Env files
-.env.*
-.env.local
-.envrc
-
-# Tmp files
-tmp
-.tmp*
-tmp*
-
-# AI
-.cursor/
-.entire/
-.serena/
- 
-# Ignore deprecated files
-*.deprecated


### PR DESCRIPTION
Entire-Checkpoint: 04088a6adeb6


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorganized `.gitignore.global` to group rules by category and add common cache, env, and tooling directories. Keeps repos clean and consistent across projects.

- **Refactors**
  - Grouped entries: AI tooling, env files, tmp files, deprecated, other, general.
  - Added ignores: `.conductor/`, `.pi/`, `.worktrees/`, `.cache/`, `.devenv/`, `.jj/`.
  - Deduplicated and moved existing env/tmp rules for clarity.

<sup>Written for commit bed02ed2c008ea105e2251fa810fb4e54902b347. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

