### PR TITLE
fix: add LD_LIBRARY_PATH for bun-installed native addons on NixOS

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -136,7 +136,7 @@ with pkgs;
   xclip
   zlib
 ]
-++ lib.optional stdenv.isLinux alsa-lib
+++ lib.optionals stdenv.isLinux [ alsa-lib ]
 ++ lib.optionals (stdenv.isLinux && isDesktop) [
   _1password-gui
   baobab

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -106,7 +106,6 @@ with pkgs;
   zoxide
 ]
 ++ lib.optionals stdenv.isLinux [
-  alsa-lib
   atop
   below
   binutils
@@ -137,6 +136,7 @@ with pkgs;
   xclip
   zlib
 ]
+++ lib.optional stdenv.isLinux alsa-lib
 ++ lib.optionals (stdenv.isLinux && isDesktop) [
   _1password-gui
   baobab

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -106,6 +106,7 @@ with pkgs;
   zoxide
 ]
 ++ lib.optionals stdenv.isLinux [
+  alsa-lib
   atop
   below
   binutils
@@ -120,17 +121,21 @@ with pkgs;
   fwupd
   gcc
   gemini-cli
+  glib
   keychain
   libiconv
+  libsecret
   opencode
   openssl
   openssl.dev
   pkg-config
   powertop
   qemu
+  stdenv.cc.cc.lib
   tailscale
   trashy
   xclip
+  zlib
 ]
 ++ lib.optionals (stdenv.isLinux && isDesktop) [
   _1password-gui

--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -52,6 +52,9 @@
           export OPENSSL_DIR="${pkgs.openssl.dev}"
           export OPENSSL_LIB_DIR="${pkgs.openssl.out}/lib"
           export OPENSSL_INCLUDE_DIR="${pkgs.openssl.dev}/include"
+
+          # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)
+          export LD_LIBRARY_PATH="${pkgs.alsa-lib}/lib:${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
       fi
 
       # Go configuration
@@ -92,6 +95,9 @@
           export OPENSSL_DIR="${pkgs.openssl.dev}"
           export OPENSSL_LIB_DIR="${pkgs.openssl.out}/lib"
           export OPENSSL_INCLUDE_DIR="${pkgs.openssl.dev}/include"
+
+          # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)
+          export LD_LIBRARY_PATH="${pkgs.alsa-lib}/lib:${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
       fi
 
       # Source .bashrc for login shells to get PATH and other settings

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -17,6 +17,9 @@
           set -gx OPENSSL_DIR "${pkgs.openssl.dev}"
           set -gx OPENSSL_LIB_DIR "${pkgs.openssl.out}/lib"
           set -gx OPENSSL_INCLUDE_DIR "${pkgs.openssl.dev}/include"
+
+          # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)
+          set -gx LD_LIBRARY_PATH "${pkgs.alsa-lib}/lib" "${pkgs.glib.out}/lib" "${pkgs.libsecret}/lib" "${pkgs.stdenv.cc.cc.lib}/lib" "${pkgs.zlib}/lib" $LD_LIBRARY_PATH
       end
 
       # Go configuration

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -40,6 +40,9 @@
           export OPENSSL_DIR="${pkgs.openssl.dev}"
           export OPENSSL_LIB_DIR="${pkgs.openssl.out}/lib"
           export OPENSSL_INCLUDE_DIR="${pkgs.openssl.dev}/include"
+
+          # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)
+          export LD_LIBRARY_PATH="${pkgs.alsa-lib}/lib:${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
       fi
 
       # Define aliases in .zshenv so non-interactive zsh invocations can use them.


### PR DESCRIPTION
## Summary
- Add `LD_LIBRARY_PATH` with `alsa-lib`, `glib`, `libsecret`, `stdenv.cc.cc.lib`, and `zlib` to fish, bash, and zsh shell configs (Linux only)
- Install corresponding packages in `home-manager/packages/default.nix`
- Fixes `omp` (oh-my-pi) crashing with `libz.so.1: cannot open shared object file` and similar errors for sharp, keytar, copilot, node-llama-cpp, etc.

## Test plan
- [ ] Rebuild NixOS / home-manager switch
- [ ] Run `omp` — should no longer error about `libz.so.1`
- [ ] Verify `ldd` on bun native addons shows no missing libs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configure `LD_LIBRARY_PATH` for `bun`-installed native addons on NixOS and install system libs to stop load failures. Fixes errors like "libz.so.1: cannot open shared object file" in `@oh-my-pi/pi-natives`, `sharp`, `keytar`, `node-llama-cpp`, and others.

- **Bug Fixes**
  - Export `LD_LIBRARY_PATH` on Linux in bash, zsh, and fish to include libs from `alsa-lib`, `glib`, `libsecret`, `stdenv.cc.cc.lib`, and `zlib`.
  - Add the same packages to Home Manager Linux packages so the libraries are present.
  - Append `alsa-lib` only on Linux using `lib.optionals` to avoid aarch64-darwin evaluation errors.

<sup>Written for commit e5bc6401a96b9ae09c706f660fa297382be653ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

