### PR TITLE
build(deps): Add btca dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,7 @@
         "acpx": "^0.5.3",
         "agent-browser": "^0.25.3",
         "agentcash": "^0.13.8",
+        "btca": "^2.0.5",
         "ccusage": "^18.0.10",
         "chrome-devtools-axi": "^0.1.15",
         "chrome-devtools-mcp": "^0.21.0",
@@ -1870,6 +1871,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
+
+    "btca": ["btca@2.0.5", "", { "bin": { "btca": "bin.js" } }, "sha512-NnVCMCs9EPtVjJyB1sRa2T940eUVVtqulvktfYwMeI6THzCNo8w7OqhUyHnJ+SUWSF5WKUX4Dh1gyxdyd+/DLQ=="],
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "acpx": "^0.5.3",
     "agent-browser": "^0.25.3",
     "agentcash": "^0.13.8",
+    "btca": "^2.0.5",
     "ccusage": "^18.0.10",
     "chrome-devtools-axi": "^0.1.15",
     "chrome-devtools-mcp": "^0.21.0",


### PR DESCRIPTION
Add btca package to project dependencies

This PR adds the btca package version ^2.0.5 to the project's
dependency list. The package is added to both package.json and the
bun.lock file has been updated accordingly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `btca` (^2.0.5) as a new runtime dependency. Updated `package.json` and `bun.lock` to include it.

<sup>Written for commit 6a9c8acad2e1adb5317d99048b93d52140a20756. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

