### PR TITLE
chore: add obsidian to brew casks and linux desktop packages

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -170,6 +170,7 @@ with pkgs;
   linux-wallpaperengine
   loupe
   mpv
+  obsidian
   nautilus
   pavucontrol
   playerctl

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -110,6 +110,7 @@
       "linear-linear"
       "lm-studio"
       "notion"
+      "obsidian"
       "ollama-app"
       "open-pencil"
       "openclaw"


### PR DESCRIPTION
## Summary
- Add `obsidian` to homebrew casks (macOS)
- Add `obsidian` to isDesktop linux packages

## Test plan
- [ ] `make build && make switch` installs obsidian

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `obsidian` to macOS Homebrew casks and to Linux desktop `home-manager` packages so it installs by default on both platforms.

- **Migration**
  - Run `make build && make switch` to install `obsidian`.

<sup>Written for commit 1b89af38f2b97320af3df11386a5128a54608616. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

