### PR TITLE
fix: use .rlib path for frankensearch local binary entry

### DIFF
--- a/.local-binaries.txt
+++ b/.local-binaries.txt
@@ -7,6 +7,7 @@
 # cass dependencies (pull + build before cass itself)
 ~/ghq/github.com/Dicklesworthstone/asupersync/target/release/libasupersync.rlib
 ~/ghq/github.com/Dicklesworthstone/franken_agent_detection/target/release/libfranken_agent_detection.rlib
+~/ghq/github.com/Dicklesworthstone/frankensearch/target/release/libfrankensearch.rlib
 ~/ghq/github.com/Dicklesworthstone/frankensqlite/target/release/libfsqlite.rlib
 
 ~/ghq/github.com/Dicklesworthstone/beads_viewer/bv


### PR DESCRIPTION
## Summary
- Changed frankensearch entry in `.local-binaries.txt` from a bare directory path to the specific `.rlib` target path
- Consistent with other library dependencies (asupersync, franken_agent_detection, frankensqlite)
- Triggers `--lib` flag in the build script, skipping unnecessary test/binary compilation

## Test plan
- [ ] Run `./scripts/update-local-binaries.sh frankensearch` and verify it builds with `--lib`
- [ ] Run `./scripts/update-local-binaries.sh cass` and verify cass links against the built rlib

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Point `frankensearch` in `.local-binaries.txt` to its release `libfrankensearch.rlib` instead of the directory. This matches other libs, forces `--lib` builds to avoid unnecessary test/binary compilation, and ensures `cass` links against the rlib.

<sup>Written for commit d919a9444668a1cb3662d3eb1ae7e5498bceba0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

