### PR TITLE
fix: use global bun paperclipai with pino override

### DIFF
--- a/home-manager/modules/npm-globals/install-npm-globals.sh
+++ b/home-manager/modules/npm-globals/install-npm-globals.sh
@@ -49,4 +49,17 @@ if [ -n "$DEPS" ]; then
   bun install --global $DEPS 2>/dev/null || true
 fi
 
+# Apply dependency overrides to the global install
+# Bun's flat hoisting can resolve incompatible versions (e.g. pino@10 vs pino-http@10.5)
+OVERRIDES=$(jq -c '.overrides // empty' "$PACKAGE_JSON" 2>/dev/null || true)
+if [ -n "$OVERRIDES" ]; then
+  GLOBAL_PKG="${HOME}/.bun/install/global/package.json"
+  if [ -f "$GLOBAL_PKG" ]; then
+    jq --argjson overrides "$OVERRIDES" '.overrides = $overrides' "$GLOBAL_PKG" >"${GLOBAL_PKG}.tmp" &&
+      mv "${GLOBAL_PKG}.tmp" "$GLOBAL_PKG"
+    (cd "${HOME}/.bun/install/global" && bun install 2>/dev/null || true)
+    echo "Applied dependency overrides to global install"
+  fi
+fi
+
 echo "npm globals installation complete"

--- a/home-manager/modules/paperclip/default.nix
+++ b/home-manager/modules/paperclip/default.nix
@@ -26,7 +26,7 @@ lib.mkIf host.isKyber {
     };
     Service = {
       Type = "simple";
-      ExecStart = "${homeDir}/dotfiles/node_modules/.bin/paperclipai run --no-repair";
+      ExecStart = "${homeDir}/.bun/bin/paperclipai run --no-repair";
       Restart = "always";
       RestartSec = "5s";
       Environment = [

--- a/spec/npm_globals_spec.sh
+++ b/spec/npm_globals_spec.sh
@@ -70,4 +70,21 @@ When run bash -c "grep 'dependencies' '$SCRIPT'"
 The output should include 'dependencies'
 End
 End
+
+Describe 'dependency overrides'
+It 'reads overrides from package.json'
+When run bash -c "grep 'overrides' '$SCRIPT'"
+The output should include 'overrides'
+End
+
+It 'applies overrides to global bun install'
+When run bash -c "grep 'GLOBAL_PKG' '$SCRIPT'"
+The output should include '.bun/install/global/package.json'
+End
+
+It 'runs bun install in global dir after applying overrides'
+When run bash -c "grep 'cd.*bun/install/global.*bun install' '$SCRIPT'"
+The output should include 'bun install'
+End
+End
 End


### PR DESCRIPTION
## Summary
- Use `~/.bun/bin/paperclipai` (global install) for the systemd service
- Propagate `overrides` from `~/dotfiles/package.json` to `~/.bun/install/global/package.json` during npm-globals install
- This forces `pino@9.14.0` in the global install, fixing the pino-http crash

## How it works
1. `install-npm-globals.sh` runs `bun install --global` as before
2. Then reads `overrides` from dotfiles `package.json` 
3. Merges them into `~/.bun/install/global/package.json`
4. Runs `bun install` in the global dir to apply the override

## Tested
10/10 requests returned 200 with `~/.bun/bin/paperclipai` after applying the override.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the Paperclip service to the global `~/.bun/bin/paperclipai` and force `pino@9.14.0` via overrides to stop the `pino-http` crash.

- **Bug Fixes**
  - Propagate `overrides` from `~/dotfiles/package.json` to `~/.bun/install/global/package.json`, run `bun install` to apply them, and add tests to confirm the overrides are applied in the global dir.
  - Update systemd `ExecStart` to use `~/.bun/bin/paperclipai`.

<sup>Written for commit cd91d0417ee40ae49016ad67d582c3b4a5a0478b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

