### PR TITLE
fix(neovim): force-manage init.lua to prevent HM clobber

### DIFF
--- a/home-manager/programs/neovim/default.nix
+++ b/home-manager/programs/neovim/default.nix
@@ -30,12 +30,10 @@ in
     vimdiffAlias = true;
     withRuby = false;
     withPython3 = false;
+    initLua = builtins.readFile nvimInitLua;
   };
 
-  home.file.".config/nvim/init.lua" = {
-    source = nvimInitLua;
-    force = true;
-  };
+  xdg.configFile."nvim/init.lua".force = true;
 
   home.file.".config/nvim/lua" = {
     source = ./lua;

--- a/home-manager/programs/neovim/default.nix
+++ b/home-manager/programs/neovim/default.nix
@@ -30,7 +30,11 @@ in
     vimdiffAlias = true;
     withRuby = false;
     withPython3 = false;
-    initLua = builtins.readFile nvimInitLua;
+  };
+
+  home.file.".config/nvim/init.lua" = {
+    source = nvimInitLua;
+    force = true;
   };
 
   home.file.".config/nvim/lua" = {


### PR DESCRIPTION
## Summary
- Moves `init.lua` from `programs.neovim.initLua` to `home.file` with `force = true`
- Matches the existing pattern already used for the `lua/` directory
- Prevents Home Manager activation failures when a pre-existing `init.lua` (e.g. a manual symlink) exists at `~/.config/nvim/init.lua`

## Context
`home-manager-skakinoki.service` was failing with:
```
Existing file '/home/skakinoki/.config/nvim/init.lua' would be clobbered
```
Even with `backupFileExtension` set, HM won't overwrite symlinks it doesn't own. Using `force = true` on `home.file` resolves this permanently.

## Test plan
- [ ] `make nix-switch` completes without clobber errors
- [ ] `~/.config/nvim/init.lua` is a valid HM-managed symlink
- [ ] Neovim starts and loads config correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force-manage Neovim `init.lua` via `xdg.configFile` to prevent Home Manager clobber errors. Activation now succeeds even if a pre-existing file or symlink exists at `~/.config/nvim/init.lua`.

- **Bug Fixes**
  - Set `xdg.configFile."nvim/init.lua".force = true`.
  - Keep `programs.neovim.initLua` as the source; only conflict handling changed.
  - Aligns with the force-managed `~/.config/nvim/lua` directory.

<sup>Written for commit 2b6375f8548654d304ca3dea1c3214dfbd28dd8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

