### PR TITLE
refactor(git): reorganize global ignore entries

### DIFF
--- a/config/gomi/config.yaml
+++ b/config/gomi/config.yaml
@@ -22,7 +22,6 @@ core:
     verbose: true
   permanent_delete:
     enable: false
-
 ui:
   density: spacious
   preview:
@@ -56,7 +55,6 @@ ui:
     deletion_dialog: "#FF007F"
   exit_message: bye!
   paginator_type: dots
-
 history:
   include:
     within_days: 100
@@ -70,7 +68,6 @@ history:
     size:
       min: ""
       max: 10GB
-
 logging:
   enabled: false
   level: info

--- a/config/gomi/config.yaml
+++ b/config/gomi/config.yaml
@@ -26,33 +26,33 @@ ui:
   density: spacious
   preview:
     syntax_highlight: true
-    colorscheme: nord
+    colorscheme: dracula
     directory_command: ls -F -A --color=always
   style:
     list_view:
-      cursor: "#AD58B4"
-      selected: "#5FB458"
-      filter_match: "#F39C12"
-      filter_prompt: "#7AA2F7"
+      cursor: "#BD93F9"
+      selected: "#50FA7B"
+      filter_match: "#FFB86C"
+      filter_prompt: "#8BE9FD"
       indent_on_select: false
     detail_view:
-      border: "#FFFFFF"
+      border: "#6272A4"
       info_pane:
         deleted_from:
-          fg: "#EEEEEE"
-          bg: "#1C1C1C"
+          fg: "#F8F8F2"
+          bg: "#282A36"
         deleted_at:
-          fg: "#EEEEEE"
-          bg: "#1C1C1C"
+          fg: "#F8F8F2"
+          bg: "#282A36"
       preview_pane:
-        border: "#3C3C3C"
+        border: "#44475A"
         size:
-          fg: "#EEEEDD"
-          bg: "#3C3C3C"
+          fg: "#F8F8F2"
+          bg: "#44475A"
         scroll:
-          fg: "#EEEEDD"
-          bg: "#3C3C3C"
-    deletion_dialog: "#FF007F"
+          fg: "#F8F8F2"
+          bg: "#44475A"
+    deletion_dialog: "#FF79C6"
   exit_message: bye!
   paginator_type: dots
 history:

--- a/home-manager/programs/git/.gitignore.global
+++ b/home-manager/programs/git/.gitignore.global
@@ -1,3 +1,29 @@
+# AI
+.conductor/
+.cursor/
+.entire/
+.pi/
+.serena/
+.worktrees/
+
+# Env files
+.env.*
+.env.local
+.envrc
+
+# Other
+.cache/
+.devenv/
+.jj/
+
+# Tmp files
+tmp
+.tmp*
+tmp*
+
+# Ignore deprecated files
+*.deprecated
+
 # General
 .DS_Store
 .AppleDouble
@@ -25,21 +51,3 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
-
-# Env files
-.env.*
-.env.local
-.envrc
-
-# Tmp files
-tmp
-.tmp*
-tmp*
-
-# AI
-.cursor/
-.entire/
-.serena/
- 
-# Ignore deprecated files
-*.deprecated


### PR DESCRIPTION
Reorganize \.gitignore.global so tool-specific, temporary, and environment-only files are grouped consistently.\n\nThis adds missing ignores for local agent and workspace state such as .conductor/, .pi/, .worktrees/, .cache/, .devenv/, and .jj/, while keeping the existing env, tmp, and deprecated-file patterns in clearer sections. That keeps machine-local artifacts out of commits and makes the global ignore list easier to scan and extend.\n\nI considered appending the new entries in place, but regrouping the existing patterns now avoids duplicate categories and keeps the non-macOS ignores in one predictable block.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorganized `.gitignore.global` into clear sections and added missing local tool and workspace directories. Also updated `gomi` UI to the dracula colorscheme and cleaned up its config.

- **Refactors**
  - Grouped env, tmp, deprecated, and tool-specific patterns.
  - Added `.conductor/`, `.cursor/`, `.entire/`, `.pi/`, `.serena/`, `.worktrees/`, `.cache/`, `.devenv/`, `.jj/`.

<sup>Written for commit 61af881b227cace9bc673be83dd24c36d3fe16e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

