### PR TITLE
feat(cliproxyapi): persist usage-export across restarts via R2

### DIFF
--- a/home-manager/services/cliproxyapi/scripts/common.sh
+++ b/home-manager/services/cliproxyapi/scripts/common.sh
@@ -58,3 +58,33 @@ cliproxy_sync_auth_to_s3() {
   local auth_dir="$1"
   cliproxy_s3_sync "$auth_dir/" "$(cliproxy_auth_s3_uri)"
 }
+
+cliproxy_usage_s3_uri() {
+  printf 's3://%s/usage-export.json' "${OBJECTSTORE_BUCKET:?OBJECTSTORE_BUCKET is required}"
+}
+
+cliproxy_upload_usage_to_s3() {
+  local src="$1"
+  [ -f "$src" ] || return 0
+  cliproxy_has_objectstore_credentials || return 0
+  AWS_ACCESS_KEY_ID="$OBJECTSTORE_ACCESS_KEY" \
+    AWS_SECRET_ACCESS_KEY="$OBJECTSTORE_SECRET_KEY" \
+    @aws@ s3 cp \
+    --endpoint-url="$OBJECTSTORE_ENDPOINT" \
+    --no-progress \
+    "$src" \
+    "$(cliproxy_usage_s3_uri)" || true
+}
+
+cliproxy_download_usage_from_s3() {
+  local dst="$1"
+  cliproxy_has_objectstore_credentials || return 0
+  mkdir -p "$(dirname "$dst")"
+  AWS_ACCESS_KEY_ID="$OBJECTSTORE_ACCESS_KEY" \
+    AWS_SECRET_ACCESS_KEY="$OBJECTSTORE_SECRET_KEY" \
+    @aws@ s3 cp \
+    --endpoint-url="$OBJECTSTORE_ENDPOINT" \
+    --no-progress \
+    "$(cliproxy_usage_s3_uri)" \
+    "$dst" || true
+}

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -27,6 +27,11 @@ if cliproxy_has_objectstore_credentials; then
   if [ -n "$(ls -A "$AUTH_DIR" 2>/dev/null)" ]; then
     cliproxy_sync_auth_to_s3 "$AUTH_DIR"
   fi
+
+  if [ ! -f "$USAGE_EXPORT_FILE" ]; then
+    echo "⚠️  Usage export missing locally; hydrating from S3" >&2
+    cliproxy_download_usage_from_s3 "$USAGE_EXPORT_FILE"
+  fi
 fi
 
 # Generate config from template
@@ -118,6 +123,7 @@ usage_export() {
     -H "Authorization: Bearer ${MANAGEMENT_KEY}" \
     "${MANAGEMENT_URL}/usage/export" \
     -o "$USAGE_EXPORT_FILE" || true
+  cliproxy_upload_usage_to_s3 "$USAGE_EXPORT_FILE"
 }
 
 wait_for_management() {


### PR DESCRIPTION
## Summary
- Add `cliproxy_upload_usage_to_s3` and `cliproxy_download_usage_from_s3` helpers in `common.sh`, plus a fixed-key `cliproxy_usage_s3_uri` (`s3://$OBJECTSTORE_BUCKET/usage-export.json`).
- On shutdown, `start.sh`'s existing `usage_export` trap now uploads `~/.cli-proxy-api/usage-export.json` to R2 right after the management API export.
- On startup, hydrate `usage-export.json` from R2 only if it's missing locally, so the post-boot `usage_import` can replay stats on a fresh machine.

## Test plan
- [ ] `make switch` applies cleanly on macOS
- [ ] Stop cliproxyapi (`launchctl kickstart -k gui/$(id -u)/org.nixos.cliproxyapi`) and confirm `s3://cliproxyapi/usage-export.json` updates
- [ ] Delete `~/.cli-proxy-api/usage-export.json`, restart, confirm it gets pulled from R2 and `/v0/management/usage/export` returns prior counters

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist usage metrics across restarts by storing usage-export.json in Cloudflare R2 (S3-compatible). On shutdown we upload the export; on startup we hydrate it if missing so usage replay works on fresh machines.

- New Features
  - Added helpers: cliproxy_upload_usage_to_s3, cliproxy_download_usage_from_s3, and a fixed S3 URI for usage-export.json.
  - On shutdown, upload ~/.cli-proxy-api/usage-export.json right after the management API export.
  - On startup, if the file is missing, download it from R2 before running usage import.

<sup>Written for commit 2f44fc797b682f2cc624ffbbc128cb0d5e8be203. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

