### PR TITLE
feat(claude): add openai/codex-plugin-cc plugin

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -439,7 +439,8 @@
     "rust-analyzer-lsp@claude-plugins-official": true,
     "swift-lsp@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
-    "worktrunk@worktrunk": true
+    "worktrunk@worktrunk": true,
+    "codex@openai-codex": true
   },
   "extraKnownMarketplaces": {
     "cc-marketplace": {
@@ -470,6 +471,12 @@
       "source": {
         "source": "github",
         "repo": "max-sixty/worktrunk"
+      }
+    },
+    "openai-codex": {
+      "source": {
+        "source": "github",
+        "repo": "openai/codex-plugin-cc"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Registers the `openai-codex` marketplace pointing to `openai/codex-plugin-cc`
- Enables the `codex@openai-codex` plugin in Claude Code settings
- Provides `/codex:review`, `/codex:adversarial-review`, `/codex:rescue`, and job management commands within Claude Code

## Test plan
- [ ] Run `/reload-plugins` in Claude Code
- [ ] Verify `/codex:setup` reports Codex is ready
- [ ] Test `/codex:review` on a branch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Codex support to Claude Code. This enables new slash commands for code review and job control.

- **New Features**
  - Register `openai-codex` marketplace pointing to `openai/codex-plugin-cc`.
  - Enable `codex@openai-codex` in `config/claude/settings.json`.
  - Add `/codex:review`, `/codex:adversarial-review`, `/codex:rescue`, and job management commands.

<sup>Written for commit 75c51a27e41fe1f0f20b8f1c706d19bbaaf38e3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

