### PR TITLE
fix(home-manager): add bubblewrap for codex sandbox

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -104,6 +104,7 @@ with pkgs;
   below
   binutils
   blueman
+  bubblewrap
   claude-code
   cmake
   codex


### PR DESCRIPTION
Add `bubblewrap` to the Linux Home Manager package set so Codex can use a system-provided `bwrap` instead of falling back to its vendored binary.

Codex currently warns that `/usr/bin/bwrap` is missing on Linux and falls back to the vendored copy. Installing `bubblewrap` through the repo-managed package set makes `bwrap` available on Linux home environments built from this repo, including the `matic` and `kyber` configurations.

I considered adding it to `environment.systemPackages`, but `home-manager/packages/default.nix` is already the shared CLI package surface for these user environments, so this keeps the change scoped to the existing package layer.

Verified by evaluating `nixosConfigurations.matic.config.home-manager.users.skakinoki.home.packages` and `homeConfigurations.kyber.config.home.packages` and confirming that `bubblewrap` is present in both outputs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `bubblewrap` to the shared Home Manager packages so `codex` uses the system `bwrap` instead of its vendored binary. This removes the missing `/usr/bin/bwrap` warning on Linux for the `matic` and `kyber` home configs.

<sup>Written for commit 185fdf87e857a549667a64daf78d9f8c6a34589f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

