### PR TITLE
fix: use nix-profile bun path for paperclip service

### DIFF
--- a/home-manager/modules/paperclip/default.nix
+++ b/home-manager/modules/paperclip/default.nix
@@ -27,7 +27,7 @@ lib.mkIf host.isKyber {
     };
     Service = {
       Type = "simple";
-      ExecStart = "${homeDir}/.bun/bin/bun run ${homeDir}/.bun/install/global/node_modules/paperclipai/dist/index.js run --no-repair";
+      ExecStart = "${homeDir}/.nix-profile/bin/bun run ${homeDir}/.bun/install/global/node_modules/paperclipai/dist/index.js run --no-repair";
       Restart = "always";
       RestartSec = "5s";
       Environment = [


### PR DESCRIPTION
## Summary
- Fix paperclip service crash loop (exit code 203/EXEC) by correcting bun binary path
- `~/.bun/bin/bun` does not exist; bun is installed at `~/.nix-profile/bin/bun`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Paperclip service crash loop (systemd 203/EXEC) by using the `bun` binary from `~/.nix-profile/bin/bun` instead of `~/.bun/bin/bun`.
Updates ExecStart in the home-manager module so the service starts reliably.

<sup>Written for commit 1d2dd4329bd9cf9b935990ed4b6497abf8229abe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

