### PR TITLE
fix: rename nix.gc.frequency to nix.gc.dates

### DIFF
--- a/home-manager/nix/nix.nix
+++ b/home-manager/nix/nix.nix
@@ -29,7 +29,7 @@
     };
     gc = {
       automatic = true;
-      frequency = "weekly";
+      dates = "weekly";
       options = "--delete-older-than 30d";
     };
   };


### PR DESCRIPTION
## Summary
- Rename deprecated `nix.gc.frequency` option to `nix.gc.dates` in home-manager nix config
- Fixes the trace warning during Linux x86_64 homeConfigurations build

## Test plan
- [ ] Build homeConfigurations on Linux x86_64 and verify the warning is gone