### PR TITLE
fix/tmux resurrect nixos

### DIFF
--- a/home-manager/programs/fish/functions/_two_function.fish
+++ b/home-manager/programs/fish/functions/_two_function.fish
@@ -8,19 +8,23 @@ function _two_function --description "Attach to tmux work session"
     return
   end
 
-  set -l restore (tmux list-keys 2>/dev/null | string match -rg '(/\S+/resurrect/scripts/restore\.sh)')
-  set -l restore $restore[1]
   set -l bootstrapped 0
 
-  # Start a server if needed so we can invoke the restore script.
+  # Start a server if needed so plugins load and resurrect becomes available.
   if not tmux list-sessions 2>/dev/null | grep -q .
     tmux new-session -d -s _bootstrap
     set bootstrapped 1
   end
 
+  # Resolve restore script after server is running (plugins are loaded).
+  set -l restore (tmux show-options -gv @resurrect-restore-script-path 2>/dev/null)
+  if test -z "$restore"
+    set restore (tmux list-keys 2>/dev/null | string match -rg '(/\S+/resurrect/scripts/restore\.sh)')
+    set restore $restore[1]
+  end
+
   if test -n "$restore"
     tmux run-shell "$restore"
-    # Give tmux-resurrect a moment to recreate the work session.
     for _i in (seq 1 50)
       if tmux has-session -t work 2>/dev/null
         if test $bootstrapped -eq 1
@@ -41,7 +45,6 @@ function _two_function --description "Attach to tmux work session"
     tmux kill-session -t _bootstrap 2>/dev/null
   end
 
-  # Restore didn't produce work — fall back to the built-in session bootstrap.
   __tmux_bootstrap_default_session work
   or return 1
 

--- a/home-manager/programs/tmux/default.nix
+++ b/home-manager/programs/tmux/default.nix
@@ -9,14 +9,38 @@
     enable = true;
     extraConfig = builtins.readFile ./tmux.conf;
     plugins = with pkgs.tmuxPlugins; [
-      continuum
-      extrakto
+      {
+        plugin = continuum;
+        extraConfig = ''
+          set -g @continuum-restore 'on'
+          set -g @continuum-save-interval '3'
+          set -g status-right "#[fg=colour250]#{?#{pane_current_command},#{pane_current_command},} #[fg=colour28]| #[fg=colour255]%Y/%m/%d %H:%M:%S #{continuum_status}"
+          set -g status-right-length 60
+        '';
+      }
+      {
+        plugin = extrakto;
+        extraConfig = "set -g @extrakto_key 'tab'";
+      }
       open
-      resurrect
+      {
+        plugin = resurrect;
+        extraConfig = ''
+          set -g @resurrect-capture-pane-contents 'on'
+          set -g @resurrect-processes 'btop fish git'
+          set -g @resurrect-hook-post-save-all 'd=~/.tmux/resurrect && f="$d/$(readlink "$d/last")" && grep -P "^(pane|window)\twork\t" "$f" > "$f.tmp" && printf "state\twork\n" >> "$f.tmp" && mv "$f.tmp" "$f"'
+        '';
+      }
       sensible
       tmux-fzf
-      tmux-sessionx
-      tmux-thumbs
+      {
+        plugin = tmux-sessionx;
+        extraConfig = "set -g @sessionx-bind 'o'";
+      }
+      {
+        plugin = tmux-thumbs;
+        extraConfig = "set -g @thumbs-key Space";
+      }
       yank
     ];
   };

--- a/home-manager/programs/tmux/default.nix
+++ b/home-manager/programs/tmux/default.nix
@@ -10,15 +10,6 @@
     extraConfig = builtins.readFile ./tmux.conf;
     plugins = with pkgs.tmuxPlugins; [
       {
-        plugin = continuum;
-        extraConfig = ''
-          set -g @continuum-restore 'on'
-          set -g @continuum-save-interval '3'
-          set -g status-right "#[fg=colour250]#{?#{pane_current_command},#{pane_current_command},} #[fg=colour28]| #[fg=colour255]%Y/%m/%d %H:%M:%S #{continuum_status}"
-          set -g status-right-length 60
-        '';
-      }
-      {
         plugin = extrakto;
         extraConfig = "set -g @extrakto_key 'tab'";
       }
@@ -29,6 +20,15 @@
           set -g @resurrect-capture-pane-contents 'on'
           set -g @resurrect-processes 'btop fish git'
           set -g @resurrect-hook-post-save-all 'd=~/.tmux/resurrect && f="$d/$(readlink "$d/last")" && grep -P "^(pane|window)\twork\t" "$f" > "$f.tmp" && printf "state\twork\n" >> "$f.tmp" && mv "$f.tmp" "$f"'
+        '';
+      }
+      {
+        plugin = continuum;
+        extraConfig = ''
+          set -g @continuum-restore 'on'
+          set -g @continuum-save-interval '3'
+          set -g status-right "#[fg=colour250]#{?#{pane_current_command},#{pane_current_command},} #[fg=colour28]| #[fg=colour255]%Y/%m/%d %H:%M:%S #{continuum_status}"
+          set -g status-right-length 60
         '';
       }
       sensible

--- a/home-manager/programs/tmux/tmux.conf
+++ b/home-manager/programs/tmux/tmux.conf
@@ -42,8 +42,6 @@ set -g @clipboard_cmd "~/.local/scripts/clipboard-copy"
 # Status bar
 set -g status "on"
 set -g status-justify "left"
-set -g status-left-length "100"
-set -g status-right-length "100"
 set -g status-left ""
 set -g status-left-style NONE
 set -g status-right-style NONE
@@ -107,9 +105,9 @@ set -g clock-mode-style 24
 # =============================================================================
 set -g status-style "bg=colour22,fg=colour255"
 set -g status-left "#[bg=colour28,fg=colour255,bold] #S #[bg=colour22,fg=colour28] "
-set -g status-right "#[fg=colour250]#{?#{pane_current_command},#{pane_current_command},} #[fg=colour28]| #[fg=colour255]%Y/%m/%d %H:%M:%S #{continuum_status}"
+# status-right and status-right-length are set in default.nix continuum
+# extraConfig so the plugin can prepend its save trigger to status-right.
 set -g status-left-length 30
-set -g status-right-length 60
 
 # Window status
 set -g window-status-format " #I:#W "
@@ -124,24 +122,11 @@ set -g pane-active-border-style "fg=colour82,bold"
 set -g message-style "bg=colour28,fg=colour255"
 
 # =============================================================================
-# Plugin configuration
+# Plugin configuration (options are in default.nix extraConfig per plugin)
 # =============================================================================
-# Resurrect + Continuum (session persistence — work session only)
-set -g @resurrect-capture-pane-contents 'on'
-set -g @resurrect-processes 'btop fish git'
-set -g @resurrect-hook-post-save-all 'd=~/.tmux/resurrect && f="$d/$(readlink "$d/last")" && grep -E "^(pane|window)	work	" "$f" > "$f.tmp" && printf "state\twork\n" >> "$f.tmp" && mv "$f.tmp" "$f"'
-set -g @continuum-restore 'on'
-set -g @continuum-save-interval '3'
-
 # Auto-save on detach/close so kills don't lose state
 set-hook -g client-detached 'run-shell #{@resurrect-save-script-path}'
 set-hook -g session-closed 'run-shell #{@resurrect-save-script-path}'
-
-# Tmux-thumbs (quick text copy)
-set -g @thumbs-key Space
-
-# Sessionx (session manager)
-set -g @sessionx-bind 'o'
 
 # Tmux sessionizer (fzf session picker)
 bind S run-shell "tmux new-window 'fish -c _tss_function'"
@@ -157,9 +142,6 @@ bind H run-shell "tmux new-window 'fish -c _tsh_function'"
 
 # Kill sessions/windows via fzf
 bind K run-shell "tmux new-window 'fish -c _tsk_function'"
-
-# Extrakto (text extraction)
-set -g @extrakto_key 'tab'
 
 set -g history-limit 2147483647
 


### PR DESCRIPTION
- **fix: tmux resurrect/continuum restore on NixOS**
- **fix: load resurrect before continuum in plugin order**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes reliable `tmux` session restore on NixOS by loading `resurrect` before `continuum` and resolving the restore script after the server starts. Moves plugin options into per-plugin `extraConfig` so hooks run with the correct settings and lets `continuum` manage `status-right`.

- **Bug Fixes**
  - Start a tmux server in `_two_function.fish` so plugins load, then read `@resurrect-restore-script-path` (fallback to key scan) and run restore.
  - Load `resurrect` before `continuum` to enable auto-restore.
  - Use `grep -P` in the post-save hook to correctly match tab-separated fields.

- **Refactors**
  - Move plugin options from `tmux.conf` to per-plugin `extraConfig` in `default.nix` (`resurrect`, `continuum`, `extrakto`, `tmux-thumbs`, `tmux-sessionx`).
  - Set `status-right` and its length in `continuum` `extraConfig` so it can prepend its save trigger; remove duplicates from `tmux.conf`.

<sup>Written for commit fcec1ba1eeb05734355e3a4d8c2b2f6d81bfe1bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

