### PR TITLE
feat(uv): add vllm-mlx to global tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ tools = [
   "ruff>=0.15.10",
   "serena-agent>=1.1.2",
   "vllm>=0.19.0",
+  "vllm-mlx>=0.2.8",
 ]
 
 [tool.uv]


### PR DESCRIPTION
## Summary
- Add `vllm-mlx>=0.2.8` to uv global tools in `pyproject.toml`
- MLX-compatible vLLM fork for macOS Apple Silicon inference

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `vllm-mlx>=0.2.8` to `uv` global tools, enabling MLX-backed vLLM inference on macOS Apple Silicon. This lets developers run local inference on Apple GPUs without manual setup.

<sup>Written for commit 2f354a85b1b85802a90e69a9b64964dcd7e875d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

