### PR TITLE
fix: use trust auth for docker-postgres

### DIFF
--- a/home-manager/services/docker-postgres/start-postgres.sh
+++ b/home-manager/services/docker-postgres/start-postgres.sh
@@ -47,6 +47,7 @@ ensure_container() {
       -p "${HOST_PORT}:${CONTAINER_PORT}" \
       -e POSTGRES_DB=trails_api \
       -e POSTGRES_PASSWORD=postgres \
+      -e POSTGRES_HOST_AUTH_METHOD=trust \
       "$IMAGE"
     log "Container '$CONTAINER_NAME' created and started"
   fi


### PR DESCRIPTION
## Summary
Add `POSTGRES_HOST_AUTH_METHOD=trust` to the docker-postgres container.

## Problem
`POSTGRES_PASSWORD` only sets the password on first container init. After crash recovery, the password in the auth system gets out of sync, causing `password authentication failed` errors that crash-loop paperclip and any other service using the postgres connection.

## Fix
Trust all connections — no password needed. Safe since this postgres is only reachable from localhost/docker bridge, not exposed externally.

## Note
Existing container needs to be recreated for this to take effect:
```bash
docker stop postgres && docker rm postgres
make systemctl-docker-postgres
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `docker-postgres` to trust auth by setting `POSTGRES_HOST_AUTH_METHOD=trust`. This prevents password mismatches after crash recovery that caused "password authentication failed" and crash loops in dependent services.

- **Migration**
  - Recreate the container to apply the env var: run `docker stop postgres && docker rm postgres`, then `make systemctl-docker-postgres`.

<sup>Written for commit 68d129351ac4c13b9866a6d998f605ad244677b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

