### PR TITLE
fix(make-updater): add neovim to service PATH

### DIFF
--- a/home-manager/services/make-updater/default.nix
+++ b/home-manager/services/make-updater/default.nix
@@ -50,6 +50,7 @@ in
             pkgs.gnused
             pkgs.go
             pkgs.libtool
+            pkgs.neovim
             pkgs.nix
             pkgs.openssl.dev
             pkgs.pkg-config


### PR DESCRIPTION
## Summary
- Add `pkgs.neovim` to the `make-updater` systemd service `PATH`
- The `neovim-update` Makefile target calls `nvim --headless` but `nvim` was not in the service's `lib.makeBinPath` list, causing every run to fail with `command not found` (exit 127)

## Test plan
- [ ] Rebuild home-manager config
- [ ] Run `systemctl --user restart make-updater.service` and verify it completes successfully
- [ ] Confirm `systemctl --user status make-updater.service` shows no failure

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `pkgs.neovim` to the `make-updater` systemd service PATH. This fixes exit 127 "command not found" errors when the `neovim-update` Makefile target runs `nvim --headless`.

<sup>Written for commit 50a52c0314421d1bbdbeffaa68347efd4293be4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

