### PR TITLE
fix(ghostty): write config to macOS Application Support for GUI app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,9 +393,9 @@ nix-format-clear-cache: ## Clear Nix format cache.
 	@echo "✅ Cache cleared"
 
 .PHONY: nix-format-check
-nix-format-check: nix-format-clear-cache ## Check Nix file formatting.
+nix-format-check: ## Check Nix file formatting.
 	@echo "🔍 Checking Nix file formatting..."
-	@$(NIX_EXEC) fmt -- --fail-on-change
+	@$(NIX_EXEC) fmt -- --clear-cache --fail-on-change
 	@echo "✅ All Nix files are properly formatted"
 
 .PHONY: nix-lint

--- a/config/ghostty/default.nix
+++ b/config/ghostty/default.nix
@@ -1,5 +1,6 @@
 { config, pkgs, ... }:
 let
+  inherit (pkgs) lib;
   fishPath = "${pkgs.fish}/bin/fish";
   staticConfig = builtins.readFile ./config;
   configText = builtins.replaceStrings [ "__FISH_PATH__" ] [ fishPath ] staticConfig;
@@ -14,4 +15,21 @@ in
   xdg.configFile."ghostty/themes/Catppuccin Latte Custom" = {
     source = ./themes + "/Catppuccin Latte Custom";
   };
+
+  # macOS GUI app reads from ~/Library/Application Support/com.mitchellh.ghostty/
+  home.file."Library/Application Support/com.mitchellh.ghostty/config" =
+    lib.mkIf pkgs.stdenv.isDarwin
+      {
+        text = configText;
+      };
+  home.file."Library/Application Support/com.mitchellh.ghostty/themes/Dracula Custom" =
+    lib.mkIf pkgs.stdenv.isDarwin
+      {
+        source = ./themes + "/Dracula Custom";
+      };
+  home.file."Library/Application Support/com.mitchellh.ghostty/themes/Catppuccin Latte Custom" =
+    lib.mkIf pkgs.stdenv.isDarwin
+      {
+        source = ./themes + "/Catppuccin Latte Custom";
+      };
 }

--- a/home-manager/modules/local-scripts/default.nix
+++ b/home-manager/modules/local-scripts/default.nix
@@ -1,4 +1,4 @@
-{ ... }:
+_:
 {
   home.file.".local/scripts/clipboard-copy" = {
     executable = true;

--- a/home-manager/modules/local-scripts/default.nix
+++ b/home-manager/modules/local-scripts/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   home.file.".local/scripts/clipboard-copy" = {
     executable = true;
     force = true;


### PR DESCRIPTION
## Summary
- Write Ghostty config and custom themes to `~/Library/Application Support/com.mitchellh.ghostty/` on macOS (via `home.file` with `lib.mkIf pkgs.stdenv.isDarwin`)
- The macOS GUI app reads from this path instead of `~/.config/ghostty/`, so `dark:`/`light:` theme switching wasn't working
- Fix statix W10 warning: replace empty pattern `{ ... }` with `_` in local-scripts

## Test plan
- [ ] Run `home-manager switch` and verify `~/Library/Application Support/com.mitchellh.ghostty/config` matches `~/.config/ghostty/config`
- [ ] Switch macOS appearance between light/dark and confirm Ghostty theme updates
- [ ] Verify `nix develop --command statix check .` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Writes Ghostty config and themes to macOS Application Support so the GUI app reads them and light/dark theme switching works. Also fixes `nix-format-check` to fail correctly and resolves a `statix` W10 warning.

- **Bug Fixes**
  - Install Ghostty `config` and `themes` to `~/Library/Application Support/com.mitchellh.ghostty/` using `home.file` with `lib.mkIf pkgs.stdenv.isDarwin` (GUI doesn’t read `~/.config/ghostty/`).
  - Update `nix-format-check` to run `nix fmt` with `--clear-cache --fail-on-change` in one command, preventing silent auto-formatting.
  - Replace empty pattern `{ ... }` with `_` in local scripts to satisfy `statix` W10.

<sup>Written for commit 5bdf647ea01fd4ad44406ec235eb2e48051360d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

