### PR TITLE
Chore mempalace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,7 @@ rtk-rewrite-sync: ## Sync rtk-rewrite.sh from upstream rtk repo.
 update: nix-update neovim-update gitalias-update llm-update overlays-update  ## Update Nix flake, overlays, Neovim plugins, LLM configs, gitalias, and bun deps
 
 .PHONY: update-lock
-update-lock: nix-flake-update bun-update cargo-update ## Update lock files for Nix flake, bun, and Cargo.
+update-lock: nix-flake-update bun-update cargo-update uv-update ## Update lock files for Nix flake, bun, and Cargo.
 
 .PHONY: bun-update
 bun-update: ## Update bun dependencies to latest and regenerate lock file.
@@ -294,19 +294,6 @@ bun-update: ## Update bun dependencies to latest and regenerate lock file.
 	@git checkout bun.lock
 	@bun install
 	@echo "✅ bun dependencies updated"
-
-.PHONY: uv-update
-uv-update: ## Update uv tool versions in pyproject.toml to latest.
-	@echo "🐍 Updating uv dependencies..."
-	@tomlq -r '.["dependency-groups"].tools[]' pyproject.toml | while read -r pkg; do \
-		name=$${pkg%%[><=!]*}; \
-		latest=$$(uv pip compile --no-deps - <<< "$$name" 2>/dev/null | grep "^$$name==" | sed "s/$$name==//"); \
-		if [ -n "$$latest" ]; then \
-			sed -i '' "s|\"$$name>=.*\"|\"$$name>=$$latest\"|" pyproject.toml; \
-			echo "  $$name -> $$latest"; \
-		fi; \
-	done
-	@echo "✅ uv dependencies updated"
 
 .PHONY: cargo-update
 cargo-update: ## Update Rust dependencies to latest and regenerate lock file.
@@ -334,6 +321,19 @@ overlays-update: ## Upgrade all custom overlays to latest versions.
 	else \
 		./scripts/upgrade-overlays.sh all; \
 	fi
+
+.PHONY: uv-update
+uv-update: ## Update uv tool versions in pyproject.toml to latest.
+	@echo "🐍 Updating uv dependencies..."
+	@tomlq -r '.["dependency-groups"].tools[]' pyproject.toml | while read -r pkg; do \
+		name=$${pkg%%[><=!]*}; \
+		latest=$$(uv pip compile --no-deps - <<< "$$name" 2>/dev/null | grep "^$$name==" | sed "s/$$name==//"); \
+		if [ -n "$$latest" ]; then \
+			sed -i '' "s|\"$$name>=.*\"|\"$$name>=$$latest\"|" pyproject.toml; \
+			echo "  $$name -> $$latest"; \
+		fi; \
+	done
+	@echo "✅ uv dependencies updated"
 
 ##@ Nix Setup
 

--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,19 @@ bun-update: ## Update bun dependencies to latest and regenerate lock file.
 	@bun install
 	@echo "✅ bun dependencies updated"
 
+.PHONY: uv-update
+uv-update: ## Update uv tool versions in pyproject.toml to latest.
+	@echo "🐍 Updating uv dependencies..."
+	@tomlq -r '.["dependency-groups"].tools[]' pyproject.toml | while read -r pkg; do \
+		name=$${pkg%%[><=!]*}; \
+		latest=$$(uv pip compile --no-deps - <<< "$$name" 2>/dev/null | grep "^$$name==" | sed "s/$$name==//"); \
+		if [ -n "$$latest" ]; then \
+			sed -i '' "s|\"$$name>=.*\"|\"$$name>=$$latest\"|" pyproject.toml; \
+			echo "  $$name -> $$latest"; \
+		fi; \
+	done
+	@echo "✅ uv dependencies updated"
+
 .PHONY: cargo-update
 cargo-update: ## Update Rust dependencies to latest and regenerate lock file.
 	@echo "🦀 Updating Cargo dependencies..."

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -424,34 +424,35 @@
     "command": "$HOME/.claude/hooks/statusline.sh"
   },
   "enabledPlugins": {
+    "clangd-lsp@claude-plugins-official": true,
     "claude-mem@claude-mem": true,
     "code-review@claude-plugins-official": true,
     "code-simplifier@claude-plugins-official": true,
+    "codex@openai-codex": true,
     "commit-commands@claude-plugins-official": true,
     "context7@claude-plugins-official": true,
+    "csharp-lsp@claude-plugins-official": true,
     "feature-dev@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true,
-    "plan-export@cc-marketplace": true,
-    "pr-review-toolkit@claude-plugins-official": true,
-    "qmd@qmd": true,
-    "ralph-loop@claude-plugins-official": true,
-    "safety-net@cc-marketplace": true,
-    "serena@claude-plugins-official": true,
-    "skill-codex@skill-codex": true,
-    "clangd-lsp@claude-plugins-official": true,
-    "csharp-lsp@claude-plugins-official": true,
     "gopls-lsp@claude-plugins-official": true,
     "jdtls-lsp@claude-plugins-official": true,
     "kotlin-lsp@claude-plugins-official": true,
     "lua-lsp@claude-plugins-official": true,
+    "mempalace@mempalace": true,
     "php-lsp@claude-plugins-official": true,
+    "plan-export@cc-marketplace": true,
+    "pr-review-toolkit@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": true,
+    "qmd@qmd": true,
+    "ralph-loop@claude-plugins-official": true,
     "ruby-lsp@claude-plugins-official": true,
     "rust-analyzer-lsp@claude-plugins-official": true,
+    "safety-net@cc-marketplace": true,
+    "serena@claude-plugins-official": true,
+    "skill-codex@skill-codex": true,
     "swift-lsp@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
-    "worktrunk@worktrunk": true,
-    "codex@openai-codex": true
+    "worktrunk@worktrunk": true
   },
   "extraKnownMarketplaces": {
     "cc-marketplace": {
@@ -464,6 +465,18 @@
       "source": {
         "source": "github",
         "repo": "thedotmack/claude-mem"
+      }
+    },
+    "mempalace": {
+      "source": {
+        "source": "github",
+        "repo": "milla-jovovich/mempalace"
+      }
+    },
+    "openai-codex": {
+      "source": {
+        "source": "github",
+        "repo": "openai/codex-plugin-cc"
       }
     },
     "qmd": {
@@ -482,12 +495,6 @@
       "source": {
         "source": "github",
         "repo": "max-sixty/worktrunk"
-      }
-    },
-    "openai-codex": {
-      "source": {
-        "source": "github",
-        "repo": "openai/codex-plugin-cc"
       }
     }
   },

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -100,6 +100,7 @@ with pkgs;
   victorialogs
   victoriametrics
   victoriatraces
+  vllm
   watchexec
   wget
   yarn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ tools = [
   "mempalace>=3.0.0",
   "mistral-vibe>=2.7.3",
   "ruff>=0.15.9",
-  "vllm>=0.19.0",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ tools = [
   "mempalace>=3.0.0",
   "mistral-vibe>=2.7.3",
   "ruff>=0.15.9",
+  "vllm>=0.19.0",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ tools = [
   "mempalace>=3.0.0",
   "mistral-vibe>=2.7.3",
   "ruff>=0.15.9",
+  "vllm>=0.11.0",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ requires-python = ">=3.13"
 [dependency-groups]
 tools = [
   "aider-chat>=0.86.2",
-  "marker-pdf>=1.10.2",
-  "mistral-vibe>=2.7.3",
   "claude-swap>=0.7.1",
+  "marker-pdf>=1.10.2",
   "mempalace>=3.0.0",
+  "mistral-vibe>=2.7.3",
   "ruff>=0.15.9",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ tools = [
   "marker-pdf>=1.10.2",
   "mistral-vibe>=2.7.3",
   "claude-swap>=0.7.1",
+  "mempalace>=3.0.0",
   "ruff>=0.15.9",
 ]
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds the `mempalace` plugin to Claude and introduces an `uv-update` task to keep Python tool versions current. Also adds `vllm` to both Nix packages and Python tools.

- **New Features**
  - Enable `mempalace` plugin and register its marketplace source.
  - Add `uv-update` Makefile target and include it in `update-lock` to bump `pyproject.toml` tool constraints using `uv`.

- **Dependencies**
  - Add `mempalace` and `vllm` to `pyproject.toml` tools; reorder entries for clarity.
  - Add `vllm` to `home-manager` packages.

<sup>Written for commit acace02e733e7df802a8478429bbf283d240e919. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

