### PR TITLE
fix(cliproxyapi): prevent token refresh by omitting expired and bumping last_refresh

### DIFF
--- a/home-manager/services/cliproxyapi/scripts/keychain-sync.sh
+++ b/home-manager/services/cliproxyapi/scripts/keychain-sync.sh
@@ -87,6 +87,12 @@ sync_claude() {
     printf '%s' "$new_json" >"$tmp" && mv "$tmp" "$dest" || rm -f "$tmp"
     echo "[$(date)] Claude: synced new token to $dest" >&2
     changed=1
+  elif [ -f "$dest" ]; then
+    # Token unchanged - just bump last_refresh to prevent cliproxyapi's
+    # built-in refresh from triggering (it checks now - last_refresh >= 4h)
+    local tmp
+    tmp=$(mktemp "${AUTH_DIR}/.claude-refresh-ts.XXXXXX")
+    $JQ --arg lr "$(date -u +%Y-%m-%dT%H:%M:%S+00:00)" '.last_refresh = $lr' "$dest" >"$tmp" && mv "$tmp" "$dest" || rm -f "$tmp"
   fi
 }
 


### PR DESCRIPTION
## Summary
- Bump `last_refresh` in the Claude auth file on every keychain-sync run, even when the token hasn't changed

## Diagnosis

cliproxyapi v6.9.5 has built-in OAuth token refresh with two trigger paths (in `shouldRefresh`, `manager.go`):

1. **Expiry-based**: `expiry.Sub(now) <= RefreshLead(4h)` - triggers 4h before token expires
2. **Staleness-based**: `now.Sub(lastRefresh) >= RefreshLead(4h)` - triggers if no refresh in 4h

When cliproxyapi refreshes a Claude token, it **rotates the refresh_token** on Anthropic's side (OAuth rotation). But keychain-sync then overwrites the auth file with the old keychain token - whose refresh_token is now invalidated. Next refresh attempt fails with `invalid_grant`, and the token eventually expires with no way to recover.

**Why only macOS (galactica)?** keychain-sync is Darwin-only (`lib.mkIf pkgs.stdenv.isDarwin`). On kyber (Linux), there's no keychain-sync, so cliproxyapi's refresh works without interference.

### Fix progression

| Fix | Blocked path | Why insufficient |
|-----|-------------|-----------------|
| `expired: ""` (PR #1308) | Path 1 (expiry-based) | Path 2 still fires after 4h of unchanged tokens |
| `refresh_interval_seconds: 999999999` | Neither | `expiry.Sub(now) <= 31.7y` is always true |
| **This PR: bump `last_refresh` every 5 min** | Path 2 (staleness-based) | Combined with `expired: ""`, blocks both paths |

### How it works now

- `expired: ""` blocks path 1 (no expiry to compare against)
- keychain-sync bumps `last_refresh` every 5 min, so `now.Sub(lastRefresh)` is always ~5 min, well under the 4h threshold - blocks path 2
- When token hasn't changed, only `last_refresh` is updated in-place (no full rewrite, no backup watcher trigger)
- Claude Code manages its own token lifecycle in keychain; keychain-sync copies it to the auth file

### Relevant cliproxyapi source (`sdk/cliproxy/auth/manager.go`)

```go
func (m *Manager) shouldRefresh(a *Auth, now time.Time) bool {
    // ...
    lead := ProviderRefreshLead(provider, a.Runtime) // 4h for Claude
    // Path 1: expiry-based (blocked by expired: "")
    if hasExpiry && !expiry.IsZero() {
        return time.Until(expiry) <= *lead
    }
    // Path 2: staleness-based (blocked by bumping last_refresh)
    if !lastRefresh.IsZero() {
        return now.Sub(lastRefresh) >= *lead
    }
    return true
}
```

## Test plan
- [x] Verified no `claude executor: refresh called` for 45+ min after fix (previously fired every 15 min)
- [ ] Wait >4h to confirm staleness path is also blocked
- [ ] Confirm kyber (Linux) unaffected