### PR TITLE
fix: add force=true to tmuxinator configs to prevent clobber errors

### DIFF
--- a/config/tmuxinator/default.nix
+++ b/config/tmuxinator/default.nix
@@ -1,6 +1,18 @@
-_: {
-  xdg.configFile."tmuxinator/primary.yml".source = ./primary.yml;
-  xdg.configFile."tmuxinator/mobile.yml".source = ./mobile.yml;
-  xdg.configFile."tmuxinator/work.yml".source = ./work.yml;
-  xdg.configFile."tmuxinator/desktop.yml".source = ./desktop.yml;
+{
+  xdg.configFile."tmuxinator/primary.yml" = {
+    source = ./primary.yml;
+    force = true;
+  };
+  xdg.configFile."tmuxinator/mobile.yml" = {
+    source = ./mobile.yml;
+    force = true;
+  };
+  xdg.configFile."tmuxinator/work.yml" = {
+    source = ./work.yml;
+    force = true;
+  };
+  xdg.configFile."tmuxinator/desktop.yml" = {
+    source = ./desktop.yml;
+    force = true;
+  };
 }


### PR DESCRIPTION
## Summary
- Adds `force = true` to all four tmuxinator xdg.configFile entries (`primary.yml`, `mobile.yml`, `work.yml`, `desktop.yml`)
- Fixes home-manager switch failure where existing tmuxinator config files would be clobbered

## Test plan
- [ ] Run `make nix-switch` and verify no clobber errors for tmuxinator files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `force = true` on `xdg.configFile` entries for `tmuxinator` configs to prevent clobber errors during `home-manager` switches. Safely overwrites `primary.yml`, `mobile.yml`, `work.yml`, and `desktop.yml`.

<sup>Written for commit dea94f55b06c9c757d1f01359f3aa62619c3d03c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

