### PR TITLE
feat(openclaw): enable cacheTrace and explicit sampleRate

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -908,7 +908,14 @@
       "serviceName": "openclaw",
       "traces": true,
       "metrics": true,
-      "logs": true
+      "logs": true,
+      "sampleRate": 1
+    },
+    "cacheTrace": {
+      "enabled": true,
+      "includeMessages": true,
+      "includePrompt": true,
+      "includeSystem": true
     }
   },
   "plugins": {

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -908,7 +908,14 @@
       "serviceName": "openclaw",
       "traces": true,
       "metrics": true,
-      "logs": true
+      "logs": true,
+      "sampleRate": 1
+    },
+    "cacheTrace": {
+      "enabled": true,
+      "includeMessages": true,
+      "includePrompt": true,
+      "includeSystem": true
     }
   },
   "plugins": {


### PR DESCRIPTION
## Summary
- Enable `diagnostics.cacheTrace` with all payload options (messages, prompt, system) for full agent run observability
- Set explicit `sampleRate: 1` (100% trace sampling) on OTLP export

## Test plan
- [x] Both JSON templates validate
- [x] `shellspec spec/openclaw_hydrate_spec.sh` passes (20 examples, 0 failures)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable full cache tracing and 100% trace sampling in `openclaw` for better observability and easier debugging. Applied to both JSON templates.

- **New Features**
  - Enabled `diagnostics.cacheTrace` with messages, prompt, and system included.
  - Set OTLP trace `sampleRate: 1` while keeping traces, metrics, and logs enabled.

<sup>Written for commit 27993aee171d723788266f1382fd05f9dfa73984. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

