### PR TITLE
fix: make WorktreeCreate hook idempotent when branch exists

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -390,7 +390,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'NAME=$(jq -r .name); REPO=$(git rev-parse --show-toplevel); DIR=\"$REPO/.worktrees/$NAME\"; wt switch --create \"$NAME\" --no-cd -y >&2 && echo \"$DIR\"'",
+            "command": "bash -c 'NAME=$(jq -r .name); REPO=$(git rev-parse --show-toplevel); DIR=\"$REPO/.worktrees/$NAME\"; (wt switch --create \"$NAME\" --no-cd -y || wt switch \"$NAME\" --no-cd -y) >&2 && echo \"$DIR\"'",
             "timeout": 30
           }
         ]


### PR DESCRIPTION
## Summary

The `WorktreeCreate` hook in `config/claude/settings.json` runs `wt switch --create "$NAME" --no-cd -y && echo "$DIR"`. When a branch/worktree for `$NAME` already exists (e.g. from a prior failed attempt or reuse), `wt switch --create` exits non-zero, the `&&` short-circuits, nothing is emitted to stdout, and Claude Code reports:

```
Error creating worktree: WorktreeCreate hook failed: no successful output
```

Fix: fall back to plain `wt switch "$NAME"` when `--create` fails, so the hook still emits the worktree path on stdout and Claude can proceed.

## Repro

```
$ echo '{"name":"test"}' | bash -c '... wt switch --create "test" ... && echo "$DIR"'
# first run: succeeds
# second run:
✗ Branch test already exists
# exit 1, nothing on stdout -> Claude: "no successful output"
```

## Test plan

- [x] First invocation still creates the worktree and echoes the path
- [x] Second invocation (branch already exists) falls through to `wt switch` and echoes the same path
- [ ] Trigger `EnterWorktree` from Claude Code against an existing branch name

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the WorktreeCreate hook idempotent so reruns on an existing branch still succeed and return the worktree path. This avoids “no successful output” errors in Claude Code when reusing a branch/worktree.

- **Bug Fixes**
  - In `config/claude/settings.json`, added a fallback: `(wt switch --create "$NAME" --no-cd -y || wt switch "$NAME" --no-cd -y) >&2 && echo "$DIR"`.

<sup>Written for commit c5af2862de240f44196048de46bc4c5c206665c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

