### PR TITLE
fix(cliproxyapi): omit expired field to prevent built-in token refresh

### DIFF
--- a/home-manager/services/cliproxyapi/scripts/keychain-sync.sh
+++ b/home-manager/services/cliproxyapi/scripts/keychain-sync.sh
@@ -52,25 +52,25 @@ sync_claude() {
   local dest="$AUTH_DIR/claude-${EMAIL}.json"
   local new_json
   # shellcheck disable=SC2016
-  # refresh_interval_seconds=999999999 disables cliproxyapi's built-in
-  # auto-refresh for this auth entry. Without this, cliproxyapi refreshes
-  # Claude tokens 4h before expiry, rotating the refresh_token. keychain-sync
-  # then overwrites with the old (now-invalidated) refresh_token, breaking the
-  # refresh chain. Let Claude Code handle its own token lifecycle instead.
+  # Omit the expired field so cliproxyapi's built-in refresh (RefreshLead=4h)
+  # won't preemptively refresh this token. Without an expiry, cliproxyapi only
+  # checks if last_refresh is >4h old - since keychain-sync writes every 5 min,
+  # last_refresh stays recent and refresh never triggers.
+  #
+  # This prevents cliproxyapi from rotating the refresh_token on Anthropic's
+  # side, which would invalidate the token in Claude Code's keychain.
   new_json=$($JQ -n \
     --arg at "$access_token" \
     --arg rt "${refresh_token:-}" \
     --arg email "$EMAIL" \
-    --arg expired "${expires_at:-}" \
     --arg last_refresh "$(date -u +%Y-%m-%dT%H:%M:%S+00:00)" \
     '{
       access_token: $at,
       disabled: false,
       email: $email,
-      expired: $expired,
+      expired: "",
       id_token: "",
       last_refresh: $last_refresh,
-      refresh_interval_seconds: 999999999,
       refresh_token: $rt,
       type: "claude"
     }')


### PR DESCRIPTION
## Summary
- Omit `expired` field from Claude auth file written by keychain-sync
- Remove `refresh_interval_seconds` (doesn't actually prevent refresh due to `expiry.Sub(now) <= interval` logic)

## Root cause
`refresh_interval_seconds: 999999999` didn't work because cliproxyapi's `shouldRefresh` checks `expiry.Sub(now) <= interval` - since 31.7 years > 8h remaining, it always evaluates to true and triggers refresh anyway.

Without the `expired` field, cliproxyapi falls back to checking `now.Sub(lastRefresh) >= RefreshLead(4h)`. Since keychain-sync writes `last_refresh` every 5 min, this is always false and refresh never triggers.

## Test plan
- [ ] `make build && make switch`
- [ ] Verify `~/.cli-proxy-api/objectstore/auths/claude-*.json` has empty `expired` field
- [ ] Check `~/.cli-proxy-api/logs/main.log` for no `claude executor: refresh called` entries

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop `cliproxyapi` from auto-refreshing Claude tokens so refresh tokens aren’t rotated and Claude Code stays signed in.

- **Bug Fixes**
  - Update keychain sync to write auth JSON without `expired` and without `refresh_interval_seconds`. With no expiry, `cliproxyapi` uses the `last_refresh` (>4h) rule, and the 5‑min sync keeps it recent so refresh never triggers.

<sup>Written for commit afc5a3563480e716960f600815a9c6f34de23141. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

