### PR TITLE
fix(obsidian): resolve headless renderer crash from Chrome 140 Fontations bug

### DIFF
--- a/home-manager/services/obsidian/default.nix
+++ b/home-manager/services/obsidian/default.nix
@@ -28,7 +28,11 @@ in
 # Only enable on kyber (gateway host) - desktops already get pkgs.obsidian
 # directly via home-manager/packages/default.nix.
 lib.mkIf host.isKyber {
-  home.packages = [ obsidianHeadless ];
+  home.packages = [
+    obsidianHeadless
+    pkgs.dejavu_fonts
+    pkgs.fontconfig
+  ];
 
   systemd.user.services.obsidian = {
     Unit = {
@@ -37,6 +41,11 @@ lib.mkIf host.isKyber {
     };
     Service = {
       Type = "simple";
+      ExecStartPre = "${pkgs.writeShellScript "obsidian-pre" ''
+        rm -f ${config.xdg.configHome}/obsidian/SingletonLock
+        rm -f ${config.xdg.configHome}/obsidian/SingletonSocket
+        rm -f ${config.xdg.configHome}/obsidian/SingletonCookie
+      ''}";
       ExecStart = "${obsidianHeadless}/bin/obsidian";
       Restart = "always";
       RestartSec = 10;

--- a/home-manager/services/obsidian/obsidian-headless.sh
+++ b/home-manager/services/obsidian/obsidian-headless.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-exec @xvfbRun@/bin/xvfb-run -a @obsidian@/bin/obsidian --no-sandbox --disable-gpu --vault @homeDir@/ghq/github.com/shunkakinoki/wiki "$@"
+exec @xvfbRun@/bin/xvfb-run -a -s "-screen 0 1280x1024x24" @obsidian@/bin/obsidian --no-sandbox --disable-gpu --disable-features=FontationsFontIndexer --vault @homeDir@/ghq/github.com/shunkakinoki/wiki "$@"


### PR DESCRIPTION
## Summary

- Fix Obsidian headless service crash caused by Chrome 140's Fontations font indexer (`NOTREACHED` in `remote_font_face_source.cc:357`)
- Add `--disable-features=FontationsFontIndexer` to fall back to FreeType
- Install `dejavu_fonts` and `fontconfig` so the renderer has system fonts
- Add `ExecStartPre` singleton lock cleanup to prevent stale locks on restart

## Context

The Electron renderer was crashing because the server had zero fonts installed (`fc-list` returned 0). Chrome 140's new Rust-based Fontations font indexer calls `GetLastResortFallbackFont()` which returns nullptr with no fonts, triggering a fatal `NOTREACHED`. This prevented the obsidian-git plugin from ever executing.

Upstream: [chromium#442747781](https://issues.chromium.org/issues/442747781), [chromium#436609543](https://issues.chromium.org/issues/436609543)

## Test plan

- [ ] Verify `systemctl --user status obsidian` shows active (running)
- [ ] Verify obsidian-git plugin loads (gitReady: true) via CDP
- [ ] Verify vault backup commits appear in wiki repo git log

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the headless Obsidian crash on Chrome 140 by disabling the Fontations font indexer and installing system fonts. The service now starts reliably and the obsidian-git plugin can run.

- **Bug Fixes**
  - Added `--disable-features=FontationsFontIndexer` to fall back to FreeType.
  - Installed `dejavu_fonts` and `fontconfig` so the renderer has fonts.
  - Clean up Obsidian Singleton lock files on start to prevent stale-lock crashes.
  - Set xvfb screen to 1280x1024x24 for stable rendering.

<sup>Written for commit c17408b31b3640a2e272c1b3c07ba4905b7b9c8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

