### PR TITLE
fix(paperclip): pass BETTER_AUTH_BASE_URL to fix startup crash

### DIFF
--- a/home-manager/services/paperclip/default.nix
+++ b/home-manager/services/paperclip/default.nix
@@ -25,7 +25,7 @@ lib.mkIf host.isKyber {
     };
     Service = {
       Type = "simple";
-      ExecStart = "${pkgs.bash}/bin/bash -c 'exec env DATABASE_URL=\"$PAPERCLIP_DATABASE_URL\" ${homeDir}/.bun/bin/paperclipai run --no-repair'";
+      ExecStart = "${pkgs.bash}/bin/bash -c 'exec env DATABASE_URL=\"$PAPERCLIP_DATABASE_URL\" BETTER_AUTH_BASE_URL=\"$PAPERCLIP_BETTER_AUTH_BASE_URL\" ${homeDir}/.bun/bin/paperclipai run --no-repair'";
       Restart = "always";
       RestartSec = "5s";
       Environment = [


### PR DESCRIPTION
## Summary
- Paperclip 2026.416.0 crashes on startup: `Cannot read properties of undefined (reading 'baseUrlMode')`
- Better Auth requires `BETTER_AUTH_BASE_URL` in authenticated deployment mode
- Passes `PAPERCLIP_BETTER_AUTH_BASE_URL` from .env to `BETTER_AUTH_BASE_URL`, matching the existing `DATABASE_URL` pattern

## Test plan
- [ ] Set `PAPERCLIP_BETTER_AUTH_BASE_URL=https://paperclip.shunkakinoki.com` in paperclip .env
- [ ] `make build && make switch` then verify `systemctl --user status paperclip` no longer crash-loops
- [ ] Verify https://paperclip.shunkakinoki.com is accessible

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a startup crash in `paperclip` 2026.416.0 with “Cannot read properties of undefined (reading 'baseUrlMode')”. We now export `BETTER_AUTH_BASE_URL` by passing `PAPERCLIP_BETTER_AUTH_BASE_URL` to the `paperclipai` service, consistent with `DATABASE_URL`.

- **Migration**
  - Set `PAPERCLIP_BETTER_AUTH_BASE_URL` in your `paperclip` .env and restart the service.

<sup>Written for commit 4fb11573d04fa3c6088898bdb4304e6a4b9c6e93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

