### PR TITLE
feat: add blur and alpha layer rules for eww-clock widget

### DIFF
--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -192,6 +192,10 @@ windowrule = suppress_event maximize, match:class .*
 
 # Slight opacity for visual depth
 windowrule = opacity 0.90 0.80, match:class ^(com.mitchellh.ghostty)$
+
+# Clock widget transparency (match ghostty)
+layerrule = blur on, match:namespace ^(eww-clock)$
+layerrule = ignore_alpha 0.3, match:namespace ^(eww-clock)$
 windowrule = opacity 0.90 0.80, match:class ^(discord)$
 windowrule = opacity 0.90 0.80, match:class ^(google-chrome)$
 windowrule = opacity 0.90 0.80, match:class ^(code)$


### PR DESCRIPTION
## Summary
- Add blur and alpha ignore layer rules for `eww-clock` namespace in Hyprland config
- Matches the transparency style used by ghostty

## Test plan
- [ ] Verify eww-clock widget renders with blur effect
- [ ] Confirm alpha transparency at 0.3 threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Hyprland layer rules to blur the `eww-clock` widget and ignore alpha below 0.3, matching `ghostty` transparency. The clock now blends with the background while keeping text clear.

<sup>Written for commit c1de15e7ba38e21948abe2a26c7f1e1ed4844a83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

