### PR TITLE
fix: run paperclip from cloned repo via pnpm dev:once

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -121,8 +121,7 @@
     "@googleworkspace/cli",
   ],
   "overrides": {
-    "pino": "9.6.0",
-    "pino-http": "9.0.0",
+    "pino": "9.14.0",
   },
   "packages": {
     "@a2a-js/sdk": ["@a2a-js/sdk@0.3.11", "", { "dependencies": { "uuid": "^11.1.0" }, "peerDependencies": { "@bufbuild/protobuf": "^2.10.2", "@grpc/grpc-js": "^1.11.0", "express": "^4.21.2 || ^5.1.0" }, "optionalPeers": ["@bufbuild/protobuf", "@grpc/grpc-js", "express"] }, "sha512-pXjjlL0ZYHgAxObov1J+W3ylfQV0rOrDBB8Eo4a9eCunqs7iNW5OIfMcV8YnZQdzeVSRomj8jHeudVz0zc4RNw=="],
@@ -1130,6 +1129,8 @@
     "@paperclipai/shared": ["@paperclipai/shared@2026.403.0-canary.10", "", { "dependencies": { "zod": "^3.24.2" } }, "sha512-jmxhbadlQJKBbHAPhXWK6HfsZ3LTgcIW+g/Zk+YEHSxzeuD/7gZntiQKVgaYVzL6x9ZvXMmwRQ8acyiPAHGaQg=="],
 
     "@pencil.dev/cli": ["@pencil.dev/cli@0.2.3", "", { "dependencies": { "@anthropic-ai/claude-agent-sdk": "^0.2.72", "@inquirer/prompts": "^8.3.0", "eventemitter3": "^5.0.1", "semver": "^7.7.4", "svgo": "^4.0.0", "ws": "^8.18.3" }, "bin": { "pencil": "dist/index.cjs" } }, "sha512-ing7fYhNMJaOBTLAqYU3ynShMWOGQZoBUODajPUGaMv+xI4OhuZU/VEnFJLKbbfx3YzrHx0MWGzl0SPYUnEtRg=="],
+
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
@@ -2225,8 +2226,6 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
-    "fast-redact": ["fast-redact@3.5.0", "", {}, "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A=="],
-
     "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
 
     "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
@@ -2971,11 +2970,11 @@
 
     "picomatch": ["picomatch@3.0.1", "", {}, "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag=="],
 
-    "pino": ["pino@9.6.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "fast-redact": "^3.1.1", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^4.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg=="],
+    "pino": ["pino@9.14.0", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^2.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^3.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w=="],
 
     "pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
 
-    "pino-http": ["pino-http@9.0.0", "", { "dependencies": { "get-caller-file": "^2.0.5", "pino": "^8.17.1", "pino-std-serializers": "^6.2.2", "process-warning": "^3.0.0" } }, "sha512-Q9QDNEz0vQmbJtMFjOVr2c9yL92vHudjmr3s3m6J1hbw3DBGFZJm3TIj9TWyynZ4GEsEA9SOtni4heRUr6lNOg=="],
+    "pino-http": ["pino-http@10.5.0", "", { "dependencies": { "get-caller-file": "^2.0.5", "pino": "^9.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0" } }, "sha512-hD91XjgaKkSsdn8P7LaebrNzhGTdB086W3pyPihX0EzGPjq5uBJBXo4N5guqNaK6mUjg9aubMF7wDViYek9dRA=="],
 
     "pino-pretty": ["pino-pretty@13.1.3", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^4.0.0", "fast-safe-stringify": "^2.1.1", "help-me": "^5.0.0", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pump": "^3.0.0", "secure-json-parse": "^4.0.0", "sonic-boom": "^4.0.1", "strip-json-comments": "^5.0.2" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg=="],
 
@@ -3027,7 +3026,7 @@
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
-    "process-warning": ["process-warning@4.0.1", "", {}, "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q=="],
+    "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
     "proggy": ["proggy@4.0.0", "", {}, "sha512-MbA4R+WQT76ZBm/5JUpV9yqcJt92175+Y0Bodg3HgiXzrmKu7Ggq+bpn6y6wHH+gN9NcyKn3yg1+d47VaKwNAQ=="],
 
@@ -4434,10 +4433,6 @@
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
     "parse5-parser-stream/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
-
-    "pino-http/pino-std-serializers": ["pino-std-serializers@6.2.2", "", {}, "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="],
-
-    "pino-http/process-warning": ["process-warning@3.0.0", "", {}, "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="],
 
     "pino-pretty/pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
 

--- a/home-manager/modules/paperclip/default.nix
+++ b/home-manager/modules/paperclip/default.nix
@@ -7,6 +7,7 @@
 let
   inherit (inputs) host;
   homeDir = config.home.homeDirectory;
+  repoDir = "${homeDir}/ghq/github.com/paperclipai/paperclip";
 in
 # Only enable on kyber (server host)
 lib.mkIf host.isKyber {
@@ -18,7 +19,9 @@ lib.mkIf host.isKyber {
   '';
 
   # Systemd service for Paperclip
-  # Uses bun runtime instead of node to avoid pino-http crash (logger[stringifySym] is not a function)
+  # Runs from cloned repo via pnpm dev:once — the global bun install has a
+  # pino-http/pino version mismatch that crashes node after the first request.
+  # The repo's lockfile resolves deps correctly.
   systemd.user.services.paperclip = {
     Unit = {
       Description = "Paperclip AI agent orchestration platform";
@@ -27,14 +30,21 @@ lib.mkIf host.isKyber {
     };
     Service = {
       Type = "simple";
-      ExecStart = "${homeDir}/.nix-profile/bin/bun run ${homeDir}/.bun/install/global/node_modules/paperclipai/dist/index.js run --no-repair";
+      ExecStart = "${homeDir}/.bun/bin/pnpm dev:once";
       Restart = "always";
       RestartSec = "5s";
       Environment = [
         "HOME=${homeDir}"
+        "HOST=0.0.0.0"
+        "PAPERCLIP_DEPLOYMENT_MODE=authenticated"
+        "PAPERCLIP_ALLOWED_HOSTNAMES=paperclip.shunkakinoki.com,172.17.0.1"
         "PATH=${homeDir}/.local/bin:${homeDir}/.bun/bin:${homeDir}/.nix-profile/bin:${homeDir}/.local/share/pnpm:${homeDir}/.local/share/fnm/current/bin:${homeDir}/.npm-global/bin:/usr/local/bin:/usr/bin:/bin"
       ];
-      WorkingDirectory = "${homeDir}/.paperclip";
+      EnvironmentFile = [
+        "${homeDir}/dotfiles/.env"
+        "${homeDir}/.paperclip/instances/default/.env"
+      ];
+      WorkingDirectory = "${repoDir}";
       StandardOutput = "append:/tmp/paperclip/paperclip.log";
       StandardError = "append:/tmp/paperclip/paperclip.log";
     };

--- a/home-manager/modules/paperclip/default.nix
+++ b/home-manager/modules/paperclip/default.nix
@@ -7,7 +7,6 @@
 let
   inherit (inputs) host;
   homeDir = config.home.homeDirectory;
-  repoDir = "${homeDir}/ghq/github.com/paperclipai/paperclip";
 in
 # Only enable on kyber (server host)
 lib.mkIf host.isKyber {
@@ -19,9 +18,6 @@ lib.mkIf host.isKyber {
   '';
 
   # Systemd service for Paperclip
-  # Runs from cloned repo with bun — the global bun install has a
-  # pino-http/pino version mismatch that crashes node after the first request.
-  # Running bun directly from the repo resolves deps correctly.
   systemd.user.services.paperclip = {
     Unit = {
       Description = "Paperclip AI agent orchestration platform";
@@ -30,7 +26,7 @@ lib.mkIf host.isKyber {
     };
     Service = {
       Type = "simple";
-      ExecStart = "${homeDir}/.bun/bin/bun run ${repoDir}/server/src/index.ts";
+      ExecStart = "${homeDir}/dotfiles/node_modules/.bin/paperclipai run --no-repair";
       Restart = "always";
       RestartSec = "5s";
       Environment = [
@@ -44,7 +40,7 @@ lib.mkIf host.isKyber {
         "${homeDir}/dotfiles/.env"
         "${homeDir}/.paperclip/instances/default/.env"
       ];
-      WorkingDirectory = "${repoDir}";
+      WorkingDirectory = "${homeDir}/.paperclip";
       StandardOutput = "append:/tmp/paperclip/paperclip.log";
       StandardError = "append:/tmp/paperclip/paperclip.log";
     };

--- a/home-manager/modules/paperclip/default.nix
+++ b/home-manager/modules/paperclip/default.nix
@@ -19,9 +19,9 @@ lib.mkIf host.isKyber {
   '';
 
   # Systemd service for Paperclip
-  # Runs from cloned repo via pnpm dev:once — the global bun install has a
+  # Runs from cloned repo with bun — the global bun install has a
   # pino-http/pino version mismatch that crashes node after the first request.
-  # The repo's lockfile resolves deps correctly.
+  # Running bun directly from the repo resolves deps correctly.
   systemd.user.services.paperclip = {
     Unit = {
       Description = "Paperclip AI agent orchestration platform";
@@ -30,7 +30,7 @@ lib.mkIf host.isKyber {
     };
     Service = {
       Type = "simple";
-      ExecStart = "${homeDir}/.bun/bin/pnpm dev:once";
+      ExecStart = "${homeDir}/.bun/bin/bun run ${repoDir}/server/src/index.ts";
       Restart = "always";
       RestartSec = "5s";
       Environment = [

--- a/package.json
+++ b/package.json
@@ -68,8 +68,7 @@
     "xcodebuildmcp": "^2.3.1"
   },
   "overrides": {
-    "pino": "9.6.0",
-    "pino-http": "9.0.0"
+    "pino": "9.14.0"
   },
   "trustedDependencies": [
     "@anthropic-ai/claude-code",


### PR DESCRIPTION
## Summary
Run paperclip from `~/ghq/github.com/paperclipai/paperclip` using `pnpm dev:once` instead of the global bun install.

## Root cause
The global `bun install -g paperclipai` flattens `pino@10` and `pino-http@10.5` together, but `pino-http@10.5` requires `pino@9`. The repo's lockfile correctly nests `pino@9.14.0` inside `pino-http`, avoiding the crash.

## Changes
- `ExecStart`: `pnpm dev:once` (runs from the cloned repo)
- `WorkingDirectory`: `~/ghq/github.com/paperclipai/paperclip`
- `EnvironmentFile`: loads both `~/dotfiles/.env` (DATABASE_URL) and instance `.env` (secrets)
- Env vars: `HOST=0.0.0.0`, `PAPERCLIP_DEPLOYMENT_MODE=authenticated`, `PAPERCLIP_ALLOWED_HOSTNAMES`

## Tested
10/10 sequential requests returned 200 with `pnpm dev:once` — no crashes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run Paperclip using the local `paperclipai` binary and pin `pino@9.14.0` to fix crashes from a `pino`/`pino-http` version mismatch. The systemd service now uses the local binary, loads env files, and sets required env vars.

- **Bug Fixes**
  - ExecStart: `${HOME}/dotfiles/node_modules/.bin/paperclipai run --no-repair`; `WorkingDirectory=${HOME}/.paperclip`.
  - Loads `~/dotfiles/.env` and the instance `.env`; sets `HOST=0.0.0.0`, `PAPERCLIP_DEPLOYMENT_MODE=authenticated`, `PAPERCLIP_ALLOWED_HOSTNAMES`.

- **Dependencies**
  - Override `pino` to `9.14.0` (remove `pino-http` override); lock now resolves `pino-http@10.5.0`.
  - `bun.lock` updated accordingly (introduces `@pinojs/redact`, replaces old `fast-redact`).

<sup>Written for commit 33995bec4f6956031c7235751357d7f0fd87c0ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

