### PR TITLE
fix(cliproxyapi): remove --exact-timestamps from S3 sync

### DIFF
--- a/home-manager/services/cliproxyapi/scripts/common.sh
+++ b/home-manager/services/cliproxyapi/scripts/common.sh
@@ -44,7 +44,6 @@ cliproxy_s3_sync() {
     @aws@ s3 sync \
     --endpoint-url="${OBJECTSTORE_ENDPOINT:?OBJECTSTORE_ENDPOINT is required}" \
     --no-progress \
-    --exact-timestamps \
     "$source_path" \
     "$destination_path" || true
 }


### PR DESCRIPTION
## Summary
Remove `--exact-timestamps` flag from `aws s3 sync` in `common.sh`.

## Root cause
The previous fixes (omitting `expired`, bumping `last_refresh`) blocked cliproxyapi from refreshing the Claude token. But S3 sync with `--exact-timestamps` was still overwriting the local auth file every 5 minutes with stale S3 copies - undoing what keychain-sync writes.

`--exact-timestamps` causes `aws s3 sync` to re-download files whenever timestamps **differ** (in either direction). So even when the local file is newer (just written by keychain-sync), S3 sync overwrites it because the S3 timestamp doesn't match exactly.

Without the flag, `aws s3 sync` only downloads when the remote file is **newer** than local, which is correct.

This was the original issue identified early in the investigation but got reverted during branch cleanup.

## Full picture of the fix (3 changes across 2 PRs)
| Change | Blocks | PR |
|--------|--------|----|
| `expired: ""` in keychain-sync | cliproxyapi expiry-based refresh | #1308 |  
| Bump `last_refresh` every 5 min | cliproxyapi staleness-based refresh | #1321 |
| **Remove `--exact-timestamps`** | **S3 sync overwriting fresh local tokens** | **This PR** |

## Test plan
- [ ] `make build && make switch`
- [ ] `/login` once for fresh token
- [ ] Verify `/tmp/cliproxyapi-sync.log` no longer re-downloads `claude-*.json` every cycle
- [ ] Verify token stays valid for >8h without `/login`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `--exact-timestamps` from `aws s3 sync` in `common.sh` to stop S3 from overwriting fresh local auth files, keeping `cliproxyapi` tokens stable.

- **Bug Fixes**
  - S3 sync now downloads only when the remote is newer, preventing stale `claude-*.json` from replacing locally refreshed tokens.

<sup>Written for commit c0af4cbb2b5bb1dfd49197b936d65cb3fb5429be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

