### PR TITLE
feat(packages): add victoriametrics, victoriatraces, victorialogs

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -92,6 +92,9 @@ with pkgs;
   tree
   turso-cli
   uv
+  victorialogs
+  victoriametrics
+  victoriatraces
   watchexec
   wget
   yarn


### PR DESCRIPTION
## Summary
- Add `victoriametrics` — time series database, Prometheus remote storage
- Add `victoriatraces` — distributed traces observability
- Add `victorialogs` — log database

## Test plan
- [ ] Verify `nix flake check` passes
- [ ] Verify packages are available after `make switch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `victoriametrics`, `victoriatraces`, and `victorialogs` to the Home Manager packages so observability tools for metrics, traces, and logs are installed by default. These are available after running `make switch`.

<sup>Written for commit 33dfb563dbe00d6f3af3dee688be786f400b06c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

