### PR TITLE
feat(services): add QMD hybrid search service for wiki

### DIFF
--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -19,6 +19,7 @@ let
   neversslKeepalive = import ./neverssl-keepalive { inherit pkgs; };
   obsidian = import ./obsidian { inherit pkgs inputs; };
   ollama = import ./ollama { inherit pkgs inputs; };
+  qmd = import ./qmd { inherit config pkgs inputs; };
   openclaw = import ./openclaw {
     inherit
       config
@@ -54,6 +55,7 @@ in
   neversslKeepalive
   obsidian
   ollama
+  qmd
   openclaw
   paperclip
   sshAgent

--- a/home-manager/services/qmd/activate.sh
+++ b/home-manager/services/qmd/activate.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+QMD_BIN="$1"
+WIKI_DIR="$2"
+
+# Add wiki collection if not already present
+if ! "$QMD_BIN" collection list 2>/dev/null | grep -q "wiki"; then
+  "$QMD_BIN" collection add "$WIKI_DIR"
+fi

--- a/home-manager/services/qmd/default.nix
+++ b/home-manager/services/qmd/default.nix
@@ -1,0 +1,45 @@
+{ config, pkgs, inputs, ... }:
+let
+  inherit (pkgs) lib;
+  inherit (inputs.host) isKyber isGalactica;
+  homeDir = config.home.homeDirectory;
+  wikiDir = "${homeDir}/ghq/github.com/shunkakinoki/wiki";
+  qmdBin = "${homeDir}/.bun/bin/qmd";
+  enabled = isKyber || isGalactica;
+in
+lib.mkIf enabled {
+  home.activation.qmdSetup = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${qmdBin}" "${wikiDir}"
+  '';
+
+  launchd.agents.qmd = lib.mkIf pkgs.stdenv.isDarwin {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        qmdBin
+        "mcp"
+        "--http"
+      ];
+      KeepAlive = true;
+      RunAtLoad = true;
+      StandardOutPath = "/tmp/qmd.log";
+      StandardErrorPath = "/tmp/qmd.error.log";
+    };
+  };
+
+  systemd.user.services.qmd = lib.mkIf pkgs.stdenv.isLinux {
+    Unit = {
+      Description = "QMD hybrid search engine";
+      After = [ "network.target" ];
+    };
+    Service = {
+      Type = "simple";
+      ExecStart = "${qmdBin} mcp --http";
+      Restart = "always";
+      RestartSec = 5;
+    };
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
+}

--- a/spec/activate_qmd_spec.sh
+++ b/spec/activate_qmd_spec.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016,SC2329
+
+Describe 'home-manager/services/qmd/activate.sh'
+SCRIPT="$PWD/home-manager/services/qmd/activate.sh"
+
+It 'uses bash shebang'
+When run bash -c "head -1 '$SCRIPT'"
+The output should include '#!/usr/bin/env bash'
+End
+
+It 'checks for existing wiki collection'
+When run bash -c "grep 'collection list' '$SCRIPT'"
+The output should include 'collection list'
+End
+
+It 'adds wiki collection when missing'
+When run bash -c "grep 'collection add' '$SCRIPT'"
+The output should include 'collection add'
+End
+End
+
+Describe 'home-manager/services/qmd/default.nix'
+It 'enables on kyber and galactica only'
+When run bash -c "grep 'isKyber || isGalactica' '$PWD/home-manager/services/qmd/default.nix'"
+The output should include 'isKyber || isGalactica'
+End
+
+It 'runs qmd mcp --http'
+When run bash -c "grep 'mcp' '$PWD/home-manager/services/qmd/default.nix'"
+The output should include '"mcp"'
+End
+
+It 'quotes the activate script arguments'
+When run cat "$PWD/home-manager/services/qmd/default.nix"
+The output should include '"${./activate.sh}" "${qmdBin}" "${wikiDir}"'
+End
+End

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -371,6 +371,7 @@ home-manager/modules/npm-globals/install-npm-globals.sh
 home-manager/services/obsidian/obsidian-headless.sh
 home-manager/services/openclaw/activate.sh
 home-manager/services/paperclip/activate.sh
+home-manager/services/qmd/activate.sh
 home-manager/modules/tailscale/activate-create-dirs.sh
 home-manager/modules/tailscale/activate-install-service.sh
 home-manager/modules/uv-globals/install-uv-globals.sh


### PR DESCRIPTION
## Summary
- Add QMD as a persistent background service (launchd on macOS, systemd on Linux)
- Runs `qmd mcp --http` to keep LLM models in VRAM across requests
- Activation hook seeds wiki collection from `~/ghq/github.com/shunkakinoki/wiki`
- Enabled on kyber and galactica only (not matic)

## Test plan
- [ ] `home-manager switch` succeeds
- [ ] `launchctl list | grep qmd` shows the agent on macOS
- [ ] `curl localhost:8080/health` returns OK
- [ ] `qmd collection list` shows wiki collection

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a persistent `qmd` hybrid search service for the wiki. Keeps models warm, auto-seeds the wiki collection on first run, and adds shellspec tests to verify the setup.

- **New Features**
  - Runs `qmd mcp --http` in the background via `launchd` (macOS) and `systemd` (Linux).
  - Seeds the wiki collection from `~/ghq/github.com/shunkakinoki/wiki` during activation (only if missing).
  - Enabled only on kyber and galactica, integrated into `home-manager` services.

<sup>Written for commit fe61a5f8227a7af03d0406e3b6afc5a0049ddd21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

