### PR TITLE
fix(ci): unbreak shell-inline-check on main

### DIFF
--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -24,7 +24,7 @@ lib.mkIf enabled {
   launchd.agents.dolt = lib.mkIf pkgs.stdenv.isDarwin {
     enable = true;
     config = {
-      ProgramArguments = [ startScript ];
+      ProgramArguments = [ "${startScript}" ];
       KeepAlive = true;
       RunAtLoad = true;
       WorkingDirectory = repoDir;

--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -11,30 +11,14 @@ let
   repoDir = "${homeDir}/dotfiles";
   beadsDir = "${repoDir}/.beads";
   enabled = isKyber || isGalactica;
-  startScript = pkgs.writeShellScript "dotfiles-dolt-start.sh" ''
-    set -euo pipefail
-
-    mkdir -p "${beadsDir}"
-
-    if [ -d "${beadsDir}/dolt" ] && [ ! -L "${beadsDir}/dolt" ]; then
-      if [ -e "${beadsDir}/df" ]; then
-        echo "Refusing to migrate ${beadsDir}/dolt because ${beadsDir}/df already exists" >&2
-        exit 1
-      fi
-
-      mv -f "${beadsDir}/dolt" "${beadsDir}/df"
-    fi
-
-    if [ -d "${beadsDir}/df" ]; then
-      ln -sfn df "${beadsDir}/dolt"
-    fi
-
-    exec "${pkgs.dolt}/bin/dolt" sql-server \
-      -H 127.0.0.1 \
-      -P 3307 \
-      --data-dir "${beadsDir}" \
-      --loglevel info
-  '';
+  startScript = pkgs.writeShellScript "dotfiles-dolt-start.sh" (
+    builtins.readFile (
+      pkgs.replaceVars ./start.sh {
+        inherit beadsDir;
+        inherit (pkgs) dolt;
+      }
+    )
+  );
 in
 lib.mkIf enabled {
   launchd.agents.dolt = lib.mkIf pkgs.stdenv.isDarwin {

--- a/home-manager/services/dolt/start.sh
+++ b/home-manager/services/dolt/start.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# @beadsDir@ and @dolt@ are substituted by pkgs.replaceVars.
+set -euo pipefail
+
+mkdir -p "@beadsDir@"
+
+if [ -d "@beadsDir@/dolt" ] && [ ! -L "@beadsDir@/dolt" ]; then
+  if [ -e "@beadsDir@/df" ]; then
+    echo "Refusing to migrate @beadsDir@/dolt because @beadsDir@/df already exists" >&2
+    exit 1
+  fi
+
+  mv -f "@beadsDir@/dolt" "@beadsDir@/df"
+fi
+
+if [ -d "@beadsDir@/df" ]; then
+  ln -sfn df "@beadsDir@/dolt"
+fi
+
+exec "@dolt@/bin/dolt" sql-server \
+  -H 127.0.0.1 \
+  -P 3307 \
+  --data-dir "@beadsDir@" \
+  --loglevel info

--- a/scripts/check-nix-inline-scripts.sh
+++ b/scripts/check-nix-inline-scripts.sh
@@ -52,12 +52,12 @@ while IFS= read -r nix_file; do
       return line ~ /^(\$DRY_RUN_CMD[[:space:]]+)?[^[:space:];|&<>`]*bin\/bash([[:space:]]+(".*"|\$\{.*\}|[^[:space:];|&<>`]+))+([[:space:]]+\|\|[[:space:]]+true)?[[:space:]]*\\?$/
     }
 
-    function block_has_violation(  i, line, saw_bash_call, saw_content) {
+    function block_has_violation(  i, n, line, saw_bash_call, saw_content) {
       saw_bash_call = 0
       saw_content = 0
-      split(body, lines, "\n")
+      n = split(body, lines, "\n")
 
-      for (i in lines) {
+      for (i = 1; i <= n; i++) {
         line = trim(lines[i])
 
         if (line == "" || line ~ /^#/) continue

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -188,6 +188,10 @@ End
 It 'has spec file for home-manager/services/docker/docker-setup.sh'
 The path "spec/docker_setup_wrapper_spec.sh" should be exist
 End
+
+It 'has spec file for home-manager/services/dolt/start.sh'
+The path "spec/dolt_start_spec.sh" should be exist
+End
 It 'has spec file for nix-darwin/services/pmset-battery-policy/power-policy.sh'
 The path "spec/pmset_battery_policy_spec.sh" should be exist
 End
@@ -402,6 +406,7 @@ home-manager/services/docker-postgres/start-postgres-wrapper.sh
 home-manager/services/docker-postgres/start-postgres.sh
 home-manager/services/docker/docker-setup.sh
 home-manager/services/docker/setup-docker.sh
+home-manager/services/dolt/start.sh
 home-manager/services/dotfiles-updater/update.sh
 home-manager/services/gas-town/start.sh
 home-manager/services/make-updater/update.sh

--- a/spec/dolt_start_spec.sh
+++ b/spec/dolt_start_spec.sh
@@ -16,7 +16,7 @@ The output should include 'set -euo pipefail'
 End
 
 It 'passes bash syntax check after stripping placeholders'
-When run bash -c "sed 's|@[a-z_]*@|/usr|g' '$SCRIPT' | bash -n"
+When run bash -c "sed 's|@[A-Za-z_][A-Za-z0-9_]*@|/usr|g' '$SCRIPT' | bash -n"
 The status should be success
 End
 End

--- a/spec/dolt_start_spec.sh
+++ b/spec/dolt_start_spec.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'home-manager/services/dolt/start.sh'
+SCRIPT="$PWD/home-manager/services/dolt/start.sh"
+
+Describe 'script properties'
+It 'uses bash shebang'
+When run bash -c "head -1 '$SCRIPT'"
+The output should include '#!/usr/bin/env bash'
+End
+
+It 'uses strict mode'
+When run bash -c "grep 'set -euo pipefail' '$SCRIPT'"
+The output should include 'set -euo pipefail'
+End
+
+It 'passes bash syntax check after stripping placeholders'
+When run bash -c "sed 's|@[a-z_]*@|/usr|g' '$SCRIPT' | bash -n"
+The status should be success
+End
+End
+
+Describe 'placeholder substitutions'
+It 'references @beadsDir@'
+When run bash -c "grep '@beadsDir@' '$SCRIPT'"
+The output should include '@beadsDir@'
+End
+
+It 'references @dolt@'
+When run bash -c "grep '@dolt@' '$SCRIPT'"
+The output should include '@dolt@'
+End
+End
+
+Describe 'dolt migration behavior'
+It 'migrates legacy dolt directory to df'
+When run bash -c "grep 'mv -f' '$SCRIPT'"
+The output should include 'mv -f'
+End
+
+It 'symlinks dolt to df for backwards compatibility'
+When run bash -c "grep 'ln -sfn df' '$SCRIPT'"
+The output should include 'ln -sfn df'
+End
+
+It 'refuses to overwrite an existing df directory'
+When run bash -c "grep 'Refusing to migrate' '$SCRIPT'"
+The output should include 'Refusing to migrate'
+End
+End
+
+Describe 'sql-server invocation'
+It 'binds to localhost'
+When run bash -c "grep -- '-H 127.0.0.1' '$SCRIPT'"
+The output should include '-H 127.0.0.1'
+End
+
+It 'listens on port 3307'
+When run bash -c "grep -- '-P 3307' '$SCRIPT'"
+The output should include '-P 3307'
+End
+
+It 'points --data-dir at the beads directory'
+When run bash -c "grep -- '--data-dir' '$SCRIPT'"
+The output should include '--data-dir'
+End
+End
+
+End

--- a/spec/fish/__tmux_bootstrap_default_session_test.fish
+++ b/spec/fish/__tmux_bootstrap_default_session_test.fish
@@ -34,7 +34,7 @@ end
 __tmux_bootstrap_default_session unknown >/dev/null 2>/dev/null
 set unknown_status $status
 
-@test "unknown session returns failure" test $unknown_status -ne 0
-@test "unknown session does not touch tmux" test ! -s $log_unknown
+@test "unknown session returns failure" $unknown_status -ne 0
+@test "unknown session does not touch tmux" ! -s $log_unknown
 
 rm -f $log_primary $log_work $log_unknown


### PR DESCRIPTION
## Summary

`shell-inline-check` has been failing on `main` since the check was introduced. Two bugs, one fix each:

- **Undefined awk iteration order.** `scripts/check-nix-inline-scripts.sh` walked `home.activation` block lines with `for (i in lines)`, whose order is indeterminate. Continuation lines (`"arg" \`) were often inspected before the `bash`-delegate line that's supposed to set `saw_bash_call = 1`, so every multi-line activation block in `named-hosts/kyber`, `named-hosts/matic`, and `home-manager/modules/tailscale` tripped the "unknown-line" branch. Switched to an ordered `for (i = 1; i <= n; i++)` using the count returned by `split`.
- **Inline dolt start script.** `home-manager/services/dolt/default.nix` had a `pkgs.writeShellScript` with a large inline string, which the first check rejects. Extracted it to `home-manager/services/dolt/start.sh` and wired it up through `pkgs.replaceVars`, matching the pattern already used for obsidian/docker services. The `${beadsDir}` and `${pkgs.dolt}` interpolations become `@beadsDir@` / `@dolt@` placeholders.

## Test plan

- [x] `bash scripts/check-nix-inline-scripts.sh` → `No inline shell or Python scripts in Nix files`
- [x] `bash -n` on both touched shell scripts
- [ ] CI `shell-inline-check` green on this PR

https://claude.ai/code/session_017g5bYHcPU5fBNebzkrX3td

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing CI `shell-inline-check` on `main` and a fishtape error. Orders AWK line processing, extracts the Dolt start script, adds tests/coverage, and stringifies the path for `launchd` `ProgramArguments`.

- **Bug Fixes**
  - Iterate AWK block lines in order (1..n) to avoid false positives on multi-line `home.activation` blocks.
  - Extract Dolt start script to `home-manager/services/dolt/start.sh` via `pkgs.replaceVars`; add `spec/dolt_start_spec.sh` and register it in `spec/coverage_spec.sh` (widen placeholder-stripping regex for `bash -n`).
  - Pass a string path to `launchd` `ProgramArguments` by interpolating `"${startScript}"`; remove a stray `test` in fishtape assertions to prevent double-wrapping in `spec/fish/__tmux_bootstrap_default_session_test.fish`.

<sup>Written for commit dc7a8c00539dee9fa0fea1df20ece7dccf817d1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

