### PR TITLE
fix: correct actions/checkout to v4 in renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       - name: Renovate
         uses: renovatebot/github-action@v46.1.7
         with:


### PR DESCRIPTION
## Summary
- `actions/checkout@v6` does not exist; latest stable is `v4`
- This caused the Renovate workflow to fail on every run
- Fixed by downgrading to the valid `actions/checkout@v4`

## Root cause
The `renovate.yml` workflow referenced `actions/checkout@v6` which is a non-existent version tag. GitHub Actions fails to resolve the action, breaking the entire Renovate job.

## Test plan
- [ ] Trigger the Renovate workflow via `workflow_dispatch` and confirm it completes successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken Renovate workflow by switching the checkout action to the valid `actions/checkout@v4` in `.github/workflows/renovate.yml`. Restores successful runs and addresses SHU-7.

<sup>Written for commit 0e86154ed3bbd33d7a6dc25acced5a35125a7ce3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

