### PR TITLE
chore: add open-pencil brew formula

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -21,6 +21,7 @@
       "paradigmxyz/brew"
       "entireio/tap"
       "manaflow-ai/cmux"
+      "open-pencil/tap"
       "sst/tap"
       "steipete/tap"
     ];
@@ -44,6 +45,7 @@
       "mactop"
       "mas"
       "mlx-lm"
+      "open-pencil"
       "opencode"
       "ollama"
       "pandoc"


### PR DESCRIPTION
## Summary
- Add `open-pencil/tap` tap and `open-pencil` brew formula to homebrew config

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `open-pencil/tap` Homebrew tap and includes the `open-pencil` formula in the nix-darwin Homebrew config. This enables automatic install of Open Pencil during system setup.

<sup>Written for commit e0ead4f06b8d60de5524388197119d41797c2866. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

