### PR TITLE
fix(kyber): resolve sudo not found in enableIpForwarding activation

### DIFF
--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -148,14 +148,39 @@ home-manager.lib.homeManagerConfiguration {
 
         # IP forwarding for Tailscale exit node
         home.activation.enableIpForwarding = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+          # Resolve an elevated command helper
+          SUDO_CMD=""
+          if command -v sudo >/dev/null 2>&1; then
+            SUDO_CMD="sudo"
+          elif [ -x /run/wrappers/bin/sudo ]; then
+            SUDO_CMD="/run/wrappers/bin/sudo"
+          elif [ -x /usr/bin/sudo ]; then
+            SUDO_CMD="/usr/bin/sudo"
+          elif command -v doas >/dev/null 2>&1; then
+            SUDO_CMD="doas"
+          elif [ -x /usr/bin/doas ]; then
+            SUDO_CMD="/usr/bin/doas"
+          elif [ "$(id -u)" -ne 0 ]; then
+            echo "IP forwarding requires root privileges, but sudo/doas is not available." >&2
+            exit 1
+          fi
+
+          run_root_cmd() {
+            if [ -n "$SUDO_CMD" ]; then
+              ''${DRY_RUN_CMD:-} "$SUDO_CMD" "$@"
+            else
+              ''${DRY_RUN_CMD:-} "$@"
+            fi
+          }
+
           if [ "$(cat /proc/sys/net/ipv4/ip_forward)" != "1" ]; then
             echo "Enabling IP forwarding for Tailscale exit node..."
-            sudo sysctl -w net.ipv4.ip_forward=1
-            sudo sysctl -w net.ipv6.conf.all.forwarding=1
+            run_root_cmd sysctl -w net.ipv4.ip_forward=1
+            run_root_cmd sysctl -w net.ipv6.conf.all.forwarding=1
           fi
           if [ ! -f /etc/sysctl.d/99-tailscale.conf ]; then
-            echo 'net.ipv4.ip_forward=1' | sudo tee /etc/sysctl.d/99-tailscale.conf
-            echo 'net.ipv6.conf.all.forwarding=1' | sudo tee -a /etc/sysctl.d/99-tailscale.conf
+            echo 'net.ipv4.ip_forward=1' | run_root_cmd tee /etc/sysctl.d/99-tailscale.conf
+            echo 'net.ipv6.conf.all.forwarding=1' | run_root_cmd tee -a /etc/sysctl.d/99-tailscale.conf
           fi
         '';
 


### PR DESCRIPTION
## Summary
- The `enableIpForwarding` home-manager activation hook used bare `sudo` which is not on PATH during activation, causing `command not found` on `make nix-switch`
- Replaced with the same sudo discovery pattern used by the tailscale module (checks `command -v sudo`, `/run/wrappers/bin/sudo`, `/usr/bin/sudo`, `doas`)
- Includes `DRY_RUN_CMD` support consistent with other activation hooks

## Test plan
- [ ] Run `make nix-switch` on kyber - should no longer fail with `sudo: command not found`
- [ ] Verify IP forwarding is enabled after activation (`cat /proc/sys/net/ipv4/ip_forward`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the kyber Home Manager activation error where `enableIpForwarding` used `sudo` that wasn’t on PATH, breaking `make nix-switch`. Adds a robust root command helper and `DRY_RUN_CMD` support so IP forwarding is applied reliably.

- **Bug Fixes**
  - Replace bare `sudo` with discovery of `sudo` (PATH, `/run/wrappers/bin/sudo`, `/usr/bin/sudo`) or `doas`; fail if neither is available and not root, matching the tailscale module pattern.
  - Add `run_root_cmd` wrapper that honors `DRY_RUN_CMD` and use it for `sysctl` and `tee`.

<sup>Written for commit 327d5fdce116221ec36176d72c6f51dbcc9e3709. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

