### PR TITLE
fix(kyber): use ubuntu as default username

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -179,7 +179,7 @@
               };
               kyber = import ./named-hosts/kyber {
                 inherit inputs;
-                username = "shunkakinoki";
+                username = "ubuntu";
                 system = "x86_64-linux";
               };
             };

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -1,7 +1,7 @@
 # Kyber - Ubuntu Linux server configuration
 {
   inputs,
-  username ? "shunkakinoki",
+  username ? "ubuntu",
   system ? "x86_64-linux",
 }:
 let


### PR DESCRIPTION
## Summary
- Latitude.sh provisions Ubuntu images with `ubuntu` as the default system user
- Kyber host config was hardcoded to `shunkakinoki`, causing Home Manager activation to fail: `USER is "ubuntu", expected "shunkakinoki"`
- Updated both `flake.nix` and `named-hosts/kyber/default.nix` to use `ubuntu`

## Test plan
- [ ] `make build && make switch` succeeds on kyber without `USER` override

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set kyber’s default username to `ubuntu` to match Latitude.sh images and fix Home Manager activation failures.

- **Bug Fixes**
  - Updated `flake.nix` and `named-hosts/kyber/default.nix` to set `username = "ubuntu"`.
  - Resolves the mismatch error: USER is "ubuntu", expected "shunkakinoki".

<sup>Written for commit 8fd2d353cee6e64a4efdc140d3fb6f11e2077ee7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

