### PR TITLE
fix(paperclip): add auth config and Better Auth env vars

### DIFF
--- a/config/paperclip/config.template.json
+++ b/config/paperclip/config.template.json
@@ -19,5 +19,9 @@
     "allowedHostnames": [
       "__ALLOWED_HOSTNAME__"
     ]
+  },
+  "auth": {
+    "baseUrlMode": "auto",
+    "disableSignUp": false
   }
 }

--- a/home-manager/services/paperclip/default.nix
+++ b/home-manager/services/paperclip/default.nix
@@ -33,6 +33,8 @@ lib.mkIf host.isKyber {
         "HOST=0.0.0.0"
         "PAPERCLIP_DEPLOYMENT_MODE=authenticated"
         "PAPERCLIP_ALLOWED_HOSTNAMES=paperclip.shunkakinoki.com,172.17.0.1"
+        "BETTER_AUTH_URL=https://paperclip.shunkakinoki.com"
+        "BETTER_AUTH_BASE_URL=https://paperclip.shunkakinoki.com"
         "PATH=${homeDir}/.local/bin:${homeDir}/.bun/bin:${homeDir}/.nix-profile/bin:${homeDir}/.local/share/pnpm:${homeDir}/.local/share/fnm/current/bin:${homeDir}/.npm-global/bin:/usr/local/bin:/usr/bin:/bin"
       ];
       EnvironmentFile = [


### PR DESCRIPTION
## Summary
- Paperclip 2026.416.0 crashes on startup: `Cannot read properties of undefined (reading 'baseUrlMode')`
- Root cause: `config.json` missing `auth` section; Zod schema defaults don't apply before `superRefine` validation
- Added `auth` section to config template with `baseUrlMode: "auto"`
- Added `BETTER_AUTH_URL` and `BETTER_AUTH_BASE_URL` env vars to systemd service

## Test plan
- [x] `systemctl --user status paperclip` shows active (running)
- [x] `curl localhost:3100` returns 200
- [x] `curl https://paperclip.shunkakinoki.com` returns 302 (auth redirect)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a startup crash in `paperclip` 2026.416.0 by adding the missing auth config and wiring Better Auth URLs. The service now starts correctly and redirects unauthenticated requests.

- **Bug Fixes**
  - Added `auth` section to config template with `baseUrlMode: "auto"` and `disableSignUp: false`.
  - Set `BETTER_AUTH_URL` and `BETTER_AUTH_BASE_URL` in the systemd service for correct auth redirects.

<sup>Written for commit 28250dcd1097c658d5818dca4a4e643307ca6b03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

