### PR TITLE
feat: enable dreaming in openclaw memory-core plugin

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -914,6 +914,13 @@
       },
       "whatsapp": {
         "enabled": true
+      },
+      "memory-core": {
+        "config": {
+          "dreaming": {
+            "enabled": true
+          }
+        }
       }
     }
   }

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -914,6 +914,13 @@
       },
       "whatsapp": {
         "enabled": true
+      },
+      "memory-core": {
+        "config": {
+          "dreaming": {
+            "enabled": true
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Enables the memory-core dreaming feature in openclaw config.

Ref: https://docs.openclaw.ai/concepts/dreaming

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable dreaming in the `memory-core` plugin by default. Sets `plugins.memory-core.config.dreaming.enabled` to `true` in both `config/openclaw/openclaw.template.json` and `config/openclaw/openclaw.tpl.json` so generated configs have dreaming turned on.

<sup>Written for commit 03baf669aabfba3610b05037fcf751e144a02d51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

