### PR TITLE
chore: update home-manager packages

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -62,6 +62,7 @@ with pkgs;
   jq
   jujutsu
   just
+  k6
   k9s
   kind
   kubeconform


### PR DESCRIPTION
Update home-manager packages

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `k6` to the `home-manager` package set to provide a built-in load testing CLI. This makes `k6` available in user profiles without manual installation.

<sup>Written for commit 598978f210a0cd1a7c745108582b67752b89ba6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

