### PR TITLE
fix(hyprland): fix Slack and Telegram keybindings

### DIFF
--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -225,9 +225,9 @@ layerrule = ignore_alpha 0.3, match:namespace ^(rofi)$
 # App Launch Hotkeys
 # =============================================================================
 bind = $mod, T, exec, ghostty
-bind = ALT SHIFT, T, exec, telegram-desktop
+bind = $mod SHIFT, T, exec, Telegram
 bind = $mod, G, exec, hyprctl clients -j | grep -q '"class": "google-chrome"' && hyprctl dispatch focuswindow class:google-chrome || google-chrome-stable
-bind = $mod, S, exec, hyprctl clients -j | grep -q '"class": "Slack"' && hyprctl dispatch focuswindow class:Slack || slack
+bind = $mod, S, exec, slack
 bind = $mod, C, exec, cursor
 bind = $mod, V, exec, code
 bind = $mod, P, exec, gtk-launch 1password


### PR DESCRIPTION
## Summary
- **Super+S (Slack)**: Always open new window instead of focus-or-launch
- **Super+Shift+T (Telegram)**: Fix modifier from ALT SHIFT to $mod SHIFT, and fix binary name from `telegram-desktop` to `Telegram`

## Test plan
- [ ] Verify Super+S opens a new Slack window
- [ ] Verify Super+Shift+T launches Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Hyprland keybindings so Slack and Telegram launch reliably.

- **Bug Fixes**
  - Super+S now runs `slack` directly, always opening a new window.
  - Super+Shift+T now uses `$mod` (not ALT) and calls `Telegram` (correct binary).

<sup>Written for commit 563bb9a15473aecdf6ca503cd552b2c4ecada7a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

