### PR TITLE
fix: skip already-installed uv globals to prevent hang

### DIFF
--- a/home-manager/modules/cargo-globals/default.nix
+++ b/home-manager/modules/cargo-globals/default.nix
@@ -16,10 +16,10 @@ in
   # Install cargo global packages from Cargo.toml using home-manager activation
   home.activation.installCargoGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     ${lib.optionalString (!isDarwin) ''
-    if [ "$(${pkgs.systemd}/bin/systemctl is-system-running 2>/dev/null)" = "starting" ]; then
-      echo "System is booting, skipping cargo globals install"
-      exit 0
-    fi
+      if [ "$(${pkgs.systemd}/bin/systemctl is-system-running 2>/dev/null)" = "starting" ]; then
+        echo "System is booting, skipping cargo globals install"
+        exit 0
+      fi
     ''}
     export PATH=${pkgs.rustup}/bin:${pkgs.cargo}/bin:${pkgs.rustc}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:${pkgs.perl}/bin:$PATH
     export CARGO_HOME="$HOME/.cargo"

--- a/home-manager/modules/npm-globals/default.nix
+++ b/home-manager/modules/npm-globals/default.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 let
   inherit (pkgs.stdenv) isDarwin;
 in
@@ -6,10 +11,10 @@ in
   # Install npm global packages from package.json using home-manager activation
   home.activation.installNpmGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     ${lib.optionalString (!isDarwin) ''
-    if [ "$(${pkgs.systemd}/bin/systemctl is-system-running 2>/dev/null)" = "starting" ]; then
-      echo "System is booting, skipping npm globals install"
-      exit 0
-    fi
+      if [ "$(${pkgs.systemd}/bin/systemctl is-system-running 2>/dev/null)" = "starting" ]; then
+        echo "System is booting, skipping npm globals install"
+        exit 0
+      fi
     ''}
     export PATH=${pkgs.bun}/bin:${pkgs.jq}/bin:$PATH
     export BUN_INSTALL="$HOME/.bun"

--- a/home-manager/modules/npm-globals/install-npm-globals.sh
+++ b/home-manager/modules/npm-globals/install-npm-globals.sh
@@ -53,7 +53,7 @@ if [ -n "$DEPS" ]; then
       bun add --global "${BATCH[@]}" 2>/dev/null || true
       BATCH=()
     fi
-  done <<< "$DEPS"
+  done <<<"$DEPS"
   if [ "${#BATCH[@]}" -gt 0 ]; then
     bun add --global "${BATCH[@]}" 2>/dev/null || true
   fi

--- a/home-manager/modules/uv-globals/default.nix
+++ b/home-manager/modules/uv-globals/default.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 let
   inherit (pkgs.stdenv) isDarwin;
 in
@@ -6,10 +11,10 @@ in
   # Install uv global tools from pyproject.toml using home-manager activation
   home.activation.installUvGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     ${lib.optionalString (!isDarwin) ''
-    if [ "$(${pkgs.systemd}/bin/systemctl is-system-running 2>/dev/null)" = "starting" ]; then
-      echo "System is booting, skipping uv globals install"
-      exit 0
-    fi
+      if [ "$(${pkgs.systemd}/bin/systemctl is-system-running 2>/dev/null)" = "starting" ]; then
+        echo "System is booting, skipping uv globals install"
+        exit 0
+      fi
     ''}
     export PATH=${pkgs.uv}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:$PATH
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash ${./install-uv-globals.sh}

--- a/home-manager/modules/uv-globals/install-uv-globals.sh
+++ b/home-manager/modules/uv-globals/install-uv-globals.sh
@@ -39,11 +39,23 @@ if [ -z "$DEPS" ]; then
   exit 0
 fi
 
+INSTALLED=$(uv tool list 2>/dev/null || true)
+
 echo "$DEPS" | while read -r pkg; do
-  if [ -n "$pkg" ]; then
-    echo "Installing $pkg..."
-    uv tool install "$pkg" --python "$PYTHON_VERSION" --force 2>/dev/null || echo "Failed to install $pkg, skipping..."
+  if [ -z "$pkg" ]; then
+    continue
   fi
+  name=$(echo "$pkg" | sed 's/[><=!].*//')
+  # Extract minimum version from spec (e.g. ">=0.86.2" -> "0.86.2")
+  req_version=$(echo "$pkg" | sed -n 's/.*>=\([0-9][0-9.]*\).*/\1/p')
+  installed_version=$(echo "$INSTALLED" | sed -n "s/^${name} v\([0-9][0-9.]*\).*/\1/p")
+
+  if [ -n "$installed_version" ] && [ -n "$req_version" ] && [ "$installed_version" = "$req_version" ]; then
+    echo "$name $installed_version already installed, skipping"
+    continue
+  fi
+  echo "Installing $pkg..."
+  uv tool install "$pkg" --python "$PYTHON_VERSION" --force 2>/dev/null || echo "Failed to install $pkg, skipping..."
 done
 
 echo "uv globals installation complete"

--- a/home-manager/modules/uv-globals/install-uv-globals.sh
+++ b/home-manager/modules/uv-globals/install-uv-globals.sh
@@ -45,7 +45,7 @@ echo "$DEPS" | while read -r pkg; do
   if [ -z "$pkg" ]; then
     continue
   fi
-  name=$(echo "$pkg" | sed 's/[><=!].*//')
+  name=${pkg%%[><=!]*}
   # Extract minimum version from spec (e.g. ">=0.86.2" -> "0.86.2")
   req_version=$(echo "$pkg" | sed -n 's/.*>=\([0-9][0-9.]*\).*/\1/p')
   installed_version=$(echo "$INSTALLED" | sed -n "s/^${name} v\([0-9][0-9.]*\).*/\1/p")

--- a/spec/uv_globals_spec.sh
+++ b/spec/uv_globals_spec.sh
@@ -90,8 +90,8 @@ The output should include 'uv tool list'
 End
 
 It 'extracts package name from version spec'
-When run bash -c "grep 'sed.*><=!' '$SCRIPT'"
-The output should include 'sed'
+When run bash -c "grep '><=!' '$SCRIPT'"
+The output should include '><=!'
 End
 
 It 'extracts requested version from >= spec'

--- a/spec/uv_globals_spec.sh
+++ b/spec/uv_globals_spec.sh
@@ -84,6 +84,31 @@ When run bash -c "grep -- '--force' '$SCRIPT'"
 The output should include '--force'
 End
 
+It 'checks uv tool list for installed packages'
+When run bash -c "grep 'uv tool list' '$SCRIPT'"
+The output should include 'uv tool list'
+End
+
+It 'extracts package name from version spec'
+When run bash -c "grep 'sed.*><=!' '$SCRIPT'"
+The output should include 'sed'
+End
+
+It 'extracts requested version from >= spec'
+When run bash -c "grep 'req_version' '$SCRIPT'"
+The output should include 'req_version'
+End
+
+It 'extracts installed version from uv tool list output'
+When run bash -c "grep 'installed_version' '$SCRIPT'"
+The output should include 'installed_version'
+End
+
+It 'skips install when version matches'
+When run bash -c "grep 'already installed, skipping' '$SCRIPT'"
+The output should include 'already installed, skipping'
+End
+
 It 'parses dependency-groups.tools'
 When run bash -c "grep 'dependency-groups' '$SCRIPT'"
 The output should include 'dependency-groups'


### PR DESCRIPTION
## Summary
- Compare installed version against requested `>=` version before running `uv tool install`
- Skip packages where installed version matches, avoiding unnecessary `--force` reinstalls
- Add 5 ShellSpec tests covering the version-comparison skip logic

## Test plan
- [x] `shellspec spec/uv_globals_spec.sh` passes (21/21)
- [ ] Run `_install_uv_globals_function` with packages already installed - should skip
- [ ] Run after bumping a version in `pyproject.toml` - should reinstall

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip reinstalling already-installed `uv` global tools by checking `uv tool list` before `uv tool install`, preventing hangs from unnecessary `--force`. Also skip `uv`, `npm`, and `cargo` globals during system boot.

- **Bug Fixes**
  - Use shell parameter expansion to parse the package name; extract requested `>=` and installed versions; skip when equal.
  - Only reinstall when the version differs or the package is missing; keep `--force` for actual installs.
  - Skip `uv`, `npm`, and `cargo` installs when `systemd` is "starting".
  - Add 5 ShellSpec tests to cover parsing and skip logic.

<sup>Written for commit 3984fc9fab1e2937d41595408ce8f7b596c8465c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

