### PR TITLE
chore: exclude synced rtk-rewrite.sh from shfmt formatting

### DIFF
--- a/treefmt.toml
+++ b/treefmt.toml
@@ -17,6 +17,10 @@ excludes = ["home-manager/programs/neovim/nvim-pack-lock.json"]
 command = "shfmt"
 options = ["-i", "2", "-s", "-w"]
 includes = ["*.sh"]
+excludes = [
+  "config/claude/hooks/rtk-rewrite.sh",
+  "config/codex/hooks/rtk-rewrite.sh",
+]
 
 [formatter.lua]
 command = "stylua"


### PR DESCRIPTION
## Summary
- Exclude `config/claude/hooks/rtk-rewrite.sh` and `config/codex/hooks/rtk-rewrite.sh` from shfmt in `treefmt.toml`
- These files are synced from upstream rtk repo and should preserve upstream formatting

## Test plan
- [ ] `make format` no longer modifies the synced rtk-rewrite.sh files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude the synced `rtk-rewrite.sh` scripts from `shfmt` in `treefmt.toml` to preserve upstream formatting and avoid local diffs. `make format` no longer changes `config/claude/hooks/rtk-rewrite.sh` or `config/codex/hooks/rtk-rewrite.sh`.

<sup>Written for commit 1db07a53c2b1ecdbc3ff23359ab1a4a134d080b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

