### PR TITLE
refactor: move ICU env vars from build script to nix shell config

### DIFF
--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -53,6 +53,11 @@
           export OPENSSL_LIB_DIR="${pkgs.openssl.out}/lib"
           export OPENSSL_INCLUDE_DIR="${pkgs.openssl.dev}/include"
 
+          # ICU for CGo builds (e.g. go-icu-regex used by beads)
+          export PKG_CONFIG_PATH="${pkgs.icu.dev}/lib/pkgconfig''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+          export CGO_CFLAGS="-I${pkgs.icu.dev}/include''${CGO_CFLAGS:+ $CGO_CFLAGS}"
+          export CGO_LDFLAGS="-L${pkgs.icu.out}/lib''${CGO_LDFLAGS:+ $CGO_LDFLAGS}"
+
           # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)
           export LD_LIBRARY_PATH="${lib.optionalString pkgs.stdenv.isLinux "${pkgs.alsa-lib}/lib:"}${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
       fi
@@ -95,6 +100,11 @@
           export OPENSSL_DIR="${pkgs.openssl.dev}"
           export OPENSSL_LIB_DIR="${pkgs.openssl.out}/lib"
           export OPENSSL_INCLUDE_DIR="${pkgs.openssl.dev}/include"
+
+          # ICU for CGo builds (e.g. go-icu-regex used by beads)
+          export PKG_CONFIG_PATH="${pkgs.icu.dev}/lib/pkgconfig''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+          export CGO_CFLAGS="-I${pkgs.icu.dev}/include''${CGO_CFLAGS:+ $CGO_CFLAGS}"
+          export CGO_LDFLAGS="-L${pkgs.icu.out}/lib''${CGO_LDFLAGS:+ $CGO_LDFLAGS}"
 
           # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)
           export LD_LIBRARY_PATH="${lib.optionalString pkgs.stdenv.isLinux "${pkgs.alsa-lib}/lib:"}${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -18,6 +18,11 @@
           set -gx OPENSSL_LIB_DIR "${pkgs.openssl.out}/lib"
           set -gx OPENSSL_INCLUDE_DIR "${pkgs.openssl.dev}/include"
 
+          # ICU for CGo builds (e.g. go-icu-regex used by beads)
+          set -gx PKG_CONFIG_PATH "${pkgs.icu.dev}/lib/pkgconfig" $PKG_CONFIG_PATH
+          set -gx CGO_CFLAGS "-I${pkgs.icu.dev}/include $CGO_CFLAGS"
+          set -gx CGO_LDFLAGS "-L${pkgs.icu.out}/lib $CGO_LDFLAGS"
+
           # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)
           set -gx LD_LIBRARY_PATH ${lib.optionalString pkgs.stdenv.isLinux ''"${pkgs.alsa-lib}/lib"''} "${pkgs.glib.out}/lib" "${pkgs.libsecret}/lib" "${pkgs.stdenv.cc.cc.lib}/lib" "${pkgs.zlib}/lib" $LD_LIBRARY_PATH
       end

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -41,6 +41,11 @@
           export OPENSSL_LIB_DIR="${pkgs.openssl.out}/lib"
           export OPENSSL_INCLUDE_DIR="${pkgs.openssl.dev}/include"
 
+          # ICU for CGo builds (e.g. go-icu-regex used by beads)
+          export PKG_CONFIG_PATH="${pkgs.icu.dev}/lib/pkgconfig''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+          export CGO_CFLAGS="-I${pkgs.icu.dev}/include''${CGO_CFLAGS:+ $CGO_CFLAGS}"
+          export CGO_LDFLAGS="-L${pkgs.icu.out}/lib''${CGO_LDFLAGS:+ $CGO_LDFLAGS}"
+
           # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)
           export LD_LIBRARY_PATH="${lib.optionalString pkgs.stdenv.isLinux "${pkgs.alsa-lib}/lib:"}${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
       fi

--- a/home-manager/services/make-updater/default.nix
+++ b/home-manager/services/make-updater/default.nix
@@ -61,6 +61,9 @@ in
         "AUTOMATED_UPDATE=true"
         "RUSTUP_HOME=%h/.rustup"
         "CARGO_HOME=%h/.cargo"
+        "PKG_CONFIG_PATH=${pkgs.openssl.dev}/lib/pkgconfig:${pkgs.icu.dev}/lib/pkgconfig"
+        "CGO_CFLAGS=-I${pkgs.icu.dev}/include"
+        "CGO_LDFLAGS=-L${pkgs.icu.out}/lib"
       ];
       Nice = 19;
       IOSchedulingPriority = 7;

--- a/scripts/update-local-binaries.sh
+++ b/scripts/update-local-binaries.sh
@@ -139,7 +139,14 @@ build_repo() {
   # Install tools via mise if mise.toml is present
   if [ -f "$build_dir/mise.toml" ] && command -v mise >/dev/null 2>&1; then
     log_step "  Installing tools via mise..."
+    (cd "$build_dir" && mise trust 2>&1) || true
     (cd "$build_dir" && mise install 2>&1) || true
+  fi
+
+  # Initialize git submodules if .gitmodules exists
+  if [ -f "$repo_dir/.gitmodules" ]; then
+    log_step "  Initializing submodules..."
+    (cd "$repo_dir" && git submodule update --init --recursive 2>&1) || true
   fi
 
   if [ -f "$build_dir/Makefile" ]; then
@@ -152,12 +159,19 @@ build_repo() {
     if (cd "$build_dir" && $make_cmd -n deps >/dev/null 2>&1); then
       (cd "$build_dir" && $make_cmd deps 2>&1) || true
     fi
-    if (cd "$build_dir" && $make_cmd build 2>&1); then
-      return 0
+    # If Makefile has no build target, fall through to other build systems
+    if (cd "$build_dir" && $make_cmd -n build >/dev/null 2>&1); then
+      if (cd "$build_dir" && $make_cmd build 2>&1); then
+        return 0
+      else
+        return 1
+      fi
     else
-      return 1
+      log_warn "  Makefile has no build target, trying other build systems..."
     fi
-  elif [ -f "$build_dir/Cargo.toml" ]; then
+  fi
+
+  if [ -f "$build_dir/Cargo.toml" ]; then
     if (cd "$build_dir" && cargo +nightly build --release 2>&1); then
       return 0
     else
@@ -165,6 +179,7 @@ build_repo() {
     fi
   elif [ -f "$build_dir/go.mod" ]; then
     # Go project: build ./cmd/{repo_name} if it exists, otherwise build root
+    # ICU/CGo env vars are provided by shell init (fish/bash/zsh via nix)
     if [ -d "$build_dir/cmd/$repo_name" ]; then
       if (cd "$build_dir" && go build "./cmd/$repo_name" 2>&1); then
         return 0


### PR DESCRIPTION
## Summary
- Add `PKG_CONFIG_PATH`, `CGO_CFLAGS`, `CGO_LDFLAGS` for `icu.dev` to fish/bash/zsh shell init (Linux block) — same pattern as existing `openssl.dev` setup
- Add same env vars to `make-updater` systemd service `Environment`
- Remove inline `nix-build` ICU logic from `update-local-binaries.sh`
- Include build robustness fixes from #1324 (Makefile fallthrough, mise trust, submodule init)

## Test plan
- [x] `make build` succeeds
- [x] `make shell-test` passes (no new failures)
- [x] `make format` clean (0 changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move ICU CGo env vars from the build script into Nix shell init and the `make-updater` service to standardize builds. Removes inline `nix-build` and makes Go/CGo builds more reliable.

- **Refactors**
  - Set ICU `PKG_CONFIG_PATH`, `CGO_CFLAGS`, `CGO_LDFLAGS` in Bash/Zsh/Fish (Linux), matching the existing OpenSSL setup.
  - Add the same env vars to the `make-updater` systemd unit `Environment`.
  - Remove ICU `nix-build` logic from `update-local-binaries.sh`.
  - Run `mise trust` before `mise install`.
  - Initialize git submodules when `.gitmodules` is present.
  - Fall through when no `make build` target and try Cargo/Go build paths.

<sup>Written for commit 42f804341b427bcf099c7cd655b6cedb914228a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

