### PR TITLE
fix: update Qwen model names in fish tests to match functions

### DIFF
--- a/spec/fish/_coxel_function_test.fish
+++ b/spec/fish/_coxel_function_test.fish
@@ -7,7 +7,7 @@ function codex; echo $argv >> $log1; end
 
 _coxel_function
 
-@test "no args uses substituted Qwen model" (grep -c "qwen/qwen3.5-9b" $log1) -ge 1
+@test "no args uses substituted Qwen model" (grep -c "qwen3.5-0.8b-optiq" $log1) -ge 1
 @test "no args enables oss mode" (grep -c -- "--oss" $log1) -ge 1
 @test "no args uses lmstudio local provider" (grep -c -- "local-provider lmstudio" $log1) -ge 1
 @test "no args lowers reasoning effort" (grep -c "model_reasoning_effort=minimal" $log1) -ge 1
@@ -20,7 +20,7 @@ _coxel_function hello world
 
 @test "with args uses exec subcommand" (grep -c "^exec " $log2) -ge 1
 @test "with args builds prompt" (grep -c "hello world" $log2) -ge 1
-@test "with args uses substituted Qwen model" (grep -c "qwen/qwen3.5-9b" $log2) -ge 1
+@test "with args uses substituted Qwen model" (grep -c "qwen3.5-0.8b-optiq" $log2) -ge 1
 @test "with args enables oss mode" (grep -c -- "--oss" $log2) -ge 1
 @test "with args uses lmstudio local provider" (grep -c -- "local-provider lmstudio" $log2) -ge 1
 @test "with args lowers reasoning effort" (grep -c "model_reasoning_effort=minimal" $log2) -ge 1

--- a/spec/fish/_coxelh_function_test.fish
+++ b/spec/fish/_coxelh_function_test.fish
@@ -10,7 +10,7 @@ function codex; echo $argv >> $log1; end
 echo "hello world" | _coxelh_function
 
 @test "non-empty prompt uses exec subcommand" (grep -c "^exec " $log1) -ge 1
-@test "non-empty prompt uses substituted Qwen model" (grep -c "qwen/qwen3.5-9b" $log1) -ge 1
+@test "non-empty prompt uses substituted Qwen model" (grep -c "qwen3.5-0.8b-optiq" $log1) -ge 1
 @test "non-empty prompt enables oss mode" (grep -c -- "--oss" $log1) -ge 1
 @test "non-empty prompt uses lmstudio local provider" (grep -c -- "local-provider lmstudio" $log1) -ge 1
 @test "non-empty prompt lowers reasoning effort" (grep -c "model_reasoning_effort=minimal" $log1) -ge 1

--- a/spec/fish/_ocxel_function_test.fish
+++ b/spec/fish/_ocxel_function_test.fish
@@ -7,7 +7,7 @@ function opencode; echo $argv >> $log1; end
 
 _ocxel_function
 
-@test "no args calls opencode with local Qwen model" (grep -c "lmstudio/qwen/qwen3.5-9b" $log1) -ge 1
+@test "no args calls opencode with local Qwen model" (grep -c "lmstudio/qwen3.5-0.8b-optiq" $log1) -ge 1
 @test "no args skips run subcommand" (grep -c "^run " $log1) -eq 0
 
 # ── with args: run mode ──────────────────────────────────
@@ -18,6 +18,6 @@ _ocxel_function hello world
 
 @test "with args uses run subcommand" (grep -c "^run " $log2) -ge 1
 @test "with args builds prompt" (grep -c "hello world" $log2) -ge 1
-@test "with args uses local Qwen model" (grep -c "lmstudio/qwen/qwen3.5-9b" $log2) -ge 1
+@test "with args uses local Qwen model" (grep -c "lmstudio/qwen3.5-0.8b-optiq" $log2) -ge 1
 
 rm -f $log1 $log2

--- a/spec/fish/_ocxelh_function_test.fish
+++ b/spec/fish/_ocxelh_function_test.fish
@@ -11,7 +11,7 @@ echo "hello world" | _ocxelh_function
 
 @test "non-empty prompt uses run subcommand" (grep -c "^run " $log1) -ge 1
 @test "non-empty prompt builds prompt" (grep -c "hello world" $log1) -ge 1
-@test "non-empty prompt uses local Qwen model" (grep -c "lmstudio/qwen/qwen3.5-9b" $log1) -ge 1
+@test "non-empty prompt uses local Qwen model" (grep -c "lmstudio/qwen3.5-0.8b-optiq" $log1) -ge 1
 
 set log2 (mktemp)
 function opencode; echo $argv >> $log2; end

--- a/spec/fish/_pixel_function_test.fish
+++ b/spec/fish/_pixel_function_test.fish
@@ -7,7 +7,7 @@ function pi; echo $argv >> $log1; end
 
 _pixel_function
 
-@test "no args calls pi with local Qwen model" (grep -c "lmstudio/qwen/qwen3.5-9b" $log1) -ge 1
+@test "no args calls pi with local Qwen model" (grep -c "lmstudio/qwen3.5-0.8b-optiq" $log1) -ge 1
 
 # ── with args: builds prompt ──────────────────────────────
 set log2 (mktemp)
@@ -16,6 +16,6 @@ function pi; echo $argv >> $log2; end
 _pixel_function hello world
 
 @test "with args builds prompt" (grep -c "hello world" $log2) -ge 1
-@test "with args uses local Qwen model" (grep -c "lmstudio/qwen/qwen3.5-9b" $log2) -ge 1
+@test "with args uses local Qwen model" (grep -c "lmstudio/qwen3.5-0.8b-optiq" $log2) -ge 1
 
 rm -f $log1 $log2

--- a/spec/fish/_pixelh_function_test.fish
+++ b/spec/fish/_pixelh_function_test.fish
@@ -10,7 +10,7 @@ function pi; echo $argv >> $log1; end
 echo "hello world" | _pixelh_function
 
 @test "non-empty prompt builds prompt" (grep -c "hello world" $log1) -ge 1
-@test "non-empty prompt uses local Qwen model" (grep -c "lmstudio/qwen/qwen3.5-9b" $log1) -ge 1
+@test "non-empty prompt uses local Qwen model" (grep -c "lmstudio/qwen3.5-0.8b-optiq" $log1) -ge 1
 @test "non-empty prompt uses print mode" (grep -c -- "-p" $log1) -ge 1
 
 set log2 (mktemp)


### PR DESCRIPTION
## Summary
- Updated 6 fish test files to use `qwen3.5-0.8b-optiq` model name matching the actual functions
- Tests were referencing old `qwen/qwen3.5-9b` model which no longer matches the implementation

## Test plan
- [x] `make shell-lint` passes
- [x] `make shell-test` passes (269/269 fish, 1016/1016 bash)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update fish tests to use the new Qwen model names used by the functions, replacing `qwen/qwen3.5-9b` with `qwen3.5-0.8b-optiq` and `lmstudio/qwen/qwen3.5-9b` with `lmstudio/qwen3.5-0.8b-optiq`. Fixes test failures by aligning expectations across `_coxel*`, `_ocxel*`, and `_pixel*` suites.

<sup>Written for commit 849bac97ef168ece77636a99609eee171932fdf3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

