### PR TITLE
fix: use nix-store awk path in openclaw hydrate and remove exec

### DIFF
--- a/config/openclaw/default.nix
+++ b/config/openclaw/default.nix
@@ -16,6 +16,7 @@ let
     let
       vars = {
         sed = "${pkgs.gnused}/bin/sed";
+        awk = "${pkgs.gawk}/bin/awk";
         template = "${./openclaw.template.json}";
         inherit mode;
       }
@@ -23,12 +24,10 @@ let
         if host.isKyber then
           {
             chromium = "${pkgs.chromium}";
-            openclaw = "${homeDir}/.bun";
           }
         else
           {
             chromium = "/unused";
-            openclaw = "/unused";
           }
       );
       names = builtins.attrNames vars;

--- a/config/openclaw/hydrate.sh
+++ b/config/openclaw/hydrate.sh
@@ -35,7 +35,8 @@ read_cliproxy_api_key_from_config() {
   local config_file="$1"
   [ -f "$config_file" ] || return 0
 
-  awk '
+  # shellcheck disable=SC2016
+  @awk@ '
     /^api-keys:/ { in_api_keys = 1; next }
     in_api_keys && /^  - / {
       value = $0
@@ -87,12 +88,6 @@ if [ "$MODE" = "gateway" ]; then
   chmod 600 "$CONFIG"
 
   echo "Generated openclaw gateway config at $CONFIG" >&2
-
-  if [ -n "$ANTHROPIC_API_KEY" ]; then
-    export ANTHROPIC_API_KEY
-  fi
-
-  exec @openclaw@/bin/openclaw gateway --port 18789 "$@"
 
 else
   # Client mode (macOS): connect through kyber's Tailscale Serve endpoint

--- a/spec/openclaw_hydrate_spec.sh
+++ b/spec/openclaw_hydrate_spec.sh
@@ -112,9 +112,9 @@ EOF
   sed \
     -e 's|@mode@|gateway|g' \
     -e 's|@sed@|sed|g' \
+    -e 's|@awk@|awk|g' \
     -e 's|@template@|'"$TEMP_HOME"'/templates/openclaw.json|g' \
     -e 's|@chromium@|'"$TEMP_HOME"'/chromium|g' \
-    -e 's|@openclaw@|'"$TEMP_HOME"'/openclaw|g' \
     "$SCRIPT" >"$PREPROCESSED_SCRIPT"
   chmod +x "$PREPROCESSED_SCRIPT"
 }
@@ -147,9 +147,9 @@ EOF
   sed \
     -e 's|@mode@|client|g' \
     -e 's|@sed@|sed|g' \
+    -e 's|@awk@|awk|g' \
     -e 's|@template@|/unused|g' \
     -e 's|@chromium@|/unused|g' \
-    -e 's|@openclaw@|/unused|g' \
     "$SCRIPT" >"$PREPROCESSED_SCRIPT"
   chmod +x "$PREPROCESSED_SCRIPT"
 }
@@ -198,14 +198,9 @@ End
 End
 
 Describe 'execution'
-It 'exports ANTHROPIC_API_KEY when set'
-When run bash -c "grep 'export ANTHROPIC_API_KEY' '$SCRIPT'"
-The output should include 'export ANTHROPIC_API_KEY'
-End
-
-It 'starts openclaw gateway'
-When run bash -c "grep 'exec.*openclaw.*gateway' '$SCRIPT'"
-The output should include 'gateway'
+It 'generates config without starting gateway'
+When run bash -c "grep 'Generated openclaw gateway config' '$SCRIPT'"
+The output should include 'Generated openclaw gateway config'
 End
 End
 


### PR DESCRIPTION
## Summary
- Replace bare `awk` with `@awk@` nix-substituted path (`${pkgs.gawk}/bin/awk`) in `hydrate.sh` — bare `awk` wasn't in the systemd service PATH, causing `set -e` to kill the script before writing the config
- Remove `exec @openclaw@/bin/openclaw gateway` from hydrate.sh — this turned the home-manager activation into a long-running gateway process, blocking activation and conflicting with the systemd unit that already manages the gateway

## Root cause
The `dotfiles-updater` timer runs `home-manager switch` every 3 hours. Each activation runs `hydrate.sh`, which failed at line 38 (`awk: command not found`) due to missing PATH. With `set -euo pipefail`, the script died before writing `openclaw.json`. A subsequent `make nix-switch` then overwrote the config with the 224-byte client-mode stub, crashing the gateway.

## Test plan
- [x] Restored gateway config from backup, gateway running
- [x] Verified `awk` is the only bare command missing nix path
- [x] Confirmed `@openclaw@` removal is safe (only used in the removed `exec` line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `hydrate.sh` failures under `systemd` and stops `home-manager` activation from starting the gateway. Uses the Nix `awk` path so activation completes; the existing `systemd` unit continues to run the gateway.

- **Bug Fixes**
  - Inject `@awk@` (`${pkgs.gawk}/bin/awk`) via `default.nix` and use it in `hydrate.sh` to avoid PATH issues during activation.
  - Remove gateway startup from `hydrate.sh` (drop `exec @openclaw@/bin/openclaw gateway` and the unused `openclaw` var); tests updated to verify config generation only.

<sup>Written for commit 83f547961ee2fbfc2b478e7843ab80f4a748e5fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

