### PR TITLE
fix: use zellij dump-layout to get current tab name in _tzo_function

### DIFF
--- a/home-manager/programs/fish/functions/_tzo_function.fish
+++ b/home-manager/programs/fish/functions/_tzo_function.fish
@@ -1,11 +1,16 @@
 function _tzo_function --description "Open tmux session named after current Zellij tab"
-  if test -z "$ZELLIJ_TAB_NAME"
-    echo "Not inside a Zellij tab" >&2
+  if test -z "$ZELLIJ"
+    echo "Not inside a Zellij session" >&2
     return 1
   end
-  if tmux has-session -t "$ZELLIJ_TAB_NAME" 2>/dev/null
-    tmux attach-session -t "$ZELLIJ_TAB_NAME"
+  set -l tab_name (zellij action dump-layout 2>/dev/null | grep -oP 'tab name="\K[^"]+(?="[^}]*focus=true)')
+  if test -z "$tab_name"
+    echo "Could not determine Zellij tab name" >&2
+    return 1
+  end
+  if tmux has-session -t "$tab_name" 2>/dev/null
+    tmux attach-session -t "$tab_name"
   else
-    tmux new-session -s "$ZELLIJ_TAB_NAME"
+    tmux new-session -s "$tab_name"
   end
 end

--- a/spec/fish/_tzo_function_test.fish
+++ b/spec/fish/_tzo_function_test.fish
@@ -10,13 +10,24 @@ function tmux
     end
 end
 
-# Test: missing ZELLIJ_TAB_NAME
-set -e ZELLIJ_TAB_NAME
+# Test: not inside Zellij
+set -e ZELLIJ
+set -e ZELLIJ_PANE_ID
+_tzo_function 2>/dev/null
+@test "missing ZELLIJ returns 1" $status -eq 1
+
+# Test: inside Zellij but tab name lookup fails
+set -gx ZELLIJ 0
+function zellij
+    return 1
+end
 _tzo_function 2>/dev/null
 @test "missing tab name returns 1" $status -eq 1
 
 # Test: creates new session
-set -gx ZELLIJ_TAB_NAME "my-tab"
+function zellij
+    echo 'tab name="my-tab" focus=true {'
+end
 _tzo_function
 
 @test "checks for existing session" (grep -c "has-session -t my-tab" $call_log) -ge 1


### PR DESCRIPTION
## Summary

- `_tzo_function` was checking for `$ZELLIJ_TAB_NAME` which Zellij never exports
- Now checks `$ZELLIJ` (which is actually set) and gets the current tab name dynamically via `zellij action dump-layout`
- Updated tests to match the new behavior

## Test plan

- [ ] Run `_tzo_function` inside a Zellij tab - should detect tab name and open/attach tmux session
- [ ] Run `_tzo_function` outside Zellij - should error with "Not inside a Zellij session"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix `_tzo_function` to correctly detect a Zellij session and read the focused tab name via `zellij action dump-layout`, then attach or create a matching `tmux` session. Adds clearer errors when not in Zellij or when the tab name cannot be determined, and updates tests.

- **Bug Fixes**
  - Detect Zellij via `$ZELLIJ`; stop checking `$ZELLIJ_TAB_NAME` (not set by Zellij).
  - Parse focused tab name from `zellij action dump-layout` and use it for `tmux` attach/new.
  - Update tests for the new detection path and failure cases.

<sup>Written for commit 21c5f468c7d683a1ab6f5b506f081c9612ee6ad0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

