### PR TITLE
fix: add nix-trust target to declaratively trust user in nix daemon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,7 @@ overlays-update: ## Upgrade all custom overlays to latest versions.
 ##@ Nix Setup
 
 .PHONY: nix-setup
-nix-setup: nix-install nix-check nix-connect ## Set up Nix environment (install, check, connect, trust caches). 
+nix-setup: nix-install nix-check nix-connect nix-trust ## Set up Nix environment (install, check, connect, trust caches).
 
 .PHONY: nix-connect
 nix-connect: ## Ensure Nix daemon is running.
@@ -371,6 +371,19 @@ nix-connect: ## Ensure Nix daemon is running.
 	@echo "⏳ Waiting for daemon to initialize..."
 	@sleep 3
 	@echo "✅ Nix daemon should now be active!"
+
+.PHONY: nix-trust
+nix-trust: ## Ensure current user is trusted by the Nix daemon.
+	@if [ "$(OS)" = "Linux" ] && [ "$(NIX_USER_TRUSTED)" = "no" ] && [ "$$CI" != "true" ] && [ "$$IN_DOCKER" != "true" ]; then \
+		echo "🔐 Adding $(NIX_USERNAME) to trusted-users in /etc/nix/nix.conf"; \
+		if grep -q '^trusted-users' /etc/nix/nix.conf 2>/dev/null; then \
+			$(SUDO) sed -i 's/^trusted-users.*/trusted-users = root $(NIX_USERNAME)/' /etc/nix/nix.conf; \
+		else \
+			echo "trusted-users = root $(NIX_USERNAME)" | $(SUDO) tee -a /etc/nix/nix.conf > /dev/null; \
+		fi; \
+		$(SUDO) systemctl restart nix-daemon.service; \
+		echo "✅ $(NIX_USERNAME) is now a trusted Nix user"; \
+	fi
 
 .PHONY: nix-check
 nix-check: ## Verify Nix environment setup.


### PR DESCRIPTION
## Summary
- Adds `nix-trust` Makefile target that ensures the current user is in `trusted-users` in `/etc/nix/nix.conf`
- Wires it into `nix-setup` so it runs automatically during initial setup
- Fixes "ignoring untrusted substituter" warnings on non-NixOS Linux by updating or appending `trusted-users` and restarting the daemon
- Only runs on Linux, non-CI, non-Docker when user isn't already trusted

## Test plan
- [ ] Run `make nix-trust` on a Linux machine where user is not yet trusted
- [ ] Verify `/etc/nix/nix.conf` contains `trusted-users = root <username>`
- [ ] Run `make build && make switch` and confirm no "ignoring untrusted substituter" warnings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `nix-trust` Makefile target and integrates it into `nix-setup` to automatically trust the current Linux user in the Nix daemon, removing “ignoring untrusted substituter” warnings.

- **New Features**
  - `nix-trust`: updates `/etc/nix/nix.conf` to set `trusted-users = root <user>` and restarts `nix-daemon`.
  - Runs only on Linux, outside CI and Docker, and only if the user isn’t already trusted; invoked by `nix-setup`.

<sup>Written for commit dff1d7caa8c893f4da3304ead1a0272907af590a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

