### PR TITLE
feat(openclaw): add dev-opus and dev-gpt-codex WhatsApp group bindings

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -770,8 +770,6 @@
   "broadcast": {
     "strategy": "parallel",
     "120363425148909388@g.us": [
-      "code-reviewer-opus",
-      "code-reviewer-sonnet",
       "code-reviewer-glm",
       "code-reviewer-gpt",
       "code-reviewer-gpt-codex",

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -356,9 +356,9 @@
         "name": "Security Scanner",
         "workspace": "__HOME__/.openclaw/workspace/agents/security",
         "model": {
-          "primary": "cliproxy/claude-opus-4-6",
+          "primary": "cliproxy/minimax-m2.7",
           "fallbacks": [
-            "cliproxy/claude-sonnet-4-6",
+            "cliproxy/glm-4.7",
             "cliproxy/free"
           ]
         },
@@ -391,7 +391,7 @@
         "name": "Docs Checker",
         "workspace": "__HOME__/.openclaw/workspace/agents/docs",
         "model": {
-          "primary": "cliproxy/claude-sonnet-4-6",
+          "primary": "cliproxy/minimax-m2.7",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"
@@ -773,7 +773,6 @@
       "code-reviewer-glm",
       "code-reviewer-gpt",
       "code-reviewer-gpt-codex",
-      "code-reviewer-gemini",
       "code-reviewer-minimax",
       "code-formatter",
       "security-scanner",

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -192,7 +192,6 @@
       "model": {
         "primary": "cliproxy/minimax-m2.7",
         "fallbacks": [
-          "cliproxy/claude-opus-4-6",
           "cliproxy/glm-4.7",
           "cliproxy/free"
         ]
@@ -263,6 +262,24 @@
         }
       },
       {
+        "id": "code-reviewer-gpt",
+        "name": "Code Reviewer (GPT)",
+        "workspace": "__HOME__/.openclaw/workspace/agents/code-review",
+        "model": {
+          "primary": "cliproxy/gpt-5.4",
+          "fallbacks": [
+            "cliproxy/glm-4.7",
+            "cliproxy/free"
+          ]
+        },
+        "tools": {
+          "allow": [
+            "read",
+            "exec"
+          ]
+        }
+      },
+      {
         "id": "code-reviewer-gpt-codex",
         "name": "Code Reviewer (GPT Codex)",
         "workspace": "__HOME__/.openclaw/workspace/agents/code-review",
@@ -287,6 +304,25 @@
         "model": {
           "primary": "cliproxy/gemini-3.1-pro-preview",
           "fallbacks": [
+            "cliproxy/glm-4.7",
+            "cliproxy/free"
+          ]
+        },
+        "tools": {
+          "allow": [
+            "read",
+            "exec"
+          ]
+        }
+      },
+      {
+        "id": "code-reviewer-minimax",
+        "name": "Code Reviewer (Minimax)",
+        "workspace": "__HOME__/.openclaw/workspace/agents/code-review",
+        "model": {
+          "primary": "cliproxy/minimax-m2.7",
+          "fallbacks": [
+            "cliproxy/claude-opus-4-6",
             "cliproxy/glm-4.7",
             "cliproxy/free"
           ]
@@ -737,8 +773,10 @@
       "code-reviewer-opus",
       "code-reviewer-sonnet",
       "code-reviewer-glm",
+      "code-reviewer-gpt",
       "code-reviewer-gpt-codex",
       "code-reviewer-gemini",
+      "code-reviewer-minimax",
       "code-formatter",
       "security-scanner",
       "test-coverage",

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -503,6 +503,7 @@
         "model": {
           "primary": "cliproxy/gpt-5.4",
           "fallbacks": [
+            "cliproxy/gpt-5.3-codex",
             "cliproxy/glm-4.7",
             "cliproxy/free"
           ]
@@ -523,6 +524,7 @@
         "model": {
           "primary": "cliproxy/gpt-5.3-codex",
           "fallbacks": [
+            "cliproxy/gpt-5.4",
             "cliproxy/glm-4.7",
             "cliproxy/free"
           ]

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -699,16 +699,6 @@
       }
     },
     {
-      "agentId": "dev-opus",
-      "match": {
-        "channel": "whatsapp",
-        "peer": {
-          "kind": "group",
-          "id": "120363405790595065@g.us"
-        }
-      }
-    },
-    {
       "agentId": "dev-gpt-codex",
       "match": {
         "channel": "whatsapp",
@@ -737,7 +727,6 @@
       "twitter-opus"
     ],
     "120363405790595065@g.us": [
-      "dev-opus",
       "dev-gpt-codex"
     ],
     "120363407321327235@g.us": [

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -497,6 +497,26 @@
         }
       },
       {
+        "id": "dev-gpt",
+        "name": "Dev (GPT)",
+        "workspace": "__HOME__/.openclaw/workspace/agents/dev",
+        "model": {
+          "primary": "cliproxy/gpt-5.4",
+          "fallbacks": [
+            "cliproxy/glm-4.7",
+            "cliproxy/free"
+          ]
+        },
+        "tools": {
+          "allow": [
+            "read",
+            "write",
+            "edit",
+            "exec"
+          ]
+        }
+      },
+      {
         "id": "dev-gpt-codex",
         "name": "Dev (GPT Codex)",
         "workspace": "__HOME__/.openclaw/workspace/agents/dev",
@@ -699,7 +719,7 @@
       }
     },
     {
-      "agentId": "dev-gpt-codex",
+      "agentId": "dev-gpt",
       "match": {
         "channel": "whatsapp",
         "peer": {
@@ -727,7 +747,7 @@
       "twitter-opus"
     ],
     "120363405790595065@g.us": [
-      "dev-gpt-codex"
+      "dev-gpt"
     ],
     "120363407321327235@g.us": [
       "strategy-opus",

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -780,16 +780,13 @@
       "docs-checker"
     ],
     "120363406322027123@g.us": [
-      "twitter-gemini",
-      "twitter-opus"
+      "twitter-gemini"
     ],
     "120363405790595065@g.us": [
       "dev-gpt"
     ],
     "120363407321327235@g.us": [
-      "strategy-opus",
-      "strategy-gpt",
-      "strategy-gemini"
+      "strategy-gpt"
     ]
   },
   "session": {

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -447,6 +447,26 @@
         "model": {
           "primary": "cliproxy/gemini-3.1-pro-preview",
           "fallbacks": [
+            "cliproxy/minimax-m2.7",
+            "cliproxy/glm-4.7",
+            "cliproxy/free"
+          ]
+        },
+        "tools": {
+          "allow": [
+            "read",
+            "exec"
+          ]
+        }
+      },
+      {
+        "id": "twitter-gpt",
+        "name": "Twitter (GPT)",
+        "workspace": "__HOME__/.openclaw/workspace/agents/twitter",
+        "model": {
+          "primary": "cliproxy/gpt-5.4",
+          "fallbacks": [
+            "cliproxy/minimax-m2.7",
             "cliproxy/glm-4.7",
             "cliproxy/free"
           ]
@@ -465,6 +485,7 @@
         "model": {
           "primary": "cliproxy/claude-opus-4-6",
           "fallbacks": [
+            "cliproxy/minimax-m2.7",
             "cliproxy/glm-4.7",
             "cliproxy/free"
           ]
@@ -780,7 +801,7 @@
       "docs-checker"
     ],
     "120363406322027123@g.us": [
-      "twitter-gemini"
+      "twitter-gpt"
     ],
     "120363405790595065@g.us": [
       "dev-gpt"

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -697,6 +697,26 @@
           "id": "120363424912006821@g.us"
         }
       }
+    },
+    {
+      "agentId": "dev-opus",
+      "match": {
+        "channel": "whatsapp",
+        "peer": {
+          "kind": "group",
+          "id": "120363405790595065@g.us"
+        }
+      }
+    },
+    {
+      "agentId": "dev-gpt-codex",
+      "match": {
+        "channel": "whatsapp",
+        "peer": {
+          "kind": "group",
+          "id": "120363405790595065@g.us"
+        }
+      }
     }
   ],
   "broadcast": {

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -720,7 +720,7 @@
     }
   ],
   "broadcast": {
-    "strategy": "sequential",
+    "strategy": "parallel",
     "120363425148909388@g.us": [
       "code-reviewer-opus",
       "code-reviewer-sonnet",

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -770,8 +770,6 @@
   "broadcast": {
     "strategy": "parallel",
     "120363425148909388@g.us": [
-      "code-reviewer-opus",
-      "code-reviewer-sonnet",
       "code-reviewer-glm",
       "code-reviewer-gpt",
       "code-reviewer-gpt-codex",

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -447,6 +447,26 @@
         "model": {
           "primary": "cliproxy/__GEMINI_PRO__",
           "fallbacks": [
+            "cliproxy/__MINIMAX__",
+            "cliproxy/__GLM__",
+            "cliproxy/free"
+          ]
+        },
+        "tools": {
+          "allow": [
+            "read",
+            "exec"
+          ]
+        }
+      },
+      {
+        "id": "twitter-gpt",
+        "name": "Twitter (GPT)",
+        "workspace": "__HOME__/.openclaw/workspace/agents/twitter",
+        "model": {
+          "primary": "cliproxy/__GPT__",
+          "fallbacks": [
+            "cliproxy/__MINIMAX__",
             "cliproxy/__GLM__",
             "cliproxy/free"
           ]
@@ -465,6 +485,7 @@
         "model": {
           "primary": "cliproxy/__CLAUDE_OPUS__",
           "fallbacks": [
+            "cliproxy/__MINIMAX__",
             "cliproxy/__GLM__",
             "cliproxy/free"
           ]

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -192,7 +192,6 @@
       "model": {
         "primary": "cliproxy/__MINIMAX__",
         "fallbacks": [
-          "cliproxy/__CLAUDE_OPUS__",
           "cliproxy/__GLM__",
           "cliproxy/free"
         ]
@@ -305,6 +304,25 @@
         "model": {
           "primary": "cliproxy/__GEMINI_PRO__",
           "fallbacks": [
+            "cliproxy/__GLM__",
+            "cliproxy/free"
+          ]
+        },
+        "tools": {
+          "allow": [
+            "read",
+            "exec"
+          ]
+        }
+      },
+      {
+        "id": "code-reviewer-minimax",
+        "name": "Code Reviewer (Minimax)",
+        "workspace": "__HOME__/.openclaw/workspace/agents/code-review",
+        "model": {
+          "primary": "cliproxy/__MINIMAX__",
+          "fallbacks": [
+            "cliproxy/__CLAUDE_OPUS__",
             "cliproxy/__GLM__",
             "cliproxy/free"
           ]

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -699,16 +699,6 @@
       }
     },
     {
-      "agentId": "dev-opus",
-      "match": {
-        "channel": "whatsapp",
-        "peer": {
-          "kind": "group",
-          "id": "120363405790595065@g.us"
-        }
-      }
-    },
-    {
       "agentId": "dev-gpt-codex",
       "match": {
         "channel": "whatsapp",
@@ -737,7 +727,6 @@
       "twitter-opus"
     ],
     "120363405790595065@g.us": [
-      "dev-opus",
       "dev-gpt-codex"
     ],
     "120363407321327235@g.us": [

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -801,16 +801,13 @@
       "docs-checker"
     ],
     "120363406322027123@g.us": [
-      "twitter-gemini",
-      "twitter-opus"
+      "twitter-gpt"
     ],
     "120363405790595065@g.us": [
       "dev-gpt"
     ],
     "120363407321327235@g.us": [
-      "strategy-opus",
-      "strategy-gpt",
-      "strategy-gemini"
+      "strategy-gpt"
     ]
   },
   "session": {

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -497,6 +497,26 @@
         }
       },
       {
+        "id": "dev-gpt",
+        "name": "Dev (GPT)",
+        "workspace": "__HOME__/.openclaw/workspace/agents/dev",
+        "model": {
+          "primary": "cliproxy/__GPT__",
+          "fallbacks": [
+            "cliproxy/__GLM__",
+            "cliproxy/free"
+          ]
+        },
+        "tools": {
+          "allow": [
+            "read",
+            "write",
+            "edit",
+            "exec"
+          ]
+        }
+      },
+      {
         "id": "dev-gpt-codex",
         "name": "Dev (GPT Codex)",
         "workspace": "__HOME__/.openclaw/workspace/agents/dev",
@@ -699,7 +719,7 @@
       }
     },
     {
-      "agentId": "dev-gpt-codex",
+      "agentId": "dev-gpt",
       "match": {
         "channel": "whatsapp",
         "peer": {
@@ -727,7 +747,7 @@
       "twitter-opus"
     ],
     "120363405790595065@g.us": [
-      "dev-gpt-codex"
+      "dev-gpt"
     ],
     "120363407321327235@g.us": [
       "strategy-opus",

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -773,7 +773,6 @@
       "code-reviewer-glm",
       "code-reviewer-gpt",
       "code-reviewer-gpt-codex",
-      "code-reviewer-gemini",
       "code-reviewer-minimax",
       "code-formatter",
       "security-scanner",

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -755,6 +755,7 @@
       "code-reviewer-opus",
       "code-reviewer-sonnet",
       "code-reviewer-glm",
+      "code-reviewer-gpt",
       "code-reviewer-gpt-codex",
       "code-reviewer-gemini",
       "code-formatter",

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -697,6 +697,26 @@
           "id": "120363424912006821@g.us"
         }
       }
+    },
+    {
+      "agentId": "dev-opus",
+      "match": {
+        "channel": "whatsapp",
+        "peer": {
+          "kind": "group",
+          "id": "120363405790595065@g.us"
+        }
+      }
+    },
+    {
+      "agentId": "dev-gpt-codex",
+      "match": {
+        "channel": "whatsapp",
+        "peer": {
+          "kind": "group",
+          "id": "120363405790595065@g.us"
+        }
+      }
     }
   ],
   "broadcast": {

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -776,6 +776,7 @@
       "code-reviewer-gpt",
       "code-reviewer-gpt-codex",
       "code-reviewer-gemini",
+      "code-reviewer-minimax",
       "code-formatter",
       "security-scanner",
       "test-coverage",

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -720,7 +720,7 @@
     }
   ],
   "broadcast": {
-    "strategy": "sequential",
+    "strategy": "parallel",
     "120363425148909388@g.us": [
       "code-reviewer-opus",
       "code-reviewer-sonnet",

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -263,6 +263,24 @@
         }
       },
       {
+        "id": "code-reviewer-gpt",
+        "name": "Code Reviewer (GPT)",
+        "workspace": "__HOME__/.openclaw/workspace/agents/code-review",
+        "model": {
+          "primary": "cliproxy/__GPT__",
+          "fallbacks": [
+            "cliproxy/__GLM__",
+            "cliproxy/free"
+          ]
+        },
+        "tools": {
+          "allow": [
+            "read",
+            "exec"
+          ]
+        }
+      },
+      {
         "id": "code-reviewer-gpt-codex",
         "name": "Code Reviewer (GPT Codex)",
         "workspace": "__HOME__/.openclaw/workspace/agents/code-review",

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -356,9 +356,9 @@
         "name": "Security Scanner",
         "workspace": "__HOME__/.openclaw/workspace/agents/security",
         "model": {
-          "primary": "cliproxy/__CLAUDE_OPUS__",
+          "primary": "cliproxy/__MINIMAX__",
           "fallbacks": [
-            "cliproxy/__CLAUDE_SONNET__",
+            "cliproxy/__GLM__",
             "cliproxy/free"
           ]
         },
@@ -391,7 +391,7 @@
         "name": "Docs Checker",
         "workspace": "__HOME__/.openclaw/workspace/agents/docs",
         "model": {
-          "primary": "cliproxy/__CLAUDE_SONNET__",
+          "primary": "cliproxy/__MINIMAX__",
           "fallbacks": [
             "cliproxy/__GLM__",
             "cliproxy/free"

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -503,6 +503,7 @@
         "model": {
           "primary": "cliproxy/__GPT__",
           "fallbacks": [
+            "cliproxy/__GPT_CODEX__",
             "cliproxy/__GLM__",
             "cliproxy/free"
           ]
@@ -523,6 +524,7 @@
         "model": {
           "primary": "cliproxy/__GPT_CODEX__",
           "fallbacks": [
+            "cliproxy/__GPT__",
             "cliproxy/__GLM__",
             "cliproxy/free"
           ]

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -144,7 +144,7 @@
       pixelh = "_pixelh_function";
       pixeh = "_pixeh_function";
       sag = "_ssh_add_github";
-      llmu = "_llm_update_function";
+      lmu = "_llm_update_function";
       slb = "_sync_local_binaries_function";
       shortcuts = "_fish_shortcuts";
       tdo = "_tdo_function";


### PR DESCRIPTION
Added WhatsApp group bindings for `dev-opus` and `dev-gpt-codex` to the dev group (120363405790595065@g.us), matching the existing broadcast config.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the dev WhatsApp group (120363405790595065@g.us) to `dev-gpt` (kept `dev-gpt-codex` for other uses; removed `dev-opus`) and changed broadcast to parallel so groups respond at the same time. Added `code-reviewer-gpt` and `code-reviewer-minimax` and updated broadcast to use them (removed deprecated reviewers incl. `code-reviewer-gemini`); moved Twitter to `twitter-gpt` with new fallbacks/tools; updated Security Scanner and Docs Checker to Minimax; added GPT↔Codex fallbacks across GPT configs for reliability; and renamed fish alias `llmu` to `lmu`.

<sup>Written for commit 83ef7f7f2e9c5b7b4b2cedb04a2c586be05c8422. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

