### PR TITLE
fix(cliproxyapi): use --exact-timestamps for S3 auth sync

### DIFF
--- a/home-manager/services/cliproxyapi/scripts/common.sh
+++ b/home-manager/services/cliproxyapi/scripts/common.sh
@@ -44,6 +44,7 @@ cliproxy_s3_sync() {
     @aws@ s3 sync \
     --endpoint-url="${OBJECTSTORE_ENDPOINT:?OBJECTSTORE_ENDPOINT is required}" \
     --no-progress \
+    --exact-timestamps \
     "$source_path" \
     "$destination_path" || true
 }


### PR DESCRIPTION
## Summary
- Adds `--exact-timestamps` to `aws s3 sync` in `common.sh` so same-size token updates are not skipped
- Without this, fresh OAuth tokens (same byte size, different content) were missed by `s3 sync` on the receiving device because R2 timestamps can differ from local

## Test plan
- [x] Verified on Mac: keychain-sync writes new Claude/Codex tokens
- [x] Verified backup watcher pushes to S3
- [x] Verified on kyber (Linux): `--exact-timestamps` downloads updated tokens
- [x] `make shell-test` passes (904 examples, 0 failures)
- [x] `make shell-lint` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `--exact-timestamps` to `aws s3 sync` in the `cliproxyapi` sync script so same-size token updates aren’t skipped. This fixes missed OAuth token rotations caused by R2 vs local timestamp differences and ensures updates propagate across devices.

<sup>Written for commit 7659601f8fbbc582addaa2d5bcacf1bfde1c57a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

