### PR TITLE
feat(nix-darwin/config): added telegram-desktop cask

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -119,6 +119,7 @@
       "sf-symbols"
       "slack"
       "tailscale-app"
+      "telegram-desktop"
       "trae"
       "vlc"
       "visual-studio-code"


### PR DESCRIPTION
- Managed Telegram Desktop in the Homebrew cask list for this host.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `telegram-desktop` to the Homebrew cask list so it’s installed and managed by nix-darwin on this host.

<sup>Written for commit 889315bdf44d2225a303b016938e377a1645fd0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

