### PR TITLE
fix: correct grep pattern in npm_globals_spec

### DIFF
--- a/spec/npm_globals_spec.sh
+++ b/spec/npm_globals_spec.sh
@@ -93,7 +93,7 @@ The output should include 'Deduplicated'
 End
 
 It 'finds nested node_modules with find command'
-When run bash -c "grep 'find.*GLOBAL_MODULES.*node_modules' '$SCRIPT'"
+When run bash -c "grep 'find.*GLOBAL_MODULES' '$SCRIPT'"
 The output should include 'find'
 End
 End


### PR DESCRIPTION
## Summary
- Fix failing shell test on main: `npm_globals_spec.sh:95` grep pattern `find.*GLOBAL_MODULES.*node_modules` fails because `find` and `node_modules` are on separate lines (line continuation with `\`)
- Simplified pattern to `find.*GLOBAL_MODULES` which correctly matches the find command line

## Test plan
- [x] `shellspec spec/npm_globals_spec.sh` passes locally (16 examples, 0 failures)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing `npm_globals_spec.sh` test by correcting the grep pattern to handle the multi-line `find` command. Simplifies the match from `find.*GLOBAL_MODULES.*node_modules` to `find.*GLOBAL_MODULES` so the test reliably detects the `find` invocation.

<sup>Written for commit 8b895899b4ddb97cfd1bd485fd54711de6c59aa7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

