### PR TITLE
fix: use k8s postgres for paperclip, remove docker-postgres dep

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,5 @@ OPENCLAW_ANTHROPIC_API_KEY=sk-ant-api03-your-key-here
 OPENCLAW_GATEWAY_TOKEN=your-gateway-token-here
 # OpenCode API key for OpenCode Go access via cliproxyapi
 OPENCODE_API_KEY=your-opencode-api-key-here
+# Paperclip database URL
+DATABASE_URL=postgres://user:password@host:5432/paperclip

--- a/config/paperclip/default.nix
+++ b/config/paperclip/default.nix
@@ -14,8 +14,7 @@ let
     template = "${./config.template.json}";
     sed = "${pkgs.gnused}/bin/sed";
     database_mode = if host.isKyber then "postgres" else "embedded-postgres";
-    database_connection_string =
-      if host.isKyber then "postgres://postgres:postgres@localhost:5432/paperclip" else "";
+    database_connection_string = "";
     deployment_mode = if host.isKyber then "authenticated" else "local_trusted";
     host = if host.isKyber then "0.0.0.0" else "127.0.0.1";
     allowed_hostname = if host.isKyber then "paperclip.shunkakinoki.com" else "";

--- a/config/paperclip/hydrate.sh
+++ b/config/paperclip/hydrate.sh
@@ -4,26 +4,38 @@ set -euo pipefail
 INSTANCE_DIR="@instance_dir@"
 CONFIG="${INSTANCE_DIR}/config.json"
 TEMPLATE="@template@"
+ENV_FILE="${HOME}/dotfiles/.env"
+
+# Source .env if it exists (for DATABASE_URL)
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$ENV_FILE"
+  set +a
+fi
 
 mkdir -p "${INSTANCE_DIR}"
 
+# Use DATABASE_URL from env if set, otherwise use the Nix default
+DB_CONNECTION="${DATABASE_URL:-@database_connection_string@}"
+
 @sed@ \
   -e "s|__DATABASE_MODE__|@database_mode@|g" \
-  -e "s|__DATABASE_CONNECTION_STRING__|@database_connection_string@|g" \
+  -e "s|__DATABASE_CONNECTION_STRING__|${DB_CONNECTION}|g" \
   -e "s|__DEPLOYMENT_MODE__|@deployment_mode@|g" \
   -e "s|__HOST__|@host@|g" \
   -e "s|__ALLOWED_HOSTNAME__|@allowed_hostname@|g" \
   "$TEMPLATE" >"$CONFIG"
 chmod 600 "$CONFIG"
 
-# Create paperclip database on docker-postgres if needed
+# Create paperclip database on k8s postgres if needed
 # @is_kyber@ is substituted by Nix replaceVars
 # shellcheck disable=SC2050
-if [ "@is_kyber@" = "true" ]; then
-  if command -v docker >/dev/null 2>&1 && docker container inspect postgres >/dev/null 2>&1; then
-    if ! docker exec postgres psql -U postgres -lqt | cut -d \| -f 1 | grep -qw paperclip; then
-      docker exec postgres createdb -U postgres paperclip
-      echo "Created paperclip database" >&2
+if [ "@is_kyber@" = "true" ] && [ -n "$DB_CONNECTION" ]; then
+  if command -v psql >/dev/null 2>&1; then
+    DB_BASE="${DB_CONNECTION%/*}/postgres"
+    if ! psql "$DB_BASE" -tAc "SELECT 1 FROM pg_database WHERE datname='paperclip'" 2>/dev/null | grep -q 1; then
+      psql "$DB_BASE" -c "CREATE DATABASE paperclip" 2>/dev/null && echo "Created paperclip database" >&2
     fi
   fi
 fi

--- a/home-manager/modules/paperclip/default.nix
+++ b/home-manager/modules/paperclip/default.nix
@@ -7,7 +7,6 @@
 let
   inherit (inputs) host;
   homeDir = config.home.homeDirectory;
-  instanceDir = "${homeDir}/.paperclip/instances/default";
 in
 # Only enable on kyber (server host)
 lib.mkIf host.isKyber {
@@ -22,12 +21,8 @@ lib.mkIf host.isKyber {
   systemd.user.services.paperclip = {
     Unit = {
       Description = "Paperclip AI agent orchestration platform";
-      After = [
-        "network-online.target"
-        "docker-postgres.service"
-      ];
+      After = [ "network-online.target" ];
       Wants = [ "network-online.target" ];
-      Requires = [ "docker-postgres.service" ];
     };
     Service = {
       Type = "simple";

--- a/spec/paperclip_hydrate_spec.sh
+++ b/spec/paperclip_hydrate_spec.sh
@@ -16,6 +16,18 @@ The output should include 'set -euo pipefail'
 End
 End
 
+Describe 'secret loading'
+It 'reads DATABASE_URL from dotfiles .env'
+When run bash -c "grep 'DATABASE_URL' '$SCRIPT'"
+The output should include 'DATABASE_URL'
+End
+
+It 'sources the env file'
+When run bash -c "grep 'ENV_FILE' '$SCRIPT'"
+The output should include 'dotfiles/.env'
+End
+End
+
 Describe 'config generation'
 It 'uses sed to substitute values in template'
 When run bash -c "grep '@sed@' '$SCRIPT'"
@@ -44,13 +56,8 @@ End
 End
 
 Describe 'database provisioning'
-It 'creates paperclip database on docker-postgres'
-When run bash -c "grep 'createdb' '$SCRIPT'"
-The output should include 'paperclip'
-End
-
-It 'checks if database already exists before creating'
-When run bash -c "grep 'grep -qw paperclip' '$SCRIPT'"
+It 'creates paperclip database if missing'
+When run bash -c "grep 'CREATE DATABASE' '$SCRIPT'"
 The output should include 'paperclip'
 End
 


### PR DESCRIPTION
## Summary
- Read `DATABASE_URL` from `~/dotfiles/.env` at hydrate time (like openclaw reads secrets)
- Remove `docker-postgres.service` dependency from systemd unit
- Use `authenticated` mode on kyber (required for `0.0.0.0` binding)
- Add `allowedHostnames` for `paperclip.shunkakinoki.com`
- Auto-create paperclip database via `psql` if missing

## Required
Add to `~/dotfiles/.env`:
```
DATABASE_URL=postgres://postgres:shunkakinoki@10.43.199.36:5432/paperclip
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Paperclip to k8s Postgres via `DATABASE_URL` and remove the `docker-postgres.service` dependency. Hydration reads from `~/dotfiles/.env`, runs Kyber in authenticated mode, and auto-creates the `paperclip` database if missing.

- **Refactors**
  - Read `DATABASE_URL` from `~/dotfiles/.env` at hydrate time.
  - Remove `docker-postgres.service` and Docker-based DB provisioning.
  - Use `authenticated` mode on Kyber and bind to `0.0.0.0`; allow paperclip.shunkakinoki.com.
  - Create `paperclip` DB via `psql` if missing.
  - Update `.env.example` and tests.

- **Migration**
  - Add `DATABASE_URL=postgres://postgres:shunkakinoki@10.43.199.36:5432/paperclip` to `~/dotfiles/.env` on Kyber.

<sup>Written for commit b2b3afaf170f582800f8c664b8221db7ebb33911. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

