### PR TITLE
fix: ensure gco/grco reset upstream tracking

### DIFF
--- a/home-manager/programs/fish/functions/_gco_function.fish
+++ b/home-manager/programs/fish/functions/_gco_function.fish
@@ -1,3 +1,4 @@
 function _gco_function --description "Checkout default branch and pull latest changes"
-  git checkout (git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@') && git pull
+  set -l default_branch (git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+  git checkout $default_branch && git branch --set-upstream-to=origin/$default_branch $default_branch && git pull
 end

--- a/home-manager/programs/fish/functions/_grco_function.fish
+++ b/home-manager/programs/fish/functions/_grco_function.fish
@@ -5,5 +5,6 @@ function _grco_function --description "Hard reset default branch to remote state
   # Ensure we have the latest refs, then hard reset local default to remote
   git fetch origin $default_branch
   git checkout $default_branch
+  git branch --set-upstream-to=origin/$default_branch $default_branch
   git reset --hard origin/$default_branch
 end

--- a/spec/fish/_gco_function_test.fish
+++ b/spec/fish/_gco_function_test.fish
@@ -13,6 +13,7 @@ end
 _gco_function
 
 @test "calls checkout on default branch" (grep -c "checkout main" $call_log) -ge 1
+@test "fixes upstream tracking" (grep -c "branch --set-upstream-to=origin/main main" $call_log) -ge 1
 @test "calls pull" (grep -c "^pull" $call_log) -ge 1
 
 rm -f $call_log

--- a/spec/fish/_grco_function_test.fish
+++ b/spec/fish/_grco_function_test.fish
@@ -14,6 +14,7 @@ _grco_function
 
 @test "fetches default branch" (grep -c "fetch origin main" $call_log) -ge 1
 @test "checks out default branch" (grep -c "checkout main" $call_log) -ge 1
+@test "fixes upstream tracking" (grep -c "branch --set-upstream-to=origin/main main" $call_log) -ge 1
 @test "resets hard to remote" (grep -c "reset --hard origin/main" $call_log) -ge 1
 
 rm -f $call_log


### PR DESCRIPTION
## Summary
- Add `git branch --set-upstream-to=origin/<default> <default>` in both `_gco_function` and `_grco_function`
- Prevents main from silently tracking a wrong remote branch after a stray `git push -u`
- Added test coverage for the new upstream tracking fix

## Test plan
- [x] `make fish-test` passes (255/255)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `_gco_function` and `_grco_function` reset upstream tracking to `origin/<default>` so the local default branch doesn’t silently track the wrong remote after a stray `git push -u`. Adds tests to cover this behavior.

- **Bug Fixes**
  - `_gco_function`: detect default branch, set `git branch --set-upstream-to=origin/<default> <default>`, then pull.
  - `_grco_function`: set upstream tracking before the hard reset.
  - Tests: added assertions to verify upstream tracking is corrected.

<sup>Written for commit 87a648b819891acc71ffd1cbed1265295e9a462c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

