### PR TITLE
fix(obsidian): pass --vault flag to open wiki vault on headless launch

### DIFF
--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -17,7 +17,7 @@ let
   gasTown = import ./gas-town { inherit pkgs; };
   makeUpdater = import ./make-updater { inherit pkgs; };
   neversslKeepalive = import ./neverssl-keepalive { inherit pkgs; };
-  obsidian = import ./obsidian { inherit pkgs inputs; };
+  obsidian = import ./obsidian { inherit config pkgs inputs; };
   ollama = import ./ollama { inherit pkgs inputs; };
   qmd = ./qmd;
   openclaw = ./openclaw;

--- a/home-manager/services/obsidian/default.nix
+++ b/home-manager/services/obsidian/default.nix
@@ -1,4 +1,5 @@
 {
+  config,
   pkgs,
   inputs,
   ...
@@ -12,11 +13,14 @@ let
   # full Electron asar, so they need a display server. We wrap the real
   # binary in `xvfb-run` so each invocation gets an ephemeral virtual X
   # server, letting the CLI run on a headless host.
+  homeDir = config.home.homeDirectory;
+
   obsidianHeadless = pkgs.writeShellScriptBin "obsidian" (
     builtins.readFile (
       pkgs.replaceVars ./obsidian-headless.sh {
         xvfbRun = pkgs.xvfb-run;
         inherit (pkgs) obsidian;
+        inherit homeDir;
       }
     )
   );

--- a/home-manager/services/obsidian/obsidian-headless.sh
+++ b/home-manager/services/obsidian/obsidian-headless.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-exec @xvfbRun@/bin/xvfb-run -a @obsidian@/bin/obsidian --no-sandbox --disable-gpu "$@"
+exec @xvfbRun@/bin/xvfb-run -a @obsidian@/bin/obsidian --no-sandbox --disable-gpu --vault @homeDir@/ghq/github.com/shunkakinoki/wiki "$@"


### PR DESCRIPTION
## Summary
- Pass `--vault` flag to Obsidian headless service so the wiki vault actually opens and plugins (obsidian-git) load
- Use `config.home.homeDirectory` instead of hardcoded path
- Pass `config` through to the obsidian service module

Without `--vault`, the headless Obsidian only opened the app shell but never loaded the vault, so obsidian-git auto-commit/push never ran.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass `--vault` to the headless Obsidian wrapper so the wiki vault opens on launch and plugins like `obsidian-git` run. Use `config.home.homeDirectory` and wire `config` into the `obsidian` service to remove the hardcoded path.

<sup>Written for commit ce2ff773e420706a6bed2f0b90b122c10beecab6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

