### PR TITLE
fix: apply shfmt formatting to auto-switch.sh and spec

### DIFF
--- a/config/claude/hooks/auto-switch.sh
+++ b/config/claude/hooks/auto-switch.sh
@@ -25,8 +25,8 @@ ERROR_DETAILS=$(echo "$INPUT" | jq -r '.error_details // empty' 2>/dev/null) || 
 
 # Check if the error is rate-limit related
 case "${ERROR}${ERROR_DETAILS}" in
-  *rate_limit*|*rate-limit*|*rate\ limit*|*overloaded*|*too_many_requests*|*429*|*quota*|*capacity*)
-    echo "[$(date)] Auto-switching Claude account due to rate limit" >&2
-    cswap --switch 2>&1 | head -5 >&2
-    ;;
+*rate_limit* | *rate-limit* | *rate\ limit* | *overloaded* | *too_many_requests* | *429* | *quota* | *capacity*)
+  echo "[$(date)] Auto-switching Claude account due to rate limit" >&2
+  cswap --switch 2>&1 | head -5 >&2
+  ;;
 esac

--- a/spec/auto_switch_spec.sh
+++ b/spec/auto_switch_spec.sh
@@ -5,10 +5,10 @@ Describe 'auto-switch.sh'
 SCRIPT="$PWD/config/claude/hooks/auto-switch.sh"
 
 It 'exits 0 when cswap is not available'
-  # Mock command so cswap is not found
-  command() { return 1; }
-  When run bash -c "command() { return 1; }; source '$SCRIPT' </dev/null"
-  The status should equal 0
+# Mock command so cswap is not found
+command() { return 1; }
+When run bash -c "command() { return 1; }; source '$SCRIPT' </dev/null"
+The status should equal 0
 End
 
 End


### PR DESCRIPTION
## Summary
- Apply shfmt formatting to `config/claude/hooks/auto-switch.sh` (case pattern indentation)
- Apply shfmt formatting to `spec/auto_switch_spec.sh` (spec body indentation)
- Fixes treefmt-check failures in nix-flake, nix-format, and nix-test CI jobs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply `shfmt` formatting to `config/claude/hooks/auto-switch.sh` and `spec/auto_switch_spec.sh` to standardize case pattern spacing and spec body indentation. This resolves `treefmt-check` failures in `nix-flake`, `nix-format`, and `nix-test`.

<sup>Written for commit 15b4853a6a2e21b1e0a74ff7abea8a606ec44ad5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

