### PR TITLE
feat: ini iso

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ tags
 result
 result-*
 ref
+*.iso
 
 .direnv/
 .env

--- a/Makefile
+++ b/Makefile
@@ -638,6 +638,57 @@ nix-setup-offline: ## Set up offline environment.
 
 ##@ Named Hosts Specific Targets
 
+.PHONY: build-vm
+build-vm: ## Build a named host VM launcher (set HOST=<name>, e.g. make build-vm HOST=viper).
+	@host="$(HOST)"; \
+	if [ -z "$$host" ]; then \
+		host="$(DETECTED_HOST)"; \
+	fi; \
+	if [ -z "$$host" ]; then \
+		echo "❌ No HOST specified and no named host auto-detected"; \
+		exit 1; \
+	fi; \
+	echo "🏗️ Building VM for $$host"; \
+	$(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#nixosConfigurations.$$host.config.system.build.vm $(NIX_FLAGS) --impure --show-trace
+
+.PHONY: run-vm
+run-vm: ## Run a named host VM launcher (set HOST=<name>, e.g. make run-vm HOST=viper).
+	@host="$(HOST)"; \
+	if [ -z "$$host" ]; then \
+		host="$(DETECTED_HOST)"; \
+	fi; \
+	if [ -z "$$host" ]; then \
+		echo "❌ No HOST specified and no named host auto-detected"; \
+		exit 1; \
+	fi; \
+	$(MAKE) build-vm HOST="$$host"; \
+	script=$$(find ./result/bin -maxdepth 1 -type f \( -name 'run-*-vm' -o -name 'run-nixos-vm' \) | head -n 1); \
+	if [ -z "$$script" ]; then \
+		echo "❌ Could not find a VM launcher under ./result/bin"; \
+		exit 1; \
+	fi; \
+	"$$script"
+
+.PHONY: build-iso
+build-iso: ## Build a named host live/install ISO and copy it to ./<host>.iso (set HOST=<name>, e.g. make build-iso HOST=viper).
+	@host="$(HOST)"; \
+	if [ -z "$$host" ]; then \
+		host="$(DETECTED_HOST)"; \
+	fi; \
+	if [ -z "$$host" ]; then \
+		echo "❌ No HOST specified and no named host auto-detected"; \
+		exit 1; \
+	fi; \
+	echo "💿 Building ISO for $$host"; \
+	$(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#nixosConfigurations.$$host"Iso".config.system.build.isoImage $(NIX_FLAGS) --impure --show-trace; \
+	iso_path=$$(find ./result -type f -name '*.iso' | head -n 1); \
+	if [ -z "$$iso_path" ]; then \
+		echo "❌ Could not find a built ISO under ./result"; \
+		exit 1; \
+	fi; \
+	cp -f "$$iso_path" "./$$host.iso"; \
+	echo "✅ Copied $$iso_path to ./$$host.iso"
+
 .PHONY: switch-%
 switch-%: ## Switch to a named host configuration (e.g., make switch-galactica).
 	@$(MAKE) nix-switch HOST=$*
@@ -1151,4 +1202,3 @@ gt-status: ## Show Gas Town health and Dolt server status.
 .PHONY: gt-dolt-status
 gt-dolt-status: ## Show Dolt server status and latency.
 	@gt dolt status
-

--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,18 @@
                 inherit inputs;
                 username = "skakinoki";
               };
+              maticIso = import ./named-hosts/matic/iso.nix {
+                inherit inputs;
+                username = "skakinoki";
+              };
+              viper = import ./named-hosts/viper {
+                inherit inputs;
+                username = "shunkakinoki";
+              };
+              viperIso = import ./named-hosts/viper/iso.nix {
+                inherit inputs;
+                username = "shunkakinoki";
+              };
             };
             homeConfigurations = {
               "ubuntu@x86_64-linux" = import ./hosts/linux {

--- a/home-manager/modules/local-scripts/clipboard-copy.sh
+++ b/home-manager/modules/local-scripts/clipboard-copy.sh
@@ -2,12 +2,12 @@
 
 set -euo pipefail
 
-if command -v pbcopy >/dev/null 2>&1; then
-  exec pbcopy
-fi
-
 if [[ -n ${WAYLAND_DISPLAY:-} ]] && command -v wl-copy >/dev/null 2>&1; then
   exec wl-copy
+fi
+
+if command -v pbcopy >/dev/null 2>&1; then
+  exec pbcopy
 fi
 
 if command -v xclip >/dev/null 2>&1; then

--- a/home-manager/modules/local-scripts/pushover-notify.sh
+++ b/home-manager/modules/local-scripts/pushover-notify.sh
@@ -12,8 +12,9 @@ priority="${3:-0}"
 
 [[ -z $message ]] && exit 0
 
-# Source credentials if not already set
-if [[ -z ${PUSHOVER_API_TOKEN:-} ]] || [[ -z ${PUSHOVER_USER_KEY:-} ]]; then
+# Source credentials only when the vars are unset. Explicitly blank values
+# should disable notifications instead of falling back to ~/.env.
+if [[ -z ${PUSHOVER_API_TOKEN+x} ]] || [[ -z ${PUSHOVER_USER_KEY+x} ]]; then
   if [[ -f "$HOME/dotfiles/.env" ]]; then
     set -a
     # shellcheck source=/dev/null
@@ -35,4 +36,4 @@ curl -s \
   --form-string "message=${message}" \
   --form-string "priority=${priority}" \
   --form-string "title=${title}" \
-  https://api.pushover.net/1/messages.json >/dev/null 2>&1
+  https://api.pushover.net/1/messages.json >/dev/null 2>&1 || exit 0

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -37,6 +37,19 @@ inputs.nixpkgs.lib.nixosSystem {
     (
       { config, lib, ... }:
       {
+        imports = [
+          (import ../shared/linux-base.nix {
+            inherit inputs pkgs username;
+            hostname = "matic";
+            userExtraGroups = [
+              "input"
+              "video"
+              "audio"
+              "docker"
+            ];
+          })
+        ];
+
         # Boot loader (EFI/systemd-boot)
         boot.loader.systemd-boot.enable = true;
         boot.loader.systemd-boot.configurationLimit = 10;
@@ -70,33 +83,10 @@ inputs.nixpkgs.lib.nixosSystem {
         ];
 
         # Networking
-        networking.hostName = "matic";
-        networking.networkmanager.enable = true;
         networking.networkmanager.wifi.powersave = true;
-
-        # Enable fish shell
-        programs.fish.enable = true;
-
-        # User configuration
-        users.users.${username} = {
-          isNormalUser = true;
-          extraGroups = [
-            "wheel"
-            "networkmanager"
-            "input"
-            "video"
-            "audio"
-            "docker"
-          ];
-          home = "/home/${username}";
-          shell = pkgs.fish;
-          initialPassword = "changemeow"; # Change this after first login with: passwd
-        };
 
         # Docker
         virtualisation.docker.enable = true;
-
-        security.sudo.wheelNeedsPassword = false;
 
         # Home Manager activation can take a long time (npm globals, cargo installs, etc.)
         systemd.services."home-manager-${username}".serviceConfig.TimeoutStartSec = lib.mkForce "30m";
@@ -344,21 +334,6 @@ inputs.nixpkgs.lib.nixosSystem {
           zlib
         ];
 
-        # NixOS-level nix settings (complements home-manager nix/)
-        nix = {
-          channel.enable = false;
-          settings = {
-            nix-path = lib.mkForce "nixpkgs=/etc/nix/inputs/nixpkgs";
-            trusted-users = [
-              username
-              "@wheel"
-              "root"
-            ];
-          };
-        };
-        environment.etc."nix/inputs/nixpkgs".source = "${inputs.nixpkgs}";
-
-        system.stateVersion = "24.11";
       }
     )
 

--- a/named-hosts/matic/iso.nix
+++ b/named-hosts/matic/iso.nix
@@ -1,0 +1,29 @@
+{
+  inputs,
+  username,
+  ...
+}:
+let
+  system = "x86_64-linux";
+  nixpkgsConfig = import ../../lib/nixpkgs-config.nix {
+    nixpkgsLib = inputs.nixpkgs.lib;
+  };
+  overlays = import ../../overlays { inherit inputs; };
+  pkgs = import inputs.nixpkgs {
+    inherit system overlays;
+    config = nixpkgsConfig;
+  };
+in
+inputs.nixpkgs.lib.nixosSystem {
+  inherit system;
+  specialArgs = {
+    inherit inputs username;
+  };
+  modules = [
+    (import ../shared/live-iso.nix {
+      inherit inputs pkgs username;
+      hostname = "matic";
+      userInitialPassword = "changemeow";
+    })
+  ];
+}

--- a/named-hosts/shared/linux-base.nix
+++ b/named-hosts/shared/linux-base.nix
@@ -1,0 +1,46 @@
+{
+  inputs,
+  pkgs,
+  username,
+  hostname,
+  userExtraGroups ? [ ],
+  userInitialPassword ? "changemeow",
+  stateVersion ? "24.11",
+}:
+{ lib, ... }:
+{
+  networking.hostName = hostname;
+  networking.networkmanager.enable = true;
+
+  programs.fish.enable = true;
+
+  users.users.${username} = {
+    isNormalUser = true;
+    extraGroups = [
+      "wheel"
+      "networkmanager"
+    ]
+    ++ userExtraGroups;
+    home = "/home/${username}";
+    shell = pkgs.fish;
+    initialPassword = userInitialPassword;
+  };
+
+  security.sudo.wheelNeedsPassword = false;
+
+  nix = {
+    channel.enable = false;
+    settings = {
+      nix-path = lib.mkForce "nixpkgs=/etc/nix/inputs/nixpkgs";
+      trusted-users = [
+        username
+        "@wheel"
+        "root"
+      ];
+    };
+  };
+
+  environment.etc."nix/inputs/nixpkgs".source = "${inputs.nixpkgs}";
+
+  system.stateVersion = stateVersion;
+}

--- a/named-hosts/shared/live-iso.nix
+++ b/named-hosts/shared/live-iso.nix
@@ -1,0 +1,33 @@
+{
+  inputs,
+  pkgs,
+  username,
+  hostname,
+  userInitialPassword,
+  isoName ? "${hostname}.iso",
+}:
+{ lib, ... }:
+{
+  imports = [
+    "${inputs.nixpkgs}/nixos/modules/installer/cd-dvd/installation-cd-minimal.nix"
+    "${inputs.nixpkgs}/nixos/modules/installer/cd-dvd/channel.nix"
+    (import ./linux-base.nix {
+      inherit
+        inputs
+        pkgs
+        username
+        hostname
+        userInitialPassword
+        ;
+    })
+  ];
+
+  environment.systemPackages = with pkgs; [
+    curl
+    git
+    vim
+  ];
+
+  image.fileName = isoName;
+  services.getty.helpLine = lib.mkForce "";
+}

--- a/named-hosts/viper/default.nix
+++ b/named-hosts/viper/default.nix
@@ -1,0 +1,65 @@
+{
+  inputs,
+  username,
+  ...
+}:
+let
+  system = "x86_64-linux";
+  nixpkgsConfig = import ../../lib/nixpkgs-config.nix {
+    nixpkgsLib = inputs.nixpkgs.lib;
+  };
+  overlays = import ../../overlays { inherit inputs; };
+  pkgs = import inputs.nixpkgs {
+    inherit system overlays;
+    config = nixpkgsConfig;
+  };
+in
+inputs.nixpkgs.lib.nixosSystem {
+  inherit system;
+  specialArgs = {
+    inherit inputs username;
+  };
+  modules = [
+    (import ../shared/linux-base.nix {
+      inherit inputs pkgs username;
+      hostname = "viper";
+      userInitialPassword = "test";
+    })
+    (
+      {
+        lib,
+        modulesPath,
+        ...
+      }:
+      {
+        imports = [ (modulesPath + "/profiles/qemu-guest.nix") ];
+
+        boot.loader.grub.enable = true;
+        boot.loader.grub.device = "/dev/vda";
+        boot.loader.timeout = 3;
+
+        fileSystems."/" = {
+          device = "/dev/disk/by-label/nixos";
+          fsType = "ext4";
+        };
+
+        environment.systemPackages = with pkgs; [
+          curl
+          git
+          vim
+        ];
+
+        services.openssh.enable = true;
+
+        virtualisation.vmVariant = {
+          virtualisation = {
+            graphics = false;
+            memorySize = 4096;
+            cores = 4;
+          };
+          users.users.${username}.initialPassword = lib.mkForce "test";
+        };
+      }
+    )
+  ];
+}

--- a/named-hosts/viper/iso.nix
+++ b/named-hosts/viper/iso.nix
@@ -1,0 +1,29 @@
+{
+  inputs,
+  username,
+  ...
+}:
+let
+  system = "x86_64-linux";
+  nixpkgsConfig = import ../../lib/nixpkgs-config.nix {
+    nixpkgsLib = inputs.nixpkgs.lib;
+  };
+  overlays = import ../../overlays { inherit inputs; };
+  pkgs = import inputs.nixpkgs {
+    inherit system overlays;
+    config = nixpkgsConfig;
+  };
+in
+inputs.nixpkgs.lib.nixosSystem {
+  inherit system;
+  specialArgs = {
+    inherit inputs username;
+  };
+  modules = [
+    (import ../shared/live-iso.nix {
+      inherit inputs pkgs username;
+      hostname = "viper";
+      userInitialPassword = "test";
+    })
+  ];
+}

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -73,6 +73,27 @@ let
           inherit inputs;
           username = "shunkakinoki";
         }).config.system.build.toplevel;
+
+    eval-nixos-matic-iso =
+      mkEvalCheck "nixos-matic-iso"
+        (import ../named-hosts/matic/iso.nix {
+          inherit inputs;
+          username = "shunkakinoki";
+        }).config.system.build.isoImage;
+
+    eval-nixos-viper =
+      mkEvalCheck "nixos-viper"
+        (import ../named-hosts/viper {
+          inherit inputs;
+          username = "shunkakinoki";
+        }).config.system.build.toplevel;
+
+    eval-nixos-viper-iso =
+      mkEvalCheck "nixos-viper-iso"
+        (import ../named-hosts/viper/iso.nix {
+          inherit inputs;
+          username = "shunkakinoki";
+        }).config.system.build.isoImage;
   };
 
   # --- Home-manager configurations (filtered by matching system) ---


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add live/installer ISO and VM workflows for named hosts and introduce the `viper` host. Shared base modules reduce duplication, and new Makefile targets make it easy to build and run VMs or ISOs.

- **New Features**
  - Makefile: `build-vm`, `run-vm`, and `build-iso` (copies to `./<host>.iso`).
  - Shared modules: `named-hosts/shared/linux-base.nix` and `live-iso.nix` for reusable host/ISO config.
  - New host `viper` with QEMU guest profile, GRUB on `/dev/vda`, and VM settings; ISO variant included.
  - Flake outputs: `maticIso`, `viper`, and `viperIso`; tests added for VM and ISO builds.

- **Refactors**
  - `matic` host now imports `linux-base.nix` to remove duplicated user/network/nix settings.
  - Clipboard script prefers `wl-copy`, then falls back to `pbcopy` and `xclip`.
  - Pushover script only sources `.env` when vars are unset; blank vars disable notifications; network errors don’t fail the script.
  - `.gitignore` now ignores `*.iso`.

<sup>Written for commit 58a4547ef749b7bb5884dc196fc4553cea066b85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

