### PR TITLE
fix: batch bun global installs to prevent resolution hang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@
 
 SHELL := bash
 
-# Include dotagents from submodule but keep the local help target authoritative.
+# Include dotagents from submodule but keep the local targets authoritative.
 DOTAGENTS_SKIP_HELP := 1
+DOTAGENTS_SKIP_SYNC := 1
 -include dotagents/Makefile
 
 # Detect architecture and OS

--- a/home-manager/modules/npm-globals/install-npm-globals.sh
+++ b/home-manager/modules/npm-globals/install-npm-globals.sh
@@ -42,11 +42,21 @@ if [ -n "$TRUSTED_DEPS" ]; then
   done
 fi
 
-# Install global packages
+# Install global packages in batches (bun hangs when resolving too many at once)
 DEPS=$(jq -r '.dependencies | keys[]' "$PACKAGE_JSON" 2>/dev/null || true)
 if [ -n "$DEPS" ]; then
-  # shellcheck disable=SC2086
-  bun install --global $DEPS 2>/dev/null || true
+  BATCH_SIZE=10
+  BATCH=()
+  while IFS= read -r dep; do
+    BATCH+=("$dep")
+    if [ "${#BATCH[@]}" -ge "$BATCH_SIZE" ]; then
+      bun add --global "${BATCH[@]}" 2>/dev/null || true
+      BATCH=()
+    fi
+  done <<< "$DEPS"
+  if [ "${#BATCH[@]}" -gt 0 ]; then
+    bun add --global "${BATCH[@]}" 2>/dev/null || true
+  fi
 fi
 
 # Apply dependency overrides to the global install

--- a/spec/npm_globals_spec.sh
+++ b/spec/npm_globals_spec.sh
@@ -60,9 +60,14 @@ When run bash -c "grep 'trustedDependencies' '$SCRIPT'"
 The output should include 'trustedDependencies'
 End
 
-It 'uses bun install --global'
-When run bash -c "grep 'bun install --global' '$SCRIPT'"
-The output should include 'bun install --global'
+It 'uses bun add --global in batches'
+When run bash -c "grep 'bun add --global' '$SCRIPT'"
+The output should include 'bun add --global'
+End
+
+It 'batches packages to avoid bun resolution hangs'
+When run bash -c "grep 'BATCH_SIZE' '$SCRIPT'"
+The output should include 'BATCH_SIZE'
 End
 
 It 'parses dependencies with jq'


### PR DESCRIPTION
## Summary
- Batch `bun add --global` calls into groups of 10 packages instead of installing all 55 at once
- bun hangs indefinitely when resolving too many packages in a single global install call
- Updated tests to reflect the change from `bun install --global` to batched `bun add --global`

## Test plan
- [x] `shellspec spec/npm_globals_spec.sh` passes (17 examples, 0 failures)
- [x] `shellcheck` passes on modified script
- [x] Verified full script completes successfully with batched installs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batched global installs to stop `bun` from hanging and unblocked upgrade CI by avoiding a `dotagents` sync collision. Packages now install in groups of 10 with `bun add --global`, and tests were updated.

- **Bug Fixes**
  - Install globals in batches of 10 with `bun add --global` to prevent resolution hangs.
  - Set `DOTAGENTS_SKIP_SYNC=1` to avoid `dotagents` sync target collision, addressing #1372.
  - Update specs to check for `bun add --global` and batching logic.

<sup>Written for commit d77dad8629722645c7db6900a578f52864fa5510. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

