### PR TITLE
feat: advertise kyber as Tailscale exit node

### DIFF
--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -157,6 +157,7 @@ home-manager.lib.homeManagerConfiguration {
           extraUpArgs = [
             "--reset"
             "--accept-dns=false"
+            "--advertise-exit-node"
           ];
         };
       }


### PR DESCRIPTION
## Summary
- Adds `--advertise-exit-node` to kyber's Tailscale config so galactica and other devices can route all traffic through kyber

## Setup after merge
1. Deploy to kyber
2. Approve exit node in [Tailscale admin console](https://login.tailscale.com/admin/machines)
3. Enable IP forwarding on kyber: `sudo sysctl -w net.ipv4.ip_forward=1`
4. On client devices: `tailscale set --exit-node=kyber`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--advertise-exit-node` to kyber’s `tailscale` config so galactica and other devices can route all traffic through kyber.

- **Migration**
  - Deploy to kyber.
  - Approve the exit node in the Tailscale admin console: https://login.tailscale.com/admin/machines
  - Enable IP forwarding on kyber: `sudo sysctl -w net.ipv4.ip_forward=1`
  - On clients: `tailscale set --exit-node=kyber`

<sup>Written for commit 1db495a7295b51963c07c7f7b2aa454aa03a1997. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

