### PR TITLE
feat: add GitHub settings blocker to Codex hooks

### DIFF
--- a/config/codex/hooks.json
+++ b/config/codex/hooks.json
@@ -40,6 +40,11 @@
           },
           {
             "type": "command",
+            "command": "$HOME/dotfiles/config/shared/hooks/block-gh-settings.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "$HOME/.codex/hooks/notify.sh",
             "timeout": 3,
             "async": true

--- a/spec/activate_config_spec.sh
+++ b/spec/activate_config_spec.sh
@@ -3,6 +3,7 @@
 
 Describe 'config/codex/activate.sh'
 SCRIPT="$PWD/config/codex/activate.sh"
+HOOKS_JSON="$PWD/config/codex/hooks.json"
 
 It 'uses bash shebang'
 When run bash -c "head -1 '$SCRIPT'"
@@ -22,6 +23,16 @@ End
 It 'copies hooks.json'
 When run bash -c "grep 'HOOKS_JSON' '$SCRIPT'"
 The output should include 'HOOKS_JSON'
+End
+
+It 'registers the shared main/master push blocker'
+When run jq -r '.hooks.PreToolUse[] | select(.matcher == "Bash") | .hooks[].command' "$HOOKS_JSON"
+The output should include 'config/shared/hooks/block-git-push.sh'
+End
+
+It 'registers the shared GitHub settings blocker'
+When run jq -r '.hooks.PreToolUse[] | select(.matcher == "Bash") | .hooks[].command' "$HOOKS_JSON"
+The output should include 'config/shared/hooks/block-gh-settings.sh'
 End
 End
 


### PR DESCRIPTION
## Summary
- add the shared `block-gh-settings.sh` hook to Codex `PreToolUse` Bash hooks
- keep the existing shared `block-git-push.sh` Codex hook covered by regression tests
- add Codex hook config specs for both shared blockers

## Tests
- `shellspec spec/activate_config_spec.sh spec/block_gh_settings_spec.sh spec/block_git_push_spec.sh`
- `make shell-test` earlier reached ShellSpec with `1372 examples, 0 failures`, then fish tests could not enter the Nix dev shell because `/nix/var/nix/daemon-socket/socket` refused connection