### PR TITLE
fix: use tomlq to parse dependency-groups.tools in uv-globals

### DIFF
--- a/home-manager/modules/local-scripts/tmux-bridge.sh
+++ b/home-manager/modules/local-scripts/tmux-bridge.sh
@@ -196,7 +196,7 @@ cmd_list() {
   printf "%-8s %-16s %-10s %-25s %-10s %s\n" "TARGET" "SESSION:WIN" "SIZE" "PROCESS" "LABEL" "CWD"
   tmx list-panes -a \
     -F '#{pane_id}|#{session_name}|#{window_index}|#{window_name}|#{pane_pid}|#{pane_width}x#{pane_height}|#{@name}|#{pane_current_path}' \
-    2>/dev/null | while IFS='|' read -r id sess widx wname pid size label cwd; do
+    2>/dev/null | while IFS='|' read -r id sess widx _wname pid size label cwd; do
       # Get the actual running process (deepest child of pane pid)
       local proc child_pid
       proc=$(ps -o comm= -p "$pid" 2>/dev/null || echo "?")

--- a/home-manager/modules/uv-globals/install-uv-globals.sh
+++ b/home-manager/modules/uv-globals/install-uv-globals.sh
@@ -8,40 +8,28 @@ if ! timeout 3 bash -c 'exec 3<>/dev/tcp/1.1.1.1/53' 2>/dev/null; then
   exit 0
 fi
 
-# Install uv global tools from pyproject.toml
-# Reads dependencies from ~/dotfiles/pyproject.toml and installs them as global tools
-
 PYPROJECT="${HOME}/dotfiles/pyproject.toml"
 
-# Exit if no pyproject.toml exists
 if [ ! -f "$PYPROJECT" ]; then
   echo "No ${PYPROJECT} found, skipping uv globals install"
   exit 0
 fi
 
-# Check for required tools
 if ! command -v uv &>/dev/null; then
   echo "uv not found, skipping uv globals install"
   exit 0
 fi
 
-if ! command -v dasel &>/dev/null; then
-  echo "dasel not found, skipping uv globals install"
+if ! command -v tomlq &>/dev/null; then
+  echo "tomlq not found, skipping uv globals install"
   exit 0
 fi
 
-if ! command -v jq &>/dev/null; then
-  echo "jq not found, skipping uv globals install"
-  exit 0
-fi
-
+# Install uv global tools from pyproject.toml
+# Reads dependencies from ~/dotfiles/pyproject.toml and installs them as global tools
 echo "Installing uv global tools from pyproject.toml..."
 
-# Parse Python version from requires-python (e.g., ">=3.13" -> "3.13")
-PYTHON_VERSION=$(dasel -f "$PYPROJECT" -r toml 'project.requires-python' 2>/dev/null | sed 's/[^0-9.]//g' || echo "3.13")
-
-# Parse dependencies from standard pyproject.toml format
-DEPS=$(dasel -f "$PYPROJECT" -r toml -w json 'project.dependencies' 2>/dev/null | jq -r '.[]' 2>/dev/null || true)
+DEPS=$(tomlq -r '.["dependency-groups"].tools[]' "$PYPROJECT" 2>/dev/null)
 
 if [ -z "$DEPS" ]; then
   echo "No dependencies found in pyproject.toml"
@@ -51,14 +39,7 @@ fi
 echo "$DEPS" | while read -r pkg; do
   if [ -n "$pkg" ]; then
     echo "Installing $pkg..."
-    # Try default Python first, fall back to version from pyproject.toml
-    if ! uv tool install "$pkg" --force 2>/dev/null; then
-      if uv tool install "$pkg" --python "$PYTHON_VERSION" --force 2>/dev/null; then
-        echo "Installed $pkg with Python $PYTHON_VERSION"
-      else
-        echo "Failed to install $pkg, skipping..."
-      fi
-    fi
+    uv tool install "$pkg" --force 2>/dev/null || echo "Failed to install $pkg, skipping..."
   fi
 done
 

--- a/home-manager/modules/uv-globals/install-uv-globals.sh
+++ b/home-manager/modules/uv-globals/install-uv-globals.sh
@@ -29,6 +29,9 @@ fi
 # Reads dependencies from ~/dotfiles/pyproject.toml and installs them as global tools
 echo "Installing uv global tools from pyproject.toml..."
 
+PYTHON_VERSION=$(tomlq -r '.project["requires-python"]' "$PYPROJECT" 2>/dev/null | sed 's/[^0-9.]//g')
+PYTHON_VERSION=${PYTHON_VERSION:-3.13}
+
 DEPS=$(tomlq -r '.["dependency-groups"].tools[]' "$PYPROJECT" 2>/dev/null)
 
 if [ -z "$DEPS" ]; then
@@ -39,7 +42,7 @@ fi
 echo "$DEPS" | while read -r pkg; do
   if [ -n "$pkg" ]; then
     echo "Installing $pkg..."
-    uv tool install "$pkg" --force 2>/dev/null || echo "Failed to install $pkg, skipping..."
+    uv tool install "$pkg" --python "$PYTHON_VERSION" --force 2>/dev/null || echo "Failed to install $pkg, skipping..."
   fi
 done
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ tools = [
   "aider-chat>=0.86.2",
   "marker-pdf>=1.10.2",
   "mistral-vibe>=2.7.0",
-  "claude-swap>=1.1.5",
+  "claude-swap>=0.7.1",
   "ruff>=0.15.8",
 ]
 

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -235,7 +235,6 @@ config/claude/hooks/pushover.sh
 config/claude/hooks/rtk-rewrite.sh
 config/claude/hooks/auto-switch.sh
 config/claude/hooks/security.sh
-config/claude/hooks/auto-switch.sh
 config/claude/hooks/atuin-history.sh
 config/claude/hooks/statusline.sh
 config/codex/hooks/atuin-history.sh
@@ -254,6 +253,7 @@ home-manager/modules/cargo-globals/install-cargo-globals.sh
 home-manager/modules/local-binaries/sync-local-binaries.sh
 home-manager/modules/local-scripts/clipboard-copy.sh
 home-manager/modules/local-scripts/notify-local.sh
+home-manager/modules/local-scripts/tmux-bridge.sh
 home-manager/modules/npm-globals/install-npm-globals.sh
 home-manager/modules/uv-globals/install-uv-globals.sh
 home-manager/programs/neovim/run_tests.sh

--- a/spec/uv_globals_spec.sh
+++ b/spec/uv_globals_spec.sh
@@ -74,5 +74,15 @@ It 'parses dependency-groups.tools'
 When run bash -c "grep 'dependency-groups' '$SCRIPT'"
 The output should include 'dependency-groups'
 End
+
+It 'parses requires-python version'
+When run bash -c "grep 'requires-python' '$SCRIPT'"
+The output should include 'requires-python'
+End
+
+It 'passes --python flag to uv tool install'
+When run bash -c "grep -- '--python' '$SCRIPT'"
+The output should include '--python'
+End
 End
 End

--- a/spec/uv_globals_spec.sh
+++ b/spec/uv_globals_spec.sh
@@ -29,14 +29,9 @@ When run bash -c "grep 'command -v uv' '$SCRIPT'"
 The output should include 'uv'
 End
 
-It 'checks for dasel command'
-When run bash -c "grep 'command -v dasel' '$SCRIPT'"
-The output should include 'dasel'
-End
-
-It 'checks for jq command'
-When run bash -c "grep 'command -v jq' '$SCRIPT'"
-The output should include 'jq'
+It 'checks for tomlq command'
+When run bash -c "grep 'command -v tomlq' '$SCRIPT'"
+The output should include 'tomlq'
 End
 End
 
@@ -60,9 +55,9 @@ End
 End
 
 Describe 'tool installation'
-It 'uses dasel to parse TOML'
-When run bash -c "grep 'dasel' '$SCRIPT'"
-The output should include 'dasel'
+It 'uses tomlq to parse TOML'
+When run bash -c "grep 'tomlq' '$SCRIPT'"
+The output should include 'tomlq'
 End
 
 It 'uses uv tool install'
@@ -75,9 +70,9 @@ When run bash -c "grep -- '--force' '$SCRIPT'"
 The output should include '--force'
 End
 
-It 'parses project.dependencies'
-When run bash -c "grep 'project.dependencies' '$SCRIPT'"
-The output should include 'project.dependencies'
+It 'parses dependency-groups.tools'
+When run bash -c "grep 'dependency-groups' '$SCRIPT'"
+The output should include 'dependency-groups'
 End
 End
 End


### PR DESCRIPTION
## Summary
- Replace `dasel`+`jq` with `tomlq` for TOML parsing in uv-globals installer
- Fix reading from wrong key (`project.dependencies` -> `dependency-groups.tools`)
- Fix coverage spec (add `tmux-bridge.sh`, remove duplicate `auto-switch.sh`)
- Fix shellcheck warning for unused `wname` variable in `tmux-bridge.sh`

## Test plan
- [x] `make shell-test` passes (961 examples, 0 failures)
- [x] `make shell-lint` passes (shellcheck clean)
- [x] `tomlq` correctly parses all 5 tools from pyproject.toml

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `uv-globals` to use `tomlq` and read `dependency-groups.tools` from `pyproject.toml`. Always install tools with the Python version from `project.requires-python` to fix failed global installs, and update tests and a shellcheck warning.

- **Bug Fixes**
  - Read `dependency-groups.tools` with `tomlq`; removed `dasel`/`jq`.
  - Pass `--python` from `project.requires-python` (default `3.13`) to `uv tool install --force`.
  - Tests: add checks for parsing `requires-python` and passing `--python`; update specs to expect `tomlq`; coverage cleanup; fix unused var in `tmux-bridge.sh`.

- **Dependencies**
  - Set `claude-swap` to `>=0.7.1` in `pyproject.toml`.

<sup>Written for commit 980e697d44899c3c46c731abd1e01436117016c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

