### PR TITLE
feat: add shared hook to block push to main/master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1069,7 +1069,7 @@ fish-test-dev: ## Run fish tests inside the Nix dev shell (mirrors CI).
 .PHONY: shell-check
 shell-check: ## Run ShellCheck on shell scripts.
 	@echo "🔍 Running ShellCheck..."
-	@git ls-files -z '*.sh' | xargs -0 shellcheck
+	@{ git ls-files -z '*.sh'; git diff --cached --name-only -z --diff-filter=A -- '*.sh'; } | sort -zu | xargs -0 shellcheck
 
 .PHONY: shell-check-dev
 shell-check-dev: ## Run ShellCheck inside the Nix dev shell (mirrors CI).

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -226,6 +226,11 @@
           },
           {
             "type": "command",
+            "command": "$HOME/dotfiles/config/shared/hooks/block-push-main.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "$HOME/.claude/hooks/notify.sh",
             "timeout": 3,
             "async": true

--- a/config/codex/hooks.json
+++ b/config/codex/hooks.json
@@ -35,6 +35,11 @@
           },
           {
             "type": "command",
+            "command": "$HOME/dotfiles/config/shared/hooks/block-push-main.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "$HOME/.codex/hooks/notify.sh",
             "timeout": 3,
             "async": true

--- a/config/shared/hooks/block-push-main.sh
+++ b/config/shared/hooks/block-push-main.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# block-push-main.sh — Shared hook for Claude Code + Codex
+# Blocks git push to main/master unless repo is in the allowlist.
+# Exit 2 = block (Codex), JSON decision output (Claude).
+set -euo pipefail
+
+# --- Allowlist: repos where push to main/master is permitted ---
+ALLOWED_REPOS=(
+  "shunkakinoki/wiki"
+  "shunkakinoki/gthq"
+)
+
+# Read tool input from stdin
+input=$(cat)
+
+# Extract command (works for both Claude and Codex input formats)
+command=$(echo "$input" | jq -r '.tool_input.command // .command // empty' 2>/dev/null)
+[[ -z $command ]] && exit 0
+
+# Only check git push commands
+if ! echo "$command" | grep -qE 'git\s+push'; then
+  exit 0
+fi
+
+# Check if pushing to main or master
+if ! echo "$command" | grep -qE '\b(main|master)\b'; then
+  exit 0
+fi
+
+# Check repo allowlist (owner/repo from git remote)
+repo=$(git remote get-url origin 2>/dev/null | sed -E 's#.+[:/]([^/]+/[^/]+?)(\.git)?$#\1#' || echo "")
+for allowed in "${ALLOWED_REPOS[@]}"; do
+  if [[ $repo == "$allowed" ]]; then
+    exit 0
+  fi
+done
+
+# Block the push
+msg="Push to main/master blocked in '$repo'. Use a feature branch + PR."
+echo "BLOCKED by block-push-main.sh: $msg" >&2
+exit 2

--- a/config/shared/hooks/block-push-main.sh
+++ b/config/shared/hooks/block-push-main.sh
@@ -28,7 +28,7 @@ if ! echo "$command" | grep -qE '\b(main|master)\b'; then
 fi
 
 # Check repo allowlist (owner/repo from git remote)
-repo=$(git remote get-url origin 2>/dev/null | sed -E 's#.+[:/]([^/]+/[^/]+?)(\.git)?$#\1#' || echo "")
+repo=$(git remote get-url origin 2>/dev/null | sed -E 's#.*[:/]([^/]+/[^/]+)$#\1#; s#\.git$##' || echo "")
 for allowed in "${ALLOWED_REPOS[@]}"; do
   if [[ $repo == "$allowed" ]]; then
     exit 0

--- a/spec/block_push_main_spec.sh
+++ b/spec/block_push_main_spec.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'block-push-main.sh'
+SCRIPT="$PWD/config/shared/hooks/block-push-main.sh"
+
+setup() {
+  TEMP_REPO=$(mktemp -d)
+  git -C "$TEMP_REPO" init -q
+  git -C "$TEMP_REPO" remote add origin "https://github.com/someorg/somerepo.git"
+}
+
+setup_allowed() {
+  TEMP_REPO=$(mktemp -d)
+  git -C "$TEMP_REPO" init -q
+  git -C "$TEMP_REPO" remote add origin "https://github.com/shunkakinoki/wiki.git"
+}
+
+cleanup() {
+  rm -rf "$TEMP_REPO"
+}
+
+After 'cleanup'
+
+Describe 'non-push commands'
+Before 'setup'
+
+It 'allows git status'
+Data '{"tool_input": {"command": "git status"}}'
+When run bash -c "cd '$TEMP_REPO' && bash '$SCRIPT'"
+The status should be success
+End
+
+It 'allows git pull'
+Data '{"tool_input": {"command": "git pull origin main"}}'
+When run bash -c "cd '$TEMP_REPO' && bash '$SCRIPT'"
+The status should be success
+End
+
+It 'allows git push to feature branch'
+Data '{"tool_input": {"command": "git push origin feat/my-branch"}}'
+When run bash -c "cd '$TEMP_REPO' && bash '$SCRIPT'"
+The status should be success
+End
+End
+
+Describe 'blocked pushes'
+Before 'setup'
+
+It 'blocks git push origin main'
+Data '{"tool_input": {"command": "git push origin main"}}'
+When run bash -c "cd '$TEMP_REPO' && bash '$SCRIPT'"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+It 'blocks git push origin master'
+Data '{"tool_input": {"command": "git push origin master"}}'
+When run bash -c "cd '$TEMP_REPO' && bash '$SCRIPT'"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+It 'blocks git push -u origin main'
+Data '{"tool_input": {"command": "git push -u origin main"}}'
+When run bash -c "cd '$TEMP_REPO' && bash '$SCRIPT'"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+It 'blocks git push --force origin main'
+Data '{"tool_input": {"command": "git push --force origin main"}}'
+When run bash -c "cd '$TEMP_REPO' && bash '$SCRIPT'"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+End
+
+Describe 'allowed repos'
+Before 'setup_allowed'
+
+It 'allows push to main in shunkakinoki/wiki'
+Data '{"tool_input": {"command": "git push origin main"}}'
+When run bash -c "cd '$TEMP_REPO' && bash '$SCRIPT'"
+The status should be success
+End
+
+It 'allows push to master in shunkakinoki/wiki'
+Data '{"tool_input": {"command": "git push origin master"}}'
+When run bash -c "cd '$TEMP_REPO' && bash '$SCRIPT'"
+The status should be success
+End
+End
+
+Describe 'codex input format'
+Before 'setup'
+
+It 'blocks codex-style input with .command key'
+Data '{"command": "git push origin main"}'
+When run bash -c "cd '$TEMP_REPO' && bash '$SCRIPT'"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+End
+
+Describe 'edge cases'
+Before 'setup'
+
+It 'passes with empty input'
+Data '{}'
+When run bash -c "cd '$TEMP_REPO' && bash '$SCRIPT'"
+The status should be success
+End
+
+It 'passes with empty command'
+Data '{"tool_input": {"command": ""}}'
+When run bash -c "cd '$TEMP_REPO' && bash '$SCRIPT'"
+The status should be success
+End
+End
+End

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -344,6 +344,7 @@ config/codex/hooks/notify.sh
 config/codex/hooks/pushover.sh
 config/codex/hooks/rtk-rewrite.sh
 config/codex/hooks/security.sh
+config/shared/hooks/block-push-main.sh
 config/cursor/activate.sh
 config/gemini/activate.sh
 config/git-ai/activate.sh


### PR DESCRIPTION
## Summary
- Add shared `block-push-main.sh` hook called by both Claude Code and Codex
- Blocks `git push` to `main`/`master` unless repo is in allowlist
- Allowlist: `shunkakinoki/wiki`, `shunkakinoki/gthq`

## Changes
- `config/shared/hooks/block-push-main.sh` - new shared hook script
- `config/claude/settings.json` - wire hook into PreToolUse
- `config/codex/hooks.json` - wire hook into PreToolUse

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a shared PreToolUse hook to block `git push` to `main`/`master` in Claude Code and Codex, with tests covering allowed/blocked cases. It runs `config/shared/hooks/block-push-main.sh`, is wired into both configs, and only allows pushes for `shunkakinoki/wiki` and `shunkakinoki/gthq`.

- **Bug Fixes**
  - Makefile: `shell-check` now includes staged `.sh` files.
  - Hook: fix macOS `sed` compatibility when parsing `origin` to detect `owner/repo`.

<sup>Written for commit 0b22dabb81271f28749b9077d7d42d95cc3cb9a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

