### PR TITLE
fix(ci): respect HOST/DETECTED_HOST on Darwin nix-build in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -439,7 +439,23 @@ nix-build: nix-connect nix-trust ## Build Nix configuration.
 	@if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \
 		echo "🤖 Running in CI/Docker environment"; \
 		if [ "$(OS)" = "Darwin" ]; then \
-			$(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#$(NIX_CONFIG_TYPE).runner.system $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
+			if [ -n "$(HOST)" ]; then \
+				case " $(NIXOS_NAMED_HOSTS) " in \
+					*" $(HOST) "*) \
+						echo "Building named NixOS host: $(HOST)"; \
+						$(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#nixosConfigurations.$(HOST).config.system.build.toplevel $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
+						;; \
+					*) \
+						echo "Building named Darwin host: $(HOST)"; \
+						$(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#darwinConfigurations.$(HOST).system $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
+						;; \
+				esac; \
+			elif [ -n "$(DETECTED_HOST)" ]; then \
+				echo "Auto-detected host: $(DETECTED_HOST)"; \
+				$(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#darwinConfigurations.$(DETECTED_HOST).system $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
+			else \
+				$(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#$(NIX_CONFIG_TYPE).runner.system $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
+			fi; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "nixosConfigurations" ]; then \
 			$(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#nixosConfigurations.runner.config.system.build.toplevel $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "homeConfigurations" ]; then \


### PR DESCRIPTION
## Summary

- The CI branch of `nix-build` in `Makefile` hardcoded `.#darwinConfigurations.runner.system`, ignoring `HOST` and `DETECTED_HOST`.
- `spec/make_build_host_resolution_spec.sh` (added in #1479) exercises host resolution via `make build OS=Darwin ...`, which runs the CI branch on GitHub Actions (`CI=true`), so both specs have been failing on main since #1479 merged.
- Mirror the non-CI Darwin host-resolution logic into the CI branch: named `HOST` maps to NixOS vs Darwin configuration via `NIXOS_NAMED_HOSTS`, falling back to `DETECTED_HOST`, then the previous `runner` default.

## Test plan

- [x] `CI=true shellspec spec/make_build_host_resolution_spec.sh` -> 2 examples, 0 failures
- [ ] Shell workflow passes on this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Darwin CI `nix-build` to respect `HOST` and `DETECTED_HOST`, aligning CI behavior with non-CI and restoring host-resolution tests.

- **Bug Fixes**
  - Mirror non-CI Darwin host resolution in `Makefile`: honor `HOST` and `DETECTED_HOST`; route NixOS hosts via `NIXOS_NAMED_HOSTS`, otherwise build the matching `darwinConfigurations`; fallback stays the `runner` target.
  - Resolves failures in `spec/make_build_host_resolution_spec.sh` introduced by #1479.

<sup>Written for commit 5b65343d5c1e596d8e18672774497d3bf00f9fd3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

