### PR TITLE
ci: add PR triage workflow for auto-labeling

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,64 @@
+name: Triage
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+jobs:
+  triage-label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Apply PR Labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const actor = context.payload.pull_request.user.login;
+            const labels = [];
+
+            // Conventional commit type -> label
+            if (/^feat(\(.+\))?!?:/.test(title)) labels.push('enhancement');
+            else if (/^fix(\(.+\))?!?:/.test(title)) labels.push('bug');
+            else if (/^docs(\(.+\))?!?:/.test(title)) labels.push('documentation');
+            else if (/^refactor(\(.+\))?!?:/.test(title)) labels.push('refactor');
+            else if (/^(chore|build)\(deps\)(\(.+\))?!?:/.test(title)) labels.push('dependencies');
+
+            // Bot authors
+            if (/^(dependabot|dependabot\[bot\]|dependabot-preview)$/.test(actor)) {
+              labels.push('dependabot');
+            } else if (/^(renovate|renovate\[bot\])$/.test(actor)) {
+              labels.push('renovate');
+            } else if (/^codex/.test(actor)) {
+              labels.push('codex');
+            }
+
+            // Automerge marker
+            if (/\[automerge\]/i.test(title)) labels.push('automerge');
+
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels,
+              });
+            }
+  triage-check:
+    if: always()
+    needs:
+      - triage-label
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Alls Green
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Changes
- Add `.github/workflows/triage.yml` workflow that auto-labels PRs on `pull_request_target` events (opened, edited, synchronize, reopened)

## Label mapping
- `feat:` -> `enhancement`
- `fix:` -> `bug`
- `docs:` -> `documentation`
- `refactor:` -> `refactor`
- `chore(deps):` / `build(deps):` -> `dependencies`
- renovate bot -> `renovate`
- dependabot bot -> `dependabot`
- codex actor -> `codex`
- `[automerge]` in title -> `automerge`

## Testing
- Workflow triggers on all PR open/edit/sync events
- Uses `actions/github-script@v7` with `pull-requests: write` permission

Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI workflow that auto-labels PRs based on title and author to reduce manual triage and support automerge tagging.

- **New Features**
  - Triggers on `pull_request_target` (opened, edited, synchronize, reopened).
  - Maps prefixes: `feat:`→`enhancement`, `fix:`→`bug`, `docs:`→`documentation`, `refactor:`→`refactor`, `chore(deps):`/`build(deps):`→`dependencies`.
  - Labels bot authors: `dependabot`, `renovate`, `codex`.
  - Adds `automerge` when `[automerge]` is in the title.
  - Uses `actions/github-script@v7` with `pull-requests: write`; includes `re-actors/alls-green@release/v1` check.

<sup>Written for commit 2b8afe6a0197666b2ac097c34a3b3130df1582ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

