### PR TITLE
fix: add CGO_CXXFLAGS for ICU C++ headers

### DIFF
--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -56,6 +56,7 @@
           # ICU for CGo builds (e.g. go-icu-regex used by beads)
           export PKG_CONFIG_PATH="${pkgs.icu.dev}/lib/pkgconfig''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
           export CGO_CFLAGS="-I${pkgs.icu.dev}/include''${CGO_CFLAGS:+ $CGO_CFLAGS}"
+          export CGO_CXXFLAGS="-I${pkgs.icu.dev}/include''${CGO_CXXFLAGS:+ $CGO_CXXFLAGS}"
           export CGO_LDFLAGS="-L${pkgs.icu.out}/lib''${CGO_LDFLAGS:+ $CGO_LDFLAGS}"
 
           # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)
@@ -104,6 +105,7 @@
           # ICU for CGo builds (e.g. go-icu-regex used by beads)
           export PKG_CONFIG_PATH="${pkgs.icu.dev}/lib/pkgconfig''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
           export CGO_CFLAGS="-I${pkgs.icu.dev}/include''${CGO_CFLAGS:+ $CGO_CFLAGS}"
+          export CGO_CXXFLAGS="-I${pkgs.icu.dev}/include''${CGO_CXXFLAGS:+ $CGO_CXXFLAGS}"
           export CGO_LDFLAGS="-L${pkgs.icu.out}/lib''${CGO_LDFLAGS:+ $CGO_LDFLAGS}"
 
           # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -21,6 +21,7 @@
           # ICU for CGo builds (e.g. go-icu-regex used by beads)
           set -gx PKG_CONFIG_PATH "${pkgs.icu.dev}/lib/pkgconfig" $PKG_CONFIG_PATH
           set -gx CGO_CFLAGS "-I${pkgs.icu.dev}/include $CGO_CFLAGS"
+          set -gx CGO_CXXFLAGS "-I${pkgs.icu.dev}/include $CGO_CXXFLAGS"
           set -gx CGO_LDFLAGS "-L${pkgs.icu.out}/lib $CGO_LDFLAGS"
 
           # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -44,6 +44,7 @@
           # ICU for CGo builds (e.g. go-icu-regex used by beads)
           export PKG_CONFIG_PATH="${pkgs.icu.dev}/lib/pkgconfig''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
           export CGO_CFLAGS="-I${pkgs.icu.dev}/include''${CGO_CFLAGS:+ $CGO_CFLAGS}"
+          export CGO_CXXFLAGS="-I${pkgs.icu.dev}/include''${CGO_CXXFLAGS:+ $CGO_CXXFLAGS}"
           export CGO_LDFLAGS="-L${pkgs.icu.out}/lib''${CGO_LDFLAGS:+ $CGO_LDFLAGS}"
 
           # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)

--- a/home-manager/services/make-updater/default.nix
+++ b/home-manager/services/make-updater/default.nix
@@ -63,6 +63,7 @@ in
         "CARGO_HOME=%h/.cargo"
         "PKG_CONFIG_PATH=${pkgs.openssl.dev}/lib/pkgconfig:${pkgs.icu.dev}/lib/pkgconfig"
         "CGO_CFLAGS=-I${pkgs.icu.dev}/include"
+        "CGO_CXXFLAGS=-I${pkgs.icu.dev}/include"
         "CGO_LDFLAGS=-L${pkgs.icu.out}/lib"
       ];
       Nice = 19;

--- a/scripts/update-local-binaries.sh
+++ b/scripts/update-local-binaries.sh
@@ -178,29 +178,16 @@ build_repo() {
       return 1
     fi
   elif [ -f "$build_dir/go.mod" ]; then
-    # Provide ICU headers for CGo builds that need them (e.g. go-icu-regex)
-    local icu_dev
-    icu_dev="$(nix-build '<nixpkgs>' -A icu.dev --no-out-link 2>/dev/null || true)"
-    local icu_lib
-    icu_lib="$(nix-build '<nixpkgs>' -A icu --no-out-link 2>/dev/null || true)"
-    local go_env=()
-    if [ -n "$icu_dev" ] && [ -n "$icu_lib" ]; then
-      go_env=(env
-        PKG_CONFIG_PATH="${icu_dev}/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
-        CGO_CFLAGS="-I${icu_dev}/include ${CGO_CFLAGS:-}"
-        CGO_LDFLAGS="-L${icu_lib}/lib ${CGO_LDFLAGS:-}"
-      )
-    fi
     # Go project: build ./cmd/{repo_name} if it exists, otherwise build root
     # ICU/CGo env vars are provided by shell init (fish/bash/zsh via nix)
     if [ -d "$build_dir/cmd/$repo_name" ]; then
-      if (cd "$build_dir" && "${go_env[@]}" go build "./cmd/$repo_name" 2>&1); then
+      if (cd "$build_dir" && go build "./cmd/$repo_name" 2>&1); then
         return 0
       else
         return 1
       fi
     else
-      if (cd "$build_dir" && "${go_env[@]}" go build 2>&1); then
+      if (cd "$build_dir" && go build 2>&1); then
         return 0
       else
         return 1


### PR DESCRIPTION
## Summary
- Add `CGO_CXXFLAGS` alongside `CGO_CFLAGS` in fish/bash/zsh and systemd service — `go-icu-regex` uses C++ ICU headers (`unicode/regex.h`) which require `CGO_CXXFLAGS`
- Remove leftover inline `nix-build` ICU logic from `update-local-binaries.sh`

Verified: `beads` builds successfully with these env vars set.

## Test plan
- [x] `make build` succeeds
- [x] `make format` clean
- [x] Manual test: beads builds with `CGO_CXXFLAGS` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `CGO_CXXFLAGS` for ICU C++ headers in shell init and the `make-updater` service to fix Go builds that use `go-icu-regex`. Removed inline Nix ICU setup from `scripts/update-local-binaries.sh`.

- **Bug Fixes**
  - Export `CGO_CXXFLAGS` with ICU include path in bash, zsh, fish, and the systemd service.
  - Ensures C++ ICU headers like `unicode/regex.h` are found during cgo builds.

- **Refactors**
  - Remove per-build `nix-build` ICU logic in `update-local-binaries.sh`; rely on shell-provided env.

<sup>Written for commit f97a78b94d2217d5783406bb99e782366b5444a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

