### PR TITLE
fix(two): restore work session from resurrect when server is dead

### DIFF
--- a/home-manager/programs/fish/functions/_two_function.fish
+++ b/home-manager/programs/fish/functions/_two_function.fish
@@ -1,17 +1,31 @@
 function _two_function --description "Attach to tmux work session"
-  set -l restore (tmux list-keys 2>/dev/null | string match -rg '(/\S+/resurrect/scripts/restore\.sh)')
-  set -l restore $restore[1]
-  if test -n "$restore"
-    tmux run-shell "$restore"
-  end
-
   if tmux has-session -t work 2>/dev/null
     if test -n "$TMUX"
       tmux switch-client -t work
     else
       tmux attach-session -t work
     end
-  else
-    tmuxinator start work
+    return
   end
+
+  # No work session — try resurrect restore
+  if test -f ~/.tmux/resurrect/last
+    # Start a detached session so the server is running
+    tmux new-session -d -s _restore 2>/dev/null
+    set -l restore (tmux list-keys 2>/dev/null | string match -rg '(/\S+/resurrect/scripts/restore\.sh)')
+    set -l restore $restore[1]
+    if test -n "$restore"
+      tmux run-shell "$restore"
+    end
+    # Clean up temp session if restore created work
+    if tmux has-session -t work 2>/dev/null
+      tmux kill-session -t _restore 2>/dev/null
+      tmux attach-session -t work
+      return
+    end
+    tmux kill-session -t _restore 2>/dev/null
+  end
+
+  # Fallback to tmuxinator
+  tmuxinator start work
 end

--- a/spec/fish/_two_function_test.fish
+++ b/spec/fish/_two_function_test.fish
@@ -1,15 +1,28 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
 source $fn/_two_function.fish
 
-# ── no resurrect, no work session → tmuxinator start work ─
+# ── no resurrect file, no work session → tmuxinator start work ─
 set log (mktemp)
 function tmux
-    if test "$argv[1]" = list-keys; echo ""; return; end
     if test "$argv[1]" = has-session; return 1; end
+    if test "$argv[1]" = new-session; return 0; end
+    if test "$argv[1]" = list-keys; echo ""; return; end
+    if test "$argv[1]" = kill-session; return 0; end
 end
 function tmuxinator; echo $argv >> $log; end
 
+# Ensure no resurrect file interferes
+set -l _bak ""
+if test -f ~/.tmux/resurrect/last
+    set _bak (mktemp)
+    mv ~/.tmux/resurrect/last $_bak
+end
+
 _two_function
+
+if test -n "$_bak"
+    mv $_bak ~/.tmux/resurrect/last
+end
 
 @test "missing work session starts via tmuxinator" (grep -c "start work" $log) -ge 1
 
@@ -17,7 +30,6 @@ _two_function
 set log2 (mktemp)
 set -e TMUX
 function tmux
-    if test "$argv[1]" = list-keys; echo ""; return; end
     if test "$argv[1]" = has-session; return 0; end
     echo $argv >> $log2
 end


### PR DESCRIPTION
## Summary
- Fix `two` function to properly restore work session via resurrect when tmux server is not running
- Starts a temp detached session to bootstrap the server, runs resurrect restore, then attaches to work
- Falls back to `tmuxinator start work` if no resurrect data exists

## Test plan
- [ ] Kill tmux server, run `two`, verify work session is restored from resurrect
- [ ] Run `two` when work session already exists, verify it attaches
- [ ] `make shell-test` passes (253/253)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `two` so it restores the `work` session when the `tmux` server is down. It bootstraps `tmux` and restores via `tmux-resurrect`.

- **Bug Fixes**
  - If `work` exists, attach or switch immediately.
  - If not, and `~/.tmux/resurrect/last` exists: start a detached `_restore` session to start `tmux`, run the `resurrect` restore script, then clean up and attach to `work`.
  - If restore data is missing or no `work` is created, fall back to `tmuxinator start work`.

<sup>Written for commit 0950d91f30389b694116550ce78c39dbca08c6c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

