### PR TITLE
fix: remap framework copy for editors

### DIFF
--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -439,4 +439,3 @@ bind = CTRL ALT SHIFT SUPER, L, exec, hyprlock
 # Notification Toggle
 # =============================================================================
 bind = $mod SHIFT, D, exec, hyprpanel toggleWindow notifications-center
-

--- a/config/keyd/app.conf
+++ b/config/keyd/app.conf
@@ -1,0 +1,6 @@
+# keyd-application-mapper normalizes classes/titles to lowercase
+# with punctuation collapsed to '-'. Slack's class becomes `slack`.
+[slack]
+leftmeta = layer(control)
+prog1 = layer(control)
+f13 = layer(control)

--- a/config/keyd/default.conf
+++ b/config/keyd/default.conf
@@ -8,11 +8,6 @@
 # input. Exclude the default xremap device id to prevent that.
 -1234:5678
 
-[global]
-# Avoid modifier tap injection around Framework chords; Slack is reacting to the
-# synthetic extra taps before the actual keypress.
-disable_modifier_guard = 1
-
 [main]
 # SUPER: CapsLock/RightAlt → Hyprland "$mod" binds (window mgmt, app launch)
 # These skip xremap and go directly to Hyprland.
@@ -36,8 +31,6 @@ rightshift = capslock
 # Every Framework+key emits Ctrl+Alt+Shift+Super+key (Hyper).
 # xremap then converts Hyper+key → Ctrl+key for apps.
 # Keys excluded from xremap (e.g. 3/4/5) pass through as Hyper to Hyprland.
-# Framework+C also follows the normal Hyper path so Slack-specific handling
-# can happen in xremap instead of keyd's modifier replay.
 
 # Framework+Tab → Super+Tab for hyprshell window switcher
 tab = M-tab

--- a/config/keyd/default.conf
+++ b/config/keyd/default.conf
@@ -31,10 +31,8 @@ rightshift = capslock
 # Every Framework+key emits Ctrl+Alt+Shift+Super+key (Hyper).
 # xremap then converts Hyper+key → Ctrl+key for apps.
 # Keys excluded from xremap (e.g. 3/4/5) pass through as Hyper to Hyprland.
-
-# Framework+C should behave like a real Ctrl+C in Slack/Electron. Emit it
-# directly from keyd instead of sending Hyper+C through xremap first.
-c = C-c
+# Framework+C also follows the normal Hyper path so Slack-specific handling
+# can happen in xremap instead of keyd's modifier replay.
 
 # Framework+Tab → Super+Tab for hyprshell window switcher
 tab = M-tab

--- a/config/keyd/default.conf
+++ b/config/keyd/default.conf
@@ -8,6 +8,11 @@
 # input. Exclude the default xremap device id to prevent that.
 -1234:5678
 
+[global]
+# Avoid modifier tap injection around Framework chords; Slack is reacting to the
+# synthetic extra taps before the actual keypress.
+disable_modifier_guard = 1
+
 [main]
 # SUPER: CapsLock/RightAlt → Hyprland "$mod" binds (window mgmt, app launch)
 # These skip xremap and go directly to Hyprland.

--- a/config/keyd/default.nix
+++ b/config/keyd/default.nix
@@ -1,4 +1,9 @@
-_: {
+{
+  pkgs,
+  username,
+  ...
+}:
+{
   services.keyd.enable = true;
 
   # Optional: silence the setgid warning (nice to have, not required for functionality)
@@ -14,4 +19,30 @@ _: {
   ];
 
   environment.etc."keyd/default.conf".source = ./default.conf;
+
+  home-manager.users.${username} = {
+    xdg.configFile."keyd/app.conf".source = ./app.conf;
+
+    systemd.user.services.keyd-application-mapper = {
+      Unit = {
+        Description = "keyd application mapper";
+        After = [ "graphical-session.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+      Service = {
+        Type = "simple";
+        # Force a unit restart on switch when app.conf changes.
+        Environment = [ "KEYD_APP_CONF_HASH=${builtins.hashFile "sha256" ./app.conf}" ];
+        # User managers can start before refreshed supplementary groups
+        # are visible in the login session. Enter the keyd group
+        # explicitly so the mapper can always reach /var/run/keyd.socket.
+        ExecStart = "${pkgs.bash}/bin/bash -lc 'exec /run/wrappers/bin/sg keyd -c \"KEYD_BIN=${pkgs.keyd}/bin/keyd ${pkgs.keyd}/bin/keyd-application-mapper\"'";
+        Restart = "on-failure";
+        RestartSec = 3;
+      };
+      Install = {
+        WantedBy = [ "graphical-session.target" ];
+      };
+    };
+  };
 }

--- a/config/keyd/default.nix
+++ b/config/keyd/default.nix
@@ -1,5 +1,4 @@
 {
-  pkgs,
   username,
   ...
 }:
@@ -21,28 +20,9 @@
   environment.etc."keyd/default.conf".source = ./default.conf;
 
   home-manager.users.${username} = {
-    xdg.configFile."keyd/app.conf".source = ./app.conf;
-
-    systemd.user.services.keyd-application-mapper = {
-      Unit = {
-        Description = "keyd application mapper";
-        After = [ "graphical-session.target" ];
-        PartOf = [ "graphical-session.target" ];
-      };
-      Service = {
-        Type = "simple";
-        # Force a unit restart on switch when app.conf changes.
-        Environment = [ "KEYD_APP_CONF_HASH=${builtins.hashFile "sha256" ./app.conf}" ];
-        # User managers can start before refreshed supplementary groups
-        # are visible in the login session. Enter the keyd group
-        # explicitly so the mapper can always reach /var/run/keyd.socket.
-        ExecStart = "${pkgs.bash}/bin/bash -lc 'exec /run/wrappers/bin/sg keyd -c \"KEYD_BIN=${pkgs.keyd}/bin/keyd ${pkgs.keyd}/bin/keyd-application-mapper\"'";
-        Restart = "on-failure";
-        RestartSec = 3;
-      };
-      Install = {
-        WantedBy = [ "graphical-session.target" ];
-      };
+    services."keyd-application-mapper" = {
+      enable = true;
+      configFile = ./app.conf;
     };
   };
 }

--- a/config/keyd/default.nix
+++ b/config/keyd/default.nix
@@ -20,9 +20,7 @@
   environment.etc."keyd/default.conf".source = ./default.conf;
 
   home-manager.users.${username} = {
-    services."keyd-application-mapper" = {
-      enable = true;
-      configFile = ./app.conf;
-    };
+    xdg.configFile."keyd/app.conf".source = ./app.conf;
+    services."keyd-application-mapper".enable = true;
   };
 }

--- a/home-manager/modules/xremap/default.nix
+++ b/home-manager/modules/xremap/default.nix
@@ -90,6 +90,11 @@ let
     "${hyperPrefix}c" = "C-Shift-c";
     "${hyperPrefix}v" = "C-Shift-v";
   };
+  slackCopyCommand = [
+    (lib.getExe pkgs.bash)
+    "-lc"
+    "sleep 0.03 && exec ${lib.getExe pkgs.wtype} -M ctrl -k c -m ctrl"
+  ];
   codeEditorAppIds = [
     "cursor"
     "Cursor"
@@ -99,7 +104,13 @@ let
   # Slack: same mapping as global but isolated so Slack-specific workarounds
   # (modifier leak, thread mark-as-read on bare `c`/`Esc`) can be tuned here
   # without affecting other apps. See commits e60e0df, 95679b8, 48ad8f5.
-  slackRemap = globalRemap;
+  slackRemap = globalRemap // {
+    # Slack/Electron still misreads xremap's synthesized Ctrl+C path on Wayland.
+    # Delegate copy to wtype so Slack sees a clean Ctrl+C without Hyper residue.
+    "${hyperPrefix}c" = {
+      launch = slackCopyCommand;
+    };
+  };
 in
 {
   config = lib.mkMerge [

--- a/home-manager/modules/xremap/default.nix
+++ b/home-manager/modules/xremap/default.nix
@@ -11,13 +11,14 @@ let
   # Hyper = Framework key (keyd: [cmd_hyper:C-A-S-M]) → remapped to Ctrl for macOS-style shortcuts
   hyperPrefix = "C-Alt-Shift-Super-";
   ctrlPrefix = "C-";
+  # "c" is excluded — keyd emits a native Ctrl+C directly so Slack/Electron
+  # can avoid xremap's synthesized Hyper->Ctrl path.
   # "f" is excluded — passes through as Hyper+F for Hyprland fullscreen bind.
   # "l" is excluded — passes through as Hyper+L for Hyprland lock screen bind.
   # See: config/hyprland/hyprland.conf (Window Management section, Lock Screen section)
   letters = [
     "a"
     "b"
-    "c"
     "d"
     "e"
     "g"

--- a/home-manager/modules/xremap/default.nix
+++ b/home-manager/modules/xremap/default.nix
@@ -11,14 +11,13 @@ let
   # Hyper = Framework key (keyd: [cmd_hyper:C-A-S-M]) → remapped to Ctrl for macOS-style shortcuts
   hyperPrefix = "C-Alt-Shift-Super-";
   ctrlPrefix = "C-";
-  # "c" is excluded — keyd emits a native Ctrl+C directly so Slack/Electron
-  # can avoid xremap's synthesized Hyper->Ctrl path.
   # "f" is excluded — passes through as Hyper+F for Hyprland fullscreen bind.
   # "l" is excluded — passes through as Hyper+L for Hyprland lock screen bind.
   # See: config/hyprland/hyprland.conf (Window Management section, Lock Screen section)
   letters = [
     "a"
     "b"
+    "c"
     "d"
     "e"
     "g"
@@ -105,8 +104,8 @@ let
   # (modifier leak, thread mark-as-read on bare `c`/`Esc`) can be tuned here
   # without affecting other apps. See commits e60e0df, 95679b8, 48ad8f5.
   slackRemap = globalRemap // {
-    # Slack/Electron still misreads xremap's synthesized Ctrl+C path on Wayland.
-    # Delegate copy to wtype so Slack sees a clean Ctrl+C without Hyper residue.
+    # Slack/Electron misreads the native Hyper->Ctrl replay path on Wayland.
+    # Delegate copy to wtype so Slack sees a clean Ctrl+C instead.
     "${hyperPrefix}c" = {
       launch = slackCopyCommand;
     };

--- a/home-manager/modules/xremap/default.nix
+++ b/home-manager/modules/xremap/default.nix
@@ -89,27 +89,15 @@ let
     "${hyperPrefix}c" = "C-Shift-c";
     "${hyperPrefix}v" = "C-Shift-v";
   };
-  slackCopyCommand = [
-    (lib.getExe pkgs.bash)
-    "-lc"
-    "sleep 0.03 && exec ${lib.getExe pkgs.wtype} -M ctrl -k c -m ctrl"
-  ];
   codeEditorAppIds = [
     "cursor"
     "Cursor"
     "code"
     "Code"
   ];
-  # Slack: same mapping as global but isolated so Slack-specific workarounds
-  # (modifier leak, thread mark-as-read on bare `c`/`Esc`) can be tuned here
-  # without affecting other apps. See commits e60e0df, 95679b8, 48ad8f5.
-  slackRemap = globalRemap // {
-    # Slack/Electron misreads the native Hyper->Ctrl replay path on Wayland.
-    # Delegate copy to wtype so Slack sees a clean Ctrl+C instead.
-    "${hyperPrefix}c" = {
-      launch = slackCopyCommand;
-    };
-  };
+  # Slack-specific Framework->Ctrl behavior is handled by keyd's
+  # application mapper on hosts that enable ~/.config/keyd/app.conf.
+  slackRemap = globalRemap;
 in
 {
   config = lib.mkMerge [

--- a/home-manager/modules/xremap/default.nix
+++ b/home-manager/modules/xremap/default.nix
@@ -80,14 +80,21 @@ let
         value = "${ctrlPrefix}${key}";
       }) keys
     );
-  # Framework+key → Ctrl+key for all apps (macOS-style shortcuts)
+  # Framework+key -> Ctrl+key for all apps (macOS-style shortcuts)
   globalRemap = mkRemap remapKeys;
-  # Ghostty: Framework+C/V → Ctrl+Shift+C/V (terminal convention: Ctrl+C = SIGINT)
-  ghosttyRemap = globalRemap // {
+  # Terminal/editor clipboard convention: Framework+C/V -> Ctrl+Shift+C/V so
+  # copy/paste does not collide with SIGINT or app-specific bare Ctrl+C handlers.
+  terminalClipboardRemap = globalRemap // {
     "C-c" = "C-Shift-c";
     "${hyperPrefix}c" = "C-Shift-c";
     "${hyperPrefix}v" = "C-Shift-v";
   };
+  codeEditorAppIds = [
+    "cursor"
+    "Cursor"
+    "code"
+    "Code"
+  ];
   # Slack: same mapping as global but isolated so Slack-specific workarounds
   # (modifier leak, thread mark-as-read on bare `c`/`Esc`) can be tuned here
   # without affecting other apps. See commits e60e0df, 95679b8, 48ad8f5.
@@ -109,10 +116,16 @@ in
           keypress_delay_ms = 10;
           keymap = [
             {
-              # Ghostty: Framework+C/V → Ctrl+Shift+C/V (terminal convention: Ctrl+C = SIGINT)
+              # Ghostty: Framework+C/V -> Ctrl+Shift+C/V (terminal convention: Ctrl+C = SIGINT)
               name = "Framework Command (Ghostty)";
               application.only = [ "com.mitchellh.ghostty" ];
-              remap = ghosttyRemap;
+              remap = terminalClipboardRemap;
+            }
+            {
+              # Cursor/VS Code: terminal-style clipboard shortcut, not bare Ctrl+C.
+              name = "Framework Command (Code Editors)";
+              application.only = codeEditorAppIds;
+              remap = terminalClipboardRemap;
             }
             {
               # Slack: isolated block so modifier-leak / thread mark-as-read

--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -16,6 +16,7 @@ let
   dockerPostgres = ./docker-postgres;
   dotfilesUpdater = import ./dotfiles-updater { inherit pkgs; };
   gasTown = import ./gas-town { inherit pkgs; };
+  keydApplicationMapper = ./keyd-application-mapper;
   makeUpdater = import ./make-updater { inherit pkgs; };
   neversslKeepalive = import ./neverssl-keepalive { inherit pkgs; };
   obsidian = import ./obsidian { inherit config pkgs inputs; };
@@ -37,6 +38,7 @@ in
   dockerPostgres
   dotfilesUpdater
   gasTown
+  keydApplicationMapper
   makeUpdater
   neversslKeepalive
   obsidian

--- a/home-manager/services/keyd-application-mapper/default.nix
+++ b/home-manager/services/keyd-application-mapper/default.nix
@@ -10,15 +10,15 @@ in
 {
   options.services."keyd-application-mapper" = {
     enable = lib.mkEnableOption "keyd application mapper user service";
-
-    configFile = lib.mkOption {
-      type = lib.types.path;
-      description = "Source keyd app.conf used by keyd-application-mapper.";
-    };
   };
 
   config = lib.mkIf (pkgs.stdenv.isLinux && cfg.enable) {
-    xdg.configFile."keyd/app.conf".source = cfg.configFile;
+    assertions = [
+      {
+        assertion = config.xdg.configFile ? "keyd/app.conf";
+        message = "services.keyd-application-mapper requires xdg.configFile.\"keyd/app.conf\"";
+      }
+    ];
 
     systemd.user.services.keyd-application-mapper = {
       Unit = {
@@ -29,7 +29,9 @@ in
       Service = {
         Type = "simple";
         # Force a unit restart on switch when app.conf changes.
-        Environment = [ "KEYD_APP_CONF_HASH=${builtins.hashFile "sha256" cfg.configFile}" ];
+        Environment = [
+          "KEYD_APP_CONF_HASH=${builtins.hashFile "sha256" config.xdg.configFile."keyd/app.conf".source}"
+        ];
         # User managers can start before refreshed supplementary groups
         # are visible in the login session. Enter the keyd group
         # explicitly so the mapper can always reach /var/run/keyd.socket.

--- a/home-manager/services/keyd-application-mapper/default.nix
+++ b/home-manager/services/keyd-application-mapper/default.nix
@@ -1,0 +1,45 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services."keyd-application-mapper";
+in
+{
+  options.services."keyd-application-mapper" = {
+    enable = lib.mkEnableOption "keyd application mapper user service";
+
+    configFile = lib.mkOption {
+      type = lib.types.path;
+      description = "Source keyd app.conf used by keyd-application-mapper.";
+    };
+  };
+
+  config = lib.mkIf (pkgs.stdenv.isLinux && cfg.enable) {
+    xdg.configFile."keyd/app.conf".source = cfg.configFile;
+
+    systemd.user.services.keyd-application-mapper = {
+      Unit = {
+        Description = "keyd application mapper";
+        After = [ "graphical-session.target" ];
+        PartOf = [ "graphical-session.target" ];
+      };
+      Service = {
+        Type = "simple";
+        # Force a unit restart on switch when app.conf changes.
+        Environment = [ "KEYD_APP_CONF_HASH=${builtins.hashFile "sha256" cfg.configFile}" ];
+        # User managers can start before refreshed supplementary groups
+        # are visible in the login session. Enter the keyd group
+        # explicitly so the mapper can always reach /var/run/keyd.socket.
+        ExecStart = "${pkgs.bash}/bin/bash -lc 'exec /run/wrappers/bin/sg keyd -c \"KEYD_BIN=${pkgs.keyd}/bin/keyd ${pkgs.keyd}/bin/keyd-application-mapper\"'";
+        Restart = "on-failure";
+        RestartSec = 3;
+      };
+      Install = {
+        WantedBy = [ "graphical-session.target" ];
+      };
+    };
+  };
+}

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -14,6 +14,7 @@ import ../../hosts/nixos {
     "video"
     "audio"
     "docker"
+    "keyd"
   ];
   modules = [
     # Framework 13" AMD AI 300 hardware support
@@ -97,6 +98,37 @@ import ../../hosts/nixos {
           (builtins.hashFile "sha256" ../../config/keyd/default.conf)
         ];
         environment.etc."keyd/default.conf".source = ../../config/keyd/default.conf;
+
+        home-manager.users.${username} = {
+          xdg.configFile."keyd/app.conf".text = ''
+            # keyd-application-mapper normalizes classes/titles to lowercase
+            # with punctuation collapsed to '-'. Slack's class becomes `slack`.
+            [slack]
+            leftmeta = layer(control)
+            prog1 = layer(control)
+            f13 = layer(control)
+          '';
+
+          systemd.user.services.keyd-application-mapper = {
+            Unit = {
+              Description = "keyd application mapper";
+              After = [ "graphical-session.target" ];
+              PartOf = [ "graphical-session.target" ];
+            };
+            Service = {
+              Type = "simple";
+              # User managers can start before refreshed supplementary groups
+              # are visible in the login session. Enter the keyd group
+              # explicitly so the mapper can always reach /var/run/keyd.socket.
+              ExecStart = "${pkgs.bash}/bin/bash -lc 'exec /run/wrappers/bin/sg keyd -c \"KEYD_BIN=${pkgs.keyd}/bin/keyd ${pkgs.keyd}/bin/keyd-application-mapper\"'";
+              Restart = "on-failure";
+              RestartSec = 3;
+            };
+            Install = {
+              WantedBy = [ "graphical-session.target" ];
+            };
+          };
+        };
 
         # Input remapping (xremap)
         hardware.uinput.enable = true;

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -23,6 +23,9 @@ import ../../hosts/nixos {
     # Hardware configuration
     ./hardware-configuration.nix
 
+    # Shared keyd config and application mapper wiring
+    ../../config/keyd/default.nix
+
     # Kolide launcher
     ./kolide.nix
 
@@ -87,49 +90,6 @@ import ../../hosts/nixos {
             ExecStop = "${pkgs.e2fsprogs}/bin/chattr -i /";
           };
         };
-        # Keyd configuration (Linux desktop only)
-        services.keyd.enable = true;
-        users.groups.keyd = { };
-        systemd.services.keyd.serviceConfig = {
-          CapabilityBoundingSet = [ "CAP_SETGID" ];
-          AmbientCapabilities = [ "CAP_SETGID" ];
-        };
-        systemd.services.keyd.restartTriggers = [
-          (builtins.hashFile "sha256" ../../config/keyd/default.conf)
-        ];
-        environment.etc."keyd/default.conf".source = ../../config/keyd/default.conf;
-
-        home-manager.users.${username} = {
-          xdg.configFile."keyd/app.conf".text = ''
-            # keyd-application-mapper normalizes classes/titles to lowercase
-            # with punctuation collapsed to '-'. Slack's class becomes `slack`.
-            [slack]
-            leftmeta = layer(control)
-            prog1 = layer(control)
-            f13 = layer(control)
-          '';
-
-          systemd.user.services.keyd-application-mapper = {
-            Unit = {
-              Description = "keyd application mapper";
-              After = [ "graphical-session.target" ];
-              PartOf = [ "graphical-session.target" ];
-            };
-            Service = {
-              Type = "simple";
-              # User managers can start before refreshed supplementary groups
-              # are visible in the login session. Enter the keyd group
-              # explicitly so the mapper can always reach /var/run/keyd.socket.
-              ExecStart = "${pkgs.bash}/bin/bash -lc 'exec /run/wrappers/bin/sg keyd -c \"KEYD_BIN=${pkgs.keyd}/bin/keyd ${pkgs.keyd}/bin/keyd-application-mapper\"'";
-              Restart = "on-failure";
-              RestartSec = 3;
-            };
-            Install = {
-              WantedBy = [ "graphical-session.target" ];
-            };
-          };
-        };
-
         # Input remapping (xremap)
         hardware.uinput.enable = true;
         services.udev.extraRules = ''


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes copy/paste in Cursor and VS Code by remapping Framework+C/V to Ctrl+Shift+C/V, matching terminal behavior and avoiding Ctrl+C conflicts. Centralizes Slack Framework→Ctrl mapping in a shared `keyd` module with a Home Manager service, and removes the `c = C-c` hack; other Framework→Ctrl shortcuts stay the same.

- **Bug Fixes**
  - Applied shared `terminalClipboardRemap` to `Cursor`/`VS Code` via `codeEditorAppIds`.
  - Moved Slack mapping into `keyd-application-mapper` using XDG `app.conf`; the shared `config/keyd/default.nix` now writes `app.conf` and enables the user unit, launched via `sg keyd` for reliable socket access.

<sup>Written for commit 45b053c3469a082b2957edcafc40e1a0c4c58b13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

