### PR TITLE
fix: isolate PATH in clipboard-copy xclip/xsel tests

### DIFF
--- a/spec/clipboard_copy_spec.sh
+++ b/spec/clipboard_copy_spec.sh
@@ -41,6 +41,11 @@ End
 Describe 'when xclip is available'
 setup() {
   mock_bin_setup xclip
+  # Restrict PATH so higher-priority backends (real xclip, pbcopy, etc.) are hidden
+  local bash_dir
+  bash_dir="$(dirname "$(readlink -f "$(command -v bash)")")"
+  export PATH="$MOCK_BIN:$bash_dir"
+  unset WAYLAND_DISPLAY
 }
 cleanup() {
   mock_bin_cleanup
@@ -57,6 +62,11 @@ End
 Describe 'when xsel is available'
 setup() {
   mock_bin_setup xsel
+  # Restrict PATH so higher-priority backends (real xclip, pbcopy, etc.) are hidden
+  local bash_dir
+  bash_dir="$(dirname "$(readlink -f "$(command -v bash)")")"
+  export PATH="$MOCK_BIN:$bash_dir"
+  unset WAYLAND_DISPLAY
 }
 cleanup() {
   mock_bin_cleanup


### PR DESCRIPTION
## Summary

- xclip and xsel tests in `clipboard_copy_spec.sh` were failing in headless environments because the real `xclip` binary on PATH was found before the mock
- After calling `mock_bin_setup`, restrict PATH to only the mock bin dir and bash so no real clipboard backends leak through
- Matches the same isolation pattern already used by the "no backend" test case

## Test plan

- [ ] `make shell-test` passes with 0 failures (was 1 failure before)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated PATH in the `xclip`/`xsel` clipboard-copy tests so they always use mocks, matching the "no backend" test. Fixes headless failures.

- Bug Fixes
  - After `mock_bin_setup`, limit PATH to the mock bin and the `bash` dir, and unset WAYLAND_DISPLAY.
  - Prevents real backends (system `xclip`, `pbcopy`, etc.) from being picked up; `make shell-test` now passes.

<sup>Written for commit 0de09507279396eb4faa9976a3bcf94c1ed67254. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

