### PR TITLE
fix: remove tmux-claude-teams plugin

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -143,16 +143,6 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Agent",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "CLAUDE_TEAMS_SOCKET=/tmp/claude-teams.sock CLAUDE_TEAMS_SEND=$HOME/ghq/github.com/shunkakinoki/tmux-claude-teams/daemon/bin/send $HOME/ghq/github.com/shunkakinoki/tmux-claude-teams/hooks/post-tool-use.sh",
-            "timeout": 5000
-          }
-        ]
-      },
-      {
         "matcher": "Write|Edit|MultiEdit",
         "hooks": [
           {
@@ -216,16 +206,6 @@
       }
     ],
     "PreToolUse": [
-      {
-        "matcher": "Agent",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "CLAUDE_TEAMS_SOCKET=/tmp/claude-teams.sock CLAUDE_TEAMS_SEND=$HOME/ghq/github.com/shunkakinoki/tmux-claude-teams/daemon/bin/send CLAUDE_TEAMS_TMUX=tmux $HOME/ghq/github.com/shunkakinoki/tmux-claude-teams/hooks/pre-tool-use.sh",
-            "timeout": 5000
-          }
-        ]
-      },
       {
         "matcher": "Bash",
         "hooks": [

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -143,6 +143,16 @@
     ],
     "PostToolUse": [
       {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CLAUDE_TEAMS_SOCKET=/tmp/claude-teams.sock CLAUDE_TEAMS_SEND=$HOME/ghq/github.com/shunkakinoki/tmux-claude-teams/daemon/bin/send $HOME/ghq/github.com/shunkakinoki/tmux-claude-teams/hooks/post-tool-use.sh",
+            "timeout": 5000
+          }
+        ]
+      },
+      {
         "matcher": "Write|Edit|MultiEdit",
         "hooks": [
           {
@@ -206,6 +216,16 @@
       }
     ],
     "PreToolUse": [
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CLAUDE_TEAMS_SOCKET=/tmp/claude-teams.sock CLAUDE_TEAMS_SEND=$HOME/ghq/github.com/shunkakinoki/tmux-claude-teams/daemon/bin/send CLAUDE_TEAMS_TMUX=tmux $HOME/ghq/github.com/shunkakinoki/tmux-claude-teams/hooks/pre-tool-use.sh",
+            "timeout": 5000
+          }
+        ]
+      },
       {
         "matcher": "Bash",
         "hooks": [

--- a/home-manager/services/cass/index.sh
+++ b/home-manager/services/cass/index.sh
@@ -13,8 +13,11 @@ echo "$(date): starting cass sync + index + analytics rebuild"
 # Sync remote sources (ignore failures for unreachable hosts)
 "$CASS" sources sync || true
 
-# Full reindex
-"$CASS" index --full
+# Full reindex (--force-rebuild to pick up new session files)
+"$CASS" index --full --force-rebuild
+
+# Build semantic vector index (ignore OOM on low-memory machines)
+"$CASS" index --semantic --embedder fastembed || true
 
 # Rebuild analytics rollup tables
 "$CASS" analytics rebuild


### PR DESCRIPTION
## Summary

- Remove `run-shell` for tmux-claude-teams from tmux.conf
- Remove claude-teams hooks from settings.json (added and removed in same branch)

Claude Code has native tmux teammate support via `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` + `teammateMode: tmux` in settings. No plugin needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `tmux-claude-teams` hooks and harden the `cass` daily index job by forcing full rebuilds and adding a semantic index build.

- **Bug Fixes**
  - Removed `tmux-claude-teams` run-shell from tmux and related hooks from settings; use Claude Code native teammate mode (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`, `teammateMode: tmux`).
  - Updated `cass` index script: run `--full --force-rebuild` to pick up new session files, then build the semantic vector index with `fastembed` and tolerate OOM (`|| true`).

<sup>Written for commit 2805de3720fc1ea94179a4a7c3c7720b009f6224. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

