### PR TITLE
fix: add missing PATH deps to globals systemd services

### DIFF
--- a/home-manager/modules/npm-globals/default.nix
+++ b/home-manager/modules/npm-globals/default.nix
@@ -31,7 +31,7 @@ in
       Service = {
         Type = "oneshot";
         Environment = [
-          "PATH=${pkgs.bun}/bin:${pkgs.jq}/bin:${pkgs.coreutils}/bin:${pkgs.bash}/bin"
+          "PATH=${pkgs.bun}/bin:${pkgs.jq}/bin:${pkgs.findutils}/bin:${pkgs.gnugrep}/bin:${pkgs.gnused}/bin:${pkgs.coreutils}/bin:${pkgs.bash}/bin"
           "BUN_INSTALL=%h/.bun"
           "HOME=%h"
         ];

--- a/home-manager/modules/uv-globals/default.nix
+++ b/home-manager/modules/uv-globals/default.nix
@@ -30,7 +30,7 @@ in
       Service = {
         Type = "oneshot";
         Environment = [
-          "PATH=${pkgs.uv}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.yq}/bin:${pkgs.coreutils}/bin:${pkgs.bash}/bin"
+          "PATH=${pkgs.uv}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.yq}/bin:${pkgs.gnused}/bin:${pkgs.gnugrep}/bin:${pkgs.coreutils}/bin:${pkgs.bash}/bin"
           "HOME=%h"
         ];
         ExecStart = "${pkgs.bash}/bin/bash ${./install-uv-globals.sh}";


### PR DESCRIPTION
## Summary
- `install-npm-globals.service` was missing `findutils`, `gnugrep`, `gnused` in its systemd PATH, causing `find`/`grep`/`sed` to fail with exit 127
- `install-uv-globals.service` was missing `gnused`, `gnugrep`, causing `sed`/`grep` to fail with exit 127

## Test plan
- [ ] `home-manager switch --flake .`
- [ ] `systemctl --user restart install-npm-globals.service && systemctl --user status install-npm-globals.service`
- [ ] `systemctl --user restart install-uv-globals.service && systemctl --user status install-uv-globals.service`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix systemd PATH for the globals installers to include required GNU tools, preventing exit 127 errors from `find`, `grep`, and `sed`.

- **Bug Fixes**
  - `install-npm-globals.service`: added `findutils`, `gnugrep`, `gnused` to PATH.
  - `install-uv-globals.service`: added `gnused`, `gnugrep` to PATH.

<sup>Written for commit b340199e2f733f49aefc2ae70d65766d805b915e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

