### PR TITLE
feat: add qwen3.6-plus model to opencode provider

### DIFF
--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -90,6 +90,8 @@ openai-compatibility:
         alias: "free"
       - name: "@preset/glm-4-7"
         alias: "glm-4.7"
+      - name: "google/gemma-4-27b-it"
+        alias: "gemma-4-27b-it"
   - name: "z-ai"
     base-url: "https://api.z.ai/api/coding/paas/v4"
     api-key-entries:

--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -115,6 +115,8 @@ openai-compatibility:
         alias: "minimax-m2.7"
       - name: "kimi-2.6"
         alias: "kimi-2.6"
+      - name: "qwen3.6-plus"
+        alias: "qwen3.6-plus"
 # payload: # Optional payload configuration
 #   default: # Default rules only set parameters when they are missing in the payload.
 #     - models:

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -115,6 +115,8 @@ openai-compatibility:
         alias: "__MINIMAX__"
       - name: "__KIMI__"
         alias: "__KIMI__"
+      - name: "__QWEN__"
+        alias: "__QWEN__"
 # payload: # Optional payload configuration
 #   default: # Default rules only set parameters when they are missing in the payload.
 #     - models:

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -90,6 +90,8 @@ openai-compatibility:
         alias: "free"
       - name: "@preset/__GLM_NONDOT__"
         alias: "__GLM__"
+      - name: "google/__GEMMA__"
+        alias: "__GEMMA__"
   - name: "z-ai"
     base-url: "https://api.z.ai/api/coding/paas/v4"
     api-key-entries:

--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -45,11 +45,6 @@ name = "OpenRouter"
 base_url = "https://openrouter.ai/api/v1"
 env_key = "OPENROUTER_API_KEY"
 
-[profiles.gemma]
-model = "lmstudio-community/gemma-4-e4b-it"
-model_provider = "lmstudio"
-model_reasoning_effort = "minimal"
-
 [profiles.qwen-local]
 model = "qwen3.5-0.8b-optiq"
 model_provider = "lmstudio"

--- a/config/codex/config.tpl.toml
+++ b/config/codex/config.tpl.toml
@@ -45,11 +45,6 @@ name = "OpenRouter"
 base_url = "https://openrouter.ai/api/v1"
 env_key = "OPENROUTER_API_KEY"
 
-[profiles.gemma]
-model = "__GEMMA__"
-model_provider = "lmstudio"
-model_reasoning_effort = "minimal"
-
 [profiles.qwen-local]
 model = "__QWEN_LOCAL__"
 model_provider = "lmstudio"

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -100,9 +100,6 @@
         "baseURL": "http://127.0.0.1:1234/v1"
       },
       "models": {
-        "lmstudio-community/gemma-4-e4b-it": {
-          "name": "Gemma 4 E4B (via LM Studio)"
-        },
         "qwen3.5-0.8b-optiq": {
           "name": "Qwen 3.5 0.8B (via LM Studio)"
         }

--- a/config/opencode/opencode.tpl.jsonc
+++ b/config/opencode/opencode.tpl.jsonc
@@ -100,9 +100,6 @@
         "baseURL": "http://127.0.0.1:1234/v1"
       },
       "models": {
-        "__GEMMA__": {
-          "name": "Gemma 4 E4B (via LM Studio)"
-        },
         "__QWEN_LOCAL__": {
           "name": "Qwen 3.5 0.8B (via LM Studio)"
         }

--- a/models.json
+++ b/models.json
@@ -11,7 +11,7 @@
   "gemini-flash": "gemini-3.1-flash-preview",
   "glm": "glm-4.7",
   "minimax": "minimax-m2.7",
-  "gemma": "lmstudio-community/gemma-4-e4b-it",
+  "gemma": "gemma-4-27b-it",
   "kimi": "kimi-2.6",
   "qwen": "qwen3.6-plus",
   "qwen-local": "qwen3.5-0.8b-optiq"

--- a/models.json
+++ b/models.json
@@ -13,5 +13,6 @@
   "minimax": "minimax-m2.7",
   "gemma": "lmstudio-community/gemma-4-e4b-it",
   "kimi": "kimi-2.6",
+  "qwen": "qwen3.6-plus",
   "qwen-local": "qwen3.5-0.8b-optiq"
 }


### PR DESCRIPTION
## Summary
- Add `qwen` (`qwen3.6-plus`) to `models.json`
- Add model entry to opencode provider in cliproxyapi config (template + generated)

## Test plan
- [ ] Verify `make llm-update` regenerates configs correctly
- [ ] Confirm qwen3.6-plus is accessible via cliproxyapi opencode provider

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `qwen3.6-plus` via the `opencode` provider in `cliproxyapi`, and update Gemma to `gemma-4-27b-it` across configs. Cleans up old LM Studio Gemma entries.

- **New Features**
  - Mapped `qwen: qwen3.6-plus` in `models.json`.
  - Added `qwen3.6-plus` to `config/cliproxyapi/config.template.yaml` and `config.tpl.yaml` for the `opencode` provider.
  - Updated `gemma` to `gemma-4-27b-it` in `models.json`, added `google/gemma-4-27b-it` in `cliproxyapi` configs, and removed LM Studio Gemma entries from `codex` and `opencode` templates.

- **Migration**
  - Run `make llm-update` to regenerate configs.
  - Verify `qwen3.6-plus` (via `opencode`) and `gemma-4-27b-it` are available in `cliproxyapi`.

<sup>Written for commit 2229e2d1423591ad1c202c4c56abaceb9c21545c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

