### PR TITLE
feat: skip globals on boot, add login oneshot services

### DIFF
--- a/home-manager/modules/cargo-globals/default.nix
+++ b/home-manager/modules/cargo-globals/default.nix
@@ -34,6 +34,30 @@ in
     fi
   '';
 
+  # Run cargo globals install after login
+  systemd.user.services.install-cargo-globals = {
+    Unit = {
+      Description = "Install cargo global packages";
+      After = [ "default.target" ];
+    };
+    Service = {
+      Type = "oneshot";
+      Environment = [
+        "PATH=${pkgs.rustup}/bin:${pkgs.cargo}/bin:${pkgs.rustc}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:${pkgs.perl}/bin:${pkgs.coreutils}/bin:${pkgs.bash}/bin"
+        "CARGO_HOME=%h/.cargo"
+        "HOME=%h"
+        "PKG_CONFIG_PATH=${pkgs.openssl.dev}/lib/pkgconfig${libiconvPkgConfigPath}"
+        "OPENSSL_DIR=${pkgs.openssl.dev}"
+        "OPENSSL_LIB_DIR=${pkgs.openssl.out}/lib"
+        "OPENSSL_INCLUDE_DIR=${pkgs.openssl.dev}/include"
+      ];
+      ExecStart = "${pkgs.bash}/bin/bash ${./install-cargo-globals.sh}";
+    };
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
+
   # Add cargo bin to PATH
   home.sessionPath = [
     "$HOME/.cargo/bin"

--- a/home-manager/modules/cargo-globals/default.nix
+++ b/home-manager/modules/cargo-globals/default.nix
@@ -15,8 +15,8 @@ in
 {
   # Install cargo global packages from Cargo.toml using home-manager activation
   home.activation.installCargoGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
-    if [ -n "''${INVOCATION_ID:-}" ]; then
-      echo "Running inside systemd service, skipping cargo globals install"
+    if [ "$(${pkgs.systemd}/bin/systemctl is-system-running 2>/dev/null)" = "starting" ]; then
+      echo "System is booting, skipping cargo globals install"
     else
     export PATH=${pkgs.rustup}/bin:${pkgs.cargo}/bin:${pkgs.rustc}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:${pkgs.perl}/bin:$PATH
     export CARGO_HOME="$HOME/.cargo"

--- a/home-manager/modules/npm-globals/default.nix
+++ b/home-manager/modules/npm-globals/default.nix
@@ -11,6 +11,26 @@
     fi
   '';
 
+  # Run npm globals install after login
+  systemd.user.services.install-npm-globals = {
+    Unit = {
+      Description = "Install npm global packages";
+      After = [ "default.target" ];
+    };
+    Service = {
+      Type = "oneshot";
+      Environment = [
+        "PATH=${pkgs.bun}/bin:${pkgs.jq}/bin:${pkgs.coreutils}/bin:${pkgs.bash}/bin"
+        "BUN_INSTALL=%h/.bun"
+        "HOME=%h"
+      ];
+      ExecStart = "${pkgs.bash}/bin/bash ${./install-npm-globals.sh}";
+    };
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
+
   home.sessionVariables = {
     BUN_INSTALL = "$HOME/.bun";
   };

--- a/home-manager/modules/npm-globals/default.nix
+++ b/home-manager/modules/npm-globals/default.nix
@@ -2,8 +2,8 @@
 {
   # Install npm global packages from package.json using home-manager activation
   home.activation.installNpmGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
-    if [ -n "''${INVOCATION_ID:-}" ]; then
-      echo "Running inside systemd service, skipping npm globals install"
+    if [ "$(${pkgs.systemd}/bin/systemctl is-system-running 2>/dev/null)" = "starting" ]; then
+      echo "System is booting, skipping npm globals install"
     else
     export PATH=${pkgs.bun}/bin:${pkgs.jq}/bin:$PATH
     export BUN_INSTALL="$HOME/.bun"

--- a/home-manager/modules/uv-globals/default.nix
+++ b/home-manager/modules/uv-globals/default.nix
@@ -2,8 +2,8 @@
 {
   # Install uv global tools from pyproject.toml using home-manager activation
   home.activation.installUvGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
-    if [ -n "''${INVOCATION_ID:-}" ]; then
-      echo "Running inside systemd service, skipping uv globals install"
+    if [ "$(${pkgs.systemd}/bin/systemctl is-system-running 2>/dev/null)" = "starting" ]; then
+      echo "System is booting, skipping uv globals install"
     else
     export PATH=${pkgs.uv}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:$PATH
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash ${./install-uv-globals.sh}

--- a/home-manager/modules/uv-globals/default.nix
+++ b/home-manager/modules/uv-globals/default.nix
@@ -10,6 +10,25 @@
     fi
   '';
 
+  # Run uv globals install after login
+  systemd.user.services.install-uv-globals = {
+    Unit = {
+      Description = "Install uv global tools";
+      After = [ "default.target" ];
+    };
+    Service = {
+      Type = "oneshot";
+      Environment = [
+        "PATH=${pkgs.uv}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.coreutils}/bin:${pkgs.bash}/bin"
+        "HOME=%h"
+      ];
+      ExecStart = "${pkgs.bash}/bin/bash ${./install-uv-globals.sh}";
+    };
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
+
   # Add uv tools bin to PATH
   home.sessionPath = [
     "$HOME/.local/bin"

--- a/spec/cargo_globals_spec.sh
+++ b/spec/cargo_globals_spec.sh
@@ -7,13 +7,13 @@ SCRIPT="$PWD/home-manager/modules/cargo-globals/install-cargo-globals.sh"
 Describe 'systemd activation skip'
 NIX_FILE="$PWD/home-manager/modules/cargo-globals/default.nix"
 
-It 'checks INVOCATION_ID to detect systemd service'
-When run bash -c "grep 'INVOCATION_ID' '$NIX_FILE'"
-The output should include 'INVOCATION_ID'
+It 'checks systemctl is-system-running to detect boot'
+When run bash -c "grep 'is-system-running' '$NIX_FILE'"
+The output should include 'is-system-running'
 End
 
-It 'skips install when running inside systemd'
-When run bash -c "grep -A 1 'INVOCATION_ID' '$NIX_FILE'"
+It 'skips install during system boot'
+When run bash -c "grep -A 1 'is-system-running' '$NIX_FILE'"
 The output should include 'skipping cargo globals install'
 End
 End

--- a/spec/npm_globals_spec.sh
+++ b/spec/npm_globals_spec.sh
@@ -7,13 +7,13 @@ SCRIPT="$PWD/home-manager/modules/npm-globals/install-npm-globals.sh"
 Describe 'systemd activation skip'
 NIX_FILE="$PWD/home-manager/modules/npm-globals/default.nix"
 
-It 'checks INVOCATION_ID to detect systemd service'
-When run bash -c "grep 'INVOCATION_ID' '$NIX_FILE'"
-The output should include 'INVOCATION_ID'
+It 'checks systemctl is-system-running to detect boot'
+When run bash -c "grep 'is-system-running' '$NIX_FILE'"
+The output should include 'is-system-running'
 End
 
-It 'skips install when running inside systemd'
-When run bash -c "grep -A 1 'INVOCATION_ID' '$NIX_FILE'"
+It 'skips install during system boot'
+When run bash -c "grep -A 1 'is-system-running' '$NIX_FILE'"
 The output should include 'skipping npm globals install'
 End
 End

--- a/spec/uv_globals_spec.sh
+++ b/spec/uv_globals_spec.sh
@@ -7,13 +7,13 @@ SCRIPT="$PWD/home-manager/modules/uv-globals/install-uv-globals.sh"
 Describe 'systemd activation skip'
 NIX_FILE="$PWD/home-manager/modules/uv-globals/default.nix"
 
-It 'checks INVOCATION_ID to detect systemd service'
-When run bash -c "grep 'INVOCATION_ID' '$NIX_FILE'"
-The output should include 'INVOCATION_ID'
+It 'checks systemctl is-system-running to detect boot'
+When run bash -c "grep 'is-system-running' '$NIX_FILE'"
+The output should include 'is-system-running'
 End
 
-It 'skips install when running inside systemd'
-When run bash -c "grep -A 1 'INVOCATION_ID' '$NIX_FILE'"
+It 'skips install during system boot'
+When run bash -c "grep -A 1 'is-system-running' '$NIX_FILE'"
 The output should include 'skipping uv globals install'
 End
 End


### PR DESCRIPTION
## Summary
- Skip npm/cargo/uv globals install during boot (`systemctl is-system-running = starting`)
- Globals still run during manual `make switch` (nixos-rebuild switch)
- Add systemd user oneshot services that install globals after login via `default.target`

## Test plan
- [ ] Reboot and verify globals install is skipped in `journalctl -u home-manager-skakinoki.service`
- [ ] Verify user services run after login: `systemctl --user status install-npm-globals`
- [ ] Run `make switch` manually and verify globals install runs in activation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip installing `npm`, `cargo`, and `uv` global tools during boot, and run them after login via user oneshot services to avoid slow activation. Manual rebuilds (`make switch` / `nixos-rebuild switch`) still run the installers.

- **New Features**
  - Detect boot via `systemctl is-system-running=starting` (replaces `INVOCATION_ID`).
  - Add systemd user oneshot services `install-npm-globals`, `install-cargo-globals`, `install-uv-globals` (`WantedBy=default.target`) to run after login.
  - Keep installs during manual rebuilds.
  - Update specs to validate the new boot detection and skip behavior.

<sup>Written for commit b2c33b65f9fc22a673fbe04aeb0f42caea3b1642. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

