### PR TITLE
Add dolt to the list of packages

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -33,6 +33,7 @@ with pkgs;
   difftastic
   direnv
   doggo
+  dolt
   doppler
   duf
   dust


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `dolt` to the Home Manager package list so it installs by default for development.

<sup>Written for commit 3044b4708ff3eec609f7db6730a08d8f9b6002dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

