### PR TITLE
feat: add tzo fish function for Zellij-to-tmux sessions

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -150,6 +150,7 @@
       tss = "_tss_function";
       tsw = "_tsw_function";
       two = "_two_function";
+      tzo = "_tzo_function";
       zdo = "_zdo_function";
       zmo = "_zmo_function";
       zpo = "_zpo_function";
@@ -251,6 +252,7 @@
         "_tss_function"
         "_tsw_function"
         "_two_function"
+        "_tzo_function"
         "_zdo_function"
         "_zmo_function"
         "_zpo_function"

--- a/home-manager/programs/fish/functions/_tzo_function.fish
+++ b/home-manager/programs/fish/functions/_tzo_function.fish
@@ -1,0 +1,11 @@
+function _tzo_function --description "Open tmux session named after current Zellij tab"
+  if test -z "$ZELLIJ_TAB_NAME"
+    echo "Not inside a Zellij tab" >&2
+    return 1
+  end
+  if tmux has-session -t "$ZELLIJ_TAB_NAME" 2>/dev/null
+    tmux attach-session -t "$ZELLIJ_TAB_NAME"
+  else
+    tmux new-session -s "$ZELLIJ_TAB_NAME"
+  end
+end

--- a/spec/fish/_tzo_function_test.fish
+++ b/spec/fish/_tzo_function_test.fish
@@ -1,0 +1,38 @@
+set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_tzo_function.fish
+
+set call_log (mktemp)
+
+function tmux
+    echo $argv >> $call_log
+    if test "$argv[1]" = has-session
+        return 1
+    end
+end
+
+# Test: missing ZELLIJ_TAB_NAME
+set -e ZELLIJ_TAB_NAME
+_tzo_function 2>/dev/null
+@test "missing tab name returns 1" $status -eq 1
+
+# Test: creates new session
+set -gx ZELLIJ_TAB_NAME "my-tab"
+_tzo_function
+
+@test "checks for existing session" (grep -c "has-session -t my-tab" $call_log) -ge 1
+@test "creates new session with tab name" (grep -c "new-session -s my-tab" $call_log) -ge 1
+
+# Test: attaches to existing session
+echo -n > $call_log
+function tmux
+    echo $argv >> $call_log
+    if test "$argv[1]" = has-session
+        return 0
+    end
+end
+
+_tzo_function
+
+@test "attaches to existing session" (grep -c "attach-session -t my-tab" $call_log) -ge 1
+
+rm -f $call_log


### PR DESCRIPTION
## Summary
- New `tzo` abbreviation opens/attaches a tmux session named after the current Zellij tab (`$ZELLIJ_TAB_NAME`)
- Errors if not inside a Zellij tab
- Added fishtape tests (4 assertions)

## Test plan
- [x] `make fish-test` passes (259/259)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `tzo` to open or attach a `tmux` session named after the current Zellij tab. Shows an error when run outside a Zellij tab and includes tests.

- New Features
  - Added `_tzo_function.fish`: uses `$ZELLIJ_TAB_NAME`; attaches if the session exists, otherwise creates it.
  - Registered `tzo` in `home-manager/programs/fish/default.nix`.
  - Added fishtape tests covering missing tab name, new session, and attach flow.

<sup>Written for commit 5c43d620f473000d9f4fee0b9aae5dfb349c4aef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

