### PR TITLE
fix: add supply chain cooldown across all package managers

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+min-release-age=7
+ignore-scripts=true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ tools = [
   "ruff>=0.15.8",
 ]
 
+[tool.uv]
+exclude-newer = "1 week"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
     ":gitSignOff",
     ":semanticCommits"
   ],
+  "minimumReleaseAge": "7 days",
   "rangeStrategy": "bump",
   "schedule": [
     "at any time"


### PR DESCRIPTION
## Summary
- Add `minimumReleaseAge: "7 days"` to Renovate config
- Add `.npmrc` with `min-release-age=7` and `ignore-scripts=true`
- Add `exclude-newer = "1 week"` to `[tool.uv]` in pyproject.toml
- Aligns all package managers with existing bunfig.toml `minimum-release-age = 604800` (7 days)

## Test plan
- [ ] Verify `bun install` still works
- [ ] Verify `uv sync` still works
- [ ] Verify Renovate respects the new cooldown setting

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a 7-day minimum release age across npm (`.npmrc`), Python `uv` (`pyproject.toml`), and Renovate (`renovate.json`) to reduce supply chain risk and avoid adopting very new releases. Aligns with existing `bunfig.toml` and disables npm lifecycle scripts by default.

<sup>Written for commit 2a9386ecb8a44141885fac7a30c0d22a69fd20c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

