### PR TITLE
fix(hooks): silence notify/pushover for paperclip heartbeats

### DIFF
--- a/config/claude/hooks/notify.sh
+++ b/config/claude/hooks/notify.sh
@@ -18,6 +18,16 @@ if [ -n "$PUSHOVER_API_TOKEN" ] && [ -n "$PUSHOVER_USER_KEY" ]; then
   exit 0
 fi
 
+# Skip notifications only for pure timer-driven Paperclip heartbeats.
+# Paperclip sets PAPERCLIP_RUN_ID for every adapter run, but PAPERCLIP_TASK_ID
+# and PAPERCLIP_WAKE_REASON are only set when the wake came from an explicit
+# trigger (issue_assigned, issue_comment_mentioned, approval_approved, etc.).
+# A bare heartbeat tick has RUN_ID set with no TASK_ID and no WAKE_REASON --
+# that is the noisy case we want silent. Triggered wakes still notify.
+if [ -n "${PAPERCLIP_RUN_ID:-}" ] && [ -z "${PAPERCLIP_TASK_ID:-}" ] && [ -z "${PAPERCLIP_WAKE_REASON:-}" ]; then
+  exit 0
+fi
+
 # Read JSON input from stdin
 input=$(cat)
 

--- a/config/claude/hooks/pushover.sh
+++ b/config/claude/hooks/pushover.sh
@@ -21,6 +21,14 @@ if [ -z "$PUSHOVER_API_TOKEN" ] || [ -z "$PUSHOVER_USER_KEY" ]; then
   exit 0
 fi
 
+# Skip notifications only for pure timer-driven Paperclip heartbeats.
+# PAPERCLIP_RUN_ID is set for every adapter run, but TASK_ID / WAKE_REASON
+# are only set when the wake came from an explicit trigger. A bare heartbeat
+# has RUN_ID with no TASK_ID and no WAKE_REASON -- silence that case only.
+if [ -n "${PAPERCLIP_RUN_ID:-}" ] && [ -z "${PAPERCLIP_TASK_ID:-}" ] && [ -z "${PAPERCLIP_WAKE_REASON:-}" ]; then
+  exit 0
+fi
+
 # Read JSON input from stdin
 input=$(cat)
 

--- a/config/codex/hooks/notify.sh
+++ b/config/codex/hooks/notify.sh
@@ -19,6 +19,14 @@ if [[ -n ${PUSHOVER_API_TOKEN:-} ]] && [[ -n ${PUSHOVER_USER_KEY:-} ]]; then
   exit 0
 fi
 
+# Skip notifications only for pure timer-driven Paperclip heartbeats.
+# PAPERCLIP_RUN_ID is set for every adapter run, but TASK_ID / WAKE_REASON
+# are only set when the wake came from an explicit trigger. A bare heartbeat
+# has RUN_ID with no TASK_ID and no WAKE_REASON -- silence that case only.
+if [[ -n ${PAPERCLIP_RUN_ID:-} ]] && [[ -z ${PAPERCLIP_TASK_ID:-} ]] && [[ -z ${PAPERCLIP_WAKE_REASON:-} ]]; then
+  exit 0
+fi
+
 input=$(cat)
 
 notify() {

--- a/config/codex/hooks/pushover.sh
+++ b/config/codex/hooks/pushover.sh
@@ -12,6 +12,14 @@ if [[ -z $pushover ]] && [[ -x "$HOME/.local/scripts/pushover-notify" ]]; then
 fi
 [[ -z $pushover ]] && exit 0
 
+# Skip notifications only for pure timer-driven Paperclip heartbeats.
+# PAPERCLIP_RUN_ID is set for every adapter run, but TASK_ID / WAKE_REASON
+# are only set when the wake came from an explicit trigger. A bare heartbeat
+# has RUN_ID with no TASK_ID and no WAKE_REASON -- silence that case only.
+if [[ -n ${PAPERCLIP_RUN_ID:-} ]] && [[ -z ${PAPERCLIP_TASK_ID:-} ]] && [[ -z ${PAPERCLIP_WAKE_REASON:-} ]]; then
+  exit 0
+fi
+
 HOSTNAME=$(scutil --get ComputerName 2>/dev/null || hostname -s 2>/dev/null || echo "unknown")
 CWD=$(echo "$input" | jq -r '.cwd // empty' | sed "s|$HOME|~|")
 


### PR DESCRIPTION
## Summary
- Skip `notify.sh` and `pushover.sh` (claude + codex variants) for pure timer-driven Paperclip heartbeat ticks
- Guard triggers only when `PAPERCLIP_RUN_ID` is set AND both `PAPERCLIP_TASK_ID` and `PAPERCLIP_WAKE_REASON` are empty
- Explicit wakes (`issue_assigned`, `issue_comment_mentioned`, `issue_commented`, `issue_reopened_via_comment`, `approval_approved`, `process_lost_retry`) still notify as before
- Guard placed after the pushover credential check so the existing short-circuit paths stay first

## Context
Paperclip injects `PAPERCLIP_RUN_ID`, and optionally `PAPERCLIP_TASK_ID` / `PAPERCLIP_WAKE_REASON` / `PAPERCLIP_WAKE_COMMENT_ID`, into every spawned adapter process. See `packages/adapters/claude-local/src/server/execute.ts:148-182` in `paperclipai/paperclip` for the injection site. The bare heartbeat tick has `RUN_ID` only, which is the noisy case we want silent.

## Test plan
- [ ] Trigger a paperclip timer heartbeat locally and confirm no pushover / local notification fires
- [ ] Trigger an issue-assigned wake and confirm notifications still fire
- [ ] Run a regular (non-paperclip) Claude Code session and confirm notifications still fire
- [ ] `home-manager switch` to propagate the updated hook scripts into `~/.claude/hooks` and `~/.codex/hooks`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences `notify.sh` and `pushover.sh` for pure timer-driven Paperclip heartbeats to stop noisy alerts, while keeping notifications for explicit wakes and normal sessions.

- **Bug Fixes**
  - Exit early when `PAPERCLIP_RUN_ID` is set and both `PAPERCLIP_TASK_ID` and `PAPERCLIP_WAKE_REASON` are empty.
  - Guard runs after pushover credential checks to keep existing short-circuit paths.
  - Applies to Claude and Codex hooks.

- **Migration**
  - Run `home-manager switch` to update hooks in `~/.claude/hooks` and `~/.codex/hooks`.

<sup>Written for commit 246918b106abc3839fcf2515f362970447aee122. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

