### PR TITLE
feat(tmux): fix resurrect and add 3rd tab to tmuxinator configs

### DIFF
--- a/config/tmuxinator/desktop.yml
+++ b/config/tmuxinator/desktop.yml
@@ -7,3 +7,4 @@ windows:
       panes:
         -
         -
+  - desktop:

--- a/config/tmuxinator/mobile.yml
+++ b/config/tmuxinator/mobile.yml
@@ -7,3 +7,4 @@ windows:
       panes:
         -
         -
+  - mobile:

--- a/config/tmuxinator/primary.yml
+++ b/config/tmuxinator/primary.yml
@@ -7,3 +7,4 @@ windows:
       panes:
         -
         -
+  - primary:

--- a/config/tmuxinator/work.yml
+++ b/config/tmuxinator/work.yml
@@ -2,3 +2,4 @@ name: work
 windows:
   - editor: nvim
   - shell:
+  - work:

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -58,6 +58,7 @@ with pkgs;
   htop
   httpie
   hyperfine
+  input-leap
   jq
   jujutsu
   just

--- a/home-manager/programs/tmux/tmux.conf
+++ b/home-manager/programs/tmux/tmux.conf
@@ -107,7 +107,7 @@ set -g clock-mode-style 24
 # =============================================================================
 set -g status-style "bg=colour22,fg=colour255"
 set -g status-left "#[bg=colour28,fg=colour255,bold] #S #[bg=colour22,fg=colour28] "
-set -g status-right "#[fg=colour250]#{?#{pane_current_command},#{pane_current_command},} #[fg=colour28]| #[fg=colour255]%Y/%m/%d %H:%M:%S "
+set -g status-right "#[fg=colour250]#{?#{pane_current_command},#{pane_current_command},} #[fg=colour28]| #[fg=colour255]%Y/%m/%d %H:%M:%S #{continuum_status}"
 set -g status-left-length 30
 set -g status-right-length 60
 
@@ -126,9 +126,10 @@ set -g message-style "bg=colour28,fg=colour255"
 # =============================================================================
 # Plugin configuration
 # =============================================================================
-# Resurrect + Continuum (session persistence)
+# Resurrect + Continuum (session persistence — work session only)
 set -g @resurrect-capture-pane-contents 'on'
 set -g @resurrect-processes 'btop fish git'
+set -g @resurrect-hook-post-save-all 'd=~/.tmux/resurrect && f="$d/$(readlink "$d/last")" && grep -E "^(pane|window)	work	" "$f" > "$f.tmp" && printf "state\twork\n" >> "$f.tmp" && mv "$f.tmp" "$f"'
 set -g @continuum-restore 'off'
 set -g @continuum-save-interval '3'
 


### PR DESCRIPTION
## Summary
- Fix tmux-resurrect by adding `#{continuum_status}` to status-right (was being overwritten)
- Filter resurrect saves to only persist the `work` session (portable macOS/Linux)
- Add 3rd shell tab to all tmuxinator configs (work, primary, desktop, mobile)
- Add `input-leap` to base packages

## Test plan
- [ ] Verify `prefix + Ctrl-s` saves only work session data in `~/.tmux/resurrect/last`
- [ ] Verify continuum auto-saves every 3 minutes
- [ ] Verify `tmuxinator start work/primary/desktop/mobile` creates 3 tabs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix tmux session persistence by showing `#{continuum_status}` and saving only the `work` session. Add a third shell tab to all `tmuxinator` profiles and include `input-leap` in base packages.

- **New Features**
  - Filter `tmux-resurrect` saves to the `work` session via a post-save hook (portable on macOS/Linux).
  - Add a third shell tab to all `tmuxinator` configs: `work`, `primary`, `desktop`, `mobile`.

- **Dependencies**
  - Add `input-leap` to base packages for all Home Manager profiles.

<sup>Written for commit 0c2eda7496a2e3ba959c1453885f116417e1a3ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

