### PR TITLE
fix: remove EnvironmentFile from paperclip service

### DIFF
--- a/home-manager/modules/paperclip/default.nix
+++ b/home-manager/modules/paperclip/default.nix
@@ -38,7 +38,6 @@ lib.mkIf host.isKyber {
         "HOME=${homeDir}"
         "PATH=${homeDir}/.local/bin:${homeDir}/.bun/bin:${homeDir}/.nix-profile/bin:${homeDir}/.local/share/pnpm:${homeDir}/.local/share/fnm/current/bin:${homeDir}/.npm-global/bin:/usr/local/bin:/usr/bin:/bin"
       ];
-      EnvironmentFile = "${instanceDir}/.env";
       WorkingDirectory = "${homeDir}/.paperclip";
       StandardOutput = "append:/tmp/paperclip/paperclip.log";
       StandardError = "append:/tmp/paperclip/paperclip.log";


### PR DESCRIPTION
## Summary
- Remove `EnvironmentFile` pointing to non-existent `~/.paperclip/instances/default/.env`
- No secrets needed in `local_trusted` mode — auth is handled at the Cloudflare tunnel / nginx ingress level

## Problem
Service was crash-looping with `Failed to load environment files: No such file or directory`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `EnvironmentFile` from the paperclip service to stop crash loops caused by a missing `.env`. This aligns with `local_trusted` mode where auth is handled at the edge.

- **Bug Fixes**
  - Dropped `EnvironmentFile` reference to `${instanceDir}/.env` to prevent “Failed to load environment files” and restart loops.
  - No secrets required in `local_trusted`; Cloudflare tunnel/nginx ingress handle auth.

<sup>Written for commit 4e4ca0a6b0f37fd29836097dabd3ccb96dff29ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

