### PR TITLE
fix: remove cargo update to preserve Cargo.lock versions

### DIFF
--- a/scripts/update-local-binaries.sh
+++ b/scripts/update-local-binaries.sh
@@ -158,7 +158,7 @@ build_repo() {
       return 1
     fi
   elif [ -f "$build_dir/Cargo.toml" ]; then
-    if (cd "$build_dir" && cargo update 2>&1 && cargo +nightly build --release 2>&1); then
+    if (cd "$build_dir" && cargo +nightly build --release 2>&1); then
       return 0
     else
       return 1


### PR DESCRIPTION
## Summary
- Remove `cargo update` from `update-local-binaries.sh` to avoid overwriting upstream `Cargo.lock`
- Keep `cargo +nightly build --release` from #1319

## Test plan
- [x] Script builds repos using their locked dependency versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `cargo update` from `scripts/update-local-binaries.sh` to respect upstream `Cargo.lock` and avoid unexpected dependency upgrades that can break builds (e.g., `digest`/`sha2` bumps in cass). The script now only runs `cargo +nightly build --release` for reproducible builds with locked deps.

<sup>Written for commit 2ca3d7c020517642967e9f79a5f270dc37b5375d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

