### PR TITLE
fix: resolve home-manager activation failures

### DIFF
--- a/home-manager/modules/cargo-globals/default.nix
+++ b/home-manager/modules/cargo-globals/default.nix
@@ -15,7 +15,7 @@ in
 {
   # Install cargo global packages from Cargo.toml using home-manager activation
   home.activation.installCargoGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
-    export PATH=${pkgs.rustup}/bin:${pkgs.cargo}/bin:${pkgs.rustc}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:$PATH
+    export PATH=${pkgs.rustup}/bin:${pkgs.cargo}/bin:${pkgs.rustc}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:${pkgs.perl}/bin:$PATH
     export CARGO_HOME="$HOME/.cargo"
     $DRY_RUN_CMD ${pkgs.rustup}/bin/rustup toolchain install stable --no-self-update || true
     $DRY_RUN_CMD ${pkgs.rustup}/bin/rustup default stable || true

--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -121,7 +121,7 @@ nixpkgs.lib.nixosSystem {
     # Home Manager activation can take a long time (npm globals, etc.)
     {
       systemd.services."home-manager-${username}".serviceConfig.TimeoutStartSec =
-        nixpkgs.lib.mkForce "30m";
+        nixpkgs.lib.mkOverride 10 "30m";
     }
     {
       home-manager.backupFileExtension = "hm-backup";

--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -118,11 +118,6 @@ nixpkgs.lib.nixosSystem {
       ];
     }
     home-manager.nixosModules.home-manager
-    # Home Manager activation can take a long time (npm globals, etc.)
-    {
-      systemd.services."home-manager-${username}".serviceConfig.TimeoutStartSec =
-        nixpkgs.lib.mkOverride 10 "30m";
-    }
     {
       home-manager.backupFileExtension = "hm-backup";
       home-manager.extraSpecialArgs = { inherit inputs; };

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -98,6 +98,10 @@ inputs.nixpkgs.lib.nixosSystem {
 
         security.sudo.wheelNeedsPassword = false;
 
+        # Home Manager activation can take a long time (npm globals, cargo installs, etc.)
+        systemd.services."home-manager-${username}".serviceConfig.TimeoutStartSec =
+          lib.mkForce "30m";
+
         # Immutable root — prevents rm -rf / by blocking top-level entry removal
         systemd.services.immutable-root = {
           description = "Set immutable flag on /";

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -99,8 +99,7 @@ inputs.nixpkgs.lib.nixosSystem {
         security.sudo.wheelNeedsPassword = false;
 
         # Home Manager activation can take a long time (npm globals, cargo installs, etc.)
-        systemd.services."home-manager-${username}".serviceConfig.TimeoutStartSec =
-          lib.mkForce "30m";
+        systemd.services."home-manager-${username}".serviceConfig.TimeoutStartSec = lib.mkForce "30m";
 
         # Immutable root — prevents rm -rf / by blocking top-level entry removal
         systemd.services.immutable-root = {


### PR DESCRIPTION
## Summary
- Add `perl` to cargo-globals PATH so `openssl-sys` (needed by `yek`) can build from source
- Use `mkOverride 10` instead of `mkForce` for home-manager service timeout to ensure 30m timeout wins over home-manager module's default 5m

## Test plan
- [ ] Run `nixos-rebuild switch` and verify `home-manager-skakinoki.service` succeeds
- [ ] Verify `systemctl show home-manager-skakinoki.service -p TimeoutStartUSec` shows 30min
- [ ] Verify `yek` installs successfully via cargo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Home Manager activation failures by adding `perl` to the cargo build PATH and applying a 30m timeout to the `home-manager` service in the actual host config (`matic`). This unblocks `yek` (via `openssl-sys`) and prevents premature timeouts.

- **Bug Fixes**
  - Add `perl` to `cargo-globals` PATH so `openssl-sys` (needed by `yek`) can build from source.
  - Set `TimeoutStartSec` to 30m with `lib.mkForce` in `named-hosts/matic`; remove the ineffective override from `hosts/nixos`.

<sup>Written for commit 47700becee461d4836daf25406a5c9dcefea0738. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

