### PR TITLE
chore(claude): enable superpowers and security-guidance plugins

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -458,8 +458,10 @@
     "ruby-lsp@claude-plugins-official": true,
     "rust-analyzer-lsp@claude-plugins-official": true,
     "safety-net@cc-marketplace": true,
+    "security-guidance@claude-plugins-official": true,
     "serena@claude-plugins-official": true,
     "skill-codex@skill-codex": true,
+    "superpowers@claude-plugins-official": true,
     "swift-lsp@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
     "worktrunk@worktrunk": true


### PR DESCRIPTION
## Summary
- Enable `superpowers@claude-plugins-official` and `security-guidance@claude-plugins-official` in the Claude settings template.
- Inserted in alphabetical order within `enabledPlugins`.

## Test plan
- [ ] `jq '.enabledPlugins | keys' config/claude/settings.json` shows both new entries in sorted order.
- [ ] Plugins load without errors on next Claude session.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enabled `superpowers@claude-plugins-official` and `security-guidance@claude-plugins-official` so these plugins load by default in new Claude sessions. Added both entries alphabetically under `enabledPlugins` in `config/claude/settings.json`.

<sup>Written for commit fa842a9549f485a47d7cb3033d4a503651ae2f4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

