### PR TITLE
fix: rename legacy telegram streamMode to streaming

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -848,7 +848,7 @@
       "reactionNotifications": "all",
       "reactionLevel": "extensive",
       "replyToMode": "first",
-      "streamMode": "partial"
+      "streaming": "partial"
     },
     "whatsapp": {
       "dmPolicy": "pairing",

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -848,7 +848,7 @@
       "reactionNotifications": "all",
       "reactionLevel": "extensive",
       "replyToMode": "first",
-      "streamMode": "partial"
+      "streaming": "partial"
     },
     "whatsapp": {
       "dmPolicy": "pairing",


### PR DESCRIPTION
## Summary
- Rename `channels.telegram.streamMode` to `channels.telegram.streaming` in both openclaw config templates
- OpenClaw updated its config schema, making `streamMode` a legacy key that causes startup validation failure

## Test plan
- [x] Fixed live config, gateway starts and runs
- [x] Templates updated to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed Telegram config key in OpenClaw templates from `streamMode` to `streaming` to match the updated schema and prevent startup validation errors.

- **Bug Fixes**
  - Updated `config/openclaw/openclaw.template.json` and `config/openclaw/openclaw.tpl.json` to use `channels.telegram.streaming: "partial"`.

<sup>Written for commit 3b4aa1671c2809f38fbba2af01ff5cbd795c28da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

