### PR TITLE
feat(worktrunk): upgrade to 0.33.0 and add copy-ignored excludes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4039,17 +4039,17 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.24.1+spec-1.1.0"
+version = "0.25.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f2eadbbc6b377a847be05f60791ef1058d9f696ecb51d2c07fe911d8569d8e"
+checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned 1.0.4",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -4985,9 +4985,9 @@ dependencies = [
 
 [[package]]
 name = "worktrunk"
-version = "0.29.4"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8fdd17cb5256e849f295531d62897b2824539671d14bc88ba503644e4d4d9a5"
+checksum = "e1c262337ff50b022825d0de9176f8514b24f626126ddbe68a4d0064f19574f2"
 dependencies = [
  "ansi-str",
  "anstream 1.0.0",
@@ -5037,8 +5037,8 @@ dependencies = [
  "tempfile",
  "termimad",
  "terminal_size",
- "toml 0.9.12+spec-1.1.0",
- "toml_edit 0.24.1+spec-1.1.0",
+ "toml 1.0.7+spec-1.1.0",
+ "toml_edit 0.25.5+spec-1.1.0",
  "tree-sitter",
  "tree-sitter-bash",
  "tree-sitter-highlight",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ path = "lib.rs"
 [dependencies]
 git-ai = { git = "https://github.com/git-ai-project/git-ai", branch = "main" }
 rtk = { git = "https://github.com/rtk-ai/rtk", branch = "master" }
-worktrunk = "0.29.4"
+worktrunk = "0.33.0"

--- a/config/worktrunk/config.toml
+++ b/config/worktrunk/config.toml
@@ -3,6 +3,9 @@ worktree-path = "{{ repo_path }}/.worktrees/{{ branch | sanitize }}"
 [post-start]
 copy = "wt step copy-ignored"
 
+[step.copy-ignored]
+exclude = [".cache/", ".devenv/", ".serena/"]
+
 [commit]
 stage = "all"
 


### PR DESCRIPTION
## Summary
- Upgrade worktrunk from 0.29.4 to 0.33.0
- Add `[step.copy-ignored]` config with custom excludes (`.cache/`, `.devenv/`, `.serena/`)

## Test plan
- [ ] Verify `wt step copy-ignored` respects new exclude patterns

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `worktrunk` to 0.33.0 and configure the `copy-ignored` step to skip ephemeral directories. This speeds up worktree setup and avoids copying cache/dev files.

- **New Features**
  - Add `[step.copy-ignored]` with `exclude = [".cache/", ".devenv/", ".serena/"]`.

- **Dependencies**
  - Bump `worktrunk` from 0.29.4 to 0.33.0.

<sup>Written for commit fb7bd3abf8f2498c70dbe462d388867ed148532a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

