### PR TITLE
fix: update local model to qwen/qwen3.5-9b and extract obsidian inline script

### DIFF
--- a/config/aichat/default.nix
+++ b/config/aichat/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   home.file.".config/aichat/config.yaml" = {
     source = ./config.yaml;
     force = true;

--- a/config/amp/default.nix
+++ b/config/amp/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   xdg.configFile."amp/settings.json" = {
     source = ./settings.json;
   };

--- a/config/cliproxyapi/default.nix
+++ b/config/cliproxyapi/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   # Template config - the service wrapper injects secrets and writes to config.yaml
   home.file.".cli-proxy-api/config.template.yaml" = {
     source = ./config.template.yaml;

--- a/config/crush/default.nix
+++ b/config/crush/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   home.file.".config/crush/crush.json" = {
     source = ./crush.json;
     force = true;

--- a/config/direnv/default.nix
+++ b/config/direnv/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   home.file.".config/direnv/direnvrc" = {
     source = ./direnvrc;
     force = true;

--- a/config/eww/default.nix
+++ b/config/eww/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   xdg.configFile."eww/eww.yuck" = {
     source = ./eww.yuck;
     force = true;

--- a/config/factory/default.nix
+++ b/config/factory/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   home.file.".factory/config.json" = {
     source = ./config.json;
     force = true;

--- a/config/gomi/default.nix
+++ b/config/gomi/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   xdg.configFile."gomi/config.yaml" = {
     source = ./config.yaml;
   };

--- a/config/hammerspoon/default.nix
+++ b/config/hammerspoon/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   home.file.".hammerspoon/init.lua" = {
     source = ./init.lua;
     force = true;

--- a/config/hyprpanel/default.nix
+++ b/config/hyprpanel/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   programs.hyprpanel = {
     enable = true;
     systemd.enable = false;

--- a/config/hyprshell/default.nix
+++ b/config/hyprshell/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   xdg.configFile."hyprshell/config.toml" = {
     source = ./config.toml;
     force = true;

--- a/config/jj/default.nix
+++ b/config/jj/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   xdg.configFile."jj/config.toml" = {
     source = ./config.toml;
   };

--- a/config/karabiner/default.nix
+++ b/config/karabiner/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   home.file.".config/karabiner/karabiner.json" = {
     source = ./karabiner.json;
     force = true;

--- a/config/nwg-dock-hyprland/default.nix
+++ b/config/nwg-dock-hyprland/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   xdg.configFile."nwg-dock-hyprland/style.css" = {
     source = ./style.css;
     force = true;

--- a/config/nwg-drawer/default.nix
+++ b/config/nwg-drawer/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   xdg.configFile."nwg-drawer/drawer.css" = {
     source = ./drawer.css;
     force = true;

--- a/config/opencode/default.nix
+++ b/config/opencode/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   home.file.".config/opencode/opencode.jsonc" = {
     source = ./opencode.jsonc;
     force = true;

--- a/config/pi/default.nix
+++ b/config/pi/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   home.file.".pi/agent/models.json" = {
     source = ./models.json;
     force = true;

--- a/config/starship/default.nix
+++ b/config/starship/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   home.file.".config/starship.toml" = {
     source = ./starship.toml;
     force = true;

--- a/config/walker/default.nix
+++ b/config/walker/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   xdg.configFile."walker/config.toml" = {
     source = ./config.toml;
     force = true;

--- a/config/worktrunk/default.nix
+++ b/config/worktrunk/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   xdg.configFile."worktrunk/config.toml" = {
     source = ./config.toml;
     force = true;

--- a/config/zellij/default.nix
+++ b/config/zellij/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   xdg.configFile."zellij/config.kdl" = {
     source = ./config.kdl;
   };

--- a/home-manager/modules/obsidian/default.nix
+++ b/home-manager/modules/obsidian/default.nix
@@ -17,9 +17,11 @@ let
   # so they get pulled into the closure automatically without needing to
   # appear directly on PATH. Only this shim is exposed as `obsidian`,
   # which is exactly what memory-wiki probes for.
-  obsidianHeadless = pkgs.writeShellScriptBin "obsidian" ''
-    exec ${pkgs.xvfb-run}/bin/xvfb-run -a ${pkgs.obsidian}/bin/obsidian "$@"
-  '';
+  obsidianHeadless = pkgs.writeShellScriptBin "obsidian"
+    (builtins.readFile (pkgs.replaceVars ./obsidian-headless.sh {
+      xvfbRun = pkgs.xvfb-run;
+      obsidian = pkgs.obsidian;
+    }));
 in
 # Only enable on kyber (gateway host) — desktops already get pkgs.obsidian
 # directly via home-manager/packages/default.nix.

--- a/home-manager/modules/obsidian/default.nix
+++ b/home-manager/modules/obsidian/default.nix
@@ -17,11 +17,14 @@ let
   # so they get pulled into the closure automatically without needing to
   # appear directly on PATH. Only this shim is exposed as `obsidian`,
   # which is exactly what memory-wiki probes for.
-  obsidianHeadless = pkgs.writeShellScriptBin "obsidian"
-    (builtins.readFile (pkgs.replaceVars ./obsidian-headless.sh {
-      xvfbRun = pkgs.xvfb-run;
-      obsidian = pkgs.obsidian;
-    }));
+  obsidianHeadless = pkgs.writeShellScriptBin "obsidian" (
+    builtins.readFile (
+      pkgs.replaceVars ./obsidian-headless.sh {
+        xvfbRun = pkgs.xvfb-run;
+        obsidian = pkgs.obsidian;
+      }
+    )
+  );
 in
 # Only enable on kyber (gateway host) — desktops already get pkgs.obsidian
 # directly via home-manager/packages/default.nix.

--- a/home-manager/modules/obsidian/obsidian-headless.sh
+++ b/home-manager/modules/obsidian/obsidian-headless.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec @xvfbRun@/bin/xvfb-run -a @obsidian@/bin/obsidian "$@"

--- a/home-manager/programs/fish/functions/_coxel_function.fish
+++ b/home-manager/programs/fish/functions/_coxel_function.fish
@@ -1,13 +1,13 @@
-function _coxel_function --description "Run Codex with a free-form prompt using the local Gemma model"
-  # Run Codex with a free-form prompt (spaces allowed) using the local Gemma model
+function _coxel_function --description "Run Codex with a free-form prompt using the local Qwen model"
+  # Run Codex with a free-form prompt (spaces allowed) using the local Qwen model
   # Usage: cxel [<prompt words...>]
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
     codex resume $argv[2]
   else if test (count $argv) -eq 0
-    codex --oss --local-provider lmstudio --model 'lmstudio-community/gemma-4-e4b-it' --full-auto -c model_reasoning_effort=minimal
+    codex --oss --local-provider lmstudio --model 'qwen/qwen3.5-9b' --full-auto -c model_reasoning_effort=minimal
   else
     set -l prompt (string join " " -- $argv)
-    codex exec --oss --local-provider lmstudio --model 'lmstudio-community/gemma-4-e4b-it' --full-auto -c model_reasoning_effort=minimal -- "$prompt"
+    codex exec --oss --local-provider lmstudio --model 'qwen/qwen3.5-9b' --full-auto -c model_reasoning_effort=minimal -- "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_coxel_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_coxel_function.tpl.fish
@@ -1,13 +1,13 @@
-function _coxel_function --description "Run Codex with a free-form prompt using the local Gemma model"
-  # Run Codex with a free-form prompt (spaces allowed) using the local Gemma model
+function _coxel_function --description "Run Codex with a free-form prompt using the local Qwen model"
+  # Run Codex with a free-form prompt (spaces allowed) using the local Qwen model
   # Usage: cxel [<prompt words...>]
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
     codex resume $argv[2]
   else if test (count $argv) -eq 0
-    codex --oss --local-provider lmstudio --model '__GEMMA__' --full-auto -c model_reasoning_effort=minimal
+    codex --oss --local-provider lmstudio --model '__QWEN_LOCAL__' --full-auto -c model_reasoning_effort=minimal
   else
     set -l prompt (string join " " -- $argv)
-    codex exec --oss --local-provider lmstudio --model '__GEMMA__' --full-auto -c model_reasoning_effort=minimal -- "$prompt"
+    codex exec --oss --local-provider lmstudio --model '__QWEN_LOCAL__' --full-auto -c model_reasoning_effort=minimal -- "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_coxelh_function.fish
+++ b/home-manager/programs/fish/functions/_coxelh_function.fish
@@ -1,5 +1,5 @@
-function _coxelh_function --description "Run Codex headlessly with the local Gemma model"
-  # Prompt for input and run Codex with the local Gemma model
+function _coxelh_function --description "Run Codex headlessly with the local Qwen model"
+  # Prompt for input and run Codex with the local Qwen model
   # Usage: coxelh
 
   set -l prompt
@@ -14,5 +14,5 @@ function _coxelh_function --description "Run Codex headlessly with the local Gem
     return 1
   end
 
-  codex exec --oss --local-provider lmstudio --model 'lmstudio-community/gemma-4-e4b-it' --full-auto -c model_reasoning_effort=minimal -- "$prompt"
+  codex exec --oss --local-provider lmstudio --model 'qwen/qwen3.5-9b' --full-auto -c model_reasoning_effort=minimal -- "$prompt"
 end

--- a/home-manager/programs/fish/functions/_coxelh_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_coxelh_function.tpl.fish
@@ -1,5 +1,5 @@
-function _coxelh_function --description "Run Codex headlessly with the local Gemma model"
-  # Prompt for input and run Codex with the local Gemma model
+function _coxelh_function --description "Run Codex headlessly with the local Qwen model"
+  # Prompt for input and run Codex with the local Qwen model
   # Usage: coxelh
 
   set -l prompt
@@ -14,5 +14,5 @@ function _coxelh_function --description "Run Codex headlessly with the local Gem
     return 1
   end
 
-  codex exec --oss --local-provider lmstudio --model '__GEMMA__' --full-auto -c model_reasoning_effort=minimal -- "$prompt"
+  codex exec --oss --local-provider lmstudio --model '__QWEN_LOCAL__' --full-auto -c model_reasoning_effort=minimal -- "$prompt"
 end

--- a/home-manager/programs/fish/functions/_ocxel_function.fish
+++ b/home-manager/programs/fish/functions/_ocxel_function.fish
@@ -1,17 +1,17 @@
-function _ocxel_function --description "Run OpenCode with a free-form prompt using the local Gemma model"
-  # Run OpenCode with a free-form prompt (spaces allowed) using the local Gemma model
+function _ocxel_function --description "Run OpenCode with a free-form prompt using the local Qwen model"
+  # Run OpenCode with a free-form prompt (spaces allowed) using the local Qwen model
   # Usage: ocxel [<prompt words...>]
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
     if test (count $argv) -gt 1
-      opencode -m 'lmstudio/lmstudio-community/gemma-4-e4b-it' --session "$argv[2]"
+      opencode -m 'lmstudio/qwen/qwen3.5-9b' --session "$argv[2]"
     else
-      opencode -m 'lmstudio/lmstudio-community/gemma-4-e4b-it' --continue
+      opencode -m 'lmstudio/qwen/qwen3.5-9b' --continue
     end
   else if test (count $argv) -eq 0
-    opencode -m 'lmstudio/lmstudio-community/gemma-4-e4b-it'
+    opencode -m 'lmstudio/qwen/qwen3.5-9b'
   else
     set -l prompt (string join " " -- $argv)
-    opencode run "$prompt" -m 'lmstudio/lmstudio-community/gemma-4-e4b-it'
+    opencode run "$prompt" -m 'lmstudio/qwen/qwen3.5-9b'
   end
 end

--- a/home-manager/programs/fish/functions/_ocxel_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_ocxel_function.tpl.fish
@@ -1,17 +1,17 @@
-function _ocxel_function --description "Run OpenCode with a free-form prompt using the local Gemma model"
-  # Run OpenCode with a free-form prompt (spaces allowed) using the local Gemma model
+function _ocxel_function --description "Run OpenCode with a free-form prompt using the local Qwen model"
+  # Run OpenCode with a free-form prompt (spaces allowed) using the local Qwen model
   # Usage: ocxel [<prompt words...>]
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
     if test (count $argv) -gt 1
-      opencode -m 'lmstudio/__GEMMA__' --session "$argv[2]"
+      opencode -m 'lmstudio/__QWEN_LOCAL__' --session "$argv[2]"
     else
-      opencode -m 'lmstudio/__GEMMA__' --continue
+      opencode -m 'lmstudio/__QWEN_LOCAL__' --continue
     end
   else if test (count $argv) -eq 0
-    opencode -m 'lmstudio/__GEMMA__'
+    opencode -m 'lmstudio/__QWEN_LOCAL__'
   else
     set -l prompt (string join " " -- $argv)
-    opencode run "$prompt" -m 'lmstudio/__GEMMA__'
+    opencode run "$prompt" -m 'lmstudio/__QWEN_LOCAL__'
   end
 end

--- a/home-manager/programs/fish/functions/_ocxelh_function.fish
+++ b/home-manager/programs/fish/functions/_ocxelh_function.fish
@@ -1,5 +1,5 @@
-function _ocxelh_function --description "Run OpenCode headlessly with the local Gemma model"
-  # Prompt for input and run OpenCode with the local Gemma model
+function _ocxelh_function --description "Run OpenCode headlessly with the local Qwen model"
+  # Prompt for input and run OpenCode with the local Qwen model
   # Usage: ocxelh
 
   set -l prompt
@@ -14,5 +14,5 @@ function _ocxelh_function --description "Run OpenCode headlessly with the local 
     return 1
   end
 
-  opencode run "$prompt" -m 'lmstudio/lmstudio-community/gemma-4-e4b-it'
+  opencode run "$prompt" -m 'lmstudio/qwen/qwen3.5-9b'
 end

--- a/home-manager/programs/fish/functions/_ocxelh_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_ocxelh_function.tpl.fish
@@ -1,5 +1,5 @@
-function _ocxelh_function --description "Run OpenCode headlessly with the local Gemma model"
-  # Prompt for input and run OpenCode with the local Gemma model
+function _ocxelh_function --description "Run OpenCode headlessly with the local Qwen model"
+  # Prompt for input and run OpenCode with the local Qwen model
   # Usage: ocxelh
 
   set -l prompt
@@ -14,5 +14,5 @@ function _ocxelh_function --description "Run OpenCode headlessly with the local 
     return 1
   end
 
-  opencode run "$prompt" -m 'lmstudio/__GEMMA__'
+  opencode run "$prompt" -m 'lmstudio/__QWEN_LOCAL__'
 end

--- a/home-manager/programs/fish/functions/_pixel_function.fish
+++ b/home-manager/programs/fish/functions/_pixel_function.fish
@@ -3,11 +3,11 @@ function _pixel_function --description "Run Pi with a free-form prompt using the
   # Usage: pixel [<prompt words...>]
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
-    pi --model 'lmstudio/qwen3.5-0.8b-optiq' --resume $argv[2]
+    pi --model 'lmstudio/qwen/qwen3.5-9b' --resume $argv[2]
   else if test (count $argv) -eq 0
-    pi --model 'lmstudio/qwen3.5-0.8b-optiq'
+    pi --model 'lmstudio/qwen/qwen3.5-9b'
   else
     set -l prompt (string join " " -- $argv)
-    pi --model 'lmstudio/qwen3.5-0.8b-optiq' "$prompt"
+    pi --model 'lmstudio/qwen/qwen3.5-9b' "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_pixelh_function.fish
+++ b/home-manager/programs/fish/functions/_pixelh_function.fish
@@ -14,5 +14,5 @@ function _pixelh_function --description "Run Pi headlessly with the local Qwen m
     return 1
   end
 
-  pi --model 'lmstudio/qwen3.5-0.8b-optiq' -p "$prompt"
+  pi --model 'lmstudio/qwen/qwen3.5-9b' -p "$prompt"
 end

--- a/home-manager/programs/ssh/default.nix
+++ b/home-manager/programs/ssh/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   home.file.".ssh/rc" = {
     source = ./rc;
     force = true;

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -257,6 +257,7 @@ home-manager/modules/local-scripts/clipboard-paste.sh
 home-manager/modules/local-scripts/notify-local.sh
 home-manager/modules/local-scripts/tmux-bridge.sh
 home-manager/modules/npm-globals/install-npm-globals.sh
+home-manager/modules/obsidian/obsidian-headless.sh
 home-manager/modules/uv-globals/install-uv-globals.sh
 home-manager/programs/neovim/run_tests.sh
 home-manager/programs/tmux/session-logger.sh

--- a/spec/obsidian_headless_spec.sh
+++ b/spec/obsidian_headless_spec.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'home-manager/modules/obsidian/obsidian-headless.sh'
+SCRIPT="$PWD/home-manager/modules/obsidian/obsidian-headless.sh"
+
+Describe 'script properties'
+It 'uses bash shebang'
+When run bash -c "head -1 '$SCRIPT'"
+The output should include '#!/usr/bin/env bash'
+End
+
+It 'passes bash syntax check after replacing placeholders'
+When run bash -c "sed -e 's|@xvfbRun@|/usr|g' -e 's|@obsidian@|/usr|g' '$SCRIPT' | bash -n"
+The status should be success
+End
+End
+
+Describe 'placeholder references'
+It 'references xvfb-run via placeholder'
+When run bash -c "grep '@xvfbRun@' '$SCRIPT'"
+The output should include '@xvfbRun@'
+End
+
+It 'references obsidian via placeholder'
+When run bash -c "grep '@obsidian@' '$SCRIPT'"
+The output should include '@obsidian@'
+End
+
+It 'uses exec to replace the process'
+When run bash -c "grep '^exec ' '$SCRIPT'"
+The output should include 'exec'
+End
+
+It 'passes all arguments through'
+When run bash -c "grep '[\$]@' '$SCRIPT'"
+The output should include '$@'
+End
+
+It 'uses xvfb-run with auto-servernum flag'
+When run bash -c "grep '\\-a' '$SCRIPT'"
+The output should include '-a'
+End
+End
+
+End


### PR DESCRIPTION
## Summary
- Replace Gemma model references with `qwen/qwen3.5-9b` in all codex/opencode/pi fish functions (both `.fish` and `.tpl.fish`)
- Extract inline shell script from `obsidian/default.nix` to external `obsidian-headless.sh` using `pkgs.replaceVars`

## Fixes
- **shell-test**: 15 failing tests expecting `__QWEN_LOCAL__` placeholder in templates and `qwen/qwen3.5-9b` in non-template functions
- **shell-inline-check**: `writeShellScriptBin` with inline string in obsidian module

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the local LLM from Gemma to Qwen 3.5 9B across Codex/OpenCode/Pi fish helpers and extract the Obsidian headless launcher into an external script with tests. Fixes failing shell tests and the inline script check; also applies Nix formatting across configs.

- **Bug Fixes**
  - Update fish functions to use `qwen/qwen3.5-9b` and templates to use `__QWEN_LOCAL__`, resolving 15 shell-test failures.
  - Replace inline `writeShellScriptBin` in the `obsidian` module with external `obsidian-headless.sh` via `pkgs.replaceVars` (uses `xvfb-run` and `obsidian`); add a test spec and include the script in coverage, satisfying the shell-inline-check.

- **Refactors**
  - Apply Nix formatting across config and module files (no functional changes).

<sup>Written for commit 4e66eb9de3d9ca03cdf0bc29a2b80350bc0e1b14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

