### PR TITLE
fix: handle detached HEAD in update-local-binaries

### DIFF
--- a/scripts/update-local-binaries.sh
+++ b/scripts/update-local-binaries.sh
@@ -235,6 +235,19 @@ update_repo() {
     rm -f "$repo_dir/.git/index.lock"
   fi
 
+  # If in detached HEAD state, switch to default branch
+  if (cd "$repo_dir" && ! git symbolic-ref -q HEAD >/dev/null 2>&1); then
+    log_warn "  Detached HEAD; switching to default branch..."
+    local default_branch
+    default_branch="$(cd "$repo_dir" && git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')" || true
+    default_branch="${default_branch:-main}"
+    if ! (cd "$repo_dir" && git checkout -f "$default_branch" 2>&1); then
+      log_error "  Failed to checkout $default_branch"
+      FAILURES+=("$repo_name (checkout failed)")
+      return 1
+    fi
+  fi
+
   # Git pull
   log_step "  Pulling latest changes..."
   if (cd "$repo_dir" && [ -n "$(git status --porcelain)" ]); then


### PR DESCRIPTION
## Summary
- Detect detached HEAD state before `git pull` in `update-local-binaries.sh`
- Force-checkout the default branch (auto-detected from `origin`) so the pull succeeds
- Fixes failures like `coding_agent_session_search` where repos are left on a specific commit

## Test plan
- [x] `make shell-test` passes (952 bash + 265 fish tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented git pull failures in `update-local-binaries.sh` when a repo is in detached HEAD by auto-switching to the default branch before pulling. This stops repos from getting stuck on a commit and fixes failures like `coding_agent_session_search`.

- **Bug Fixes**
  - Detects detached HEAD and checks out the default branch from `origin`; falls back to `main`.
  - Forces checkout and logs/records failures if the checkout cannot be completed.

<sup>Written for commit 9345181fc5ba1b0ed3988a28a862caeb5d89c6a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

