### PR TITLE
fix: use bun runtime for paperclip to avoid pino-http node crash

### DIFF
--- a/home-manager/modules/paperclip/default.nix
+++ b/home-manager/modules/paperclip/default.nix
@@ -18,6 +18,7 @@ lib.mkIf host.isKyber {
   '';
 
   # Systemd service for Paperclip
+  # Uses bun runtime instead of node to avoid pino-http crash (logger[stringifySym] is not a function)
   systemd.user.services.paperclip = {
     Unit = {
       Description = "Paperclip AI agent orchestration platform";
@@ -26,7 +27,7 @@ lib.mkIf host.isKyber {
     };
     Service = {
       Type = "simple";
-      ExecStart = "${homeDir}/.bun/bin/paperclipai run";
+      ExecStart = "${homeDir}/.bun/bin/bun run ${homeDir}/.bun/install/global/node_modules/paperclipai/dist/index.js run --no-repair";
       Restart = "always";
       RestartSec = "5s";
       Environment = [


### PR DESCRIPTION
## Summary
Run paperclipai with `bun` instead of `node` to work around a pino-http crash (`logger[stringifySym] is not a function`) on Node.js 22.

## Root cause
The globally installed `paperclipai` npm package has a pino/pino-http version incompatibility with Node 22. The server crashes after serving the first HTTP response when the logger tries to serialize it. Running under `bun` avoids this because bun handles pino's internal symbols differently.

## Change
`ExecStart` changed from:
```
paperclipai run
```
to:
```
bun run ~/.bun/install/global/node_modules/paperclipai/dist/index.js run --no-repair
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `paperclipai` under `bun` instead of Node.js to work around a `pino-http` crash (`logger[stringifySym] is not a function`) on Node 22. Updates the systemd user service to call `bun run ~/.bun/install/global/node_modules/paperclipai/dist/index.js run --no-repair`.

<sup>Written for commit c63e60b7ee0374e86b2b7caab30376c460e08b0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

