### PR TITLE
fix: upgrade postgresql client to v18

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -77,7 +77,7 @@ with pkgs;
   navi
   ncdu
   pingu
-  postgresql
+  postgresql_18
   procs
   qwen-code
   ripgrep


### PR DESCRIPTION
## Summary
- Upgrade `postgresql` → `postgresql_18` in home-manager packages
- Fixes `pg_dump` version mismatch when dumping from PostgreSQL 18 server (pg_dump v17 refuses to dump a newer server)

## Test plan
- [ ] Rebuild NixOS config (`sudo nixos-rebuild switch`)
- [ ] Verify `pg_dump --version` shows v18
- [ ] Run `make db-up` in trails-api and confirm `schema.sql` is generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the PostgreSQL client in Home Manager from `postgresql` to `postgresql_18` to match our v18 server. This resolves `pg_dump` v17 refusing to dump a newer server and restores `schema.sql` generation in trails-api.

- **Migration**
  - Rebuild: sudo nixos-rebuild switch
  - Verify: pg_dump --version shows 18; rerun make db-up if needed

<sup>Written for commit f9295900f848b28baf698be01b46dfb5c8984fe3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

