### PR TITLE
fix(cliproxyapi): write empty refresh_token to prevent token rotation

### DIFF
--- a/home-manager/services/cliproxyapi/scripts/keychain-sync.sh
+++ b/home-manager/services/cliproxyapi/scripts/keychain-sync.sh
@@ -59,9 +59,12 @@ sync_claude() {
   #
   # This prevents cliproxyapi from rotating the refresh_token on Anthropic's
   # side, which would invalidate the token in Claude Code's keychain.
+  # Write empty refresh_token so cliproxyapi cannot refresh (and rotate)
+  # the token. cliproxyapi's refresh invalidates the token in Claude Code's
+  # keychain. This file gets pushed to S3 by the backup watcher, so the
+  # empty refresh_token also persists across hydrate/switch cycles.
   new_json=$($JQ -n \
     --arg at "$access_token" \
-    --arg rt "${refresh_token:-}" \
     --arg email "$EMAIL" \
     --arg last_refresh "$(date -u +%Y-%m-%dT%H:%M:%S+00:00)" \
     '{
@@ -71,7 +74,7 @@ sync_claude() {
       expired: "",
       id_token: "",
       last_refresh: $last_refresh,
-      refresh_token: $rt,
+      refresh_token: "",
       type: "claude"
     }')
 


### PR DESCRIPTION
## Summary
Write empty `refresh_token` in Claude auth file so cliproxyapi can never rotate it.

## Root cause
`make build && make switch` runs the hydrate activation hook which pulls from S3. The S3 copy still had `refresh_token` populated. cliproxyapi restarts during switch, sees the refresh_token, and immediately refreshes - rotating the token on Anthropic's side and invalidating Claude Code's keychain copy.

Previous fixes (empty `expired`, `last_refresh` bump) only blocked scheduled refreshes. They didn't block the initial refresh check on restart when `refresh_token` is present.

## Test plan
- [ ] `make build && make switch`
- [ ] Verify no `/login` needed after switch
- [ ] Check `~/.cli-proxy-api/logs/main.log` - no `claude executor: refresh called`
- [ ] Verify S3 copy gets updated with empty `refresh_token` after backup watcher runs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent Claude token rotation by writing an empty `refresh_token` in the generated auth JSON so `cliproxyapi` never refreshes on restart. This avoids invalidating Claude Code’s keychain and persists across hydrate/switch cycles via S3.

- **Bug Fixes**
  - Always set `refresh_token` to "" in the Claude auth file written by `home-manager/services/cliproxyapi/scripts/keychain-sync.sh`.
  - Eliminates startup refresh/rotation in `cliproxyapi` and keeps the empty token synced to S3 for future hydrates.

<sup>Written for commit 3326076f6e2eef18a4e9de05714d0bab71fcb189. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

