### PR TITLE
fix: add --disable-gpu to obsidian headless wrapper

### DIFF
--- a/home-manager/modules/obsidian/obsidian-headless.sh
+++ b/home-manager/modules/obsidian/obsidian-headless.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-exec @xvfbRun@/bin/xvfb-run -a @obsidian@/bin/obsidian --no-sandbox "$@"
+exec @xvfbRun@/bin/xvfb-run -a @obsidian@/bin/obsidian --no-sandbox --disable-gpu "$@"


### PR DESCRIPTION
## Summary
- Adds `--disable-gpu` flag to the obsidian headless wrapper to prevent GLX/ANGLE initialization errors on kyber (headless host without GPU)
- Follows up on #1433 which added `--no-sandbox`

## Test plan
- [ ] Rebuild home-manager on kyber and run `obsidian` CLI
- [ ] Verify no more `ANGLE Display::initialize error` / `GLX is not present` stderr spam

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add --disable-gpu to the Obsidian headless wrapper to prevent GLX/ANGLE initialization errors on GPU-less hosts (e.g., kyber) and stop stderr spam. Follows up on #1433 which added --no-sandbox.

<sup>Written for commit d05bce99a37336483f0193961c04ef62f271a08f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

