### PR TITLE
feat(nvim): add dotenv treesitter parser and show dotfiles in nvim-tree

### DIFF
--- a/home-manager/programs/neovim/lua/config/treesitter.lua
+++ b/home-manager/programs/neovim/lua/config/treesitter.lua
@@ -38,6 +38,7 @@ require("nvim-treesitter").setup({
 		"csv",
 		"diff",
 		"dockerfile",
+		"dotenv",
 		"fish",
 		"git_config",
 		"git_rebase",

--- a/home-manager/programs/neovim/lua/config/ui.lua
+++ b/home-manager/programs/neovim/lua/config/ui.lua
@@ -66,6 +66,9 @@ require("auto-dark-mode").setup({
 -- Sidebar file explorer built in Lua for quick navigation.
 -- From: https://github.com/nvim-tree/nvim-tree.lua
 require("nvim-tree").setup({
+	filters = {
+		dotfiles = false,
+	},
 	view = {
 		width = 30,
 	},


### PR DESCRIPTION
## Summary
- Add `dotenv` to treesitter `ensure_installed` for `.env` file syntax highlighting
- Set `filters.dotfiles = false` in nvim-tree to show `.env` files in the file explorer by default