### PR TITLE
feat(wallpaper): hardware Vulkan, battery pause, change wallpaper

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -431,7 +431,7 @@ inputs.nixpkgs.lib.nixosSystem {
             wallpapers = [
               {
                 monitor = "eDP-1";
-                wallpaperId = "1845706469";
+                wallpaperId = "2826529529";
                 scaling = "fill";
                 fps = 30;
                 audio.silent = true;

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -126,6 +126,8 @@ inputs.nixpkgs.lib.nixosSystem {
           KERNEL=="uinput", GROUP="input", TAG+="uaccess", MODE:="0660", OPTIONS+="static_node=uinput"
           KERNEL=="event*", ATTRS{name}=="keyd virtual keyboard", GROUP="input", MODE:="0660"
           KERNEL=="event*", ATTRS{name}=="keyd virtual pointer", GROUP="input", MODE:="0660"
+          # Restart wallpaper power monitor on AC state change
+          SUBSYSTEM=="power_supply", ATTR{type}=="Mains", RUN+="${pkgs.systemd}/bin/systemctl --machine=${username}@.host --user restart wallpaper-power-monitor.service"
         '';
 
         # AMD graphics with hardware acceleration
@@ -429,12 +431,40 @@ inputs.nixpkgs.lib.nixosSystem {
             wallpapers = [
               {
                 monitor = "eDP-1";
-                wallpaperId = "3602362048";
+                wallpaperId = "1845706469";
                 scaling = "fill";
                 fps = 30;
                 audio.silent = true;
               }
             ];
+          };
+
+          # Force RADV (hardware Vulkan) for wallpaper engine instead of lavapipe (software rendering)
+          systemd.user.services.linux-wallpaperengine.Service.Environment = [
+            "VK_DRIVER_FILES=/run/opengl-driver/share/vulkan/icd.d/radeon_icd.x86_64.json"
+          ];
+
+          # Pause animated wallpaper on battery to save power (SIGSTOP/SIGCONT)
+          systemd.user.services.wallpaper-power-monitor = {
+            Unit = {
+              Description = "Pause wallpaper engine on battery, resume on AC";
+              After = [ "linux-wallpaperengine.service" ];
+              Requires = [ "linux-wallpaperengine.service" ];
+            };
+            Service = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              ExecStart = pkgs.writeShellScript "wallpaper-power-check" (
+                builtins.readFile (
+                  pkgs.replaceVars ../../scripts/wallpaper-power-check.sh {
+                    ac_supply_path = "/sys/class/power_supply/ACAD/online";
+                    systemctl = "${pkgs.systemd}/bin/systemctl";
+                    kill = "${pkgs.coreutils}/bin/kill";
+                  }
+                )
+              );
+            };
+            Install.WantedBy = [ "linux-wallpaperengine.service" ];
           };
 
           # Agenix configuration for GitHub SSH key

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -126,8 +126,6 @@ inputs.nixpkgs.lib.nixosSystem {
           KERNEL=="uinput", GROUP="input", TAG+="uaccess", MODE:="0660", OPTIONS+="static_node=uinput"
           KERNEL=="event*", ATTRS{name}=="keyd virtual keyboard", GROUP="input", MODE:="0660"
           KERNEL=="event*", ATTRS{name}=="keyd virtual pointer", GROUP="input", MODE:="0660"
-          # Restart wallpaper power monitor on AC state change
-          SUBSYSTEM=="power_supply", ATTR{type}=="Mains", RUN+="${pkgs.systemd}/bin/systemctl --machine=${username}@.host --user restart wallpaper-power-monitor.service"
         '';
 
         # AMD graphics with hardware acceleration
@@ -449,17 +447,19 @@ inputs.nixpkgs.lib.nixosSystem {
             Unit = {
               Description = "Pause wallpaper engine on battery, resume on AC";
               After = [ "linux-wallpaperengine.service" ];
-              Requires = [ "linux-wallpaperengine.service" ];
+              BindsTo = [ "linux-wallpaperengine.service" ];
             };
             Service = {
-              Type = "oneshot";
-              RemainAfterExit = true;
+              Type = "simple";
+              Restart = "on-failure";
+              RestartSec = 5;
               ExecStart = pkgs.writeShellScript "wallpaper-power-check" (
                 builtins.readFile (
                   pkgs.replaceVars ../../scripts/wallpaper-power-check.sh {
                     ac_supply_path = "/sys/class/power_supply/ACAD/online";
                     systemctl = "${pkgs.systemd}/bin/systemctl";
                     kill = "${pkgs.coreutils}/bin/kill";
+                    sleep = "${pkgs.coreutils}/bin/sleep";
                   }
                 )
               );

--- a/scripts/wallpaper-power-check.sh
+++ b/scripts/wallpaper-power-check.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Pause/resume linux-wallpaperengine based on AC power state.
+# SIGSTOP freezes on last frame (zero CPU/GPU), SIGCONT resumes animation.
+# @ac_supply_path@, @systemctl@, @kill@ are substituted by pkgs.replaceVars.
+set -euo pipefail
+
+AC_ONLINE="$(cat "@ac_supply_path@")"
+PID="$(@systemctl@ --user show -p MainPID --value linux-wallpaperengine.service)"
+
+if [ -z "$PID" ] || [ "$PID" = "0" ]; then
+  exit 0
+fi
+
+if [ "$AC_ONLINE" = "0" ]; then
+  @kill@ -STOP "$PID" 2>/dev/null || true
+else
+  @kill@ -CONT "$PID" 2>/dev/null || true
+fi

--- a/scripts/wallpaper-power-check.sh
+++ b/scripts/wallpaper-power-check.sh
@@ -1,18 +1,39 @@
 #!/usr/bin/env bash
-# Pause/resume linux-wallpaperengine based on AC power state.
+# Monitor AC power state and pause/resume linux-wallpaperengine accordingly.
 # SIGSTOP freezes on last frame (zero CPU/GPU), SIGCONT resumes animation.
-# @ac_supply_path@, @systemctl@, @kill@ are substituted by pkgs.replaceVars.
+# @ac_supply_path@, @systemctl@, @kill@, @sleep@ are substituted by pkgs.replaceVars.
 set -euo pipefail
 
-AC_ONLINE="$(cat "@ac_supply_path@")"
-PID="$(@systemctl@ --user show -p MainPID --value linux-wallpaperengine.service)"
+AC_PATH="@ac_supply_path@"
+LAST_STATE=""
 
-if [ -z "$PID" ] || [ "$PID" = "0" ]; then
-  exit 0
-fi
+get_pid() {
+  @systemctl@ --user show -p MainPID --value linux-wallpaperengine.service 2>/dev/null || echo "0"
+}
 
-if [ "$AC_ONLINE" = "0" ]; then
-  @kill@ -STOP "$PID" 2>/dev/null || true
-else
-  @kill@ -CONT "$PID" 2>/dev/null || true
-fi
+apply_state() {
+  local ac_online="$1"
+  local pid
+  pid="$(get_pid)"
+
+  if [ -z "$pid" ] || [ "$pid" = "0" ]; then
+    return
+  fi
+
+  if [ "$ac_online" = "0" ]; then
+    @kill@ -STOP "$pid" 2>/dev/null || true
+  else
+    @kill@ -CONT "$pid" 2>/dev/null || true
+  fi
+}
+
+while true; do
+  CURRENT_STATE="$(cat "$AC_PATH" 2>/dev/null || echo "")"
+
+  if [ -n "$CURRENT_STATE" ] && [ "$CURRENT_STATE" != "$LAST_STATE" ]; then
+    apply_state "$CURRENT_STATE"
+    LAST_STATE="$CURRENT_STATE"
+  fi
+
+  @sleep@ 5
+done

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -109,6 +109,10 @@ It 'has spec file for scripts/upgrade-overlays.sh'
 The path "spec/upgrade_overlays_spec.sh" should be exist
 End
 
+It 'has spec file for scripts/wallpaper-power-check.sh'
+The path "spec/wallpaper_power_check_spec.sh" should be exist
+End
+
 It 'has spec file for home-manager/modules/local-binaries/sync-local-binaries.sh'
 The path "spec/local_binaries_spec.sh" should be exist
 End
@@ -259,7 +263,8 @@ scripts/fishtape-wrapper.sh
 scripts/llm-update.sh
 scripts/update-gitalias.sh
 scripts/update-local-binaries.sh
-scripts/upgrade-overlays.sh"
+scripts/upgrade-overlays.sh
+scripts/wallpaper-power-check.sh"
 
 # Get actual scripts from git (excluding spec directory)
 actual_scripts=$(git ls-files '*.sh' 2>/dev/null | grep -v '^spec/' | sort)

--- a/spec/wallpaper_power_check_spec.sh
+++ b/spec/wallpaper_power_check_spec.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'scripts/wallpaper-power-check.sh'
+SCRIPT="$PWD/scripts/wallpaper-power-check.sh"
+
+Describe 'script properties'
+It 'uses bash shebang'
+When run bash -c "head -1 '$SCRIPT'"
+The output should include '#!/usr/bin/env bash'
+End
+
+It 'uses strict mode'
+When run bash -c "head -5 '$SCRIPT'"
+The output should include 'set -euo pipefail'
+End
+End
+
+Describe 'AC power state check'
+It 'reads AC supply path'
+When run bash -c "cat '$SCRIPT'"
+The output should include '@ac_supply_path@'
+End
+
+It 'gets wallpaperengine PID via systemctl'
+When run bash -c "cat '$SCRIPT'"
+The output should include 'linux-wallpaperengine.service'
+End
+End
+
+Describe 'signal handling'
+It 'sends SIGSTOP on battery'
+When run bash -c "cat '$SCRIPT'"
+The output should include '-STOP'
+End
+
+It 'sends SIGCONT on AC'
+When run bash -c "cat '$SCRIPT'"
+The output should include '-CONT'
+End
+
+It 'exits cleanly when PID is missing'
+When run bash -c "cat '$SCRIPT'"
+The output should include 'exit 0'
+End
+End
+
+End

--- a/spec/wallpaper_power_check_spec.sh
+++ b/spec/wallpaper_power_check_spec.sh
@@ -39,9 +39,9 @@ When run bash -c "cat '$SCRIPT'"
 The output should include '-CONT'
 End
 
-It 'exits cleanly when PID is missing'
+It 'skips cleanly when PID is missing'
 When run bash -c "cat '$SCRIPT'"
-The output should include 'exit 0'
+The output should include 'return'
 End
 End
 


### PR DESCRIPTION
## Summary
- Force RADV (hardware Vulkan) for linux-wallpaperengine instead of lavapipe software renderer — was rendering entirely on CPU
- Add wallpaper-power-monitor service that freezes wallpaper (SIGSTOP) on battery and resumes (SIGCONT) on AC
- Add udev rule to trigger on AC plug/unplug events
- Change wallpaper to Nier:Automata (1845706469)
- Extract power check script to `scripts/wallpaper-power-check.sh` with `pkgs.replaceVars`

## Test plan
- [x] `make shell-test` passes (848 + 220 examples, 0 failures)
- [x] Nix eval builds successfully
- [ ] Verify wallpaper renders with RADV after rebuild
- [ ] Verify SIGSTOP on unplug, SIGCONT on plug

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `linux-wallpaperengine` to hardware Vulkan (RADV) and adds a long-running, power-aware pause to cut CPU/GPU use on battery. Updates the default wallpaper to a Star Wars scene.

- **New Features**
  - Force RADV via `VK_DRIVER_FILES` for `linux-wallpaperengine` to avoid `lavapipe` (software rendering).
  - Add user `wallpaper-power-monitor` service that polls AC state every 5s and sends SIGSTOP on battery and SIGCONT on AC using `scripts/wallpaper-power-check.sh`.
  - Change wallpaper to Star Wars scene (2826529529).

- **Bug Fixes**
  - Replace oneshot + `udev` approach with a long-running polling service to avoid a boot-time race; remove the `udev` rule.

<sup>Written for commit 8fa8d1cbe656b1fec2e034025b5b580185302f97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

