### PR TITLE
fix(cass): add macOS-native config path for sources.toml

### DIFF
--- a/config/iterm2/default.nix
+++ b/config/iterm2/default.nix
@@ -1,6 +1,7 @@
-{ config, ... }:
+{ pkgs, ... }:
 {
   home.file."Library/Application Support/iTerm2/DynamicProfiles/dotfiles.json" = {
+    enable = pkgs.stdenv.isDarwin;
     source = ./profile.json;
     force = true;
   };

--- a/home-manager/programs/cass/default.nix
+++ b/home-manager/programs/cass/default.nix
@@ -1,7 +1,8 @@
-{ lib, pkgs, ... }:
+{ pkgs, ... }:
 {
   xdg.configFile."cass/sources.toml".source = ./sources.toml;
-  home.file."Library/Application Support/cass/sources.toml" = lib.mkIf pkgs.stdenv.isDarwin {
+  home.file."Library/Application Support/cass/sources.toml" = {
+    enable = pkgs.stdenv.isDarwin;
     source = ./sources.toml;
   };
 }

--- a/home-manager/programs/cass/default.nix
+++ b/home-manager/programs/cass/default.nix
@@ -1,4 +1,5 @@
 { ... }:
 {
   xdg.configFile."cass/sources.toml".source = ./sources.toml;
+  home.file."Library/Application Support/cass/sources.toml".source = ./sources.toml;
 }

--- a/home-manager/programs/cass/default.nix
+++ b/home-manager/programs/cass/default.nix
@@ -1,5 +1,7 @@
-{ ... }:
+{ lib, pkgs, ... }:
 {
   xdg.configFile."cass/sources.toml".source = ./sources.toml;
-  home.file."Library/Application Support/cass/sources.toml".source = ./sources.toml;
+  home.file."Library/Application Support/cass/sources.toml" = lib.mkIf pkgs.stdenv.isDarwin {
+    source = ./sources.toml;
+  };
 }


### PR DESCRIPTION
## Summary
- Place `sources.toml` at `~/Library/Application Support/cass/` in addition to `~/.config/cass/`
- cass on macOS uses `dirs::config_dir()` which resolves to `~/Library/Application Support/`, not `~/.config/`
- Without this, `cass sources list` reports "No sources configured" on macOS

## Context
- Upstream issue: https://github.com/Dicklesworthstone/coding_agent_session_search/issues/152

## Test plan
- [ ] Run `home-manager switch`
- [ ] Verify `~/Library/Application Support/cass/sources.toml` exists
- [ ] Run `cass sources list` and confirm kyber source is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `cass` finds `sources.toml` on macOS by also installing it to `~/Library/Application Support/cass/`, and gate all `Library/Application Support` paths to macOS, including iTerm2. Fixes `cass sources list` showing "No sources configured" on macOS.

<sup>Written for commit 74bb9c0e0e4c9fa879487fc081618cf80f93c7eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

