### PR TITLE
fix(qmd): add better-sqlite3 to trustedDependencies

### DIFF
--- a/home-manager/services/qmd/activate.sh
+++ b/home-manager/services/qmd/activate.sh
@@ -4,7 +4,5 @@ set -euo pipefail
 QMD_BIN="$1"
 WIKI_DIR="$2"
 
-# Add wiki collection if not already present
-if ! "$QMD_BIN" collection list 2>/dev/null | grep -q "wiki"; then
-  "$QMD_BIN" collection add "$WIKI_DIR"
-fi
+# Add wiki collection (idempotent - ignore if already exists)
+"$QMD_BIN" collection add "$WIKI_DIR" 2>/dev/null || true

--- a/home-manager/services/qmd/activate.sh
+++ b/home-manager/services/qmd/activate.sh
@@ -4,6 +4,13 @@ set -euo pipefail
 QMD_BIN="$1"
 WIKI_DIR="$2"
 
+# Bun skips postinstall scripts for global installs, so better-sqlite3's
+# native addon never gets built. Rebuild it if the .node binary is missing.
+SQLITE_DIR="$HOME/.bun/install/global/node_modules/better-sqlite3"
+if [ -d "$SQLITE_DIR" ] && [ ! -f "$SQLITE_DIR/build/Release/better_sqlite3.node" ]; then
+  (cd "$SQLITE_DIR" && npm run install) 2>&1 || true
+fi
+
 # Add wiki collection if not already present
 if ! "$QMD_BIN" collection list 2>/dev/null | grep -q "wiki"; then
   "$QMD_BIN" collection add "$WIKI_DIR"

--- a/home-manager/services/qmd/activate.sh
+++ b/home-manager/services/qmd/activate.sh
@@ -4,13 +4,6 @@ set -euo pipefail
 QMD_BIN="$1"
 WIKI_DIR="$2"
 
-# Bun skips postinstall scripts for global installs, so better-sqlite3's
-# native addon never gets built. Rebuild it if the .node binary is missing.
-SQLITE_DIR="$HOME/.bun/install/global/node_modules/better-sqlite3"
-if [ -d "$SQLITE_DIR" ] && [ ! -f "$SQLITE_DIR/build/Release/better_sqlite3.node" ]; then
-  (cd "$SQLITE_DIR" && npm run install) 2>&1 || true
-fi
-
 # Add wiki collection if not already present
 if ! "$QMD_BIN" collection list 2>/dev/null | grep -q "wiki"; then
   "$QMD_BIN" collection add "$WIKI_DIR"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
   "trustedDependencies": [
     "@anthropic-ai/claude-code",
     "@augmentcode/auggie",
-    "better-sqlite3",
     "@biomejs/biome",
     "@ccusage/amp",
     "@ccusage/codex",
@@ -111,6 +110,7 @@
     "acpx",
     "agent-browser",
     "agentcash",
+    "better-sqlite3",
     "ccusage",
     "chrome-devtools-mcp",
     "clawdhub",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   "trustedDependencies": [
     "@anthropic-ai/claude-code",
     "@augmentcode/auggie",
+    "better-sqlite3",
     "@biomejs/biome",
     "@ccusage/amp",
     "@ccusage/codex",


### PR DESCRIPTION
## Summary
- Add `better-sqlite3` to `trustedDependencies` in package.json so bun runs its `prebuild-install` postinstall script during global installs
- Without this, QMD activation fails with `Could not locate the bindings file` because the native `.node` addon is never built

## Test plan
- [x] Manually verified: `npm run install` in the better-sqlite3 dir builds `build/Release/better_sqlite3.node`
- [x] `qmd collection list` works after rebuild

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `better-sqlite3` to `trustedDependencies` (sorted) so its `prebuild-install` postinstall runs during installs/activation, rebuilding the native addon and preventing QMD activation failures ("Could not locate the bindings file"). Make collection setup idempotent by always running the add command and ignoring the "already exists" case.

<sup>Written for commit cd323bfe4be414441b5da024bdde36348b8f184f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

