### PR TITLE
fix(qmd): add node/bun to PATH for activation and systemd service

### DIFF
--- a/home-manager/services/qmd/default.nix
+++ b/home-manager/services/qmd/default.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, inputs, ... }:
+{
+  config,
+  pkgs,
+  inputs,
+  ...
+}:
 let
   inherit (pkgs) lib;
   inherit (inputs.host) isKyber isGalactica;

--- a/home-manager/services/qmd/default.nix
+++ b/home-manager/services/qmd/default.nix
@@ -9,7 +9,8 @@ let
 in
 lib.mkIf enabled {
   home.activation.qmdSetup = config.lib.dag.entryAfter [ "writeBoundary" ] ''
-    $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${qmdBin}" "${wikiDir}"
+    PATH="${pkgs.nodejs}/bin:${homeDir}/.bun/bin:$PATH" \
+      $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${qmdBin}" "${wikiDir}"
   '';
 
   launchd.agents.qmd = lib.mkIf pkgs.stdenv.isDarwin {
@@ -30,13 +31,21 @@ lib.mkIf enabled {
   systemd.user.services.qmd = lib.mkIf pkgs.stdenv.isLinux {
     Unit = {
       Description = "QMD hybrid search engine";
-      After = [ "network.target" ];
+      After = [
+        "network.target"
+        "install-npm-globals.service"
+      ];
+      Wants = [ "network.target" ];
     };
     Service = {
       Type = "simple";
       ExecStart = "${qmdBin} mcp --http";
       Restart = "always";
       RestartSec = 5;
+      Environment = [
+        "HOME=${homeDir}"
+        "PATH=${homeDir}/.local/bin:${homeDir}/.bun/bin:${homeDir}/.nix-profile/bin:${homeDir}/.local/share/pnpm:${homeDir}/.local/share/fnm/current/bin:${homeDir}/.npm-global/bin:/usr/local/bin:/usr/bin:/bin"
+      ];
     };
     Install = {
       WantedBy = [ "default.target" ];


### PR DESCRIPTION
## Summary
- Prepend `nodejs` and `~/.bun/bin` to PATH during `qmdSetup` activation so `qmd` can find `node`
- Add `Environment` with full PATH to the systemd service (matching openclaw/paperclip pattern)
- Add `After = install-npm-globals.service` so qmd starts after bun globals are installed

Fixes `exec: node: not found` error on kyber during `nix-switch`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes qmd startup failures by ensuring `nodejs` and Bun are in PATH during activation and in the systemd user service. Also delays qmd until Bun globals are installed to avoid missing binaries.

- **Bug Fixes**
  - Prepend `${pkgs.nodejs}/bin` and `~/.bun/bin` to PATH in `qmdSetup` activation.
  - Add systemd user service `Environment` with `HOME` and a complete PATH so `qmd` can find `node`/Bun at runtime.
  - Start after `install-npm-globals.service` and add `Wants=network.target` to improve startup reliability.

<sup>Written for commit 28a9412999733f79e879dfe4cd13f30a5864ce31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

