### PR TITLE
fix: resolve upgrade CI failure from dotagents sync target collision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@
 
 SHELL := bash
 
-# Include dotagents from submodule but keep the local help target authoritative.
+# Include dotagents from submodule but keep the local targets authoritative.
 DOTAGENTS_SKIP_HELP := 1
+DOTAGENTS_SKIP_SYNC := 1
 -include dotagents/Makefile
 
 # Detect architecture and OS


### PR DESCRIPTION
## Summary
- Set `DOTAGENTS_SKIP_SYNC := 1` in parent Makefile to prevent dotagents `sync` recipe from leaking when included via `-include dotagents/Makefile`
- Updated dotagents submodule with fix for missing `/` separator in `ruler-apply-global` (`dotagents.ruler` -> `dotagents/.ruler`)

**Root cause**: The parent Makefile includes dotagents/Makefile, which caused GNU Make to merge the `sync` target prerequisites and recipe. The dotagents `sync` recipe (calling `ruler-apply-global`, `commands-sync`, etc.) would run at the parent level where paths didn't resolve correctly. Additionally, `$(abspath ...)` strips trailing slashes, so `.ruler` was concatenated directly to the directory name.

Closes #1372

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the `sync` target from `dotagents` running in the parent Makefile, which caused path errors and broke upgrade CI (fixes #1372). Also updates `dotagents` to fix a missing `/` in `ruler-apply-global`.

- **Bug Fixes**
  - Parent `Makefile`: set `DOTAGENTS_SKIP_SYNC := 1` to stop `dotagents/Makefile` from merging and running its `sync` recipe in the parent.
  - Updated `dotagents` submodule to use `dotagents/.ruler` (instead of `dotagents.ruler`) in `ruler-apply-global`.

<sup>Written for commit d98cf9426a882693b73acacc734ee561328ef9af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

