### PR TITLE
fix: use sort -V for globals version comparison to prevent redundant installs

### DIFF
--- a/home-manager/modules/npm-globals/install-npm-globals.sh
+++ b/home-manager/modules/npm-globals/install-npm-globals.sh
@@ -57,9 +57,14 @@ if [ -n "$DEPS" ]; then
     if [ -f "$pkg_json" ]; then
       installed_ver=$(jq -r '.version // empty' "$pkg_json" 2>/dev/null || true)
     fi
-    if [ -n "$installed_ver" ] && [ -n "$wanted_ver" ] && [ "$installed_ver" = "$wanted_ver" ]; then
-      echo "$dep@$installed_ver already installed, skipping"
-    elif [ -n "$installed_ver" ]; then
+    if [ -n "$installed_ver" ] && [ -n "$wanted_ver" ]; then
+      min_ver=$(printf '%s\n%s\n' "$wanted_ver" "$installed_ver" | sort -V | head -n1)
+      if [ "$min_ver" = "$wanted_ver" ]; then
+        echo "$dep@$installed_ver already installed, skipping"
+        continue
+      fi
+    fi
+    if [ -n "$installed_ver" ]; then
       echo "$dep@$installed_ver installed, want $wanted_ver, updating"
       MISSING+=("$dep")
     else

--- a/home-manager/modules/uv-globals/install-uv-globals.sh
+++ b/home-manager/modules/uv-globals/install-uv-globals.sh
@@ -50,9 +50,11 @@ echo "$DEPS" | while read -r pkg; do
   req_version=$(echo "$pkg" | sed -n 's/.*>=\([0-9][0-9.]*\).*/\1/p')
   installed_version=$(echo "$INSTALLED" | sed -n "s/^${name} v\([0-9][0-9.]*\).*/\1/p")
 
-  if [ -n "$installed_version" ] && [ -n "$req_version" ] && [ "$installed_version" = "$req_version" ]; then
-    echo "$name $installed_version already installed, skipping"
-    continue
+  if [ -n "$installed_version" ] && [ -n "$req_version" ]; then
+    if printf '%s\n%s\n' "$req_version" "$installed_version" | sort -V | head -n1 | grep -qx "$req_version"; then
+      echo "$name $installed_version already installed, skipping"
+      continue
+    fi
   fi
   echo "Installing $pkg..."
   uv tool install "$pkg" --python "$PYTHON_VERSION" --force 2>/dev/null || echo "Failed to install $pkg, skipping..."

--- a/spec/npm_globals_spec.sh
+++ b/spec/npm_globals_spec.sh
@@ -101,6 +101,29 @@ When run bash -c "grep 'already installed, skipping' '$SCRIPT'"
 The output should include 'already installed, skipping'
 End
 
+It 'uses sort -V for version comparison instead of exact match'
+When run bash -c "grep 'sort -V' '$SCRIPT'"
+The output should include 'sort -V'
+End
+
+It 'skips when installed version is newer than wanted'
+# Simulate: installed=2.9.4, wanted=2.9.3 -> should skip (min is 2.9.3)
+When run bash -c "printf '2.9.3\n2.9.4\n' | sort -V | head -n1"
+The output should eq '2.9.3'
+End
+
+It 'skips when installed version equals wanted'
+# Simulate: installed=2.1.92, wanted=2.1.92 -> should skip
+When run bash -c "printf '2.1.92\n2.1.92\n' | sort -V | head -n1"
+The output should eq '2.1.92'
+End
+
+It 'detects when installed version is older than wanted'
+# Simulate: installed=0.65.0, wanted=0.65.2 -> min is 0.65.0, not 0.65.2
+When run bash -c "printf '0.65.2\n0.65.0\n' | sort -V | head -n1"
+The output should eq '0.65.0'
+End
+
 It 'detects when update is needed'
 When run bash -c "grep 'updating' '$SCRIPT'"
 The output should include 'updating'

--- a/spec/uv_globals_spec.sh
+++ b/spec/uv_globals_spec.sh
@@ -109,6 +109,29 @@ When run bash -c "grep 'already installed, skipping' '$SCRIPT'"
 The output should include 'already installed, skipping'
 End
 
+It 'uses sort -V for version comparison instead of exact match'
+When run bash -c "grep 'sort -V' '$SCRIPT'"
+The output should include 'sort -V'
+End
+
+It 'skips when installed version is newer than required'
+# Simulate: installed=0.15.9, required=0.15.8 -> should skip
+When run bash -c "printf '0.15.8\n0.15.9\n' | sort -V | head -n1"
+The output should eq '0.15.8'
+End
+
+It 'skips when installed version equals required'
+# Simulate: installed=0.86.2, required=0.86.2 -> should skip
+When run bash -c "printf '0.86.2\n0.86.2\n' | sort -V | head -n1"
+The output should eq '0.86.2'
+End
+
+It 'detects when installed version is older than required'
+# Simulate: installed=2.6.9, required=2.7.0 -> min is 2.6.9, not 2.7.0
+When run bash -c "printf '2.7.0\n2.6.9\n' | sort -V | head -n1"
+The output should eq '2.6.9'
+End
+
 It 'parses dependency-groups.tools'
 When run bash -c "grep 'dependency-groups' '$SCRIPT'"
 The output should include 'dependency-groups'


### PR DESCRIPTION
## Summary
- Both uv and npm globals install scripts used exact version match (`=`) to skip already-installed packages
- Packages with newer-than-required versions (e.g. ruff 0.15.9 installed vs `>=0.15.8` required) were reinstalled every run
- Replaced with `sort -V` based `>=` comparison so newer installed versions correctly skip
- Added version comparison tests for both scripts

## Test plan
- [x] `shellspec spec/uv_globals_spec.sh` - 25 examples, 0 failures
- [x] `shellspec spec/npm_globals_spec.sh` - 31 examples, 0 failures
- [x] New tests verify sort -V behavior for newer, equal, and older versions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent redundant installs of global tools by switching version checks in the `uv` and `npm` globals installers to a `sort -V` >= comparison. Newer or equal installed versions now skip; added shellspec tests for newer/equal/older cases.

<sup>Written for commit 22b843aa946eda443235c32fbd7429e43f5524e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

