### PR TITLE
fix: paperclip authenticated mode and required config fields

### DIFF
--- a/config/paperclip/config.template.json
+++ b/config/paperclip/config.template.json
@@ -16,6 +16,8 @@
     "exposure": "private",
     "host": "__HOST__",
     "port": 3100,
-    "allowedHostnames": ["__ALLOWED_HOSTNAME__"]
+    "allowedHostnames": [
+      "__ALLOWED_HOSTNAME__"
+    ]
   }
 }

--- a/config/paperclip/config.template.json
+++ b/config/paperclip/config.template.json
@@ -1,9 +1,19 @@
 {
+  "$meta": {
+    "version": 1,
+    "updatedAt": "2026-04-04T00:00:00.000Z",
+    "source": "configure"
+  },
   "database": {
     "mode": "__DATABASE_MODE__",
     "connectionString": "__DATABASE_CONNECTION_STRING__"
   },
+  "logging": {
+    "mode": "file"
+  },
   "server": {
+    "deploymentMode": "__DEPLOYMENT_MODE__",
+    "exposure": "private",
     "host": "__HOST__",
     "port": 3100
   }

--- a/config/paperclip/config.template.json
+++ b/config/paperclip/config.template.json
@@ -15,6 +15,7 @@
     "deploymentMode": "__DEPLOYMENT_MODE__",
     "exposure": "private",
     "host": "__HOST__",
-    "port": 3100
+    "port": 3100,
+    "allowedHostnames": ["__ALLOWED_HOSTNAME__"]
   }
 }

--- a/config/paperclip/default.nix
+++ b/config/paperclip/default.nix
@@ -18,6 +18,7 @@ let
       if host.isKyber then "postgres://postgres:postgres@localhost:5432/paperclip" else "";
     deployment_mode = if host.isKyber then "authenticated" else "local_trusted";
     host = if host.isKyber then "0.0.0.0" else "127.0.0.1";
+    allowed_hostname = if host.isKyber then "paperclip.shunkakinoki.com" else "";
     is_kyber = if host.isKyber then "true" else "false";
   };
 in

--- a/config/paperclip/default.nix
+++ b/config/paperclip/default.nix
@@ -16,6 +16,7 @@ let
     database_mode = if host.isKyber then "postgres" else "embedded-postgres";
     database_connection_string =
       if host.isKyber then "postgres://postgres:postgres@localhost:5432/paperclip" else "";
+    deployment_mode = if host.isKyber then "authenticated" else "local_trusted";
     host = if host.isKyber then "0.0.0.0" else "127.0.0.1";
     is_kyber = if host.isKyber then "true" else "false";
   };

--- a/config/paperclip/hydrate.sh
+++ b/config/paperclip/hydrate.sh
@@ -12,6 +12,7 @@ mkdir -p "${INSTANCE_DIR}"
   -e "s|__DATABASE_CONNECTION_STRING__|@database_connection_string@|g" \
   -e "s|__DEPLOYMENT_MODE__|@deployment_mode@|g" \
   -e "s|__HOST__|@host@|g" \
+  -e "s|__ALLOWED_HOSTNAME__|@allowed_hostname@|g" \
   "$TEMPLATE" >"$CONFIG"
 chmod 600 "$CONFIG"
 

--- a/config/paperclip/hydrate.sh
+++ b/config/paperclip/hydrate.sh
@@ -10,6 +10,7 @@ mkdir -p "${INSTANCE_DIR}"
 @sed@ \
   -e "s|__DATABASE_MODE__|@database_mode@|g" \
   -e "s|__DATABASE_CONNECTION_STRING__|@database_connection_string@|g" \
+  -e "s|__DEPLOYMENT_MODE__|@deployment_mode@|g" \
   -e "s|__HOST__|@host@|g" \
   "$TEMPLATE" >"$CONFIG"
 chmod 600 "$CONFIG"

--- a/home-manager/modules/paperclip/default.nix
+++ b/home-manager/modules/paperclip/default.nix
@@ -38,7 +38,6 @@ lib.mkIf host.isKyber {
         "HOME=${homeDir}"
         "PATH=${homeDir}/.local/bin:${homeDir}/.bun/bin:${homeDir}/.nix-profile/bin:${homeDir}/.local/share/pnpm:${homeDir}/.local/share/fnm/current/bin:${homeDir}/.npm-global/bin:/usr/local/bin:/usr/bin:/bin"
       ];
-      EnvironmentFile = "${instanceDir}/.env";
       WorkingDirectory = "${homeDir}/.paperclip";
       StandardOutput = "append:/tmp/paperclip/paperclip.log";
       StandardError = "append:/tmp/paperclip/paperclip.log";


### PR DESCRIPTION
## Summary
- Use `authenticated` mode on kyber (`local_trusted` rejects `0.0.0.0` binding)
- Add required `$meta` (version, updatedAt, source) and `logging` fields to template
- Auth is still handled at Cloudflare tunnel / nginx ingress level

## Problem
- `local_trusted` mode rejects `0.0.0.0` host binding — but we need it for k8s to reach paperclip
- Config validation requires `$meta.updatedAt`, `$meta.source` (enum), and `logging` section

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Paperclip on Kyber to authenticated mode, adds required config metadata/logging, and restricts access to the expected hostname. Fixes `0.0.0.0` binding rejection and config validation errors.

- **Bug Fixes**
  - Set `server.deploymentMode` to `authenticated` on Kyber (keep `local_trusted` elsewhere); required for k8s `0.0.0.0` binding; external auth stays at Cloudflare tunnel/nginx ingress.
  - Add required `$meta` (version, updatedAt, source) and `logging` to `config.template.json`.
  - Add `server.allowedHostnames` and set `paperclip.shunkakinoki.com` on Kyber.
  - Wire `__DEPLOYMENT_MODE__` and `__ALLOWED_HOSTNAME__` via Nix and `hydrate.sh`. Remove `EnvironmentFile` from the Paperclip systemd service.
  - Format `config.template.json` for consistency.

<sup>Written for commit 0ef7968a49538b1a02b82ed4a9dd12caaf1a8fda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

