### PR TITLE
fix: increase home-manager service timeout to 30m

### DIFF
--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -118,6 +118,11 @@ nixpkgs.lib.nixosSystem {
       ];
     }
     home-manager.nixosModules.home-manager
+    # Home Manager activation can take a long time (npm globals, etc.)
+    {
+      systemd.services."home-manager-${username}".serviceConfig.TimeoutStartSec =
+        nixpkgs.lib.mkForce "30m";
+    }
     {
       home-manager.backupFileExtension = "hm-backup";
       home-manager.extraSpecialArgs = { inherit inputs; };


### PR DESCRIPTION
## Summary
- Home-manager activation takes ~7.5 minutes (npm globals, yek install, docker-postgres restart, etc.), exceeding the default 5m `TimeoutStartSec`
- This causes `make switch` to fail with status 4 (`NOPERMISSION`) even though the service eventually completes successfully
- Increases timeout to 30m to accommodate heavy activation steps

## Test plan
- [ ] Run `make switch` on matic and verify it completes without the restart failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the `home-manager-${username}` systemd service start timeout to 30m on all NixOS hosts to prevent `make switch` failures during ~7.5m activations. Uses `nixpkgs.lib.mkForce` to override the 5m default via `systemd.services."home-manager-${username}".serviceConfig.TimeoutStartSec = "30m"`.

<sup>Written for commit 02eeaffaf74d15a619f32d43f4316a52f0f46c18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

