### PR TITLE
feat: add Obsidian headless systemd service for kyber

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -907,7 +907,7 @@ launchctl-tmux-session-logger: ## Restart tmux-session-logger launchd agent.
 ##@ Systemd Services (Linux)
 
 .PHONY: systemctl
-systemctl: systemctl-cliproxyapi systemctl-cliproxyapi-backup systemctl-code-syncer systemctl-docker-postgres systemctl-dotfiles-updater systemctl-make-updater systemctl-neverssl-keepalive systemctl-ollama systemctl-openclaw systemctl-paperclip systemctl-tmux-session-logger ## Restart all systemd user services.
+systemctl: systemctl-cliproxyapi systemctl-cliproxyapi-backup systemctl-code-syncer systemctl-docker-postgres systemctl-dotfiles-updater systemctl-make-updater systemctl-neverssl-keepalive systemctl-obsidian systemctl-ollama systemctl-openclaw systemctl-paperclip systemctl-tmux-session-logger ## Restart all systemd user services.
 
 .PHONY: systemctl-cliproxyapi
 systemctl-cliproxyapi: ## Restart cliproxyapi systemd user service.
@@ -951,6 +951,17 @@ systemctl-neverssl-keepalive: ## Restart neverssl-keepalive systemd timer and se
 	@echo "🔄 Restarting neverssl-keepalive..."
 	@systemctl --user restart neverssl-keepalive.timer || true
 	@echo "✅ neverssl-keepalive restarted"
+
+.PHONY: systemctl-obsidian
+systemctl-obsidian: ## Restart Obsidian headless systemd user service.
+	@echo "🔄 Restarting obsidian..."
+	@if [ "$(DETECTED_HOST)" = "kyber" ] || [ "$(HOST)" = "kyber" ]; then \
+		systemctl --user daemon-reload; \
+		systemctl --user restart obsidian.service; \
+	else \
+		echo "Skipping obsidian.service (host not kyber)"; \
+	fi
+	@echo "✅ obsidian restarted"
 
 .PHONY: systemctl-ollama
 systemctl-ollama: ## Restart ollama systemd user service.

--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -15,9 +15,9 @@ let
   dockerPostgres = import ./docker-postgres { inherit pkgs; };
   dotfilesUpdater = import ./dotfiles-updater { inherit pkgs; };
   gasTown = import ./gas-town { inherit pkgs; };
-  obsidian = import ./obsidian { inherit pkgs inputs; };
   makeUpdater = import ./make-updater { inherit pkgs; };
   neversslKeepalive = import ./neverssl-keepalive { inherit pkgs; };
+  obsidian = import ./obsidian { inherit pkgs inputs; };
   ollama = import ./ollama { inherit pkgs inputs; };
   sshAgent = import ./ssh-agent {
     inherit config lib pkgs;
@@ -34,9 +34,9 @@ in
   dockerPostgres
   dotfilesUpdater
   gasTown
-  obsidian
   makeUpdater
   neversslKeepalive
+  obsidian
   ollama
   sshAgent
   tmuxSessionLogger

--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -15,6 +15,7 @@ let
   dockerPostgres = import ./docker-postgres { inherit pkgs; };
   dotfilesUpdater = import ./dotfiles-updater { inherit pkgs; };
   gasTown = import ./gas-town { inherit pkgs; };
+  obsidian = import ./obsidian { inherit pkgs inputs; };
   makeUpdater = import ./make-updater { inherit pkgs; };
   neversslKeepalive = import ./neverssl-keepalive { inherit pkgs; };
   ollama = import ./ollama { inherit pkgs inputs; };
@@ -33,6 +34,7 @@ in
   dockerPostgres
   dotfilesUpdater
   gasTown
+  obsidian
   makeUpdater
   neversslKeepalive
   ollama

--- a/home-manager/services/obsidian/default.nix
+++ b/home-manager/services/obsidian/default.nix
@@ -1,0 +1,35 @@
+{
+  pkgs,
+  inputs,
+  ...
+}:
+let
+  inherit (pkgs) lib;
+  inherit (inputs) host;
+
+  obsidianHeadless = pkgs.writeShellScriptBin "obsidian" (
+    builtins.readFile (
+      pkgs.replaceVars ../../modules/obsidian/obsidian-headless.sh {
+        xvfbRun = pkgs.xvfb-run;
+        inherit (pkgs) obsidian;
+      }
+    )
+  );
+in
+lib.mkIf host.isKyber {
+  systemd.user.services.obsidian = {
+    Unit = {
+      Description = "Obsidian headless daemon (xvfb-run CLI socket)";
+      After = [ "network.target" ];
+    };
+    Service = {
+      Type = "simple";
+      ExecStart = "${obsidianHeadless}/bin/obsidian";
+      Restart = "always";
+      RestartSec = 10;
+    };
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `obsidian.service` systemd user service that runs Obsidian headlessly via xvfb-run on kyber, keeping the CLI socket available for memory-wiki and other tools
- Adds `make systemctl-obsidian` target with kyber host guard (matches openclaw/paperclip pattern)
- Wires service into `home-manager/services/default.nix`

## Test plan
- [ ] `make switch` on kyber succeeds
- [ ] `systemctl --user status obsidian` shows active after login
- [ ] `obsidian list-vaults` works via the running daemon socket
- [ ] `make systemctl-obsidian` restarts the service on kyber
- [ ] `make systemctl-obsidian` skips gracefully on non-kyber hosts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a headless `obsidian.service` user service on kyber to keep the Obsidian CLI socket available, plus a `make systemctl-obsidian` target to restart it.

- **New Features**
  - `obsidian.service`: runs Obsidian via `xvfb-run`, `Restart=always`, `WantedBy=default.target`.
  - `make systemctl-obsidian`: restarts the service; skips on non-kyber; included in `make systemctl`.
  - Integrated into `home-manager/services/default.nix` behind `host.isKyber`; alphabetized service imports.

<sup>Written for commit 716c03f0497f6f8fefc56965dd965d6ded2ebb6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

