### PR TITLE
fix(ci): use nvim -u for lua-check instead of symlinking ~/.config/nvim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -669,19 +669,10 @@ lua-check-neovim: ## Check Neovim configuration.
 		exit 1; \
 	fi
 	@echo "📝 Validating Neovim configuration syntax..."
-	@mkdir -p ~/.config/nvim
-	@if [ -L "$(HOME)/.config/nvim/lua" ] || [ -d "$(HOME)/.config/nvim/lua" ]; then \
-		rm -rf "$(HOME)/.config/nvim/lua"; \
-	fi
-	@ln -sf "$(PWD)/home-manager/programs/neovim/init.lua" ~/.config/nvim/init.lua
-	@ln -sf "$(PWD)/home-manager/programs/neovim/lua" ~/.config/nvim/lua
-	@if [ -f "$(PWD)/home-manager/programs/neovim/nvim-pack-lock.json" ]; then \
-		ln -sf "$(PWD)/home-manager/programs/neovim/nvim-pack-lock.json" ~/.config/nvim/nvim-pack-lock.json; \
-	fi
 	@echo "📦 Installing plugins..."
-	@nvim --headless +"lua vim.pack.update()" +qa 2>&1
+	@nvim -u "$(PWD)/home-manager/programs/neovim/init.lua" --headless +"lua vim.pack.update()" +qa 2>&1
 	@bash $(PWD)/scripts/build-neovim-plugins.sh
-	@nvim --headless -c "lua dofile('$(PWD)/home-manager/programs/neovim/init.lua')" -c "qa" 2>&1 | tee /tmp/nvim-check.log; \
+	@nvim -u "$(PWD)/home-manager/programs/neovim/init.lua" --headless -c "qa" 2>&1 | tee /tmp/nvim-check.log; \
 	if grep -q "^E[0-9]\|^Error\|module .* not found" /tmp/nvim-check.log; then \
 		echo "❌ Neovim configuration has errors"; \
 		exit 1; \


### PR DESCRIPTION
## Summary
- `lua-check-neovim` was symlinking `~/.config/nvim/lua` → repo's `lua/` dir to validate the config
- This caused `make switch` (home-manager) to follow the symlink and replace repo files with nix store symlinks (typechange)
- Fix: use `nvim -u <path>` to load the config directly — no symlinks, no side effects

## Test plan
- [x] `make lua-check-neovim` passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `nvim -u` to load `home-manager/programs/neovim/init.lua` for plugin install and lua-check instead of symlinking into `~/.config/nvim`. This prevents `home-manager` from replacing repo files with nix store symlinks during `make switch`.

<sup>Written for commit 260166c62524190d9d557643a942ac805f7dd06d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

