### PR TITLE
feat(fish): accept inline args for all headless functions

### DIFF
--- a/home-manager/programs/fish/functions/_cltxeh_function.fish
+++ b/home-manager/programs/fish/functions/_cltxeh_function.fish
@@ -2,7 +2,13 @@ function _cltxeh_function --description "Run Claude Code headlessly with a promp
   # Prompt for input and run Claude Code
   # Usage: cltxeh
 
-  read -P "Prompt: " prompt
+  set -l prompt
+  if test (count $argv) -gt 0
+    set prompt (string join " " $argv)
+  else
+    read -P "Prompt: " prompt
+  end
+
   if test -z "$prompt"
     echo "No prompt provided, aborting." >&2
     return 1

--- a/home-manager/programs/fish/functions/_clwxeh_function.fish
+++ b/home-manager/programs/fish/functions/_clwxeh_function.fish
@@ -2,7 +2,13 @@ function _clwxeh_function --description "Run Claude Code headlessly with a promp
   # Prompt for input and run Claude Code
   # Usage: clwxeh
 
-  read -P "Prompt: " prompt
+  set -l prompt
+  if test (count $argv) -gt 0
+    set prompt (string join " " $argv)
+  else
+    read -P "Prompt: " prompt
+  end
+
   if test -z "$prompt"
     echo "No prompt provided, aborting." >&2
     return 1

--- a/home-manager/programs/fish/functions/_clxeh_function.fish
+++ b/home-manager/programs/fish/functions/_clxeh_function.fish
@@ -1,8 +1,14 @@
 function _clxeh_function --description "Run Claude Code headlessly with a prompted input"
-  # Prompt for input and run Claude Code
-  # Usage: clxeh
+  # Run Claude Code headlessly
+  # Usage: clxeh "prompt here" or clxeh (interactive)
 
-  read -P "Prompt: " prompt
+  set -l prompt
+  if test (count $argv) -gt 0
+    set prompt (string join " " $argv)
+  else
+    read -P "Prompt: " prompt
+  end
+
   if test -z "$prompt"
     echo "No prompt provided, aborting." >&2
     return 1

--- a/home-manager/programs/fish/functions/_coxeh_function.fish
+++ b/home-manager/programs/fish/functions/_coxeh_function.fish
@@ -2,7 +2,13 @@ function _coxeh_function --description "Run Codex headlessly with a prompted inp
   # Prompt for input and run Codex
   # Usage: coxeh
 
-  read -P "Prompt: " prompt
+  set -l prompt
+  if test (count $argv) -gt 0
+    set prompt (string join " " $argv)
+  else
+    read -P "Prompt: " prompt
+  end
+
   if test -z "$prompt"
     echo "No prompt provided, aborting." >&2
     return 1

--- a/home-manager/programs/fish/functions/_coxeh_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_coxeh_function.tpl.fish
@@ -2,7 +2,13 @@ function _coxeh_function --description "Run Codex headlessly with a prompted inp
   # Prompt for input and run Codex
   # Usage: coxeh
 
-  read -P "Prompt: " prompt
+  set -l prompt
+  if test (count $argv) -gt 0
+    set prompt (string join " " $argv)
+  else
+    read -P "Prompt: " prompt
+  end
+
   if test -z "$prompt"
     echo "No prompt provided, aborting." >&2
     return 1

--- a/home-manager/programs/fish/functions/_coxelh_function.fish
+++ b/home-manager/programs/fish/functions/_coxelh_function.fish
@@ -2,7 +2,13 @@ function _coxelh_function --description "Run Codex headlessly with the local Qwe
   # Prompt for input and run Codex with the local Qwen model
   # Usage: coxelh
 
-  read -P "Prompt: " prompt
+  set -l prompt
+  if test (count $argv) -gt 0
+    set prompt (string join " " $argv)
+  else
+    read -P "Prompt: " prompt
+  end
+
   if test -z "$prompt"
     echo "No prompt provided, aborting." >&2
     return 1

--- a/home-manager/programs/fish/functions/_coxelh_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_coxelh_function.tpl.fish
@@ -2,7 +2,13 @@ function _coxelh_function --description "Run Codex headlessly with the local Qwe
   # Prompt for input and run Codex with the local Qwen model
   # Usage: coxelh
 
-  read -P "Prompt: " prompt
+  set -l prompt
+  if test (count $argv) -gt 0
+    set prompt (string join " " $argv)
+  else
+    read -P "Prompt: " prompt
+  end
+
   if test -z "$prompt"
     echo "No prompt provided, aborting." >&2
     return 1

--- a/home-manager/programs/fish/functions/_ocxeh_function.fish
+++ b/home-manager/programs/fish/functions/_ocxeh_function.fish
@@ -2,7 +2,13 @@ function _ocxeh_function --description "Run OpenCode headlessly with a prompted 
   # Prompt for input and run OpenCode
   # Usage: ocxeh
 
-  read -P "Prompt: " prompt
+  set -l prompt
+  if test (count $argv) -gt 0
+    set prompt (string join " " $argv)
+  else
+    read -P "Prompt: " prompt
+  end
+
   if test -z "$prompt"
     echo "No prompt provided, aborting." >&2
     return 1

--- a/home-manager/programs/fish/functions/_ocxeh_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_ocxeh_function.tpl.fish
@@ -2,7 +2,13 @@ function _ocxeh_function --description "Run OpenCode headlessly with a prompted 
   # Prompt for input and run OpenCode
   # Usage: ocxeh
 
-  read -P "Prompt: " prompt
+  set -l prompt
+  if test (count $argv) -gt 0
+    set prompt (string join " " $argv)
+  else
+    read -P "Prompt: " prompt
+  end
+
   if test -z "$prompt"
     echo "No prompt provided, aborting." >&2
     return 1

--- a/home-manager/programs/fish/functions/_ocxelh_function.fish
+++ b/home-manager/programs/fish/functions/_ocxelh_function.fish
@@ -2,7 +2,13 @@ function _ocxelh_function --description "Run OpenCode headlessly with the local 
   # Prompt for input and run OpenCode with the local Qwen model
   # Usage: ocxelh
 
-  read -P "Prompt: " prompt
+  set -l prompt
+  if test (count $argv) -gt 0
+    set prompt (string join " " $argv)
+  else
+    read -P "Prompt: " prompt
+  end
+
   if test -z "$prompt"
     echo "No prompt provided, aborting." >&2
     return 1

--- a/home-manager/programs/fish/functions/_ocxelh_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_ocxelh_function.tpl.fish
@@ -2,7 +2,13 @@ function _ocxelh_function --description "Run OpenCode headlessly with the local 
   # Prompt for input and run OpenCode with the local Qwen model
   # Usage: ocxelh
 
-  read -P "Prompt: " prompt
+  set -l prompt
+  if test (count $argv) -gt 0
+    set prompt (string join " " $argv)
+  else
+    read -P "Prompt: " prompt
+  end
+
   if test -z "$prompt"
     echo "No prompt provided, aborting." >&2
     return 1

--- a/home-manager/programs/fish/functions/_ompxeh_function.fish
+++ b/home-manager/programs/fish/functions/_ompxeh_function.fish
@@ -2,7 +2,13 @@ function _ompxeh_function --description "Run OMP headlessly with a prompted inpu
   # Prompt for input and run OMP in print mode
   # Usage: ompxeh
 
-  read -P "Prompt: " prompt
+  set -l prompt
+  if test (count $argv) -gt 0
+    set prompt (string join " " $argv)
+  else
+    read -P "Prompt: " prompt
+  end
+
   if test -z "$prompt"
     echo "No prompt provided, aborting." >&2
     return 1

--- a/home-manager/programs/fish/functions/_pixeh_function.fish
+++ b/home-manager/programs/fish/functions/_pixeh_function.fish
@@ -2,7 +2,13 @@ function _pixeh_function --description "Run Pi headlessly with a prompted input"
   # Prompt for input and run Pi in print mode
   # Usage: pixeh
 
-  read -P "Prompt: " prompt
+  set -l prompt
+  if test (count $argv) -gt 0
+    set prompt (string join " " $argv)
+  else
+    read -P "Prompt: " prompt
+  end
+
   if test -z "$prompt"
     echo "No prompt provided, aborting." >&2
     return 1

--- a/home-manager/programs/fish/functions/_pixeh_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_pixeh_function.tpl.fish
@@ -2,7 +2,13 @@ function _pixeh_function --description "Run Pi headlessly with a prompted input"
   # Prompt for input and run Pi in print mode
   # Usage: pixeh
 
-  read -P "Prompt: " prompt
+  set -l prompt
+  if test (count $argv) -gt 0
+    set prompt (string join " " $argv)
+  else
+    read -P "Prompt: " prompt
+  end
+
   if test -z "$prompt"
     echo "No prompt provided, aborting." >&2
     return 1

--- a/home-manager/programs/fish/functions/_pixelh_function.fish
+++ b/home-manager/programs/fish/functions/_pixelh_function.fish
@@ -2,7 +2,13 @@ function _pixelh_function --description "Run Pi headlessly with the local Qwen m
   # Prompt for input and run Pi in print mode with the local Qwen model
   # Usage: pixelh
 
-  read -P "Prompt: " prompt
+  set -l prompt
+  if test (count $argv) -gt 0
+    set prompt (string join " " $argv)
+  else
+    read -P "Prompt: " prompt
+  end
+
   if test -z "$prompt"
     echo "No prompt provided, aborting." >&2
     return 1

--- a/home-manager/programs/fish/functions/_pixelh_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_pixelh_function.tpl.fish
@@ -2,7 +2,13 @@ function _pixelh_function --description "Run Pi headlessly with the local Qwen m
   # Prompt for input and run Pi in print mode with the local Qwen model
   # Usage: pixelh
 
-  read -P "Prompt: " prompt
+  set -l prompt
+  if test (count $argv) -gt 0
+    set prompt (string join " " $argv)
+  else
+    read -P "Prompt: " prompt
+  end
+
   if test -z "$prompt"
     echo "No prompt provided, aborting." >&2
     return 1

--- a/spec/fish/_cltxeh_function_test.fish
+++ b/spec/fish/_cltxeh_function_test.fish
@@ -3,3 +3,13 @@ source $fn/_cltxeh_function.fish
 
 @test "empty prompt rejects" (echo "" | _cltxeh_function 2>&1) = "No prompt provided, aborting."
 @test "empty prompt returns 1" (echo "" | _cltxeh_function 2>/dev/null; echo $status) = 1
+
+set log1 (mktemp)
+function claude; echo $argv >> $log1; end
+
+_cltxeh_function hello world
+
+@test "inline args forwards prompt" (grep -c "hello world" $log1) -ge 1
+@test "inline args uses print mode" (grep -c -- "--print" $log1) -ge 1
+
+rm -f $log1

--- a/spec/fish/_clwxeh_function_test.fish
+++ b/spec/fish/_clwxeh_function_test.fish
@@ -3,3 +3,13 @@ source $fn/_clwxeh_function.fish
 
 @test "empty prompt rejects" (echo "" | _clwxeh_function 2>&1) = "No prompt provided, aborting."
 @test "empty prompt returns 1" (echo "" | _clwxeh_function 2>/dev/null; echo $status) = 1
+
+set log1 (mktemp)
+function claude; echo $argv >> $log1; end
+
+_clwxeh_function hello world
+
+@test "inline args forwards prompt" (grep -c "hello world" $log1) -ge 1
+@test "inline args uses print mode" (grep -c -- "--print" $log1) -ge 1
+
+rm -f $log1

--- a/spec/fish/_clxeh_function_test.fish
+++ b/spec/fish/_clxeh_function_test.fish
@@ -3,3 +3,13 @@ source $fn/_clxeh_function.fish
 
 @test "empty prompt rejects" (echo "" | _clxeh_function 2>&1) = "No prompt provided, aborting."
 @test "empty prompt returns 1" (echo "" | _clxeh_function 2>/dev/null; echo $status) = 1
+
+set log1 (mktemp)
+function claude; echo $argv >> $log1; end
+
+_clxeh_function hello world
+
+@test "inline args forwards prompt" (grep -c "hello world" $log1) -ge 1
+@test "inline args uses print mode" (grep -c -- "--print" $log1) -ge 1
+
+rm -f $log1

--- a/spec/fish/_coxeh_function.tpl_test.fish
+++ b/spec/fish/_coxeh_function.tpl_test.fish
@@ -3,3 +3,13 @@ source $fn/_coxeh_function.tpl.fish
 
 @test "empty prompt rejects" (echo "" | _coxeh_function 2>&1) = "No prompt provided, aborting."
 @test "empty prompt returns 1" (echo "" | _coxeh_function 2>/dev/null; echo $status) = 1
+
+set log1 (mktemp)
+function codex; echo $argv >> $log1; end
+
+_coxeh_function hello world
+
+@test "inline args forwards prompt" (grep -c "hello world" $log1) -ge 1
+@test "inline args uses full-auto" (grep -c -- "--full-auto" $log1) -ge 1
+
+rm -f $log1

--- a/spec/fish/_coxeh_function_test.fish
+++ b/spec/fish/_coxeh_function_test.fish
@@ -3,3 +3,13 @@ source $fn/_coxeh_function.fish
 
 @test "empty prompt rejects" (echo "" | _coxeh_function 2>&1) = "No prompt provided, aborting."
 @test "empty prompt returns 1" (echo "" | _coxeh_function 2>/dev/null; echo $status) = 1
+
+set log1 (mktemp)
+function codex; echo $argv >> $log1; end
+
+_coxeh_function hello world
+
+@test "inline args forwards prompt" (grep -c "hello world" $log1) -ge 1
+@test "inline args uses full-auto" (grep -c -- "--full-auto" $log1) -ge 1
+
+rm -f $log1

--- a/spec/fish/_coxelh_function.tpl_test.fish
+++ b/spec/fish/_coxelh_function.tpl_test.fish
@@ -16,4 +16,12 @@ echo "hello world" | _coxelh_function
 @test "non-empty prompt lowers reasoning effort" (grep -c "model_reasoning_effort=minimal" $log1) -ge 1
 @test "non-empty prompt forwards prompt" (grep -c "hello world" $log1) -ge 1
 
-rm -f $log1
+set log2 (mktemp)
+function codex; echo $argv >> $log2; end
+
+_coxelh_function hello world
+
+@test "inline args forwards prompt" (grep -c "hello world" $log2) -ge 1
+@test "inline args uses exec subcommand" (grep -c "^exec " $log2) -ge 1
+
+rm -f $log1 $log2

--- a/spec/fish/_coxelh_function_test.fish
+++ b/spec/fish/_coxelh_function_test.fish
@@ -16,4 +16,12 @@ echo "hello world" | _coxelh_function
 @test "non-empty prompt lowers reasoning effort" (grep -c "model_reasoning_effort=minimal" $log1) -ge 1
 @test "non-empty prompt forwards prompt" (grep -c "hello world" $log1) -ge 1
 
-rm -f $log1
+set log2 (mktemp)
+function codex; echo $argv >> $log2; end
+
+_coxelh_function hello world
+
+@test "inline args forwards prompt" (grep -c "hello world" $log2) -ge 1
+@test "inline args uses exec subcommand" (grep -c "^exec " $log2) -ge 1
+
+rm -f $log1 $log2

--- a/spec/fish/_ocxeh_function.tpl_test.fish
+++ b/spec/fish/_ocxeh_function.tpl_test.fish
@@ -3,3 +3,13 @@ source $fn/_ocxeh_function.tpl.fish
 
 @test "empty prompt rejects" (echo "" | _ocxeh_function 2>&1) = "No prompt provided, aborting."
 @test "empty prompt returns 1" (echo "" | _ocxeh_function 2>/dev/null; echo $status) = 1
+
+set log1 (mktemp)
+function opencode; echo $argv >> $log1; end
+
+_ocxeh_function hello world
+
+@test "inline args forwards prompt" (grep -c "hello world" $log1) -ge 1
+@test "inline args uses run subcommand" (grep -c "^run " $log1) -ge 1
+
+rm -f $log1

--- a/spec/fish/_ocxeh_function_test.fish
+++ b/spec/fish/_ocxeh_function_test.fish
@@ -3,3 +3,13 @@ source $fn/_ocxeh_function.fish
 
 @test "empty prompt rejects" (echo "" | _ocxeh_function 2>&1) = "No prompt provided, aborting."
 @test "empty prompt returns 1" (echo "" | _ocxeh_function 2>/dev/null; echo $status) = 1
+
+set log1 (mktemp)
+function opencode; echo $argv >> $log1; end
+
+_ocxeh_function hello world
+
+@test "inline args forwards prompt" (grep -c "hello world" $log1) -ge 1
+@test "inline args uses run subcommand" (grep -c "^run " $log1) -ge 1
+
+rm -f $log1

--- a/spec/fish/_ocxelh_function.tpl_test.fish
+++ b/spec/fish/_ocxelh_function.tpl_test.fish
@@ -13,4 +13,12 @@ echo "hello world" | _ocxelh_function
 @test "non-empty prompt builds prompt" (grep -c "hello world" $log1) -ge 1
 @test "non-empty prompt uses templated local Qwen model" (grep -c "lmstudio/__QWEN_LOCAL__" $log1) -ge 1
 
-rm -f $log1
+set log2 (mktemp)
+function opencode; echo $argv >> $log2; end
+
+_ocxelh_function hello world
+
+@test "inline args forwards prompt" (grep -c "hello world" $log2) -ge 1
+@test "inline args uses run subcommand" (grep -c "^run " $log2) -ge 1
+
+rm -f $log1 $log2

--- a/spec/fish/_ocxelh_function_test.fish
+++ b/spec/fish/_ocxelh_function_test.fish
@@ -13,4 +13,12 @@ echo "hello world" | _ocxelh_function
 @test "non-empty prompt builds prompt" (grep -c "hello world" $log1) -ge 1
 @test "non-empty prompt uses local Qwen model" (grep -c "lmstudio/qwen/qwen3.5-9b" $log1) -ge 1
 
-rm -f $log1
+set log2 (mktemp)
+function opencode; echo $argv >> $log2; end
+
+_ocxelh_function hello world
+
+@test "inline args forwards prompt" (grep -c "hello world" $log2) -ge 1
+@test "inline args uses run subcommand" (grep -c "^run " $log2) -ge 1
+
+rm -f $log1 $log2

--- a/spec/fish/_ompxeh_function_test.fish
+++ b/spec/fish/_ompxeh_function_test.fish
@@ -13,4 +13,13 @@ echo "hello world" | _ompxeh_function
 @test "non-empty prompt uses print mode" (grep -Fx -c 'arg=-p' $log1) -ge 1
 @test "non-empty prompt preserves spaces in the prompt" (grep -Fx -c 'arg=hello world' $log1) -ge 1
 
-rm -f $log1
+set log2 (mktemp)
+function omp; echo "argc="(count $argv) >> $log2; for arg in $argv; echo "arg=$arg" >> $log2; end; end
+
+_ompxeh_function hello world
+
+@test "inline args passes two arguments" (grep -Fx -c 'argc=2' $log2) -ge 1
+@test "inline args uses print mode" (grep -Fx -c 'arg=-p' $log2) -ge 1
+@test "inline args preserves spaces in the prompt" (grep -Fx -c 'arg=hello world' $log2) -ge 1
+
+rm -f $log1 $log2

--- a/spec/fish/_pixeh_function.tpl_test.fish
+++ b/spec/fish/_pixeh_function.tpl_test.fish
@@ -13,4 +13,12 @@ echo "hello world" | _pixeh_function
 @test "non-empty prompt uses templated cliproxyapi model" (grep -c "cliproxyapi/__GLM__" $log1) -ge 1
 @test "non-empty prompt uses print mode" (grep -c -- "-p" $log1) -ge 1
 
-rm -f $log1
+set log2 (mktemp)
+function pi; echo $argv >> $log2; end
+
+_pixeh_function hello world
+
+@test "inline args forwards prompt" (grep -c "hello world" $log2) -ge 1
+@test "inline args uses print mode" (grep -c -- "-p" $log2) -ge 1
+
+rm -f $log1 $log2

--- a/spec/fish/_pixeh_function_test.fish
+++ b/spec/fish/_pixeh_function_test.fish
@@ -13,4 +13,12 @@ echo "hello world" | _pixeh_function
 @test "non-empty prompt uses cliproxyapi model" (grep -c "cliproxyapi/glm-4.7" $log1) -ge 1
 @test "non-empty prompt uses print mode" (grep -c -- "-p" $log1) -ge 1
 
-rm -f $log1
+set log2 (mktemp)
+function pi; echo $argv >> $log2; end
+
+_pixeh_function hello world
+
+@test "inline args forwards prompt" (grep -c "hello world" $log2) -ge 1
+@test "inline args uses print mode" (grep -c -- "-p" $log2) -ge 1
+
+rm -f $log1 $log2

--- a/spec/fish/_pixelh_function.tpl_test.fish
+++ b/spec/fish/_pixelh_function.tpl_test.fish
@@ -13,4 +13,12 @@ echo "hello world" | _pixelh_function
 @test "non-empty prompt uses templated local Qwen model" (grep -c "lmstudio/__QWEN_LOCAL__" $log1) -ge 1
 @test "non-empty prompt uses print mode" (grep -c -- "-p" $log1) -ge 1
 
-rm -f $log1
+set log2 (mktemp)
+function pi; echo $argv >> $log2; end
+
+_pixelh_function hello world
+
+@test "inline args forwards prompt" (grep -c "hello world" $log2) -ge 1
+@test "inline args uses print mode" (grep -c -- "-p" $log2) -ge 1
+
+rm -f $log1 $log2

--- a/spec/fish/_pixelh_function_test.fish
+++ b/spec/fish/_pixelh_function_test.fish
@@ -13,4 +13,12 @@ echo "hello world" | _pixelh_function
 @test "non-empty prompt uses local Qwen model" (grep -c "lmstudio/qwen/qwen3.5-9b" $log1) -ge 1
 @test "non-empty prompt uses print mode" (grep -c -- "-p" $log1) -ge 1
 
-rm -f $log1
+set log2 (mktemp)
+function pi; echo $argv >> $log2; end
+
+_pixelh_function hello world
+
+@test "inline args forwards prompt" (grep -c "hello world" $log2) -ge 1
+@test "inline args uses print mode" (grep -c -- "-p" $log2) -ge 1
+
+rm -f $log1 $log2


### PR DESCRIPTION
## Summary
- All headless functions (`clxeh`, `cltxeh`, `clwxeh`, `coxeh`, `coxelh`, `ocxeh`, `ocxelh`, `pixeh`, `pixelh`, `ompxeh`) now accept inline arguments (e.g. `_clxeh_function "/pr-create auto to main"`)
- Falls back to interactive `read` prompt when no arguments are given
- Updated both `.fish` and `.tpl.fish` template files (16 function files total)
- Added inline args tests to all 16 corresponding test files

## Test plan
- [x] Existing empty-prompt rejection tests still pass (piped empty input → falls through to `read`)
- [x] New inline args tests verify prompt is forwarded correctly
- [x] Interactive mode preserved when called with no arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add inline-argument support to all headless fish functions with an interactive fallback when no args are provided. This makes one-liners and scripts easier while keeping current behavior.

- **New Features**
  - All headless functions and their `.tpl.fish` templates now accept inline prompts via `$argv`; fall back to `read` when none are given.
  - Added inline-args tests for each function; existing empty-input rejection and interactive mode tests still pass.

<sup>Written for commit 3f3e3bf467dee3dc9f99ba4e73b55172c7729202. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

