### PR TITLE
fix(security): disable docker-postgres on kyber

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -79,8 +79,8 @@ jobs:
             COMMIT_SHA=${{ github.sha }}
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
             GITHUB_PR=${{ github.event.pull_request.number }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache-${{ matrix.build.arch }}
+          cache-to: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache-${{ matrix.build.arch }},mode=max
       - name: Export digest
         run: |
           mkdir -p ${{ runner.temp }}/digests

--- a/config/mempalace/default.nix
+++ b/config/mempalace/default.nix
@@ -1,5 +1,4 @@
-{ ... }:
-{
+_: {
   home.file.".mempalace/config.json" = {
     source = ./config.json;
     force = true;

--- a/home-manager/modules/secure-dotenv/default.nix
+++ b/home-manager/modules/secure-dotenv/default.nix
@@ -6,24 +6,13 @@
 }:
 let
   homeDir = config.home.homeDirectory;
-  script = pkgs.writeShellScript "secure-dotenv" ''
-    set -euo pipefail
-    # Enforce 600 on all .env files under home directory
-    ${pkgs.findutils}/bin/find "${homeDir}" \
-      -maxdepth 4 \
-      -name '.env' -o -name '.env.*' -o -name '*.env' \
-      2>/dev/null | while IFS= read -r f; do
-      if [ -f "$f" ] && [ ! -L "$f" ]; then
-        current=$(${pkgs.coreutils}/bin/stat -c '%a' "$f")
-        if [ "$current" != "600" ]; then
-          chmod 600 "$f"
-        fi
-      fi
-    done
-  '';
+  script = pkgs.replaceVars ./secure-dotenv.sh {
+    find = "${pkgs.findutils}/bin/find";
+    stat = "${pkgs.coreutils}/bin/stat";
+  };
 in
 {
   home.activation.secureDotenv = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    $DRY_RUN_CMD ${script}
+    $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${script}" "${homeDir}"
   '';
 }

--- a/home-manager/modules/secure-dotenv/secure-dotenv.sh
+++ b/home-manager/modules/secure-dotenv/secure-dotenv.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# @find@ and @stat@ are substituted by pkgs.replaceVars.
+set -euo pipefail
+
+HOME_DIR="$1"
+
+@find@ "${HOME_DIR}" \
+  -maxdepth 4 \
+  \( -name '.env' -o -name '.env.*' -o -name '*.env' \) \
+  2>/dev/null | while IFS= read -r f; do
+  if [ -f "$f" ] && [ ! -L "$f" ]; then
+    current=$(@stat@ -c '%a' "$f")
+    if [ "$current" != "600" ]; then
+      chmod 600 "$f"
+    fi
+  fi
+done

--- a/home-manager/services/docker-postgres/default.nix
+++ b/home-manager/services/docker-postgres/default.nix
@@ -6,7 +6,7 @@
 }:
 let
   inherit (inputs.host) isGalactica isMatic;
-  enabled = !(isGalactica || isMatic);
+  enabled = isGalactica || isMatic;
   startScript = ./start-postgres.sh;
 
   # Smart wrapper that handles both NixOS and non-NixOS Linux

--- a/home-manager/services/ollama/default.nix
+++ b/home-manager/services/ollama/default.nix
@@ -1,4 +1,9 @@
-{ pkgs, lib, inputs, ... }:
+{
+  pkgs,
+  lib,
+  inputs,
+  ...
+}:
 let
   inherit (inputs.host) isGalactica isMatic;
   enabled = isGalactica || isMatic;

--- a/spec/clipboard_copy_spec.sh
+++ b/spec/clipboard_copy_spec.sh
@@ -116,7 +116,7 @@ Before 'setup'
 After 'cleanup'
 
 It 'uses OSC 52 escape sequence'
-When run bash "$SCRIPT" <<< "hello"
+When run bash "$SCRIPT" <<<"hello"
 The status should be success
 The output should start with $'\033]52;c;'
 End

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -153,6 +153,10 @@ It 'has spec file for home-manager/modules/npm-globals/install-npm-globals.sh'
 The path "spec/npm_globals_spec.sh" should be exist
 End
 
+It 'has spec file for home-manager/modules/secure-dotenv/secure-dotenv.sh'
+The path "spec/secure_dotenv_spec.sh" should be exist
+End
+
 It 'has spec file for home-manager/modules/uv-globals/install-uv-globals.sh'
 The path "spec/uv_globals_spec.sh" should be exist
 End
@@ -379,6 +383,7 @@ home-manager/modules/local-scripts/notify-local.sh
 home-manager/modules/local-scripts/pushover-notify.sh
 home-manager/modules/local-scripts/tmux-bridge.sh
 home-manager/modules/npm-globals/install-npm-globals.sh
+home-manager/modules/secure-dotenv/secure-dotenv.sh
 home-manager/services/obsidian/obsidian-git-trigger.sh
 home-manager/services/obsidian/obsidian-headless.sh
 home-manager/services/openclaw/activate.sh

--- a/spec/secure_dotenv_spec.sh
+++ b/spec/secure_dotenv_spec.sh
@@ -44,18 +44,18 @@ Describe 'functional behavior'
 setup() {
   TEST_HOME="$(mktemp -d)"
   # Create .env files with non-600 permissions
-  echo "SECRET=value" > "$TEST_HOME/.env"
+  echo "SECRET=value" >"$TEST_HOME/.env"
   chmod 644 "$TEST_HOME/.env"
 
   mkdir -p "$TEST_HOME/subdir"
-  echo "DB_URL=postgres://..." > "$TEST_HOME/subdir/.env.local"
+  echo "DB_URL=postgres://..." >"$TEST_HOME/subdir/.env.local"
   chmod 755 "$TEST_HOME/subdir/.env.local"
 
-  echo "KEY=val" > "$TEST_HOME/app.env"
+  echo "KEY=val" >"$TEST_HOME/app.env"
   chmod 644 "$TEST_HOME/app.env"
 
   # Create a file already at 600
-  echo "OK=true" > "$TEST_HOME/.env.safe"
+  echo "OK=true" >"$TEST_HOME/.env.safe"
   chmod 600 "$TEST_HOME/.env.safe"
 
   # Create a symlink (should be skipped)
@@ -66,7 +66,7 @@ setup() {
   sed \
     -e "s|@find@|$(command -v find)|g" \
     -e "s|@stat@|$(command -v stat)|g" \
-    "$SCRIPT" > "$PROCESSED_SCRIPT"
+    "$SCRIPT" >"$PROCESSED_SCRIPT"
   chmod +x "$PROCESSED_SCRIPT"
 
   export TEST_HOME PROCESSED_SCRIPT

--- a/spec/secure_dotenv_spec.sh
+++ b/spec/secure_dotenv_spec.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329,SC2016
+
+Describe 'home-manager/modules/secure-dotenv/secure-dotenv.sh'
+SCRIPT="$PWD/home-manager/modules/secure-dotenv/secure-dotenv.sh"
+
+Describe 'script properties'
+It 'uses bash shebang'
+When run bash -c "head -1 '$SCRIPT'"
+The output should include '#!/usr/bin/env bash'
+End
+
+It 'uses strict mode'
+When run bash -c "head -5 '$SCRIPT'"
+The output should include 'set -euo pipefail'
+End
+
+It 'passes bash syntax check after stripping placeholders'
+When run bash -c "sed 's|@[A-Za-z_][A-Za-z0-9_]*@|/usr/bin/test|g' '$SCRIPT' | bash -n"
+The status should be success
+End
+End
+
+Describe 'placeholder substitutions'
+It 'references @find@'
+When run bash -c "grep '@find@' '$SCRIPT'"
+The output should include '@find@'
+End
+
+It 'references @stat@'
+When run bash -c "grep '@stat@' '$SCRIPT'"
+The output should include '@stat@'
+End
+End
+
+Describe 'requires HOME_DIR argument'
+It 'reads HOME_DIR from $1'
+When run bash -c "grep 'HOME_DIR=.\$1.' '$SCRIPT'"
+The output should include 'HOME_DIR="$1"'
+End
+End
+
+Describe 'functional behavior'
+setup() {
+  TEST_HOME="$(mktemp -d)"
+  # Create .env files with non-600 permissions
+  echo "SECRET=value" > "$TEST_HOME/.env"
+  chmod 644 "$TEST_HOME/.env"
+
+  mkdir -p "$TEST_HOME/subdir"
+  echo "DB_URL=postgres://..." > "$TEST_HOME/subdir/.env.local"
+  chmod 755 "$TEST_HOME/subdir/.env.local"
+
+  echo "KEY=val" > "$TEST_HOME/app.env"
+  chmod 644 "$TEST_HOME/app.env"
+
+  # Create a file already at 600
+  echo "OK=true" > "$TEST_HOME/.env.safe"
+  chmod 600 "$TEST_HOME/.env.safe"
+
+  # Create a symlink (should be skipped)
+  ln -s "$TEST_HOME/.env" "$TEST_HOME/.env.link"
+
+  # Preprocess the script, replacing placeholders with real commands
+  PROCESSED_SCRIPT="$TEST_HOME/secure-dotenv-test.sh"
+  sed \
+    -e "s|@find@|$(command -v find)|g" \
+    -e "s|@stat@|$(command -v stat)|g" \
+    "$SCRIPT" > "$PROCESSED_SCRIPT"
+  chmod +x "$PROCESSED_SCRIPT"
+
+  export TEST_HOME PROCESSED_SCRIPT
+}
+cleanup() {
+  rm -rf "$TEST_HOME"
+  unset TEST_HOME PROCESSED_SCRIPT
+}
+Before 'setup'
+After 'cleanup'
+
+It 'changes .env from 644 to 600'
+When run bash "$PROCESSED_SCRIPT" "$TEST_HOME"
+The status should be success
+End
+
+It 'changes .env.local from 755 to 600'
+When run bash -c "bash '$PROCESSED_SCRIPT' '$TEST_HOME' && stat -c '%a' '$TEST_HOME/subdir/.env.local'"
+The output should equal '600'
+End
+
+It 'changes app.env from 644 to 600'
+When run bash -c "bash '$PROCESSED_SCRIPT' '$TEST_HOME' && stat -c '%a' '$TEST_HOME/app.env'"
+The output should equal '600'
+End
+
+It 'leaves already-600 files unchanged'
+When run bash -c "bash '$PROCESSED_SCRIPT' '$TEST_HOME' && stat -c '%a' '$TEST_HOME/.env.safe'"
+The output should equal '600'
+End
+
+It 'does not follow symlinks'
+When run bash -c "bash '$PROCESSED_SCRIPT' '$TEST_HOME' && test -L '$TEST_HOME/.env.link' && echo 'still-symlink'"
+The output should equal 'still-symlink'
+End
+End
+
+Describe 'depth limit'
+It 'uses maxdepth 4'
+When run bash -c "grep 'maxdepth 4' '$SCRIPT'"
+The output should include 'maxdepth 4'
+End
+End
+
+End


### PR DESCRIPTION
## Summary
- Postgres container on kyber was compromised via public 0.0.0.0:5432 with trust auth, running a cryptominer as /tmp/mysql
- Inverts docker-postgres enable condition: now only runs on galactica and matic, not kyber
- Compromised container already stopped and removed

## Test plan
- [ ] Verify kyber home-manager switch no longer creates docker-postgres systemd service
- [ ] Verify galactica/matic still get docker-postgres service

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable `docker-postgres` on kyber to prevent reinfection; the service now runs only on galactica and matic. Also extracted `secure-dotenv` into a script with tests and switched CI Docker cache to the registry for stability.

- **Bug Fixes**
  - Inverted enable condition in `home-manager/services/docker-postgres`: enabled only on galactica/matic.
  - Stopped and removed the compromised container that was exposed on 0.0.0.0:5432 with trust auth.

- **Refactors**
  - Moved `secure-dotenv` logic to `home-manager/modules/secure-dotenv/secure-dotenv.sh` and call it from activation with the home dir; uses Nix var substitution for `find`/`stat`.
  - Added `spec/secure_dotenv_spec.sh` and coverage checks; minor shfmt/nixfmt fixes and small cleanups (`ollama` args, mempalace module).
  - CI: switched `.github/workflows/docker.yml` cache from GHA to registry-based `cache-from/cache-to` to avoid auth timeouts.

<sup>Written for commit 83525b09928200c5d9f79980422a65560c8488fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

