### PR TITLE
fix: openclaw gateway bind lan and correct controlUi origin

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -789,16 +789,13 @@
   },
   "gateway": {
     "mode": "local",
-    "bind": "loopback",
-    "tailscale": {
-      "mode": "serve"
-    },
+    "bind": "lan",
     "controlUi": {
       "allowedOrigins": [
         "http://localhost:18789",
         "http://127.0.0.1:18789",
         "https://openclaw.shunkakinoki.com",
-        "https://kyber.tail950b36.ts.net"
+        "https://kyber.tail950b36.ts.net:18789"
       ]
     },
     "auth": {

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -789,16 +789,13 @@
   },
   "gateway": {
     "mode": "local",
-    "bind": "loopback",
-    "tailscale": {
-      "mode": "serve"
-    },
+    "bind": "lan",
     "controlUi": {
       "allowedOrigins": [
         "http://localhost:18789",
         "http://127.0.0.1:18789",
         "https://openclaw.shunkakinoki.com",
-        "https://kyber.tail950b36.ts.net"
+        "https://kyber.tail950b36.ts.net:18789"
       ]
     },
     "auth": {


### PR DESCRIPTION
## Summary
- Change gateway bind from `loopback` to `lan` to allow LAN/Tailscale access (was causing startup failures when config drifted)
- Remove unused `tailscale.mode: serve` config (not used by current OpenClaw version)
- Add `:18789` port to Tailscale controlUi origin to match actual gateway port

## Context
The live `openclaw.json` on kyber drifted from the declarative template — gateway mode was overwritten to `remote` (client mode), causing crash loops. The template already had the correct model config (`minimax-m2.7`), but `gateway.bind` was set to `loopback` instead of `lan`, which doesn't match the working production config.

## Test plan
- [x] Hydrated config from updated template on kyber
- [x] `openclaw-gateway.service` starts and stays running
- [x] Gateway accessible on LAN/Tailscale

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the OpenClaw gateway to bind on LAN and fix the `controlUi` origin port to match `:18789`, preventing crash loops and enabling LAN/Tailscale access.

- **Bug Fixes**
  - Set `gateway.bind` from `loopback` to `lan` for LAN/Tailscale reachability.
  - Removed unused Tailscale `mode: serve` config.
  - Added `:18789` to `kyber.tail950b36.ts.net` in `controlUi.allowedOrigins` to match the gateway port.

<sup>Written for commit 66c672097e063311266cdbd51020c896b124febc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

