### PR TITLE
fix: migrate config.lib.dag to lib.hm.dag and fix eager service evaluation

### DIFF
--- a/config/ccs/default.nix
+++ b/config/ccs/default.nix
@@ -1,5 +1,6 @@
 {
   config,
+  lib,
   pkgs,
   ...
 }:
@@ -19,7 +20,7 @@ in
   # Hydrate CCS settings templates with secrets from .env
   # ANTHROPIC_AUTH_TOKEN is substituted from CLIPROXY_API_KEY at activation time
   # Processes all *.settings.template.json files in config/ccs/
-  home.activation.hydrateCcsSettings = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.hydrateCcsSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     ${pkgs.bash}/bin/bash ${hydrateScript} || true
   '';
 }

--- a/config/gemini/default.nix
+++ b/config/gemini/default.nix
@@ -1,8 +1,8 @@
-{ config, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 {
   # Use activation script to copy settings.json instead of symlinking
   # This allows ruler and other tools to modify the file
-  home.activation.geminiSettings = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.geminiSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${./settings.json}"
   '';
 }

--- a/config/gemini/default.nix
+++ b/config/gemini/default.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 {
   # Use activation script to copy settings.json instead of symlinking
   # This allows ruler and other tools to modify the file

--- a/config/k3s/default.nix
+++ b/config/k3s/default.nix
@@ -13,7 +13,7 @@
 
   # Activation script to sync config to /etc/rancher/k3s/
   home.activation.k3s-config = lib.mkIf pkgs.stdenv.isLinux (
-    config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
       $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}"
     ''
   );

--- a/config/obsidian/default.nix
+++ b/config/obsidian/default.nix
@@ -11,7 +11,7 @@ let
 in
 {
   home.activation.obsidianConfig = lib.mkIf enabled (
-    config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
       $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" \
         "${./obsidian.json}" \
         "${config.home.homeDirectory}" \

--- a/config/openclaw/default.nix
+++ b/config/openclaw/default.nix
@@ -1,5 +1,6 @@
 {
   config,
+  lib,
   pkgs,
   inputs,
   ...
@@ -42,7 +43,7 @@ in
 {
   # Hydrate OpenClaw config from .env secrets
   # Gateway mode on Kyber, client mode everywhere else
-  home.activation.hydrateOpenclawConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.hydrateOpenclawConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     ${pkgs.bash}/bin/bash "${hydrateScript}" || true
   '';
 }

--- a/config/paperclip/default.nix
+++ b/config/paperclip/default.nix
@@ -1,5 +1,6 @@
 {
   config,
+  lib,
   pkgs,
   inputs,
   ...
@@ -22,7 +23,7 @@ let
   };
 in
 {
-  home.activation.paperclipConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.paperclipConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     ${pkgs.bash}/bin/bash ${setupScript} || true
   '';
 }

--- a/config/serena/default.nix
+++ b/config/serena/default.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   serenaConfigDest = "${config.home.homeDirectory}/.serena/serena_config.yml";
 in

--- a/config/serena/default.nix
+++ b/config/serena/default.nix
@@ -1,9 +1,9 @@
-{ config, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 let
   serenaConfigDest = "${config.home.homeDirectory}/.serena/serena_config.yml";
 in
 {
-  home.activation.serenaConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.serenaConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${./serena_config.yml}" "${serenaConfigDest}"
   '';
 }

--- a/home-manager/modules/cargo-globals/default.nix
+++ b/home-manager/modules/cargo-globals/default.nix
@@ -14,7 +14,7 @@ let
 in
 {
   # Install cargo global packages from Cargo.toml using home-manager activation
-  home.activation.installCargoGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.installCargoGlobals = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     export PATH=${pkgs.rustup}/bin:${pkgs.cargo}/bin:${pkgs.rustc}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:${pkgs.perl}/bin:$PATH
     export CARGO_HOME="$HOME/.cargo"
     export PKG_CONFIG_PATH="${pkgs.openssl.dev}/lib/pkgconfig${libiconvPkgConfigPath}''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"

--- a/home-manager/modules/local-binaries/default.nix
+++ b/home-manager/modules/local-binaries/default.nix
@@ -1,10 +1,10 @@
-{ config, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 {
   # Create ~/.local/bin directory
   home.file.".local/bin/.keep".text = "";
 
   # Symlink local binaries during activation
-  home.activation.symlinkLocalBinaries = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.symlinkLocalBinaries = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./sync-local-binaries.sh}"
   '';
 }

--- a/home-manager/modules/local-binaries/default.nix
+++ b/home-manager/modules/local-binaries/default.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 {
   # Create ~/.local/bin directory
   home.file.".local/bin/.keep".text = "";

--- a/home-manager/modules/npm-globals/default.nix
+++ b/home-manager/modules/npm-globals/default.nix
@@ -9,7 +9,7 @@ let
 in
 {
   # Install npm global packages from package.json using home-manager activation
-  home.activation.installNpmGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.installNpmGlobals = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     export PATH=${pkgs.bun}/bin:${pkgs.jq}/bin:$PATH
     export BUN_INSTALL="$HOME/.bun"
     ${lib.optionalString (!isDarwin) ''export SYSTEMCTL_BIN="${pkgs.systemd}/bin/systemctl"''}

--- a/home-manager/modules/tailscale/default.nix
+++ b/home-manager/modules/tailscale/default.nix
@@ -201,7 +201,7 @@ in
       Install.WantedBy = [ "default.target" ];
     };
 
-    home.activation.createTailscaleDirs = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    home.activation.createTailscaleDirs = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
       $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-create-dirs.sh}" \
         "${config.xdg.dataHome}/tailscale" \
         "$(dirname "${cfg.tailscaled.socketPath}")"
@@ -210,7 +210,7 @@ in
     # Install system-level tailscaled service (requires sudo)
     # Uses nix-generated service file for full declarative config
     home.activation.installTailscaleService = mkIf cfg.installSystemService (
-      config.lib.dag.entryAfter [ "writeBoundary" ] ''
+      lib.hm.dag.entryAfter [ "writeBoundary" ] ''
         $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-install-service.sh}" \
           "${tailscaledServiceFile}" \
           "${config.home.homeDirectory}"

--- a/home-manager/modules/uv-globals/default.nix
+++ b/home-manager/modules/uv-globals/default.nix
@@ -9,7 +9,7 @@ let
 in
 {
   # Install uv global tools from pyproject.toml using home-manager activation
-  home.activation.installUvGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.installUvGlobals = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     export PATH=${pkgs.uv}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.yq}/bin:$PATH
     ${lib.optionalString (!isDarwin) ''export SYSTEMCTL_BIN="${pkgs.systemd}/bin/systemctl"''}
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./install-uv-globals.sh}"

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -100,7 +100,6 @@ with pkgs;
   victorialogs
   victoriametrics
   victoriatraces
-  vllm
   watchexec
   wget
   yarn
@@ -139,6 +138,7 @@ with pkgs;
   stdenv.cc.cc.lib
   tailscale
   trashy
+  vllm
   xclip
   zlib
 ]

--- a/home-manager/programs/fnm/default.nix
+++ b/home-manager/programs/fnm/default.nix
@@ -21,7 +21,7 @@ in
   '';
 
   # Pre-install node versions and set default
-  home.activation.fnmSetup = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.fnmSetup = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     export PATH="${pkgs.fnm}/bin:$PATH"
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" \
       "${pkgs.fnm}/bin/fnm" \

--- a/home-manager/programs/neovim/default.nix
+++ b/home-manager/programs/neovim/default.nix
@@ -40,11 +40,11 @@ in
     force = true;
   };
 
-  home.activation.copyNvimPackLock = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.copyNvimPackLock = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-copy-pack-lock.sh}" "${nvimPackLockJson}"
   '';
 
-  home.activation.buildNvimNativePlugins = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.buildNvimNativePlugins = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     export PATH="${lib.makeBinPath buildTools}:$PATH"
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-build-plugins.sh}" "${packDir}" "${libExt}"
   '';

--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -54,7 +54,7 @@ let
 in
 {
   # Hydrate auth cache after home-manager switch
-  home.activation.hydrateCliproxyAuths = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.hydrateCliproxyAuths = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     ${pkgs.bash}/bin/bash ${hydrateScript} || true
   '';
 

--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -19,26 +19,10 @@ let
   neversslKeepalive = import ./neverssl-keepalive { inherit pkgs; };
   obsidian = import ./obsidian { inherit pkgs inputs; };
   ollama = import ./ollama { inherit pkgs inputs; };
-  qmd = import ./qmd { inherit config pkgs inputs; };
-  openclaw = import ./openclaw {
-    inherit
-      config
-      lib
-      pkgs
-      inputs
-      ;
-  };
-  paperclip = import ./paperclip {
-    inherit
-      config
-      lib
-      pkgs
-      inputs
-      ;
-  };
-  sshAgent = import ./ssh-agent {
-    inherit config lib pkgs;
-  };
+  qmd = ./qmd;
+  openclaw = ./openclaw;
+  paperclip = ./paperclip;
+  sshAgent = ./ssh-agent;
   tmuxSessionLogger = import ./tmux-session-logger { inherit pkgs; };
 in
 [

--- a/home-manager/services/openclaw/default.nix
+++ b/home-manager/services/openclaw/default.nix
@@ -12,7 +12,7 @@ in
 # Only enable on kyber (gateway host)
 lib.mkIf host.isKyber {
   # Ensure OpenClaw directories exist with correct permissions
-  home.activation.openclawSetup = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.openclawSetup = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${homeDir}"
   '';
 

--- a/home-manager/services/paperclip/default.nix
+++ b/home-manager/services/paperclip/default.nix
@@ -12,7 +12,7 @@ in
 # Only enable on kyber (server host)
 lib.mkIf host.isKyber {
   # Ensure Paperclip directories exist with correct permissions
-  home.activation.paperclipSetup = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.paperclipSetup = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${homeDir}"
   '';
 

--- a/home-manager/services/qmd/default.nix
+++ b/home-manager/services/qmd/default.nix
@@ -13,7 +13,7 @@ let
   enabled = isKyber || isGalactica;
 in
 lib.mkIf enabled {
-  home.activation.qmdSetup = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.qmdSetup = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     PATH="${pkgs.nodejs}/bin:${homeDir}/.bun/bin:$PATH" \
       $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${qmdBin}" "${wikiDir}"
   '';

--- a/home-manager/services/qmd/default.nix
+++ b/home-manager/services/qmd/default.nix
@@ -1,11 +1,11 @@
 {
   config,
+  lib,
   pkgs,
   inputs,
   ...
 }:
 let
-  inherit (pkgs) lib;
   inherit (inputs.host) isKyber isGalactica;
   homeDir = config.home.homeDirectory;
   wikiDir = "${homeDir}/ghq/github.com/shunkakinoki/wiki";

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -58,18 +58,18 @@ home-manager.lib.homeManagerConfiguration {
         ) (import ./secrets.nix);
 
         # Ensure SSH directory exists before agenix tries to deploy secrets
-        home.activation.ensureSshDirectory = config.lib.dag.entryBefore [ "writeBoundary" ] ''
+        home.activation.ensureSshDirectory = lib.hm.dag.entryBefore [ "writeBoundary" ] ''
           $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-directory.sh}" "700" "${config.home.homeDirectory}/.ssh"
         '';
 
         # Ensure agenix config directory exists
-        home.activation.ensureAgenixDirectory = config.lib.dag.entryBefore [ "writeBoundary" ] ''
+        home.activation.ensureAgenixDirectory = lib.hm.dag.entryBefore [ "writeBoundary" ] ''
           $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-directory.sh}" "700" "${config.home.homeDirectory}/.config/agenix"
         '';
 
         # Manually deploy agenix secrets during activation
         # This ensures secrets are deployed even if the agenix activation hook doesn't run properly
-        home.activation.deployAgenixSecrets = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+        home.activation.deployAgenixSecrets = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
           $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/deploy-agenix-secret.sh}" \
             "${config.home.homeDirectory}/.ssh/id_ed25519_github" \
             "${builtins.toString ../galactica/keys/id_github.age}" \
@@ -79,7 +79,7 @@ home-manager.lib.homeManagerConfiguration {
 
         # Import GPG key from agenix (all systems with dotfiles)
         # Fails silently if SSH key isn't authorized to decrypt
-        home.activation.importGpgKey = config.lib.dag.entryAfter [ "linkGeneration" ] ''
+        home.activation.importGpgKey = lib.hm.dag.entryAfter [ "linkGeneration" ] ''
           $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/import-gpg-key.sh}" \
             "${config.home.homeDirectory}/dotfiles/named-hosts/galactica/keys/gpg.age" \
             "${config.home.homeDirectory}/.ssh/id_ed25519" \
@@ -118,7 +118,7 @@ home-manager.lib.homeManagerConfiguration {
         xdg.enable = true;
 
         # IP forwarding for Tailscale exit node
-        home.activation.enableIpForwarding = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+        home.activation.enableIpForwarding = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
           $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-ip-forwarding.sh}"
         '';
 

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -505,18 +505,18 @@ inputs.nixpkgs.lib.nixosSystem {
           ) (import ./secrets.nix);
 
           # Ensure SSH directory exists before agenix tries to deploy secrets
-          home.activation.ensureSshDirectory = config.lib.dag.entryBefore [ "writeBoundary" ] ''
+          home.activation.ensureSshDirectory = lib.hm.dag.entryBefore [ "writeBoundary" ] ''
             $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-directory.sh}" "700" "${config.home.homeDirectory}/.ssh"
           '';
 
           # Ensure agenix config directory exists
-          home.activation.ensureAgenixDirectory = config.lib.dag.entryBefore [ "writeBoundary" ] ''
+          home.activation.ensureAgenixDirectory = lib.hm.dag.entryBefore [ "writeBoundary" ] ''
             $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-directory.sh}" "700" "${config.home.homeDirectory}/.config/agenix"
           '';
 
           # Manually deploy agenix secrets during activation
           # This ensures secrets are deployed even if the agenix activation hook doesn't run properly
-          home.activation.deployAgenixSecrets = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+          home.activation.deployAgenixSecrets = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
             $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/deploy-agenix-secret.sh}" \
               "${config.home.homeDirectory}/.ssh/id_ed25519_github" \
               "${builtins.toString ../galactica/keys/id_ed25519.age}" \
@@ -526,7 +526,7 @@ inputs.nixpkgs.lib.nixosSystem {
 
           # Import GPG key from agenix (all systems with dotfiles)
           # Fails silently if SSH key isn't authorized to decrypt
-          home.activation.importGpgKey = config.lib.dag.entryAfter [ "linkGeneration" ] ''
+          home.activation.importGpgKey = lib.hm.dag.entryAfter [ "linkGeneration" ] ''
             $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/import-gpg-key.sh}" \
               "${config.home.homeDirectory}/dotfiles/named-hosts/galactica/keys/gpg.age" \
               "${config.home.homeDirectory}/.ssh/id_ed25519" \


### PR DESCRIPTION
## Summary
- Replaced deprecated `config.lib.dag.entryAfter`/`entryBefore` with `lib.hm.dag` across 21 files
- Changed qmd, openclaw, paperclip, ssh-agent from eagerly-evaluated function calls to module path imports in `services/default.nix` - the root cause was `config = {}` being passed through the call chain, making `config.lib.dag` and `config.home.*` unavailable
- Added `lib` to module function args where missing (config modules imported as paths get `lib` with `hm` from the module system)

## Test plan
- [x] `make build` passes on darwin
- [x] `make switch` succeeds on galactica (darwin/arm64)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated activation hooks from config.lib.dag to lib.hm.dag and stopped eager evaluation of select services, fixing missing config/lib during evaluation. Restores activation order reliability and brings back the `vllm` package on Linux.

- **Bug Fixes**
  - Replaced config.lib.dag entryBefore/entryAfter with lib.hm.dag across modules.
  - Loaded `qmd`, `openclaw`, `paperclip`, and `ssh-agent` via module paths instead of eager function calls to avoid `config = {}` and restore access to config.home.* and dag.
  - Added missing lib to module args where needed so hm functions are available.
  - Restored `vllm` in Linux package set.

<sup>Written for commit a35f253f219b32a344bf3e00c42bec74bd4ee7dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

