### PR TITLE
feat(cliproxyapi): add proactive OAuth token refresh

### DIFF
--- a/.local-binaries.txt
+++ b/.local-binaries.txt
@@ -2,6 +2,12 @@
 # Add one binary path per line
 # Lines starting with # are comments
 # Use path:alias to create a symlink with a custom name (e.g., ~/path/to/pi:pir)
+# Dependencies (lib-only repos) must appear before the binaries that need them
+
+# cass dependencies (pull + build before cass itself)
+~/ghq/github.com/Dicklesworthstone/asupersync/target/release/libasupersync.rlib
+~/ghq/github.com/Dicklesworthstone/franken_agent_detection/target/release/libfranken_agent_detection.rlib
+~/ghq/github.com/Dicklesworthstone/frankensqlite/target/release/libfsqlite.rlib
 
 ~/ghq/github.com/Dicklesworthstone/beads_viewer/bv
 ~/ghq/github.com/Dicklesworthstone/coding_agent_session_search/target/release/cass

--- a/home-manager/modules/local-binaries/sync-local-binaries.sh
+++ b/home-manager/modules/local-binaries/sync-local-binaries.sh
@@ -44,6 +44,11 @@ while IFS= read -r line || [ -n "$line" ]; do
   # Expand ~ to $HOME
   line="${line/#\~/$HOME}"
 
+  # Skip library files silently (dependencies listed for update-local-binaries.sh)
+  case "$line" in
+  *.rlib | *.a | *.so | *.dylib) continue ;;
+  esac
+
   # Check if binary exists and is executable
   if [ ! -f "$line" ] || [ ! -x "$line" ]; then
     echo "Skipping (not found or not executable): $line"

--- a/home-manager/programs/cass/default.nix
+++ b/home-manager/programs/cass/default.nix
@@ -1,0 +1,4 @@
+{ ... }:
+{
+  xdg.configFile."cass/sources.toml".source = ./sources.toml;
+}

--- a/home-manager/programs/cass/sources.toml
+++ b/home-manager/programs/cass/sources.toml
@@ -1,0 +1,6 @@
+[[sources]]
+name = "kyber"
+type = "ssh"
+host = "ubuntu@kyber"
+platform = "linux"
+sync_schedule = "daily"

--- a/home-manager/programs/default.nix
+++ b/home-manager/programs/default.nix
@@ -9,6 +9,7 @@ let
   bash = import ./bash { inherit lib pkgs; };
   bat = import ./bat;
   btop = import ./btop;
+  cass = import ./cass;
   clang = import ./clang;
   dart = import ./dart;
   delta = import ./delta;
@@ -55,6 +56,7 @@ in
   bash
   bat
   btop
+  cass
   clang
   dart
   delta

--- a/home-manager/programs/ssh/default.nix
+++ b/home-manager/programs/ssh/default.nix
@@ -37,6 +37,10 @@
           StrictHostKeyChecking = "false";
         };
       };
+      "kyber" = {
+        hostname = "100.74.174.97";
+        user = "ubuntu";
+      };
       "github.com" = {
         serverAliveInterval = 0;
         identityFile = "~/.ssh/id_ed25519_github";

--- a/home-manager/services/cliproxyapi/scripts/keychain-sync.sh
+++ b/home-manager/services/cliproxyapi/scripts/keychain-sync.sh
@@ -52,6 +52,11 @@ sync_claude() {
   local dest="$AUTH_DIR/claude-${EMAIL}.json"
   local new_json
   # shellcheck disable=SC2016
+  # refresh_interval_seconds=999999999 disables cliproxyapi's built-in
+  # auto-refresh for this auth entry. Without this, cliproxyapi refreshes
+  # Claude tokens 4h before expiry, rotating the refresh_token. keychain-sync
+  # then overwrites with the old (now-invalidated) refresh_token, breaking the
+  # refresh chain. Let Claude Code handle its own token lifecycle instead.
   new_json=$($JQ -n \
     --arg at "$access_token" \
     --arg rt "${refresh_token:-}" \
@@ -65,6 +70,7 @@ sync_claude() {
       expired: $expired,
       id_token: "",
       last_refresh: $last_refresh,
+      refresh_interval_seconds: 999999999,
       refresh_token: $rt,
       type: "claude"
     }')
@@ -76,7 +82,9 @@ sync_claude() {
   fi
 
   if [ "$access_token" != "$existing_at" ]; then
-    printf '%s' "$new_json" >"$dest"
+    local tmp
+    tmp=$(mktemp "${AUTH_DIR}/.claude-sync.XXXXXX")
+    printf '%s' "$new_json" >"$tmp" && mv "$tmp" "$dest" || rm -f "$tmp"
     echo "[$(date)] Claude: synced new token to $dest" >&2
     changed=1
   fi
@@ -129,7 +137,9 @@ sync_codex() {
   fi
 
   if [ "$access_token" != "$existing_at" ]; then
-    printf '%s' "$new_json" >"$dest"
+    local tmp
+    tmp=$(mktemp "${AUTH_DIR}/.codex-sync.XXXXXX")
+    printf '%s' "$new_json" >"$tmp" && mv "$tmp" "$dest" || rm -f "$tmp"
     echo "[$(date)] Codex: synced new token to $dest" >&2
     changed=1
   fi


### PR DESCRIPTION
## Summary
- Adds a `token-refresh.sh` script that proactively refreshes Claude OAuth tokens using the refresh_token grant before the access_token expires
- Runs every 5 minutes via launchd (macOS) and systemd timer (Linux)
- Writes refreshed tokens back to both cliproxyapi auth file and macOS Keychain, keeping Claude Code in sync
- Uses 10-minute threshold — skips refresh if token still has >600s remaining

## Context
OAuth tokens synced via S3 between machines expire frequently (~10min–1hr), causing 401 errors in cliproxyapi. Previously each machine managed its own tokens, but S3 sync introduced stale snapshot tokens. This script uses `platform.claude.com/v1/oauth/token` with client_id `9d1c250a-e61b-44d9-88ed-5944d1962f5e` to refresh proactively.

## Test plan
- [ ] `make build && make switch` on macOS
- [ ] Verify `launchctl list | grep token-refresh` shows the agent
- [ ] Wait for token to approach expiry, check `/tmp/cliproxyapi-token-refresh.log` for successful refresh
- [ ] Confirm no more 401 errors in cliproxyapi

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proactively refreshes Claude OAuth tokens in `cliproxyapi` to avoid expiries and 401s. Disables built-in auto-refresh to stop refresh_token rotation conflicts; timers run every 3 minutes and prevent stale overwrites.

- **New Features**
  - Token-refresh script uses the refresh_token grant; skips if >600s remain; writes refreshed tokens to the `cliproxyapi` auth file and macOS Keychain.
  - `launchd` (macOS) and `systemd` (Linux) timers run every 3 minutes with sanitized logs.
  - Hardening: keychain sync sets `refresh_interval_seconds=999999999` to disable `cliproxyapi` auto-refresh, adds atomic writes for Claude and Codex auth files, and drops `--exact-timestamps` from S3 sync to prevent stale or corrupt tokens.

- **Refactors**
  - Added `cass` program module (installs a kyber SSH source with daily sync), ordered `cass` lib deps before the binary and skipped library files in local-binaries sync, and added SSH host alias `kyber` (100.74.174.97) for Tailscale.

<sup>Written for commit 027f19c06f33244f68d1e28a62ec7cf2b14b4979. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

