### PR TITLE
fix: prevent oneshot services from blocking HM activation

### DIFF
--- a/home-manager/services/cass/default.nix
+++ b/home-manager/services/cass/default.nix
@@ -58,6 +58,7 @@ in
   systemd.user.services.cass-daily = lib.mkIf pkgs.stdenv.isLinux {
     Unit = {
       Description = "cass daily remote sync and analytics rebuild";
+      X-SwitchMethod = "keep-old";
     };
     Service = {
       Type = "oneshot";

--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -204,6 +204,7 @@ in
 
   systemd.user.services.cliproxyapi-backup = lib.mkIf pkgs.stdenv.isLinux {
     Unit.Description = "CLIProxyAPI auth backup";
+    Unit.X-SwitchMethod = "keep-old";
     Service = {
       Type = "oneshot";
       ExecStart = "${pkgs.bash}/bin/bash ${backupScript}";
@@ -230,6 +231,7 @@ in
 
   systemd.user.services.cliproxyapi-sync = lib.mkIf pkgs.stdenv.isLinux {
     Unit.Description = "CLIProxyAPI auth sync from S3";
+    Unit.X-SwitchMethod = "keep-old";
     Service = {
       Type = "oneshot";
       ExecStart = "${pkgs.bash}/bin/bash ${hydrateScript}";

--- a/home-manager/services/docker-postgres/default.nix
+++ b/home-manager/services/docker-postgres/default.nix
@@ -47,6 +47,7 @@ lib.mkIf enabled {
         "docker.service"
       ];
       Wants = [ "docker.service" ];
+      X-SwitchMethod = "keep-old";
     };
     Service = {
       Type = "oneshot";

--- a/home-manager/services/dotfiles-updater/default.nix
+++ b/home-manager/services/dotfiles-updater/default.nix
@@ -28,6 +28,7 @@ in
   systemd.user.services.dotfiles-updater = lib.mkIf pkgs.stdenv.isLinux {
     Unit = {
       Description = "Dotfiles auto-updater service";
+      X-SwitchMethod = "keep-old";
     };
     Service = {
       Type = "oneshot";

--- a/home-manager/services/make-updater/default.nix
+++ b/home-manager/services/make-updater/default.nix
@@ -30,6 +30,7 @@ in
   systemd.user.services.make-updater = lib.mkIf pkgs.stdenv.isLinux {
     Unit = {
       Description = "Make update service";
+      X-SwitchMethod = "keep-old";
     };
     Service = {
       Type = "oneshot";

--- a/home-manager/services/neverssl-keepalive/default.nix
+++ b/home-manager/services/neverssl-keepalive/default.nix
@@ -26,6 +26,7 @@ in
       Description = "Keep captive portal alive via neverssl.com";
       Wants = [ "network-online.target" ];
       After = [ "network-online.target" ];
+      X-SwitchMethod = "keep-old";
     };
     Service = {
       Type = "oneshot";

--- a/home-manager/services/obsidian/default.nix
+++ b/home-manager/services/obsidian/default.nix
@@ -66,6 +66,7 @@ lib.mkIf host.isKyber {
     Unit = {
       Description = "Trigger obsidian-git auto-backup via CDP";
       After = [ "obsidian.service" ];
+      X-SwitchMethod = "keep-old";
     };
     Service = {
       Type = "oneshot";

--- a/home-manager/services/tmux-session-logger/default.nix
+++ b/home-manager/services/tmux-session-logger/default.nix
@@ -29,6 +29,7 @@ in
   systemd.user.services.tmux-session-logger = lib.mkIf pkgs.stdenv.isLinux {
     Unit = {
       Description = "Persist tmux pane history snapshots";
+      X-SwitchMethod = "keep-old";
     };
     Service = {
       Type = "oneshot";


### PR DESCRIPTION
## Summary
- Add `X-SwitchMethod = "keep-old"` to 9 timer-triggered oneshot systemd user services
- Prevents `sd-switch` from restarting them during home-manager activation, which was blocking the entire switch (cass-daily analytics rebuild alone took 3+ minutes)
- Services affected: cass-daily, dotfiles-updater, make-updater, neverssl-keepalive, tmux-session-logger, cliproxyapi-backup, cliproxyapi-sync, obsidian-git-trigger, docker-postgres

## Test plan
- [ ] `make build && make switch` completes without waiting on oneshot services
- [ ] Timer-triggered services still fire on schedule

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented timer-triggered oneshot user services from blocking `home-manager` activation. Set `X-SwitchMethod = "keep-old"` so `sd-switch` skips restarting them during a switch.

- **Bug Fixes**
  - Switch completes without waiting on long oneshots (e.g., `cass-daily`).
  - Updated services: `cass-daily`, `dotfiles-updater`, `make-updater`, `neverssl-keepalive`, `tmux-session-logger`, `cliproxyapi-backup`, `cliproxyapi-sync`, `obsidian-git-trigger`, `docker-postgres`.
  - Timers still run on schedule.

<sup>Written for commit 4d5494f88f0fca4888069170cc7a35d9ff8b7fd3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

