### PR TITLE
fix: resolve nix build failure and deprecation warnings

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -54,7 +54,7 @@ with pkgs;
   gomi
   go-task
   google-cloud-sdk
-  goose-cli
+
   gping
   grc
   htop

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -54,7 +54,6 @@ with pkgs;
   gomi
   go-task
   google-cloud-sdk
-
   gping
   grc
   htop

--- a/home-manager/programs/git/default.nix
+++ b/home-manager/programs/git/default.nix
@@ -82,6 +82,7 @@
       signing = {
         signByDefault = true;
         key = "shunkakinoki@gmail.com";
+        format = "openpgp";
       };
       ignores = lib.splitString "\n" (builtins.readFile ./.gitignore.global);
     };

--- a/home-manager/programs/neovim/default.nix
+++ b/home-manager/programs/neovim/default.nix
@@ -28,7 +28,9 @@ in
     defaultEditor = true;
     vimAlias = true;
     vimdiffAlias = true;
-    extraLuaConfig = builtins.readFile nvimInitLua;
+    withRuby = false;
+    withPython3 = false;
+    initLua = builtins.readFile nvimInitLua;
   };
 
   home.file.".config/nvim/lua" = {


### PR DESCRIPTION
## Summary
- Remove `goose-cli` from nix packages (redundant with `block-goose` in Homebrew, fails to build due to Rust recursion limit)
- Rename `extraLuaConfig` to `initLua` for neovim (deprecated option)
- Set `withRuby = false` and `withPython3 = false` for neovim (new defaults in 26.05)
- Add `format = "openpgp"` to git signing config (new default changed to `null`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Nix build and removes deprecation warnings. Drops `goose-cli`, updates Neovim options for 26.05, and sets Git signing format to OpenPGP.

- **Bug Fixes**
  - Remove `goose-cli` from Nix packages to fix build failure; covered by `block-goose` in Homebrew.
  - Remove `google-cloud-sdk` from Nix packages.
  - Neovim: rename `extraLuaConfig` to `initLua`; set `withRuby = false` and `withPython3 = false`.
  - Git: set `signing.format = "openpgp"` to avoid null default.

<sup>Written for commit 88cdd844ed0674d5adcf4ea46d210d9a9c323b62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

