### PR TITLE
chore: bump claude-opus to 4-7

### DIFF
--- a/config/ccs/agy.settings.template.json
+++ b/config/ccs/agy.settings.template.json
@@ -2,9 +2,9 @@
   "env": {
     "ANTHROPIC_BASE_URL": "http://127.0.0.1:8317/api/provider/agy",
     "ANTHROPIC_AUTH_TOKEN": "__CLIPROXY_API_KEY__",
-    "ANTHROPIC_MODEL": "claude-opus-4-6",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-6",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-opus-4-6",
+    "ANTHROPIC_MODEL": "claude-opus-4-7",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-7",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-opus-4-7",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-4-6"
   }
 }

--- a/config/llm/extra-openai-models.yaml
+++ b/config/llm/extra-openai-models.yaml
@@ -4,7 +4,7 @@
   api_base: http://localhost:8317/v1
   api_key_name: cliproxyapi
 - model_id: claude-opus
-  model_name: claude-opus-4-6
+  model_name: claude-opus-4-7
   api_base: http://localhost:8317/v1
   api_key_name: cliproxyapi
 - model_id: claude-haiku

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -14,8 +14,8 @@
         "api": "openai-completions",
         "models": [
           {
-            "id": "claude-opus-4-6",
-            "name": "Claude Opus 4.6",
+            "id": "claude-opus-4-7",
+            "name": "Claude Opus 4.7",
             "reasoning": true,
             "input": [
               "text",
@@ -220,7 +220,7 @@
         "name": "Code Reviewer (Opus)",
         "workspace": "__HOME__/.openclaw/workspace/agents/code-review",
         "model": {
-          "primary": "cliproxy/claude-opus-4-6",
+          "primary": "cliproxy/claude-opus-4-7",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"
@@ -329,7 +329,7 @@
         "model": {
           "primary": "cliproxy/minimax-m2.7",
           "fallbacks": [
-            "cliproxy/claude-opus-4-6",
+            "cliproxy/claude-opus-4-7",
             "cliproxy/glm-4.7",
             "cliproxy/free"
           ]
@@ -490,7 +490,7 @@
         "name": "Twitter (Opus)",
         "workspace": "__HOME__/.openclaw/workspace/agents/twitter",
         "model": {
-          "primary": "cliproxy/claude-opus-4-6",
+          "primary": "cliproxy/claude-opus-4-7",
           "fallbacks": [
             "cliproxy/minimax-m2.7",
             "cliproxy/glm-4.7",
@@ -509,7 +509,7 @@
         "name": "Mindset Coach",
         "workspace": "__HOME__/.openclaw/workspace/agents/mindset",
         "model": {
-          "primary": "cliproxy/claude-opus-4-6",
+          "primary": "cliproxy/claude-opus-4-7",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"
@@ -545,7 +545,7 @@
         "name": "Dev (Opus)",
         "workspace": "__HOME__/.openclaw/workspace/agents/dev",
         "model": {
-          "primary": "cliproxy/claude-opus-4-6",
+          "primary": "cliproxy/claude-opus-4-7",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"
@@ -625,7 +625,7 @@
         "name": "Strategy (Opus)",
         "workspace": "__HOME__/.openclaw/workspace/agents/strategy",
         "model": {
-          "primary": "cliproxy/claude-opus-4-6",
+          "primary": "cliproxy/claude-opus-4-7",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -24,8 +24,8 @@
         "apiKey": "{env:CLIPROXY_API_KEY}"
       },
       "models": {
-        "claude-opus-4-6": {
-          "name": "Claude Opus 4.6 (via shunkakinoki's CLIProxy)"
+        "claude-opus-4-7": {
+          "name": "Claude Opus 4.7 (via shunkakinoki's CLIProxy)"
         },
         "claude-sonnet-4-6": {
           "name": "Claude Sonnet 4.6 (via shunkakinoki's CLIProxy)"
@@ -58,8 +58,8 @@
         "apiKey": "{env:CLIPROXY_API_KEY}"
       },
       "models": {
-        "claude-opus-4-6": {
-          "name": "Claude Opus 4.6 (via local CLIProxyAPI)"
+        "claude-opus-4-7": {
+          "name": "Claude Opus 4.7 (via local CLIProxyAPI)"
         },
         "claude-sonnet-4-6": {
           "name": "Claude Sonnet 4.6 (via local CLIProxyAPI)"

--- a/config/pi/models.json
+++ b/config/pi/models.json
@@ -74,8 +74,8 @@
           "maxTokens": 65536
         },
         {
-          "id": "claude-opus-4-6",
-          "name": "Claude Opus 4.6",
+          "id": "claude-opus-4-7",
+          "name": "Claude Opus 4.7",
           "reasoning": true,
           "input": [
             "text",

--- a/models.json
+++ b/models.json
@@ -1,5 +1,5 @@
 {
-  "claude-opus": "claude-opus-4-6",
+  "claude-opus": "claude-opus-4-7",
   "claude-sonnet": "claude-sonnet-4-6",
   "claude-haiku": "claude-haiku-4-5-20251001",
   "gpt": "gpt-5.4",


### PR DESCRIPTION
## Summary
- Bump `claude-opus` from `claude-opus-4-6` to `claude-opus-4-7` in models.json
- Regenerate downstream configs via `scripts/llm-update.sh`

## Test plan
- [ ] Verify Claude opus references resolve in aichat, opencode, openclaw, pi, ccs, llm configs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `claude-opus` from `claude-opus-4-6` to `claude-opus-4-7` across configs and templates to standardize on the latest Opus. Updates model IDs and display names in `models.json`, `pi`, `opencode`, `openclaw`, `ccs`, and `llm` configs.

- **Migration**
  - Update any local overrides from `claude-opus-4-6` to `claude-opus-4-7` and restart affected services (`opencode`, `openclaw`, `pi`, `ccs`, `llm`).

<sup>Written for commit 79c2404f791a3d7a9765ab2060025d1e4beaa220. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

