### PR TITLE
fix: guard systemd references behind isDarwin check in globals modules

### DIFF
--- a/home-manager/modules/cargo-globals/default.nix
+++ b/home-manager/modules/cargo-globals/default.nix
@@ -15,9 +15,12 @@ in
 {
   # Install cargo global packages from Cargo.toml using home-manager activation
   home.activation.installCargoGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    ${lib.optionalString (!isDarwin) ''
     if [ "$(${pkgs.systemd}/bin/systemctl is-system-running 2>/dev/null)" = "starting" ]; then
       echo "System is booting, skipping cargo globals install"
-    else
+      exit 0
+    fi
+    ''}
     export PATH=${pkgs.rustup}/bin:${pkgs.cargo}/bin:${pkgs.rustc}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:${pkgs.perl}/bin:$PATH
     export CARGO_HOME="$HOME/.cargo"
     $DRY_RUN_CMD ${pkgs.rustup}/bin/rustup toolchain install stable --no-self-update || true
@@ -31,30 +34,31 @@ in
     ${lib.optionalString isDarwin ''export LDFLAGS="${libiconvLdFlags}''${LDFLAGS:-}"''}
     ${lib.optionalString isDarwin ''export CPPFLAGS="${libiconvCppFlags}''${CPPFLAGS:-}"''}
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash ${./install-cargo-globals.sh}
-    fi
   '';
 
-  # Run cargo globals install after login
-  systemd.user.services.install-cargo-globals = {
-    Unit = {
-      Description = "Install cargo global packages";
-      After = [ "default.target" ];
-    };
-    Service = {
-      Type = "oneshot";
-      Environment = [
-        "PATH=${pkgs.rustup}/bin:${pkgs.cargo}/bin:${pkgs.rustc}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:${pkgs.perl}/bin:${pkgs.coreutils}/bin:${pkgs.bash}/bin"
-        "CARGO_HOME=%h/.cargo"
-        "HOME=%h"
-        "PKG_CONFIG_PATH=${pkgs.openssl.dev}/lib/pkgconfig${libiconvPkgConfigPath}"
-        "OPENSSL_DIR=${pkgs.openssl.dev}"
-        "OPENSSL_LIB_DIR=${pkgs.openssl.out}/lib"
-        "OPENSSL_INCLUDE_DIR=${pkgs.openssl.dev}/include"
-      ];
-      ExecStart = "${pkgs.bash}/bin/bash ${./install-cargo-globals.sh}";
-    };
-    Install = {
-      WantedBy = [ "default.target" ];
+  # Run cargo globals install after login (Linux only - systemd)
+  systemd.user.services = lib.mkIf (!isDarwin) {
+    install-cargo-globals = {
+      Unit = {
+        Description = "Install cargo global packages";
+        After = [ "default.target" ];
+      };
+      Service = {
+        Type = "oneshot";
+        Environment = [
+          "PATH=${pkgs.rustup}/bin:${pkgs.cargo}/bin:${pkgs.rustc}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:${pkgs.perl}/bin:${pkgs.coreutils}/bin:${pkgs.bash}/bin"
+          "CARGO_HOME=%h/.cargo"
+          "HOME=%h"
+          "PKG_CONFIG_PATH=${pkgs.openssl.dev}/lib/pkgconfig${libiconvPkgConfigPath}"
+          "OPENSSL_DIR=${pkgs.openssl.dev}"
+          "OPENSSL_LIB_DIR=${pkgs.openssl.out}/lib"
+          "OPENSSL_INCLUDE_DIR=${pkgs.openssl.dev}/include"
+        ];
+        ExecStart = "${pkgs.bash}/bin/bash ${./install-cargo-globals.sh}";
+      };
+      Install = {
+        WantedBy = [ "default.target" ];
+      };
     };
   };
 

--- a/home-manager/modules/npm-globals/default.nix
+++ b/home-manager/modules/npm-globals/default.nix
@@ -1,33 +1,40 @@
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
+let
+  inherit (pkgs.stdenv) isDarwin;
+in
 {
   # Install npm global packages from package.json using home-manager activation
   home.activation.installNpmGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    ${lib.optionalString (!isDarwin) ''
     if [ "$(${pkgs.systemd}/bin/systemctl is-system-running 2>/dev/null)" = "starting" ]; then
       echo "System is booting, skipping npm globals install"
-    else
+      exit 0
+    fi
+    ''}
     export PATH=${pkgs.bun}/bin:${pkgs.jq}/bin:$PATH
     export BUN_INSTALL="$HOME/.bun"
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash ${./install-npm-globals.sh}
-    fi
   '';
 
-  # Run npm globals install after login
-  systemd.user.services.install-npm-globals = {
-    Unit = {
-      Description = "Install npm global packages";
-      After = [ "default.target" ];
-    };
-    Service = {
-      Type = "oneshot";
-      Environment = [
-        "PATH=${pkgs.bun}/bin:${pkgs.jq}/bin:${pkgs.coreutils}/bin:${pkgs.bash}/bin"
-        "BUN_INSTALL=%h/.bun"
-        "HOME=%h"
-      ];
-      ExecStart = "${pkgs.bash}/bin/bash ${./install-npm-globals.sh}";
-    };
-    Install = {
-      WantedBy = [ "default.target" ];
+  # Run npm globals install after login (Linux only - systemd)
+  systemd.user.services = lib.mkIf (!isDarwin) {
+    install-npm-globals = {
+      Unit = {
+        Description = "Install npm global packages";
+        After = [ "default.target" ];
+      };
+      Service = {
+        Type = "oneshot";
+        Environment = [
+          "PATH=${pkgs.bun}/bin:${pkgs.jq}/bin:${pkgs.coreutils}/bin:${pkgs.bash}/bin"
+          "BUN_INSTALL=%h/.bun"
+          "HOME=%h"
+        ];
+        ExecStart = "${pkgs.bash}/bin/bash ${./install-npm-globals.sh}";
+      };
+      Install = {
+        WantedBy = [ "default.target" ];
+      };
     };
   };
 

--- a/home-manager/modules/uv-globals/default.nix
+++ b/home-manager/modules/uv-globals/default.nix
@@ -1,31 +1,38 @@
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
+let
+  inherit (pkgs.stdenv) isDarwin;
+in
 {
   # Install uv global tools from pyproject.toml using home-manager activation
   home.activation.installUvGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    ${lib.optionalString (!isDarwin) ''
     if [ "$(${pkgs.systemd}/bin/systemctl is-system-running 2>/dev/null)" = "starting" ]; then
       echo "System is booting, skipping uv globals install"
-    else
+      exit 0
+    fi
+    ''}
     export PATH=${pkgs.uv}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:$PATH
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash ${./install-uv-globals.sh}
-    fi
   '';
 
-  # Run uv globals install after login
-  systemd.user.services.install-uv-globals = {
-    Unit = {
-      Description = "Install uv global tools";
-      After = [ "default.target" ];
-    };
-    Service = {
-      Type = "oneshot";
-      Environment = [
-        "PATH=${pkgs.uv}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.coreutils}/bin:${pkgs.bash}/bin"
-        "HOME=%h"
-      ];
-      ExecStart = "${pkgs.bash}/bin/bash ${./install-uv-globals.sh}";
-    };
-    Install = {
-      WantedBy = [ "default.target" ];
+  # Run uv globals install after login (Linux only - systemd)
+  systemd.user.services = lib.mkIf (!isDarwin) {
+    install-uv-globals = {
+      Unit = {
+        Description = "Install uv global tools";
+        After = [ "default.target" ];
+      };
+      Service = {
+        Type = "oneshot";
+        Environment = [
+          "PATH=${pkgs.uv}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.coreutils}/bin:${pkgs.bash}/bin"
+          "HOME=%h"
+        ];
+        ExecStart = "${pkgs.bash}/bin/bash ${./install-uv-globals.sh}";
+      };
+      Install = {
+        WantedBy = [ "default.target" ];
+      };
     };
   };
 


### PR DESCRIPTION
## Summary
- Wrap `pkgs.systemd` / `systemctl` boot-detection guard in `lib.optionalString (!isDarwin)` so it is only emitted on Linux
- Wrap `systemd.user.services` definitions in `lib.mkIf (!isDarwin)` since systemd does not exist on macOS
- Fixes `make build` failure on aarch64-darwin: `Refusing to evaluate package 'systemd-259'`

Affected modules: `cargo-globals`, `npm-globals`, `uv-globals`

## Test plan
- [ ] `make build && make switch` succeeds on aarch64-darwin
- [ ] Linux builds remain unaffected (systemd guard + oneshot services still active)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded all `systemd` references behind `isDarwin` checks in the globals modules so macOS builds don’t evaluate `systemd`. Fixes `make build` failing on `aarch64-darwin` while keeping Linux behavior unchanged.

- **Bug Fixes**
  - Wrapped `pkgs.systemd`/`systemctl` boot checks with `lib.optionalString (!isDarwin)`.
  - Gated `systemd.user.services` with `lib.mkIf (!isDarwin)` so oneshot services run only on Linux.
  - Applied to `cargo-globals`, `npm-globals`, and `uv-globals`.

<sup>Written for commit fbf0b80e66490ab36c453af3384cbd2ec2dc0072. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

