### PR TITLE
feat: add opencode-claude-hooks plugin for notifications

### DIFF
--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -198,5 +198,5 @@
       }
     }
   },
-  "plugin": ["cc-safety-net", "opencode-atuin-history"]
+  "plugin": ["cc-safety-net", "opencode-atuin-history", "opencode-claude-hooks"]
 }

--- a/config/opencode/opencode.tpl.jsonc
+++ b/config/opencode/opencode.tpl.jsonc
@@ -198,5 +198,5 @@
       }
     }
   },
-  "plugin": ["cc-safety-net", "opencode-atuin-history"]
+  "plugin": ["cc-safety-net", "opencode-atuin-history", "opencode-claude-hooks"]
 }


### PR DESCRIPTION
## Summary
- Add `opencode-claude-hooks` plugin to OpenCode config to enable drop-in compatibility with existing Claude Code hooks
- This enables pushover notifications, local notifications, security checks, atuin history, and rtk-rewrite hooks in OpenCode by reading `~/.claude/settings.json`

## Test plan
- [ ] Run `home-manager switch` to deploy config
- [ ] Open OpenCode and verify hooks load without errors
- [ ] Confirm pushover notifications fire on session stop/permission request

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `opencode-claude-hooks` to the OpenCode plugin list to run existing Claude Code hooks from `~/.claude/settings.json`. This enables Pushover/local notifications, security checks, atuin history, and rtk-rewrite hooks in OpenCode without extra config.

- **Migration**
  - No action needed if you already use `~/.claude/settings.json`; hooks load on next OpenCode start.
  - For new setups, create `~/.claude/settings.json` with your hooks.

<sup>Written for commit 191204d98ec6439d127f401e81af211885b5f308. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

