### PR TITLE
fix(services): disable macOS ollama agent and fix local-binaries linker

### DIFF
--- a/scripts/update-local-binaries.sh
+++ b/scripts/update-local-binaries.sh
@@ -4,6 +4,15 @@
 
 set -euo pipefail
 
+# Ensure the linker can find clang_rt on macOS (Xcode clang version may differ
+# from the version some Rust crates hard-code in their build scripts).
+if [ "$(uname)" = "Darwin" ]; then
+  CLANG_LIB="$(echo /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/*/lib/darwin)"
+  if [ -d "$CLANG_LIB" ]; then
+    export LIBRARY_PATH="${CLANG_LIB}${LIBRARY_PATH:+:$LIBRARY_PATH}"
+  fi
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CONFIG_FILE="$REPO_ROOT/.local-binaries.txt"


### PR DESCRIPTION
## Summary
- Remove launchd ollama agent on macOS — native Ollama.app already binds `:11434`, causing perpetual "address already in use" errors in `/tmp/ollama.error.log`
- Export `LIBRARY_PATH` in `update-local-binaries.sh` to point to the actual Xcode clang runtime dir, fixing Rust crate builds that hard-code an older clang lib search path (e.g. clang 17 vs installed clang 21)

## Test plan
- [x] `make shell-test` — 253 tests, 892 examples, 0 failures
- [x] Verified `coding_agent_session_search` builds successfully with the `LIBRARY_PATH` fix
- [x] Verified native Ollama.app continues serving on `:11434` after removing the home-manager agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the Ollama `launchd` agent on macOS to prevent :11434 conflicts with Ollama.app. Export the Xcode clang runtime path in `update-local-binaries.sh` so Rust crates link `clang_rt` correctly on macOS.

- **Bug Fixes**
  - macOS: skip the Ollama `launchd` agent; keep the Linux `systemd` user service.
  - macOS: in `update-local-binaries.sh`, export `LIBRARY_PATH` to the Xcode clang `lib/darwin` dir when present, fixing `clang_rt` linking errors.

<sup>Written for commit 089814e85d139e13059e5c87ae2b4dd6b0f2722f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

