### PR TITLE
feat: add claude-swap auto-switch on rate limit

### DIFF
--- a/spec/auto_switch_spec.sh
+++ b/spec/auto_switch_spec.sh
@@ -1,14 +1,123 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2329
+# shellcheck disable=SC2329,SC2016
 
 Describe 'auto-switch.sh'
 SCRIPT="$PWD/config/claude/hooks/auto-switch.sh"
 
-It 'exits 0 when cswap is not available'
-# Mock command so cswap is not found
-command() { return 1; }
-When run bash -c "command() { return 1; }; source '$SCRIPT' </dev/null"
-The status should equal 0
+Describe 'when cswap is not installed'
+It 'exits 0 silently'
+When run bash -c 'echo "{}" | PATH="/usr/bin:/bin" bash '"$SCRIPT"
+The status should be success
+The output should eq ''
+End
+End
+
+Describe 'when cswap has fewer than 2 accounts'
+setup() {
+  mock_bin_setup cswap
+  cat >"$MOCK_BIN/cswap" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "--list" ]]; then
+  echo "  1) account-a (active)"
+fi
+exit 0
+EOF
+  chmod +x "$MOCK_BIN/cswap"
+}
+cleanup() {
+  mock_bin_cleanup
+}
+Before 'setup'
+After 'cleanup'
+
+It 'exits 0 silently'
+When run bash -c 'echo "{}" | bash '"$SCRIPT"
+The status should be success
+The output should eq ''
+End
+End
+
+Describe 'when cswap has 2+ accounts'
+setup() {
+  MOCK_BIN="$(mktemp -d)"
+  MOCK_LOG="$MOCK_BIN/mock.log"
+  : >"$MOCK_LOG"
+  MOCK_ORIGINAL_PATH="${PATH:-}"
+  export MOCK_BIN MOCK_LOG MOCK_ORIGINAL_PATH
+  export PATH="$MOCK_BIN:$MOCK_ORIGINAL_PATH"
+
+  cat >"$MOCK_BIN/cswap" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "--list" ]]; then
+  printf '  1) account-a (active)\n  2) account-b\n'
+elif [[ "$1" == "--switch" ]]; then
+  echo "Switched to account-b"
+fi
+exit 0
+EOF
+  chmod +x "$MOCK_BIN/cswap"
+}
+cleanup() {
+  if [[ -n ${MOCK_ORIGINAL_PATH:-} ]]; then
+    export PATH="$MOCK_ORIGINAL_PATH"
+  fi
+  if [[ -n ${MOCK_BIN:-} ]]; then
+    rm -rf "$MOCK_BIN"
+  fi
+  unset MOCK_BIN MOCK_LOG MOCK_ORIGINAL_PATH
+}
+Before 'setup'
+After 'cleanup'
+
+It 'does nothing for non-rate-limit errors'
+When run bash -c 'echo "{\"error\": \"some_other_error\"}" | bash '"$SCRIPT"
+The status should be success
+The output should eq ''
+The error should eq ''
+End
+
+It 'switches on rate_limit error'
+When run bash -c 'echo "{\"error\": \"rate_limit\"}" | bash '"$SCRIPT"
+The status should be success
+The error should include 'Auto-switching'
+End
+
+It 'switches on 429 in error_details'
+When run bash -c 'echo "{\"error_details\": \"status 429\"}" | bash '"$SCRIPT"
+The status should be success
+The error should include 'Auto-switching'
+End
+
+It 'switches on overloaded error'
+When run bash -c 'echo "{\"error\": \"overloaded\"}" | bash '"$SCRIPT"
+The status should be success
+The error should include 'Auto-switching'
+End
+
+It 'switches on too_many_requests error'
+When run bash -c 'echo "{\"error\": \"too_many_requests\"}" | bash '"$SCRIPT"
+The status should be success
+The error should include 'Auto-switching'
+End
+
+It 'switches on quota error'
+When run bash -c 'echo "{\"error\": \"quota_exceeded\"}" | bash '"$SCRIPT"
+The status should be success
+The error should include 'Auto-switching'
+End
+
+It 'switches on capacity error'
+When run bash -c 'echo "{\"error\": \"capacity\"}" | bash '"$SCRIPT"
+The status should be success
+The error should include 'Auto-switching'
+End
+
+It 'does nothing for empty JSON'
+When run bash -c 'echo "{}" | bash '"$SCRIPT"
+The status should be success
+The output should eq ''
+The error should eq ''
+End
 End
 
 End

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -33,6 +33,10 @@ It 'has spec file for config/claude/hooks/statusline.sh'
 The path "spec/statusline_spec.sh" should be exist
 End
 
+It 'has spec file for config/claude/hooks/auto-switch.sh'
+The path "spec/auto_switch_spec.sh" should be exist
+End
+
 It 'has spec file for config/hyprland/scripts/record-screen.sh'
 The path "spec/hyprland_record_screen_spec.sh" should be exist
 End
@@ -231,6 +235,7 @@ config/claude/hooks/pushover.sh
 config/claude/hooks/rtk-rewrite.sh
 config/claude/hooks/auto-switch.sh
 config/claude/hooks/security.sh
+config/claude/hooks/auto-switch.sh
 config/claude/hooks/atuin-history.sh
 config/claude/hooks/statusline.sh
 config/codex/hooks/atuin-history.sh


### PR DESCRIPTION
- Add StopFailure hook that detects rate limit errors and runs
  cswap --switch to rotate to the next Claude account
- Add claude-swap to uv global tools (pyproject.toml)
- Hook reads error/error_details from stdin, only triggers on
  rate_limit/429/overloaded/quota patterns

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically switches to the next Claude account when rate limit or overload errors occur, keeping sessions unblocked. Adds a StopFailure hook that runs `$HOME/.claude/hooks/auto-switch.sh` to rotate accounts using `claude-swap`.

- **New Features**
  - StopFailure hook in `config/claude/settings.json` with a 10s timeout.
  - Hook reads `error`/`error_details` from stdin; triggers on: rate_limit, overloaded, too_many_requests, 429, quota/quota_exceeded, capacity. No-op unless `cswap` is installed and there are 2+ accounts; otherwise runs `cswap --switch`.
  - Added tests in `spec/auto_switch_spec.sh` covering no-op cases (no `cswap`, <2 accounts) and switch triggers; updated coverage in `spec/coverage_spec.sh`.

- **Dependencies**
  - Added `claude-swap>=1.1.5` to `pyproject.toml` tools.

<sup>Written for commit a8d9506e549d1f8ce6bc606f269aa59868b39977. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

