### PR TITLE
fix: add yq to uv globals PATH for tomlq availability

### DIFF
--- a/home-manager/modules/uv-globals/default.nix
+++ b/home-manager/modules/uv-globals/default.nix
@@ -16,7 +16,7 @@ in
         exit 0
       fi
     ''}
-    export PATH=${pkgs.uv}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:$PATH
+    export PATH=${pkgs.uv}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.yq}/bin:$PATH
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash ${./install-uv-globals.sh}
   '';
 
@@ -30,7 +30,7 @@ in
       Service = {
         Type = "oneshot";
         Environment = [
-          "PATH=${pkgs.uv}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.coreutils}/bin:${pkgs.bash}/bin"
+          "PATH=${pkgs.uv}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.yq}/bin:${pkgs.coreutils}/bin:${pkgs.bash}/bin"
           "HOME=%h"
         ];
         ExecStart = "${pkgs.bash}/bin/bash ${./install-uv-globals.sh}";


### PR DESCRIPTION
## Summary
- Add `pkgs.yq` to PATH in both activation script and systemd service for uv globals
- Fixes `tomlq not found, skipping uv globals install` since `tomlq` is provided by the `yq` package

## Test plan
- [ ] Verify `tomlq` is available during home-manager activation
- [ ] Verify uv globals install completes successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `pkgs.yq` to the uv-globals activation script and systemd service `PATH` so `tomlq` is available. Fixes "tomlq not found, skipping uv globals install" and ensures the install completes during Home Manager activation.

<sup>Written for commit 5532e08b9fddd2ce58bcaed1cd49335f83e62873. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

