### PR TITLE
fix: skip globals install during systemd activation

### DIFF
--- a/home-manager/modules/cargo-globals/default.nix
+++ b/home-manager/modules/cargo-globals/default.nix
@@ -15,6 +15,9 @@ in
 {
   # Install cargo global packages from Cargo.toml using home-manager activation
   home.activation.installCargoGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    if [ -n "''${INVOCATION_ID:-}" ]; then
+      echo "Running inside systemd service, skipping cargo globals install"
+    else
     export PATH=${pkgs.rustup}/bin:${pkgs.cargo}/bin:${pkgs.rustc}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:${pkgs.perl}/bin:$PATH
     export CARGO_HOME="$HOME/.cargo"
     $DRY_RUN_CMD ${pkgs.rustup}/bin/rustup toolchain install stable --no-self-update || true
@@ -28,6 +31,7 @@ in
     ${lib.optionalString isDarwin ''export LDFLAGS="${libiconvLdFlags}''${LDFLAGS:-}"''}
     ${lib.optionalString isDarwin ''export CPPFLAGS="${libiconvCppFlags}''${CPPFLAGS:-}"''}
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash ${./install-cargo-globals.sh}
+    fi
   '';
 
   # Add cargo bin to PATH

--- a/home-manager/modules/npm-globals/default.nix
+++ b/home-manager/modules/npm-globals/default.nix
@@ -2,9 +2,13 @@
 {
   # Install npm global packages from package.json using home-manager activation
   home.activation.installNpmGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    if [ -n "''${INVOCATION_ID:-}" ]; then
+      echo "Running inside systemd service, skipping npm globals install"
+    else
     export PATH=${pkgs.bun}/bin:${pkgs.jq}/bin:$PATH
     export BUN_INSTALL="$HOME/.bun"
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash ${./install-npm-globals.sh}
+    fi
   '';
 
   home.sessionVariables = {

--- a/home-manager/modules/uv-globals/default.nix
+++ b/home-manager/modules/uv-globals/default.nix
@@ -2,8 +2,12 @@
 {
   # Install uv global tools from pyproject.toml using home-manager activation
   home.activation.installUvGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    if [ -n "''${INVOCATION_ID:-}" ]; then
+      echo "Running inside systemd service, skipping uv globals install"
+    else
     export PATH=${pkgs.uv}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:$PATH
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash ${./install-uv-globals.sh}
+    fi
   '';
 
   # Add uv tools bin to PATH

--- a/spec/cargo_globals_spec.sh
+++ b/spec/cargo_globals_spec.sh
@@ -4,6 +4,20 @@
 Describe 'cargo-globals/install-cargo-globals.sh'
 SCRIPT="$PWD/home-manager/modules/cargo-globals/install-cargo-globals.sh"
 
+Describe 'systemd activation skip'
+NIX_FILE="$PWD/home-manager/modules/cargo-globals/default.nix"
+
+It 'checks INVOCATION_ID to detect systemd service'
+When run bash -c "grep 'INVOCATION_ID' '$NIX_FILE'"
+The output should include 'INVOCATION_ID'
+End
+
+It 'skips install when running inside systemd'
+When run bash -c "grep -A 1 'INVOCATION_ID' '$NIX_FILE'"
+The output should include 'skipping cargo globals install'
+End
+End
+
 Describe 'script properties'
 It 'uses bash shebang'
 When run bash -c "head -1 '$SCRIPT'"

--- a/spec/npm_globals_spec.sh
+++ b/spec/npm_globals_spec.sh
@@ -4,6 +4,20 @@
 Describe 'npm-globals/install-npm-globals.sh'
 SCRIPT="$PWD/home-manager/modules/npm-globals/install-npm-globals.sh"
 
+Describe 'systemd activation skip'
+NIX_FILE="$PWD/home-manager/modules/npm-globals/default.nix"
+
+It 'checks INVOCATION_ID to detect systemd service'
+When run bash -c "grep 'INVOCATION_ID' '$NIX_FILE'"
+The output should include 'INVOCATION_ID'
+End
+
+It 'skips install when running inside systemd'
+When run bash -c "grep -A 1 'INVOCATION_ID' '$NIX_FILE'"
+The output should include 'skipping npm globals install'
+End
+End
+
 Describe 'script properties'
 It 'uses bash shebang'
 When run bash -c "head -1 '$SCRIPT'"

--- a/spec/uv_globals_spec.sh
+++ b/spec/uv_globals_spec.sh
@@ -4,6 +4,20 @@
 Describe 'uv-globals/install-uv-globals.sh'
 SCRIPT="$PWD/home-manager/modules/uv-globals/install-uv-globals.sh"
 
+Describe 'systemd activation skip'
+NIX_FILE="$PWD/home-manager/modules/uv-globals/default.nix"
+
+It 'checks INVOCATION_ID to detect systemd service'
+When run bash -c "grep 'INVOCATION_ID' '$NIX_FILE'"
+The output should include 'INVOCATION_ID'
+End
+
+It 'skips install when running inside systemd'
+When run bash -c "grep -A 1 'INVOCATION_ID' '$NIX_FILE'"
+The output should include 'skipping uv globals install'
+End
+End
+
 Describe 'script properties'
 It 'uses bash shebang'
 When run bash -c "head -1 '$SCRIPT'"


### PR DESCRIPTION
## Summary
- Skip npm, cargo, and uv globals installation when home-manager activation runs inside systemd (during `nixos-rebuild switch` / boot)
- Uses `INVOCATION_ID` env var detection - set by systemd for all services, absent during manual `home-manager switch`
- Globals still install normally when running `home-manager switch` manually

## Test plan
- [ ] Run `nixos-rebuild switch` and verify globals install is skipped in `journalctl -u home-manager-skakinoki.service`
- [ ] Run `home-manager switch` manually and verify globals install runs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip installing `npm`, `cargo`, and `uv` globals when `home-manager` runs under systemd during `nixos-rebuild switch` or boot. Use `INVOCATION_ID` to detect systemd; manual `home-manager switch` still installs globals.

- **Bug Fixes**
  - Guarded activation steps with `INVOCATION_ID` to skip installs in systemd units and log a message.
  - Added specs to verify systemd detection and skip messages for `npm`, `cargo`, and `uv`.

<sup>Written for commit 8d0a463d2788f51fd4b7c08a67c8fded0efb62b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

