### PR TITLE
fix: set gtk4.theme to silence home-manager deprecation warning

### DIFF
--- a/config/gtk/default.nix
+++ b/config/gtk/default.nix
@@ -18,5 +18,9 @@
       name = "Adwaita";
       size = 24;
     };
+    gtk4.theme = {
+      name = "Adwaita";
+      package = pkgs.gnome-themes-extra;
+    };
   };
 }


### PR DESCRIPTION
## Summary
- Sets `gtk.gtk4.theme` explicitly to match `gtk.theme` (Adwaita)
- Silences the Home Manager evaluation warning about `gtk.gtk4.theme` default changing in 26.05

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the GTK4 theme to Adwaita to match the existing GTK theme and silence the `home-manager` 26.05 warning about the upcoming default change. Adds `gtk.gtk4.theme` with name "Adwaita" and package `pkgs.gnome-themes-extra`.

<sup>Written for commit 006042b918e8e6ed8b522b897459413a976926d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

