### PR TITLE
fix: update .gitignore files to include additional ignored patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,14 @@
 # AI
-.claude/*
+.aider.tags.cache.v4
+.claude
 !.claude/settings.json
+.codex
+.conductor
+.crush
+.cursor
+.paperclip
 .pi
+.serena
 .worktrees
 prompts.db
 
@@ -11,6 +18,9 @@ config/ccs/accounts.json
 # Local binaries list (machine-specific)
 .devenv.nix
 objectstore
+
+# JJ
+.jj
 
 # Nix
 .devenv

--- a/config/worktrunk/config.toml
+++ b/config/worktrunk/config.toml
@@ -4,7 +4,7 @@ worktree-path = "{{ repo_path }}/.worktrees/{{ branch | sanitize }}"
 copy = "wt step copy-ignored"
 
 [step.copy-ignored]
-exclude = [".cache/", ".devenv/", ".serena/"]
+exclude = [".cache/", ".devenv/", ".serena/", ".paperclip/"]
 
 [commit]
 stage = "all"

--- a/home-manager/programs/git/.gitignore.global
+++ b/home-manager/programs/git/.gitignore.global
@@ -1,7 +1,11 @@
 # AI
+.aider.tags.cache.*/
+.claude/
 .conductor/
+.crush/
 .cursor/
 .entire/
+.paperclip/
 .pi/
 .serena/
 .worktrees/


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expand repo and global .gitignore to ignore common tool caches (e.g., .claude, .cursor, .paperclip, .serena, .aider tags) and JJ’s .jj directory to prevent accidental commits. Also update Worktrunk config to exclude .paperclip in the copy-ignored step.

<sup>Written for commit c71157d89bf4eba9155c49e12b74a2363ca6057c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

