### PR TITLE
fix(hooks): silence notify/pushover for all paperclip adapter runs

### DIFF
--- a/config/claude/hooks/notify.sh
+++ b/config/claude/hooks/notify.sh
@@ -18,13 +18,12 @@ if [ -n "$PUSHOVER_API_TOKEN" ] && [ -n "$PUSHOVER_USER_KEY" ]; then
   exit 0
 fi
 
-# Skip notifications only for pure timer-driven Paperclip heartbeats.
-# Paperclip sets PAPERCLIP_RUN_ID for every adapter run, but PAPERCLIP_TASK_ID
-# and PAPERCLIP_WAKE_REASON are only set when the wake came from an explicit
-# trigger (issue_assigned, issue_comment_mentioned, approval_approved, etc.).
-# A bare heartbeat tick has RUN_ID set with no TASK_ID and no WAKE_REASON --
-# that is the noisy case we want silent. Triggered wakes still notify.
-if [ -n "${PAPERCLIP_RUN_ID:-}" ] && [ -z "${PAPERCLIP_TASK_ID:-}" ] && [ -z "${PAPERCLIP_WAKE_REASON:-}" ]; then
+# Skip notifications for any Paperclip-spawned adapter run (heartbeat ticks,
+# cron routines, assignment wakes, etc.). PAPERCLIP_RUN_ID is injected by
+# paperclip on every adapter invocation (see
+# packages/adapters/*/src/server/execute.ts in paperclipai/paperclip) and is
+# never set for interactive Claude Code sessions.
+if [ -n "${PAPERCLIP_RUN_ID:-}" ]; then
   exit 0
 fi
 

--- a/config/claude/hooks/pushover.sh
+++ b/config/claude/hooks/pushover.sh
@@ -21,11 +21,11 @@ if [ -z "$PUSHOVER_API_TOKEN" ] || [ -z "$PUSHOVER_USER_KEY" ]; then
   exit 0
 fi
 
-# Skip notifications only for pure timer-driven Paperclip heartbeats.
-# PAPERCLIP_RUN_ID is set for every adapter run, but TASK_ID / WAKE_REASON
-# are only set when the wake came from an explicit trigger. A bare heartbeat
-# has RUN_ID with no TASK_ID and no WAKE_REASON -- silence that case only.
-if [ -n "${PAPERCLIP_RUN_ID:-}" ] && [ -z "${PAPERCLIP_TASK_ID:-}" ] && [ -z "${PAPERCLIP_WAKE_REASON:-}" ]; then
+# Skip notifications for any Paperclip-spawned adapter run (heartbeat ticks,
+# cron routines, assignment wakes, etc.). PAPERCLIP_RUN_ID is injected by
+# paperclip on every adapter invocation and is never set for interactive
+# Claude Code sessions.
+if [ -n "${PAPERCLIP_RUN_ID:-}" ]; then
   exit 0
 fi
 

--- a/config/codex/hooks/notify.sh
+++ b/config/codex/hooks/notify.sh
@@ -19,11 +19,11 @@ if [[ -n ${PUSHOVER_API_TOKEN:-} ]] && [[ -n ${PUSHOVER_USER_KEY:-} ]]; then
   exit 0
 fi
 
-# Skip notifications only for pure timer-driven Paperclip heartbeats.
-# PAPERCLIP_RUN_ID is set for every adapter run, but TASK_ID / WAKE_REASON
-# are only set when the wake came from an explicit trigger. A bare heartbeat
-# has RUN_ID with no TASK_ID and no WAKE_REASON -- silence that case only.
-if [[ -n ${PAPERCLIP_RUN_ID:-} ]] && [[ -z ${PAPERCLIP_TASK_ID:-} ]] && [[ -z ${PAPERCLIP_WAKE_REASON:-} ]]; then
+# Skip notifications for any Paperclip-spawned adapter run (heartbeat ticks,
+# cron routines, assignment wakes, etc.). PAPERCLIP_RUN_ID is injected by
+# paperclip on every adapter invocation and is never set for interactive
+# Codex sessions.
+if [[ -n ${PAPERCLIP_RUN_ID:-} ]]; then
   exit 0
 fi
 

--- a/config/codex/hooks/pushover.sh
+++ b/config/codex/hooks/pushover.sh
@@ -12,11 +12,11 @@ if [[ -z $pushover ]] && [[ -x "$HOME/.local/scripts/pushover-notify" ]]; then
 fi
 [[ -z $pushover ]] && exit 0
 
-# Skip notifications only for pure timer-driven Paperclip heartbeats.
-# PAPERCLIP_RUN_ID is set for every adapter run, but TASK_ID / WAKE_REASON
-# are only set when the wake came from an explicit trigger. A bare heartbeat
-# has RUN_ID with no TASK_ID and no WAKE_REASON -- silence that case only.
-if [[ -n ${PAPERCLIP_RUN_ID:-} ]] && [[ -z ${PAPERCLIP_TASK_ID:-} ]] && [[ -z ${PAPERCLIP_WAKE_REASON:-} ]]; then
+# Skip notifications for any Paperclip-spawned adapter run (heartbeat ticks,
+# cron routines, assignment wakes, etc.). PAPERCLIP_RUN_ID is injected by
+# paperclip on every adapter invocation and is never set for interactive
+# Codex sessions.
+if [[ -n ${PAPERCLIP_RUN_ID:-} ]]; then
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- Broaden the previous guard to silence notify/pushover for any Paperclip-spawned adapter run, not just timer heartbeat ticks
- Covers heartbeat ticks, cron routine fires, issue_assigned wakes, approval wakes, etc.
- Applies to `config/claude/hooks/{notify,pushover}.sh` and `config/codex/hooks/{notify,pushover}.sh`

## Why the previous guard missed cron
The prior check required both `PAPERCLIP_TASK_ID` and `PAPERCLIP_WAKE_REASON` to be empty. Cron routines in paperclip dispatch via `server/src/services/routines.ts` -> `queueIssueAssignmentWakeup` with `reason: "issue_assigned"` and a freshly created issue, so both vars are populated and the guard fell through. Paperclip exposes no env var that distinguishes a system-actor routine fire from a user-initiated assignment (`requestedByActorType` stays server-side), so the only reliable signal available to the hook is the presence of `PAPERCLIP_RUN_ID` itself.

`PAPERCLIP_RUN_ID` is injected on every adapter invocation in `packages/adapters/*/src/server/execute.ts` and is never present in interactive Claude Code / Codex sessions, so gating on it cleanly separates paperclip-orchestrated runs from human-driven sessions.

## Test plan
- [ ] Paperclip heartbeat timer tick: no notification
- [ ] Paperclip cron routine fire: no notification
- [ ] Paperclip issue assignment wake: no notification (acceptable — user is remote from the machine running the agent)
- [ ] Regular interactive Claude Code / Codex session: notifications still fire
- [ ] `home-manager switch` to propagate the updated hooks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences notify/pushover for all Paperclip‑spawned adapter runs by gating on PAPERCLIP_RUN_ID. Interactive Claude/Codex sessions still notify.

- **Bug Fixes**
  - Exit early in hooks when PAPERCLIP_RUN_ID is set.
  - Updated config/claude/hooks/{notify,pushover}.sh and config/codex/hooks/{notify,pushover}.sh.

<sup>Written for commit 75b7860a19de37933012685041905ca144c50493. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

