### PR TITLE
feat: add Makefile targets for remote gt operations (df-ral)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1100,3 +1100,31 @@ doppler-upload: ## Upload .env file to Doppler (dotfiles/prd).
 	@doppler secrets upload --project dotfiles --config prd .env
 	@echo "✅ .env uploaded to Doppler (dotfiles/prd)"
 
+##@ Gas Town
+
+.PHONY: gt-remote-setup
+gt-remote-setup: ## Bootstrap Gas Town on a remote server (init town, add rig, start services).
+	@echo "🏭 Bootstrapping Gas Town on remote..."
+	@./scripts/gt-remote-bootstrap.sh
+	@echo "✅ Gas Town bootstrapped"
+
+.PHONY: gt-sync
+gt-sync: ## Push local Dolt databases to configured DoltHub remotes.
+	@echo "🔄 Syncing Dolt databases to remotes..."
+	@gt dolt sync
+	@echo "✅ Dolt databases synced"
+
+.PHONY: gt-pull
+gt-pull: ## Pull Dolt databases from configured remotes.
+	@echo "🔄 Pulling Dolt databases from remotes..."
+	@gt dolt pull
+	@echo "✅ Dolt databases pulled"
+
+.PHONY: gt-status
+gt-status: ## Show Gas Town health and Dolt server status.
+	@gt health
+
+.PHONY: gt-dolt-status
+gt-dolt-status: ## Show Dolt server status and latency.
+	@gt dolt status
+


### PR DESCRIPTION
## Summary

Add Makefile targets for common remote Gas Town operations:
- `gt-remote-setup` - Bootstrap Gas Town on a remote server
- `gt-sync` - Push local Dolt databases to remotes
- `gt-pull` - Pull Dolt databases from remotes
- `gt-status` - Show Gas Town health
- `gt-dolt-status` - Show Dolt server status and latency

**Issue**: df-ral
**Polecat**: nux
**Branch**: polecat/nux-mnthjpp0
**Tests**: Passed (verified by refinery)

---
*Created by Gas Town Refinery*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Makefile targets to set up Gas Town on remote servers and manage Dolt sync and health from one place. Addresses df-ral by enabling remote setup, sync, and status checks.

- **New Features**
  - Added `gt-remote-setup`, `gt-sync`, `gt-pull`, `gt-status`, and `gt-dolt-status` targets to bootstrap remotes, push/pull Dolt data via `gt`, and check health/latency.

<sup>Written for commit 4b412f5a03c428dc152f37d8bc6b49af4e9ef2bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

