### PR TITLE
feat(obsidian): register wiki vault with cross-platform path

### DIFF
--- a/config/obsidian/default.nix
+++ b/config/obsidian/default.nix
@@ -1,13 +1,24 @@
 {
+  config,
   inputs,
+  pkgs,
   ...
 }:
 let
-  inherit (inputs.host) isKyber;
+  inherit (inputs.host) isKyber isGalactica;
+  enabled = isKyber || isGalactica;
+  obsidianJson = pkgs.writeText "obsidian.json" (builtins.toJSON {
+    cli = true;
+    vaults.wiki = {
+      path = "${config.home.homeDirectory}/ghq/github.com/shunkakinoki/wiki";
+      ts = 0;
+      open = true;
+    };
+  });
 in
 {
   xdg.configFile."obsidian/obsidian.json" = {
-    source = ./obsidian.json;
-    enable = isKyber;
+    source = obsidianJson;
+    enable = enabled;
   };
 }


### PR DESCRIPTION
## Summary

- Generate `obsidian.json` dynamically via Nix using `config.home.homeDirectory` so the vault path resolves correctly on both kyber (`/home/ubuntu`) and galactica (`/Users/shunkakinoki`)
- Set `open = true` on the vault so the headless daemon auto-opens it on startup, enabling the Obsidian CLI
- Enable the config on both `isKyber` and `isGalactica` (was kyber-only)

## Test plan

- [x] Verified `obsidian help` works on kyber after `make switch` + service restart
- [ ] Verify on galactica after next `make switch`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers the Obsidian wiki vault with a cross‑platform path and auto‑opens it on startup to enable the headless `obsidian` CLI. Fixes “Vault not found” on kyber and galactica.

- **New Features**
  - Dynamically generates `obsidian.json` via Nix using `config.home.homeDirectory` so the vault path resolves on both hosts.
  - Enables the config on kyber and galactica; sets `open = true` so the daemon opens the vault automatically.

<sup>Written for commit e29ed90e4d97899509dc3c453bc025945673818f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

