### PR TITLE
fix: use cargo nightly and update deps for local binary builds

### DIFF
--- a/scripts/update-local-binaries.sh
+++ b/scripts/update-local-binaries.sh
@@ -158,7 +158,7 @@ build_repo() {
       return 1
     fi
   elif [ -f "$build_dir/Cargo.toml" ]; then
-    if (cd "$build_dir" && cargo build --release 2>&1); then
+    if (cd "$build_dir" && cargo update 2>&1 && cargo +nightly build --release 2>&1); then
       return 0
     else
       return 1

--- a/spec/update_local_binaries_spec.sh
+++ b/spec/update_local_binaries_spec.sh
@@ -162,9 +162,9 @@ When run bash -c "grep 'Cargo.toml' '$SCRIPT'"
 The output should include 'Cargo.toml'
 End
 
-It 'runs cargo build --release for Rust projects'
-When run bash -c "grep 'cargo build --release' '$SCRIPT'"
-The output should include 'cargo build --release'
+It 'runs cargo +nightly build --release for Rust projects'
+When run bash -c "grep 'cargo +nightly build --release' '$SCRIPT'"
+The output should include 'cargo +nightly build --release'
 End
 
 It 'detects go.mod for go build'


### PR DESCRIPTION
## Summary
- Run `cargo update` before building Cargo projects in `update-local-binaries.sh` to bump stale deps (fixes `openssl-sys 0.9.111` incompatibility with Rust 1.94)
- Use `cargo +nightly build --release` instead of `cargo build --release`
- Update corresponding shell test assertion

## Test plan
- [x] `make format` passes (0 changed)
- [x] `make shell-test` — the related test passes; remaining 2 failures are pre-existing and unrelated (clipboard, notify-local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix local Rust binary builds by running `cargo update` and compiling with `cargo +nightly`. This resolves failures from `openssl-sys` 0.9.111 on Rust 1.94 and restores the make-updater service.

- **Bug Fixes**
  - For Cargo projects, run `cargo update` then `cargo +nightly build --release` in `update-local-binaries.sh`.
  - Update shell spec to assert the nightly build command.

<sup>Written for commit 93c14f16b79b911304568b70330aaa6b8a0b175f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

