### PR TITLE
fix(paperclip): remove redundant env var and disable signups

### DIFF
--- a/config/paperclip/config.template.json
+++ b/config/paperclip/config.template.json
@@ -22,6 +22,6 @@
   },
   "auth": {
     "baseUrlMode": "auto",
-    "disableSignUp": false
+    "disableSignUp": true
   }
 }

--- a/home-manager/services/paperclip/default.nix
+++ b/home-manager/services/paperclip/default.nix
@@ -25,7 +25,7 @@ lib.mkIf host.isKyber {
     };
     Service = {
       Type = "simple";
-      ExecStart = "${pkgs.bash}/bin/bash -c 'exec env DATABASE_URL=\"$PAPERCLIP_DATABASE_URL\" BETTER_AUTH_BASE_URL=\"$PAPERCLIP_BETTER_AUTH_BASE_URL\" ${homeDir}/.bun/bin/paperclipai run --no-repair'";
+      ExecStart = "${pkgs.bash}/bin/bash -c 'exec env DATABASE_URL=\"$PAPERCLIP_DATABASE_URL\" ${homeDir}/.bun/bin/paperclipai run --no-repair'";
       Restart = "always";
       RestartSec = "5s";
       Environment = [
@@ -34,7 +34,6 @@ lib.mkIf host.isKyber {
         "PAPERCLIP_DEPLOYMENT_MODE=authenticated"
         "PAPERCLIP_ALLOWED_HOSTNAMES=paperclip.shunkakinoki.com,172.17.0.1"
         "BETTER_AUTH_URL=https://paperclip.shunkakinoki.com"
-        "BETTER_AUTH_BASE_URL=https://paperclip.shunkakinoki.com"
         "PATH=${homeDir}/.local/bin:${homeDir}/.bun/bin:${homeDir}/.nix-profile/bin:${homeDir}/.local/share/pnpm:${homeDir}/.local/share/fnm/current/bin:${homeDir}/.npm-global/bin:/usr/local/bin:/usr/bin:/bin"
       ];
       EnvironmentFile = [


### PR DESCRIPTION
## Summary
- Removed `BETTER_AUTH_BASE_URL` (Better Auth reads `BETTER_AUTH_URL`, not `_BASE_URL`)
- Removed `BETTER_AUTH_BASE_URL` passthrough from ExecStart (was from PR #1518, no longer needed)
- Set `disableSignUp: true` in auth config template

## Test plan
- [ ] `make build && make switch` succeeds
- [ ] Paperclip starts without crash
- [ ] Signup is disabled on paperclip.shunkakinoki.com

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the redundant BETTER_AUTH_BASE_URL from the Paperclip systemd config and standardized on BETTER_AUTH_URL to avoid misconfigurations. Disabled user signups in the auth template to lock down the deployment.

<sup>Written for commit bedbdc831dc5e62a489277c20b7f5624ca040c2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

