### PR TITLE
chore: upgrade

### DIFF
--- a/home-manager/programs/fish/functions/_pixelh_function.fish
+++ b/home-manager/programs/fish/functions/_pixelh_function.fish
@@ -1,0 +1,18 @@
+function _pixelh_function --description "Run Pi headlessly with the local Qwen model"
+  # Prompt for input and run Pi in print mode with the local Qwen model
+  # Usage: pixelh
+
+  set -l prompt
+  if test (count $argv) -gt 0
+    set prompt (string join " " $argv)
+  else
+    read -P "Prompt: " prompt
+  end
+
+  if test -z "$prompt"
+    echo "No prompt provided, aborting." >&2
+    return 1
+  end
+
+  pi --model 'lmstudio/qwen3.5-0.8b-optiq' -p "$prompt"
+end


### PR DESCRIPTION
Automated upgrade

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Fish function to run Pi headlessly with the local Qwen model. It reads the prompt from args or an interactive prompt, aborts on empty input, and runs `pi --model 'lmstudio/qwen3.5-0.8b-optiq'`.

<sup>Written for commit 0e94c9c0f5faeb39ce9930784b1feed8cf5c19d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

