### PR TITLE
fix: disable Electron SUID sandbox for obsidian headless wrapper

### DIFF
--- a/home-manager/modules/obsidian/obsidian-headless.sh
+++ b/home-manager/modules/obsidian/obsidian-headless.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-exec @xvfbRun@/bin/xvfb-run -a @obsidian@/bin/obsidian "$@"
+exec @xvfbRun@/bin/xvfb-run -a @obsidian@/bin/obsidian --no-sandbox "$@"


### PR DESCRIPTION
## Summary
- Add `--no-sandbox` to the obsidian headless wrapper to fix SUID sandbox crash on NixOS
- The Nix store cannot provide root-owned setuid binaries, so `chrome-sandbox` always fails
- Safe for this use case since the wrapper runs headless CLI commands, not untrusted web content

## Test plan
- [ ] Run `obsidian` CLI on kyber and verify it no longer crashes with SUID sandbox error
- [ ] Verify `obsidian --help` and vault commands work under `xvfb-run`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Electron SUID sandbox in the Obsidian headless wrapper to stop crashes on NixOS. Adds `--no-sandbox` to the `obsidian` call under `xvfb-run`, which is safe for our headless CLI usage.

<sup>Written for commit 8c60e55cc052c7e06597042737df118e751687d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

