### PR TITLE
fix: prevent powertop autosuspend on touchpad for idle detection

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -243,9 +243,8 @@ inputs.nixpkgs.lib.nixosSystem {
 
         # Power button behavior - lock screen instead of shutdown
         services.logind.settings.Login.HandlePowerKey = "lock";
-        # On battery: suspend immediately when lid closed
-        # On AC: ignore lid close — let hypridle's 30-min idle timer handle suspension
-        services.logind.settings.Login.HandleLidSwitch = "suspend";
+        # Ignore lid close on both battery and AC — let hypridle's idle timer handle suspension
+        services.logind.settings.Login.HandleLidSwitch = "ignore";
         services.logind.settings.Login.HandleLidSwitchExternalPower = "ignore";
 
         # Auto timezone (via geolocation)

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -127,6 +127,8 @@ inputs.nixpkgs.lib.nixosSystem {
           KERNEL=="uinput", GROUP="input", TAG+="uaccess", MODE:="0660", OPTIONS+="static_node=uinput"
           KERNEL=="event*", ATTRS{name}=="keyd virtual keyboard", GROUP="input", MODE:="0660"
           KERNEL=="event*", ATTRS{name}=="keyd virtual pointer", GROUP="input", MODE:="0660"
+          # Prevent powertop autosuspend on touchpad so idle detection works on battery
+          ACTION=="add", SUBSYSTEM=="i2c", DRIVERS=="i2c_hid_acpi", ATTRS{name}=="PIXA3854:00 093A:0274", ATTR{power/control}="on"
         '';
 
         # AMD graphics with hardware acceleration


### PR DESCRIPTION
## Summary
- Adds udev rule to keep touchpad power control as `on`, preventing powertop `--auto-tune` from enabling autosuspend on the PIXA3854 touchpad
- Fixes hypridle not detecting mouse/touchpad input on battery, causing false idle triggers (screen dim, lock, suspend) even during active use

## Root cause
`powertop --auto-tune` sets touchpad `power/control` to `auto`, which allows the kernel to suspend the touchpad after brief inactivity on battery. When suspended, touchpad events don't reach Hyprland, so hypridle thinks the system is idle.

## Test plan
- [ ] Rebuild and switch on matic
- [ ] Verify `cat /sys/bus/i2c/devices/i2c-PIXA3854:00/power/control` shows `on` after reboot
- [ ] Confirm screen doesn't dim/lock while actively using touchpad on battery

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents touchpad autosuspend so idle detection works on battery and stops false screen dim/lock. Also ignores lid-close events so `hypridle` manages suspend consistently.

- **Bug Fixes**
  - Add udev rule to keep PIXA3854 touchpad `power/control` set to `on`, overriding `powertop --auto-tune` and restoring input events to `hypridle`.
  - Set logind `HandleLidSwitch` to `ignore` on battery and AC, relying on `hypridle` timers for suspend.

<sup>Written for commit ba5c5827f34a7de2a6e79bbc58c8b68749d0867b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

