### PR TITLE
opsec

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -232,7 +232,7 @@
           },
           {
             "type": "command",
-            "command": "$HOME/dotfiles/config/shared/hooks/block-push-main.sh",
+            "command": "$HOME/dotfiles/config/shared/hooks/block-git-push.sh",
             "timeout": 5
           },
           {

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -237,6 +237,11 @@
           },
           {
             "type": "command",
+            "command": "$HOME/dotfiles/config/shared/hooks/block-gh-settings.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "$HOME/.claude/hooks/notify.sh",
             "timeout": 3,
             "async": true

--- a/config/codex/hooks.json
+++ b/config/codex/hooks.json
@@ -35,7 +35,7 @@
           },
           {
             "type": "command",
-            "command": "$HOME/dotfiles/config/shared/hooks/block-push-main.sh",
+            "command": "$HOME/dotfiles/config/shared/hooks/block-git-push.sh",
             "timeout": 5
           },
           {

--- a/config/shared/hooks/block-gh-settings.sh
+++ b/config/shared/hooks/block-gh-settings.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# block-gh-settings.sh — Shared hook for Claude Code + Codex
+# Blocks gh CLI commands that modify GitHub repository settings.
+# Exit 2 = block (Codex), JSON decision output (Claude).
+set -euo pipefail
+
+# Read tool input from stdin
+input=$(cat)
+
+# Extract command
+command=$(echo "$input" | jq -r '.tool_input.command // .command // empty' 2>/dev/null)
+[[ -z $command ]] && exit 0
+
+# Block: gh repo <destructive-subcommand>
+if echo "$command" | grep -qE 'gh\s+repo\s+(delete|rename|archive|transfer|edit)\b'; then
+  subcommand=$(echo "$command" | grep -oE 'gh\s+repo\s+(delete|rename|archive|transfer|edit)' | awk '{print $3}')
+  msg="'gh repo $subcommand' is blocked. Repo settings must be changed manually."
+  echo "BLOCKED by block-gh-settings.sh: $msg" >&2
+  exit 2
+fi
+
+# Block: gh api -X PATCH|DELETE|PUT targeting /repos/
+if echo "$command" | grep -qE 'gh\s+api'; then
+  if echo "$command" | grep -qE '\-X\s+(PATCH|DELETE|PUT)' && echo "$command" | grep -qE '/repos/'; then
+    method=$(echo "$command" | grep -oE '\-X\s+(PATCH|DELETE|PUT)' | awk '{print $2}')
+    msg="'gh api -X $method /repos/...' is blocked. Repo API mutations must be done manually."
+    echo "BLOCKED by block-gh-settings.sh: $msg" >&2
+    exit 2
+  fi
+fi
+
+exit 0

--- a/config/shared/hooks/block-git-push.sh
+++ b/config/shared/hooks/block-git-push.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# block-push-main.sh — Shared hook for Claude Code + Codex
+# block-git-push.sh - Shared hook for Claude Code + Codex
 # Blocks git push to main/master unless repo is in the allowlist.
 # Exit 2 = block (Codex), JSON decision output (Claude).
 set -euo pipefail
@@ -37,5 +37,5 @@ done
 
 # Block the push
 msg="Push to main/master blocked in '$repo'. Use a feature branch + PR."
-echo "BLOCKED by block-push-main.sh: $msg" >&2
+echo "BLOCKED by block-git-push.sh: $msg" >&2
 exit 2

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -71,7 +71,34 @@ import ../../hosts/nixos {
         ];
 
         # Networking
-        networking.networkmanager.wifi.powersave = true;
+        networking.networkmanager.wifi = {
+          powersave = true;
+          scanRandMacAddress = true;
+          macAddress = "stable-ssid";
+        };
+
+        networking.firewall = {
+          enable = true;
+          trustedInterfaces = [ "tailscale0" ];
+          allowedTCPPorts = [ ];
+          allowedUDPPorts = [ ];
+          logRefusedConnections = true;
+        };
+
+        # Audit logging
+        security.auditd.enable = true;
+        security.audit = {
+          enable = true;
+          rules = [
+            "-a exit,always -F arch=b64 -S execve -k exec"
+            "-a exit,always -F arch=b32 -S execve -k exec"
+            "-a exit,always -F arch=b64 -S setuid,setgid,setresuid,setresgid -k priv_esc"
+            "-w /etc/sudoers -p wa -k sudoers"
+            "-w /etc/passwd -p wa -k identity"
+            "-w /etc/shadow -p wa -k identity"
+            "-w /etc/ssh -p wa -k ssh"
+          ];
+        };
 
         # Docker
         virtualisation.docker.enable = true;

--- a/spec/block_gh_settings_spec.sh
+++ b/spec/block_gh_settings_spec.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'block-gh-settings.sh'
+SCRIPT="$PWD/config/shared/hooks/block-gh-settings.sh"
+
+Describe 'non-modifying commands'
+
+It 'allows gh pr list'
+Data '{"tool_input": {"command": "gh pr list"}}'
+When run bash "$SCRIPT"
+The status should be success
+End
+
+It 'allows gh repo view'
+Data '{"tool_input": {"command": "gh repo view"}}'
+When run bash "$SCRIPT"
+The status should be success
+End
+
+It 'allows gh repo clone'
+Data '{"tool_input": {"command": "gh repo clone owner/repo"}}'
+When run bash "$SCRIPT"
+The status should be success
+End
+
+It 'allows gh api GET'
+Data '{"tool_input": {"command": "gh api /repos/owner/repo"}}'
+When run bash "$SCRIPT"
+The status should be success
+End
+
+It 'allows gh api -X POST to non-repo path'
+Data '{"tool_input": {"command": "gh api -X POST /gists"}}'
+When run bash "$SCRIPT"
+The status should be success
+End
+
+End
+
+Describe 'blocked gh repo subcommands'
+
+It 'blocks gh repo delete'
+Data '{"tool_input": {"command": "gh repo delete owner/repo"}}'
+When run bash "$SCRIPT"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+It 'blocks gh repo rename'
+Data '{"tool_input": {"command": "gh repo rename new-name"}}'
+When run bash "$SCRIPT"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+It 'blocks gh repo archive'
+Data '{"tool_input": {"command": "gh repo archive owner/repo"}}'
+When run bash "$SCRIPT"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+It 'blocks gh repo transfer'
+Data '{"tool_input": {"command": "gh repo transfer owner/repo new-owner"}}'
+When run bash "$SCRIPT"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+It 'blocks gh repo edit'
+Data '{"tool_input": {"command": "gh repo edit --description new-desc"}}'
+When run bash "$SCRIPT"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+End
+
+Describe 'blocked gh api mutations on /repos/'
+
+It 'blocks gh api -X PATCH /repos/...'
+Data '{"tool_input": {"command": "gh api -X PATCH /repos/owner/repo"}}'
+When run bash "$SCRIPT"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+It 'blocks gh api -X DELETE /repos/...'
+Data '{"tool_input": {"command": "gh api -X DELETE /repos/owner/repo/branches/main/protection"}}'
+When run bash "$SCRIPT"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+It 'blocks gh api -X PUT /repos/...'
+Data '{"tool_input": {"command": "gh api -X PUT /repos/owner/repo/collaborators/user"}}'
+When run bash "$SCRIPT"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+End
+
+Describe 'codex input format'
+
+It 'blocks codex-style input with .command key'
+Data '{"command": "gh repo delete owner/repo"}'
+When run bash "$SCRIPT"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+End
+
+Describe 'edge cases'
+
+It 'passes with empty input'
+Data '{}'
+When run bash "$SCRIPT"
+The status should be success
+End
+
+It 'passes with empty command'
+Data '{"tool_input": {"command": ""}}'
+When run bash "$SCRIPT"
+The status should be success
+End
+
+End
+
+End

--- a/spec/block_git_push_spec.sh
+++ b/spec/block_git_push_spec.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2329
 
-Describe 'block-push-main.sh'
-SCRIPT="$PWD/config/shared/hooks/block-push-main.sh"
+Describe 'block-git-push.sh'
+SCRIPT="$PWD/config/shared/hooks/block-git-push.sh"
 
 setup() {
   TEMP_REPO=$(mktemp -d)

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -356,6 +356,7 @@ config/codex/hooks/notify.sh
 config/codex/hooks/pushover.sh
 config/codex/hooks/rtk-rewrite.sh
 config/codex/hooks/security.sh
+config/shared/hooks/block-gh-settings.sh
 config/shared/hooks/block-git-push.sh
 config/cursor/activate.sh
 config/gemini/activate.sh

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -356,7 +356,7 @@ config/codex/hooks/notify.sh
 config/codex/hooks/pushover.sh
 config/codex/hooks/rtk-rewrite.sh
 config/codex/hooks/security.sh
-config/shared/hooks/block-push-main.sh
+config/shared/hooks/block-git-push.sh
 config/cursor/activate.sh
 config/gemini/activate.sh
 config/git-ai/activate.sh


### PR DESCRIPTION
- **feat: opsec**
- **feat: opsec**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hook to block `gh` commands that modify repo settings and hardens the `matic` host’s network and audit config. This prevents accidental repo mutations and improves system visibility.

- **New Features**
  - Added `block-gh-settings.sh` and wired it into `config/claude/settings.json`: blocks `gh repo delete|rename|archive|transfer|edit` and `gh api -X PATCH|DELETE|PUT /repos/...`; includes ShellSpec tests and is listed in `spec/coverage_spec.sh`. Renamed `block-push-main.sh` to `block-git-push.sh` and updated references in `config/claude/settings.json`, `config/codex/hooks.json`, and tests.
  - Hardened `named-hosts/matic/default.nix`: enabled firewall with trusted `tailscale0` and refused-connection logs, Wi‑Fi scan MAC randomization and stable-SSID MAC, and `auditd` rules for exec, priv‑esc, identity files, and SSH.

<sup>Written for commit 06f2ee27594325c5964e0f3fd78120c1b260871c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

