### PR TITLE
fix: use extra-substituters to avoid untrusted user warnings

### DIFF
--- a/home-manager/nix/nix.nix
+++ b/home-manager/nix/nix.nix
@@ -14,16 +14,13 @@
         "nix-command"
         "flakes"
       ];
-      use-xdg-base-directories = true;
-      substituters = [
-        "https://cache.nixos.org"
+      extra-substituters = [
         "https://cache.garnix.io"
         "https://cloudtide.cachix.org"
         "https://nix-community.cachix.org"
         "https://yazi.cachix.org"
       ];
-      trusted-public-keys = [
-        "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+      extra-trusted-public-keys = [
         "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
         "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
         "cloudtide.cachix.org-1:9NZ1Mah2+u8cd/CmVffFV23z5uFNpZSrhfgTt5fuN/4="


### PR DESCRIPTION
## Summary
- Replace `substituters` / `trusted-public-keys` with `extra-substituters` / `extra-trusted-public-keys` in Home Manager nix settings
- Remove `use-xdg-base-directories` (restricted setting not allowed for untrusted users)
- Remove redundant `cache.nixos.org` entry (already in default substituters)

Fixes the repeated "ignoring untrusted substituter" and "ignoring the client-specified setting" warnings during `make build && make switch`.

The `extra-` prefixed settings are not restricted, so they work for non-trusted users in standalone Home Manager setups (kyber).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Home Manager Nix config to `extra-substituters`/`extra-trusted-public-keys` and remove restricted options to stop “untrusted substituter” and “ignoring the client-specified setting” warnings for non‑trusted users during build/switch. Removed `use-xdg-base-directories` (restricted) and the redundant `cache.nixos.org` entry since it’s included by default.

<sup>Written for commit 2536bdd672765e1e835254fc2470fbde9dbe975e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

