### PR TITLE
feat: add resume flag to all coding agent fish aliases

### DIFF
--- a/home-manager/programs/fish/functions/_cltxe_function.fish
+++ b/home-manager/programs/fish/functions/_cltxe_function.fish
@@ -2,7 +2,9 @@ function _cltxe_function --description "Run Claude Code with a free-form prompt 
   # Run Claude Code with a free-form prompt (spaces allowed) and bypass permission checks
   # Usage: cltxe [<prompt words...>]
 
-  if test (count $argv) -eq 0
+  if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
+    claude --dangerously-skip-permissions --worktree --tmux --resume $argv[2]
+  else if test (count $argv) -eq 0
     claude --dangerously-skip-permissions --worktree --tmux
   else
     set -l prompt (string join " " -- $argv)

--- a/home-manager/programs/fish/functions/_clwxe_function.fish
+++ b/home-manager/programs/fish/functions/_clwxe_function.fish
@@ -2,7 +2,9 @@ function _clwxe_function --description "Run Claude Code with a free-form prompt 
   # Run Claude Code with a free-form prompt (spaces allowed) and bypass permission checks
   # Usage: clwxe [<prompt words...>]
 
-  if test (count $argv) -eq 0
+  if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
+    claude --dangerously-skip-permissions --worktree --resume $argv[2]
+  else if test (count $argv) -eq 0
     claude --dangerously-skip-permissions --worktree
   else
     set -l prompt (string join " " -- $argv)

--- a/home-manager/programs/fish/functions/_clxe_function.fish
+++ b/home-manager/programs/fish/functions/_clxe_function.fish
@@ -1,8 +1,10 @@
 function _clxe_function --description "Run Claude Code with a free-form prompt while skipping permissions"
   # Run Claude Code with a free-form prompt (spaces allowed) and bypass permission checks
-  # Usage: clxe [<prompt words...>]
+  # Usage: clxe [--resume | -r] [<prompt words...>]
 
-  if test (count $argv) -eq 0
+  if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
+    claude --dangerously-skip-permissions --resume $argv[2]
+  else if test (count $argv) -eq 0
     claude --dangerously-skip-permissions
   else
     set -l prompt (string join " " -- $argv)

--- a/home-manager/programs/fish/functions/_coxe_function.fish
+++ b/home-manager/programs/fish/functions/_coxe_function.fish
@@ -2,7 +2,9 @@ function _coxe_function --description "Run Codex with a free-form prompt"
   # Run Codex with a free-form prompt (spaces allowed)
   # Usage: cxe [<prompt words...>]
 
-  if test (count $argv) -eq 0
+  if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
+    codex resume $argv[2]
+  else if test (count $argv) -eq 0
     codex --model 'gpt-5.4' --full-auto -c model_reasoning_summary_format=experimental
   else
     set -l prompt (string join " " -- $argv)

--- a/home-manager/programs/fish/functions/_coxe_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_coxe_function.tpl.fish
@@ -2,7 +2,9 @@ function _coxe_function --description "Run Codex with a free-form prompt"
   # Run Codex with a free-form prompt (spaces allowed)
   # Usage: cxe [<prompt words...>]
 
-  if test (count $argv) -eq 0
+  if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
+    codex resume $argv[2]
+  else if test (count $argv) -eq 0
     codex --model '__GPT__' --full-auto -c model_reasoning_summary_format=experimental
   else
     set -l prompt (string join " " -- $argv)

--- a/home-manager/programs/fish/functions/_coxel_function.fish
+++ b/home-manager/programs/fish/functions/_coxel_function.fish
@@ -2,7 +2,9 @@ function _coxel_function --description "Run Codex with a free-form prompt using 
   # Run Codex with a free-form prompt (spaces allowed) using the local Qwen model
   # Usage: cxel [<prompt words...>]
 
-  if test (count $argv) -eq 0
+  if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
+    codex resume $argv[2]
+  else if test (count $argv) -eq 0
     codex --oss --local-provider lmstudio --model 'qwen/qwen3.5-9b' --full-auto -c model_reasoning_effort=minimal
   else
     set -l prompt (string join " " -- $argv)

--- a/home-manager/programs/fish/functions/_coxel_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_coxel_function.tpl.fish
@@ -2,7 +2,9 @@ function _coxel_function --description "Run Codex with a free-form prompt using 
   # Run Codex with a free-form prompt (spaces allowed) using the local Qwen model
   # Usage: cxel [<prompt words...>]
 
-  if test (count $argv) -eq 0
+  if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
+    codex resume $argv[2]
+  else if test (count $argv) -eq 0
     codex --oss --local-provider lmstudio --model '__QWEN_LOCAL__' --full-auto -c model_reasoning_effort=minimal
   else
     set -l prompt (string join " " -- $argv)

--- a/home-manager/programs/fish/functions/_ocxe_function.fish
+++ b/home-manager/programs/fish/functions/_ocxe_function.fish
@@ -2,7 +2,13 @@ function _ocxe_function --description "Run OpenCode with a free-form prompt"
   # Run OpenCode with a free-form prompt (spaces allowed)
   # Usage: ocxe [<prompt words...>]
 
-  if test (count $argv) -eq 0
+  if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
+    if test (count $argv) -gt 1
+      opencode -m 'cliproxyapi/glm-4.7' --session "$argv[2]"
+    else
+      opencode -m 'cliproxyapi/glm-4.7' --continue
+    end
+  else if test (count $argv) -eq 0
     opencode -m 'cliproxyapi/glm-4.7'
   else
     set -l prompt (string join " " -- $argv)

--- a/home-manager/programs/fish/functions/_ocxe_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_ocxe_function.tpl.fish
@@ -2,7 +2,13 @@ function _ocxe_function --description "Run OpenCode with a free-form prompt"
   # Run OpenCode with a free-form prompt (spaces allowed)
   # Usage: ocxe [<prompt words...>]
 
-  if test (count $argv) -eq 0
+  if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
+    if test (count $argv) -gt 1
+      opencode -m 'cliproxyapi/__GLM__' --session "$argv[2]"
+    else
+      opencode -m 'cliproxyapi/__GLM__' --continue
+    end
+  else if test (count $argv) -eq 0
     opencode -m 'cliproxyapi/__GLM__'
   else
     set -l prompt (string join " " -- $argv)

--- a/home-manager/programs/fish/functions/_ocxel_function.fish
+++ b/home-manager/programs/fish/functions/_ocxel_function.fish
@@ -2,7 +2,13 @@ function _ocxel_function --description "Run OpenCode with a free-form prompt usi
   # Run OpenCode with a free-form prompt (spaces allowed) using the local Qwen model
   # Usage: ocxel [<prompt words...>]
 
-  if test (count $argv) -eq 0
+  if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
+    if test (count $argv) -gt 1
+      opencode -m 'lmstudio/qwen/qwen3.5-9b' --session "$argv[2]"
+    else
+      opencode -m 'lmstudio/qwen/qwen3.5-9b' --continue
+    end
+  else if test (count $argv) -eq 0
     opencode -m 'lmstudio/qwen/qwen3.5-9b'
   else
     set -l prompt (string join " " -- $argv)

--- a/home-manager/programs/fish/functions/_ocxel_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_ocxel_function.tpl.fish
@@ -2,7 +2,13 @@ function _ocxel_function --description "Run OpenCode with a free-form prompt usi
   # Run OpenCode with a free-form prompt (spaces allowed) using the local Qwen model
   # Usage: ocxel [<prompt words...>]
 
-  if test (count $argv) -eq 0
+  if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
+    if test (count $argv) -gt 1
+      opencode -m 'lmstudio/__QWEN_LOCAL__' --session "$argv[2]"
+    else
+      opencode -m 'lmstudio/__QWEN_LOCAL__' --continue
+    end
+  else if test (count $argv) -eq 0
     opencode -m 'lmstudio/__QWEN_LOCAL__'
   else
     set -l prompt (string join " " -- $argv)

--- a/home-manager/programs/fish/functions/_ompxe_function.fish
+++ b/home-manager/programs/fish/functions/_ompxe_function.fish
@@ -2,7 +2,9 @@ function _ompxe_function --description "Run OMP with a free-form prompt"
   # Run OMP with a free-form prompt (spaces allowed)
   # Usage: ompxe [<prompt words...>]
 
-  if test (count $argv) -eq 0
+  if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
+    omp --resume $argv[2]
+  else if test (count $argv) -eq 0
     omp
   else
     set -l prompt (string join " " -- $argv)

--- a/home-manager/programs/fish/functions/_pixe_function.fish
+++ b/home-manager/programs/fish/functions/_pixe_function.fish
@@ -2,7 +2,9 @@ function _pixe_function --description "Run Pi with a free-form prompt"
   # Run Pi with a free-form prompt (spaces allowed)
   # Usage: pixe [<prompt words...>]
 
-  if test (count $argv) -eq 0
+  if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
+    pi --model 'cliproxyapi/glm-4.7' --resume $argv[2]
+  else if test (count $argv) -eq 0
     pi --model 'cliproxyapi/glm-4.7'
   else
     set -l prompt (string join " " -- $argv)

--- a/home-manager/programs/fish/functions/_pixe_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_pixe_function.tpl.fish
@@ -2,7 +2,9 @@ function _pixe_function --description "Run Pi with a free-form prompt"
   # Run Pi with a free-form prompt (spaces allowed)
   # Usage: pixe [<prompt words...>]
 
-  if test (count $argv) -eq 0
+  if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
+    pi --model 'cliproxyapi/__GLM__' --resume $argv[2]
+  else if test (count $argv) -eq 0
     pi --model 'cliproxyapi/__GLM__'
   else
     set -l prompt (string join " " -- $argv)

--- a/home-manager/programs/fish/functions/_pixel_function.fish
+++ b/home-manager/programs/fish/functions/_pixel_function.fish
@@ -2,7 +2,9 @@ function _pixel_function --description "Run Pi with a free-form prompt using the
   # Run Pi with a free-form prompt (spaces allowed) using the local Qwen model
   # Usage: pixel [<prompt words...>]
 
-  if test (count $argv) -eq 0
+  if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
+    pi --model 'lmstudio/qwen/qwen3.5-9b' --resume $argv[2]
+  else if test (count $argv) -eq 0
     pi --model 'lmstudio/qwen/qwen3.5-9b'
   else
     set -l prompt (string join " " -- $argv)

--- a/home-manager/programs/fish/functions/_pixel_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_pixel_function.tpl.fish
@@ -2,7 +2,9 @@ function _pixel_function --description "Run Pi with a free-form prompt using the
   # Run Pi with a free-form prompt (spaces allowed) using the local Qwen model
   # Usage: pixel [<prompt words...>]
 
-  if test (count $argv) -eq 0
+  if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
+    pi --model 'lmstudio/__QWEN_LOCAL__' --resume $argv[2]
+  else if test (count $argv) -eq 0
     pi --model 'lmstudio/__QWEN_LOCAL__'
   else
     set -l prompt (string join " " -- $argv)


### PR DESCRIPTION
## Summary
- Adds unified `--resume` / `-r` / `--continue` / `-c` flag to all 10 interactive coding agent fish wrappers
- Each alias maps to the underlying CLI's native resume mechanism (claude `--resume`, codex `resume`, opencode `--continue`/`--session`, omp `--resume`, pi `--resume`)
- Optional session ID supported: `clxe -r <id>` or `clxe -r` for latest

## Test plan
- [x] `make shell-test` passes (253/253)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a unified resume flag across all coding agent fish aliases to quickly resume the latest or a specific session with a consistent UX. Use `-r`/`--resume` (also accepts `--continue`/`-c`) across aliases.

- **New Features**
  - Supported on: `clxe`, `clwxe`, `cltxe`, `coxe`, `coxel`, `ocxe`, `ocxel`, `ompxe`, `pixe`, `pixel`, plus their `*.tpl.fish` templates for model substitution.
  - Usage: `<alias> -r [<session-id>]` resumes the latest or the given session.
  - Maps to native CLIs: `claude` → `--resume`; `codex` → `resume`; `opencode` → `--continue` or `--session <id>`; `omp` → `--resume`; `pi` → `--resume`.

<sup>Written for commit 2a7539463eda171be6ffdd86419a390141cc78b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

