### PR TITLE
chore: add .codex to global gitignore

### DIFF
--- a/home-manager/programs/git/.gitignore.global
+++ b/home-manager/programs/git/.gitignore.global
@@ -1,6 +1,7 @@
 # AI
 .aider.tags.cache.*/
 .claude/
+.codex/
 .conductor/
 .crush/
 .cursor/


### PR DESCRIPTION
## Summary
- Add `.codex/` to the global gitignore so it is excluded from all repos automatically

## Test plan
- [ ] Verify `.codex/` is ignored in repos without a local gitignore entry

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.codex/` to the global gitignore so it’s ignored across all repositories. Prevents accidental commits of local workspace files.

<sup>Written for commit f07f3ecb518a90d05766b426cacd5870461f212c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

