### PR TITLE
fix: remove deprecated networking.networkmanager.wifi.band option

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -73,7 +73,6 @@ inputs.nixpkgs.lib.nixosSystem {
         networking.hostName = "matic";
         networking.networkmanager.enable = true;
         networking.networkmanager.wifi.powersave = true;
-        networking.networkmanager.wifi.band = "a";
 
         # Enable fish shell
         programs.fish.enable = true;


### PR DESCRIPTION
## Summary
- Remove `networking.networkmanager.wifi.band = "a"` from matic host config
- This option was removed upstream in NixOS and causes build failure

## Test plan
- [ ] `make build && make switch` succeeds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove deprecated `networking.networkmanager.wifi.band` from the `matic` host config. This matches upstream NixOS and fixes the build failure.

<sup>Written for commit f10b559a75610a5bc06b96537d93b4cb61f9c3a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

