### PR TITLE
fix: skip package installs during activation when offline

### DIFF
--- a/home-manager/modules/cargo-globals/install-cargo-globals.sh
+++ b/home-manager/modules/cargo-globals/install-cargo-globals.sh
@@ -2,6 +2,12 @@
 
 set -euo pipefail
 
+# Skip if offline
+if ! timeout 3 bash -c 'exec 3<>/dev/tcp/1.1.1.1/53' 2>/dev/null; then
+  echo "Network unavailable, skipping cargo globals install"
+  exit 0
+fi
+
 # Set macOS SDK path for linker (required in Nix environments)
 if [[ $OSTYPE == "darwin"* ]]; then
   if command -v xcrun &>/dev/null; then

--- a/home-manager/modules/npm-globals/install-npm-globals.sh
+++ b/home-manager/modules/npm-globals/install-npm-globals.sh
@@ -2,6 +2,12 @@
 
 set -euo pipefail
 
+# Skip if offline
+if ! timeout 3 bash -c 'exec 3<>/dev/tcp/1.1.1.1/53' 2>/dev/null; then
+  echo "Network unavailable, skipping npm globals install"
+  exit 0
+fi
+
 # Install npm global packages from package.json using bun
 # Reads dependencies from ~/dotfiles/package.json and installs them globally
 

--- a/home-manager/modules/uv-globals/install-uv-globals.sh
+++ b/home-manager/modules/uv-globals/install-uv-globals.sh
@@ -2,6 +2,12 @@
 
 set -euo pipefail
 
+# Skip if offline
+if ! timeout 3 bash -c 'exec 3<>/dev/tcp/1.1.1.1/53' 2>/dev/null; then
+  echo "Network unavailable, skipping uv globals install"
+  exit 0
+fi
+
 # Install uv global tools from pyproject.toml
 # Reads dependencies from ~/dotfiles/pyproject.toml and installs them as global tools
 

--- a/spec/cargo_globals_spec.sh
+++ b/spec/cargo_globals_spec.sh
@@ -47,6 +47,18 @@ The output should include 'exit 0'
 End
 End
 
+Describe 'offline skip'
+It 'checks network connectivity before installing'
+When run bash -c "grep 'timeout 3 bash' '$SCRIPT'"
+The output should include 'timeout 3 bash'
+End
+
+It 'exits gracefully when offline'
+When run bash -c "grep -A 2 'Network unavailable' '$SCRIPT'"
+The output should include 'exit 0'
+End
+End
+
 Describe 'package installation'
 It 'uses dasel to parse TOML'
 When run bash -c "grep 'dasel' '$SCRIPT'"

--- a/spec/clipboard_copy_spec.sh
+++ b/spec/clipboard_copy_spec.sh
@@ -74,16 +74,22 @@ Describe 'when no clipboard backend is available'
 setup() {
   MOCK_BIN="$(mktemp -d)"
   MOCK_ORIGINAL_PATH="${PATH:-}"
+  MOCK_ORIGINAL_WAYLAND="${WAYLAND_DISPLAY:-}"
   # Keep bash on PATH but nothing else
+  # Use readlink -f to resolve to nix store path (avoids NixOS profile bin with all packages)
   local bash_dir
-  bash_dir="$(dirname "$(command -v bash)")"
+  bash_dir="$(dirname "$(readlink -f "$(command -v bash)")")"
   export PATH="$MOCK_BIN:$bash_dir"
-  export MOCK_BIN MOCK_ORIGINAL_PATH
+  unset WAYLAND_DISPLAY
+  export MOCK_BIN MOCK_ORIGINAL_PATH MOCK_ORIGINAL_WAYLAND
 }
 cleanup() {
   export PATH="$MOCK_ORIGINAL_PATH"
+  if [ -n "$MOCK_ORIGINAL_WAYLAND" ]; then
+    export WAYLAND_DISPLAY="$MOCK_ORIGINAL_WAYLAND"
+  fi
   rm -rf "$MOCK_BIN"
-  unset MOCK_BIN MOCK_ORIGINAL_PATH
+  unset MOCK_BIN MOCK_ORIGINAL_PATH MOCK_ORIGINAL_WAYLAND
 }
 Before 'setup'
 After 'cleanup'

--- a/spec/codex_pushover_spec.sh
+++ b/spec/codex_pushover_spec.sh
@@ -5,9 +5,32 @@ Describe 'codex hooks/pushover.sh'
 SCRIPT="$PWD/config/codex/hooks/pushover.sh"
 
 Describe 'without pushover-notify'
+setup() {
+  MOCK_BIN="$(mktemp -d)"
+  MOCK_ORIGINAL_PATH="${PATH:-}"
+  # Build a PATH with basic utilities but without pushover-notify
+  local bash_dir cat_dir jq_dir sed_dir hostname_dir head_dir grep_dir
+  bash_dir="$(dirname "$(command -v bash)")"
+  cat_dir="$(dirname "$(command -v cat)")"
+  jq_dir="$(dirname "$(command -v jq 2>/dev/null || echo /nonexistent)")"
+  sed_dir="$(dirname "$(command -v sed)")"
+  hostname_dir="$(dirname "$(command -v hostname 2>/dev/null || echo /nonexistent)")"
+  head_dir="$(dirname "$(command -v head)")"
+  grep_dir="$(dirname "$(command -v grep)")"
+  export PATH="$MOCK_BIN:$bash_dir:$cat_dir:$jq_dir:$sed_dir:$hostname_dir:$head_dir:$grep_dir"
+  export MOCK_BIN MOCK_ORIGINAL_PATH
+}
+cleanup() {
+  export PATH="$MOCK_ORIGINAL_PATH"
+  rm -rf "$MOCK_BIN"
+  unset MOCK_BIN MOCK_ORIGINAL_PATH
+}
+Before 'setup'
+After 'cleanup'
+
 It 'exits silently when pushover-notify is not available'
 Data '{"hook_event_name": "Stop", "cwd": "/tmp"}'
-When run bash -c "PATH=/usr/bin:/bin bash '$SCRIPT'"
+When run bash "$SCRIPT"
 The status should be success
 End
 End

--- a/spec/notify_local_spec.sh
+++ b/spec/notify_local_spec.sh
@@ -53,13 +53,11 @@ Describe 'with notify-send available (no osascript)'
 setup() {
   mock_bin_setup notify-send
   # Hide osascript so notify-send path is taken
-  if command -v osascript >/dev/null 2>&1; then
-    local bash_dir cat_dir printf_dir
-    bash_dir="$(dirname "$(command -v bash)")"
-    cat_dir="$(dirname "$(command -v cat)")"
-    printf_dir="$(dirname "$(command -v printf)")"
-    export PATH="$MOCK_BIN:$bash_dir:$cat_dir:$printf_dir"
-  fi
+  # Use readlink -f to resolve to nix store path (avoids NixOS profile bin with all packages)
+  local bash_dir cat_dir
+  bash_dir="$(dirname "$(readlink -f "$(command -v bash)")")"
+  cat_dir="$(dirname "$(readlink -f "$(command -v cat)")")"
+  export PATH="$MOCK_BIN:$bash_dir:$cat_dir"
 }
 cleanup() {
   mock_bin_cleanup
@@ -79,14 +77,12 @@ End
 Describe 'with terminal-notifier available (no osascript or notify-send)'
 setup() {
   mock_bin_setup terminal-notifier
-  # Hide osascript so terminal-notifier path is taken
-  if command -v osascript >/dev/null 2>&1; then
-    local bash_dir cat_dir printf_dir
-    bash_dir="$(dirname "$(command -v bash)")"
-    cat_dir="$(dirname "$(command -v cat)")"
-    printf_dir="$(dirname "$(command -v printf)")"
-    export PATH="$MOCK_BIN:$bash_dir:$cat_dir:$printf_dir"
-  fi
+  # Hide osascript and notify-send so terminal-notifier path is taken
+  # Use readlink -f to resolve to nix store path (avoids NixOS profile bin with all packages)
+  local bash_dir cat_dir
+  bash_dir="$(dirname "$(readlink -f "$(command -v bash)")")"
+  cat_dir="$(dirname "$(readlink -f "$(command -v cat)")")"
+  export PATH="$MOCK_BIN:$bash_dir:$cat_dir"
 }
 cleanup() {
   mock_bin_cleanup
@@ -107,8 +103,9 @@ Describe 'with no notification backend'
 setup() {
   MOCK_BIN="$(mktemp -d)"
   MOCK_ORIGINAL_PATH="${PATH:-}"
+  # Use readlink -f to resolve to nix store path (avoids NixOS profile bin with all packages)
   local bash_dir
-  bash_dir="$(dirname "$(command -v bash)")"
+  bash_dir="$(dirname "$(readlink -f "$(command -v bash)")")"
   export PATH="$MOCK_BIN:$bash_dir"
   export MOCK_BIN MOCK_ORIGINAL_PATH
 }

--- a/spec/npm_globals_spec.sh
+++ b/spec/npm_globals_spec.sh
@@ -42,6 +42,18 @@ The output should include 'exit 0'
 End
 End
 
+Describe 'offline skip'
+It 'checks network connectivity before installing'
+When run bash -c "grep 'timeout 3 bash' '$SCRIPT'"
+The output should include 'timeout 3 bash'
+End
+
+It 'exits gracefully when offline'
+When run bash -c "grep -A 2 'Network unavailable' '$SCRIPT'"
+The output should include 'exit 0'
+End
+End
+
 Describe 'package installation'
 It 'reads trustedDependencies from package.json'
 When run bash -c "grep 'trustedDependencies' '$SCRIPT'"

--- a/spec/uv_globals_spec.sh
+++ b/spec/uv_globals_spec.sh
@@ -47,6 +47,18 @@ The output should include 'exit 0'
 End
 End
 
+Describe 'offline skip'
+It 'checks network connectivity before installing'
+When run bash -c "grep 'timeout 3 bash' '$SCRIPT'"
+The output should include 'timeout 3 bash'
+End
+
+It 'exits gracefully when offline'
+When run bash -c "grep -A 2 'Network unavailable' '$SCRIPT'"
+The output should include 'exit 0'
+End
+End
+
 Describe 'tool installation'
 It 'uses dasel to parse TOML'
 When run bash -c "grep 'dasel' '$SCRIPT'"


### PR DESCRIPTION
## Summary
- Add network connectivity check (TCP to 1.1.1.1:53) to npm-globals, uv-globals, and cargo-globals install scripts so home-manager activation succeeds without network access
- Fix NixOS-specific shell test failures where `dirname $(command -v bash)` resolved to the profile bin (containing all packages) instead of the isolated nix store path — use `readlink -f` to get the actual binary location
- Fix codex pushover spec to construct a proper PATH instead of hardcoding `/usr/bin:/bin` (which doesn't exist on NixOS)

## Test plan
- [x] `make shell-test` passes (951 shellspec + 253 fishtape, 0 failures)
- [ ] Verify home-manager activation works offline (disconnect network, run `home-manager switch`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip global package installs during home-manager activation when offline to avoid failures. Adds a fast network check and fixes NixOS test PATH handling.

- **Bug Fixes**
  - Add TCP connectivity check (1.1.1.1:53) to `npm-globals`, `uv-globals`, and `cargo-globals` installers; if offline, skip with exit 0.
  - Resolve true binary paths with `readlink -f` in tests to avoid NixOS profile bin; adjust `WAYLAND_DISPLAY` handling in clipboard tests.
  - Build a minimal PATH in the codex `pushover` hook spec instead of hardcoding `'/usr/bin:/bin'`.

<sup>Written for commit cca94155514160269be2a695af5285db90e17a39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

