### PR TITLE
feat: add doppler-diff Makefile command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1262,6 +1262,10 @@ doppler-sync: ## Sync Doppler secrets (dotfiles/prd) to .env file.
 	@doppler secrets download --project dotfiles --config prd --format env --no-file > .env
 	@echo "✅ .env file updated from Doppler (dotfiles/prd)"
 
+.PHONY: doppler-diff
+doppler-diff: ## Show diff between Doppler secrets and local .env file.
+	@doppler secrets download --project dotfiles --config prd --format env --no-file | diff - .env || true
+
 .PHONY: doppler-upload
 doppler-upload: ## Upload .env file to Doppler (dotfiles/prd).
 	@echo "🔐 Uploading .env to Doppler..."


### PR DESCRIPTION
## Summary
- Adds `make doppler-diff` command to show diff between upstream Doppler secrets (dotfiles/prd) and local `.env` file

## Test plan
- [ ] Run `make doppler-diff` and verify it shows differences between Doppler and local .env