### PR TITLE
fix: build --lib only for .rlib targets to skip harness binaries

### DIFF
--- a/scripts/update-local-binaries.sh
+++ b/scripts/update-local-binaries.sh
@@ -172,7 +172,14 @@ build_repo() {
   fi
 
   if [ -f "$build_dir/Cargo.toml" ]; then
-    if (cd "$build_dir" && cargo +nightly build --release 2>&1); then
+    # If the target is a .rlib, only build the library (avoids compiling all
+    # test/harness binaries in large workspaces like frankensqlite).
+    local cargo_flags="--release"
+    local expanded_bin="${binary_path/#\~/$HOME}"
+    if [[ "$expanded_bin" == *.rlib ]]; then
+      cargo_flags="--release --lib"
+    fi
+    if (cd "$build_dir" && cargo +nightly build $cargo_flags 2>&1); then
       return 0
     else
       return 1

--- a/scripts/update-local-binaries.sh
+++ b/scripts/update-local-binaries.sh
@@ -176,7 +176,7 @@ build_repo() {
     # test/harness binaries in large workspaces like frankensqlite).
     local expanded_bin="${binary_path/#\~/$HOME}"
     local extra_flags=()
-    if [[ "$expanded_bin" == *.rlib ]]; then
+    if [[ $expanded_bin == *.rlib ]]; then
       extra_flags=(--lib)
     fi
     if (cd "$build_dir" && cargo +nightly build --release "${extra_flags[@]}" 2>&1); then

--- a/scripts/update-local-binaries.sh
+++ b/scripts/update-local-binaries.sh
@@ -174,12 +174,12 @@ build_repo() {
   if [ -f "$build_dir/Cargo.toml" ]; then
     # If the target is a .rlib, only build the library (avoids compiling all
     # test/harness binaries in large workspaces like frankensqlite).
-    local cargo_flags="--release"
     local expanded_bin="${binary_path/#\~/$HOME}"
+    local extra_flags=()
     if [[ "$expanded_bin" == *.rlib ]]; then
-      cargo_flags="--release --lib"
+      extra_flags=(--lib)
     fi
-    if (cd "$build_dir" && cargo +nightly build $cargo_flags 2>&1); then
+    if (cd "$build_dir" && cargo +nightly build --release "${extra_flags[@]}" 2>&1); then
       return 0
     else
       return 1


### PR DESCRIPTION
## Summary
- When `update-local-binaries.sh` encounters a `.rlib` target (e.g. `frankensqlite/target/release/libfsqlite.rlib`), it now passes `--lib` to `cargo build` instead of building all targets
- Avoids compiling 200+ harness/e2e binaries in large workspaces, cutting frankensqlite build time from ~4min to ~30-60s on warm cache

## Test plan
- [ ] Run `update-local-binaries.sh` and confirm frankensqlite lib builds without triggering harness binary compilation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `cargo build --lib` for `.rlib` targets in `update-local-binaries.sh` to skip harness/test binaries, leaving other targets unchanged.
Pass extra `cargo` flags via an array to satisfy ShellCheck/shell tests and apply formatting; `frankensqlite` drops from ~4m to ~30–60s on warm cache.

<sup>Written for commit fea46287a774bd2c2e8edb7b00e7551487f1d985. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

