### PR TITLE
fix(home-manager-xremap): added keypress delay for xremap shortcuts

### DIFF
--- a/home-manager/modules/xremap/default.nix
+++ b/home-manager/modules/xremap/default.nix
@@ -99,6 +99,9 @@ in
         # Only intercept keyd output — SUPER (CapsLock/RightAlt) goes straight to Hyprland
         deviceNames = [ "keyd virtual keyboard" ];
         config = {
+          # Slack/Electron on Wayland can misread synthesized Hyper->Ctrl
+          # shortcuts when xremap replays them with no delay.
+          keypress_delay_ms = 10;
           keymap = [
             {
               # Ghostty: Framework+C/V → Ctrl+Shift+C/V (terminal convention: Ctrl+C = SIGINT)


### PR DESCRIPTION
- Set keypress_delay_ms to 10 ms so Slack/Electron on Wayland read synthesized shortcuts reliably.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 10 ms keypress delay in `xremap` so Slack/Electron on Wayland reliably detect synthesized shortcuts (e.g., Hyper->Ctrl).

<sup>Written for commit fdc26e603062a342b2710f12724f6917da23a94a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

