### PR TITLE
fix: use master branch for rtk-rewrite sync URL

### DIFF
--- a/scripts/sync-rtk-rewrite.sh
+++ b/scripts/sync-rtk-rewrite.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-URL="https://raw.githubusercontent.com/rtk-ai/rtk/main/.claude/hooks/rtk-rewrite.sh"
+URL="https://raw.githubusercontent.com/rtk-ai/rtk/master/.claude/hooks/rtk-rewrite.sh"
 
 tmpfile=$(mktemp)
 trap 'rm -f "$tmpfile"' EXIT


### PR DESCRIPTION
## Summary
- rtk repo uses `master` not `main` — fixes 404 in `make upgrade`

## Test plan
- [ ] `make upgrade` passes rtk-rewrite-sync step

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch rtk-rewrite sync to the `master` branch of `rtk-ai/rtk` to fix 404s during `make upgrade`.
Updates `scripts/sync-rtk-rewrite.sh` to fetch the correct `.claude/hooks/rtk-rewrite.sh` URL.

<sup>Written for commit dfa5dacba2a2d1bc9277e73c9ad9e2bf60e1a658. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

