### PR TITLE
fix: resolve shellcheck warnings in keychain-sync.sh

### DIFF
--- a/home-manager/services/cliproxyapi/scripts/keychain-sync.sh
+++ b/home-manager/services/cliproxyapi/scripts/keychain-sync.sh
@@ -84,15 +84,21 @@ sync_claude() {
   if [ "$access_token" != "$existing_at" ]; then
     local tmp
     tmp=$(mktemp "${AUTH_DIR}/.claude-sync.XXXXXX")
-    printf '%s' "$new_json" >"$tmp" && mv "$tmp" "$dest" || rm -f "$tmp"
-    echo "[$(date)] Claude: synced new token to $dest" >&2
-    changed=1
+    if printf '%s' "$new_json" >"$tmp" && mv "$tmp" "$dest"; then
+      echo "[$(date)] Claude: synced new token to $dest" >&2
+      changed=1
+    else
+      rm -f "$tmp"
+    fi
   elif [ -f "$dest" ]; then
     # Token unchanged - just bump last_refresh to prevent cliproxyapi's
     # built-in refresh from triggering (it checks now - last_refresh >= 4h)
     local tmp
     tmp=$(mktemp "${AUTH_DIR}/.claude-refresh-ts.XXXXXX")
-    $JQ --arg lr "$(date -u +%Y-%m-%dT%H:%M:%S+00:00)" '.last_refresh = $lr' "$dest" >"$tmp" && mv "$tmp" "$dest" || rm -f "$tmp"
+    # shellcheck disable=SC2016
+    if ! $JQ --arg lr "$(date -u +%Y-%m-%dT%H:%M:%S+00:00)" '.last_refresh = $lr' "$dest" >"$tmp" || ! mv "$tmp" "$dest"; then
+      rm -f "$tmp"
+    fi
   fi
 }
 
@@ -145,8 +151,12 @@ sync_codex() {
   if [ "$access_token" != "$existing_at" ]; then
     local tmp
     tmp=$(mktemp "${AUTH_DIR}/.codex-sync.XXXXXX")
-    printf '%s' "$new_json" >"$tmp" && mv "$tmp" "$dest" || rm -f "$tmp"
-    echo "[$(date)] Codex: synced new token to $dest" >&2
+    if printf '%s' "$new_json" >"$tmp" && mv "$tmp" "$dest"; then
+      echo "[$(date)] Codex: synced new token to $dest" >&2
+    else
+      rm -f "$tmp"
+      return 1
+    fi
     changed=1
   fi
 }


### PR DESCRIPTION
## Summary
- Replace `A && B || C` patterns with proper `if-then-else` to fix SC2015
- Suppress SC2016 for intentional single-quoted jq expression

## Test plan
- [x] `make shell-lint` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ShellCheck warnings in `keychain-sync.sh` and makes token sync safer. Replaces fragile chained commands with explicit checks, adds proper temp-file cleanup, and tightens error handling.

- **Bug Fixes**
  - Replaced `A && B || C` patterns with `if/then/else` to resolve SC2015.
  - Suppressed SC2016 for the intentional single-quoted `jq` filter and guarded the `last_refresh` update with cleanup on failure.
  - Only log success and set `changed=1` after successful writes; `sync_codex` now returns non-zero on write failure.

<sup>Written for commit f1b6013eb3b9bef54c759e6acca2cd1285b1f7e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

