### PR TITLE
fix: guard alsa-lib with lib.optionalString to prevent darwin eval failure

### DIFF
--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -54,7 +54,7 @@
           export OPENSSL_INCLUDE_DIR="${pkgs.openssl.dev}/include"
 
           # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)
-          export LD_LIBRARY_PATH="${pkgs.alsa-lib}/lib:${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+          export LD_LIBRARY_PATH="${lib.optionalString pkgs.stdenv.isLinux "${pkgs.alsa-lib}/lib:"}${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
       fi
 
       # Go configuration
@@ -97,7 +97,7 @@
           export OPENSSL_INCLUDE_DIR="${pkgs.openssl.dev}/include"
 
           # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)
-          export LD_LIBRARY_PATH="${pkgs.alsa-lib}/lib:${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+          export LD_LIBRARY_PATH="${lib.optionalString pkgs.stdenv.isLinux "${pkgs.alsa-lib}/lib:"}${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
       fi
 
       # Source .bashrc for login shells to get PATH and other settings

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -19,7 +19,7 @@
           set -gx OPENSSL_INCLUDE_DIR "${pkgs.openssl.dev}/include"
 
           # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)
-          set -gx LD_LIBRARY_PATH "${pkgs.alsa-lib}/lib" "${pkgs.glib.out}/lib" "${pkgs.libsecret}/lib" "${pkgs.stdenv.cc.cc.lib}/lib" "${pkgs.zlib}/lib" $LD_LIBRARY_PATH
+          set -gx LD_LIBRARY_PATH ${lib.optionalString pkgs.stdenv.isLinux ''"${pkgs.alsa-lib}/lib"''} "${pkgs.glib.out}/lib" "${pkgs.libsecret}/lib" "${pkgs.stdenv.cc.cc.lib}/lib" "${pkgs.zlib}/lib" $LD_LIBRARY_PATH
       end
 
       # Go configuration

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -42,7 +42,7 @@
           export OPENSSL_INCLUDE_DIR="${pkgs.openssl.dev}/include"
 
           # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)
-          export LD_LIBRARY_PATH="${pkgs.alsa-lib}/lib:${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+          export LD_LIBRARY_PATH="${lib.optionalString pkgs.stdenv.isLinux "${pkgs.alsa-lib}/lib:"}${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
       fi
 
       # Define aliases in .zshenv so non-interactive zsh invocations can use them.


### PR DESCRIPTION
## Summary
- Wrap `alsa-lib` references in shell configs with `lib.optionalString pkgs.stdenv.isLinux` to prevent Nix from evaluating the derivation on darwin
- Fixes `e2e-run (MacOS)` CI failure from #1309 where `alsa-lib` (Linux-only in `meta.platforms`) caused eval to throw on `aarch64-darwin`

## Test plan
- [ ] `nix build .#darwinConfigurations.runner.system --dry-run` no longer throws alsa-lib error
- [ ] `e2e-run (MacOS)` CI check passes
- [ ] `omp` still works on NixOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded `alsa-lib` in shell configs using `lib.optionalString pkgs.stdenv.isLinux` to stop Darwin from evaluating a Linux-only derivation. Fixes MacOS eval errors and keeps Linux behavior unchanged.

- **Bug Fixes**
  - Wrap `alsa-lib` in `LD_LIBRARY_PATH` for bash, zsh, and fish with `lib.optionalString pkgs.stdenv.isLinux`.
  - Prevent Nix from evaluating `alsa-lib` on `aarch64-darwin` (not in its `meta.platforms`).

<sup>Written for commit f95ac021e6c337040bd99815b675eff6ea8077fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

