### PR TITLE
feat(tmux): auto-save on detach/close and fix restore timing

### DIFF
--- a/home-manager/programs/fish/functions/_two_function.fish
+++ b/home-manager/programs/fish/functions/_two_function.fish
@@ -16,7 +16,6 @@ function _two_function --description "Attach to tmux work session"
     set -l restore $restore[1]
     if test -n "$restore"
       tmux run-shell "$restore"
-      sleep 1
     end
     # Clean up temp session if restore created work
     if tmux has-session -t work 2>/dev/null

--- a/home-manager/programs/fish/functions/_two_function.fish
+++ b/home-manager/programs/fish/functions/_two_function.fish
@@ -16,6 +16,7 @@ function _two_function --description "Attach to tmux work session"
     set -l restore $restore[1]
     if test -n "$restore"
       tmux run-shell "$restore"
+      sleep 1
     end
     # Clean up temp session if restore created work
     if tmux has-session -t work 2>/dev/null

--- a/home-manager/programs/tmux/tmux.conf
+++ b/home-manager/programs/tmux/tmux.conf
@@ -133,6 +133,10 @@ set -g @resurrect-hook-post-save-all 'd=~/.tmux/resurrect && f="$d/$(readlink "$
 set -g @continuum-restore 'off'
 set -g @continuum-save-interval '3'
 
+# Auto-save on detach/close so kills don't lose state
+set-hook -g client-detached 'run-shell #{@resurrect-save-script-path}'
+set-hook -g session-closed 'run-shell #{@resurrect-save-script-path}'
+
 # Tmux-thumbs (quick text copy)
 set -g @thumbs-key Space
 


### PR DESCRIPTION
## Summary
- Add tmux hooks to auto-save resurrect state on client detach and session close
- Add sleep after resurrect restore in `two` to fix race condition

## Test plan
- [ ] Kill tmux server, run `two`, verify work session restores
- [ ] Detach from tmux, check `~/.tmux/resurrect/last` is updated

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-saves `tmux-resurrect` state on detach and session close, and adjusts `two` restore timing to avoid races and lost state.

- **New Features**
  - Add `tmux` hooks: `client-detached` and `session-closed` run `@resurrect-save-script-path` to persist state.

- **Bug Fixes**
  - In `_two_function.fish`, add `sleep 1` after `tmux-resurrect` restore to avoid a startup race.

<sup>Written for commit c6350b519edad3fb26a18650b2825e9f20fdb1d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

