### PR TITLE
feat: add tmux-claude-teams plugin

### DIFF
--- a/home-manager/programs/tmux/tmux.conf
+++ b/home-manager/programs/tmux/tmux.conf
@@ -163,4 +163,9 @@ set -g @extrakto_key 'tab'
 
 set -g history-limit 2147483647
 
+# =============================================================================
+# Claude Code Agent Teams
+# =============================================================================
+run-shell ~/ghq/github.com/shunkakinoki/tmux-claude-teams/claude-teams.tmux
+
 # Persistent session history logger is managed by launchd/systemd.


### PR DESCRIPTION
## Summary

- Add `tmux-claude-teams` plugin via `run-shell` from local ghq clone
- `prefix + T` launches Claude Code with agent teams as native tmux pane splits
- Subagents auto-stack vertically in a right column using `main-vertical` layout

Plugin repo: https://github.com/shunkakinoki/tmux-claude-teams

## Test plan

- [ ] `tmux source ~/.config/tmux/tmux.conf` to reload
- [ ] `prefix + T` to launch Claude with agent teams
- [ ] Verify subagents spawn as right-column pane splits
- [ ] Verify layout rebalances when agents exit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `tmux-claude-teams` plugin by sourcing `~/ghq/github.com/shunkakinoki/tmux-claude-teams/claude-teams.tmux`. Press prefix+T to launch Claude Code agent teams; subagents open as right-column splits using the main-vertical layout and panes rebalance when agents exit.

<sup>Written for commit 0abead8c797aa6b3702ad35869405a77a9f1a2fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

