### PR TITLE
feat(install): forward HOST env var to make install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
  curl -fsSL https://raw.githubusercontent.com/shunkakinoki/dotfiles/main/install.sh | sh
 ```
 
+To pin a named host (skips hostname auto-detection):
+
+```bash
+ curl -fsSL https://raw.githubusercontent.com/shunkakinoki/dotfiles/main/install.sh | HOST={NAMED_HOST_HERE} sh
+```
+
 For troubleshooting and frequently asked questions, see [FAQ.md](./FAQ.md).
 
 ## Credits

--- a/install.sh
+++ b/install.sh
@@ -140,14 +140,17 @@ fi
 
 # Install Nix packages
 echo "Running installation commands..."
+if [ -n "$HOST" ]; then
+  echo "Forwarding HOST=$HOST to make install (overrides hostname auto-detection)."
+fi
 if [ -n "$NIX_EFFECTIVE_BIN_PATH" ] && [ -d "$NIX_EFFECTIVE_BIN_PATH" ]; then
   echo "Prepending $NIX_EFFECTIVE_BIN_PATH to PATH for 'make install' command."
   echo "Ensuring USER=$USER and CI=$CI are passed to make install."
-  env PATH="$NIX_EFFECTIVE_BIN_PATH:$PATH" USER="$USER" CI="$CI" make install
+  env PATH="$NIX_EFFECTIVE_BIN_PATH:$PATH" USER="$USER" CI="$CI" HOST="$HOST" make install
 else
   echo "Warning: NIX_EFFECTIVE_BIN_PATH ('$NIX_EFFECTIVE_BIN_PATH') is not set or not a directory."
   echo "Running 'make install' with potentially incomplete PATH. Current PATH: $PATH"
   echo "Attempting to find nix via 'command -v nix': $(command -v nix || echo 'nix not found in current PATH')"
   echo "USER=$USER will be available to make install (exported)."
-  make install
+  HOST="$HOST" make install
 fi

--- a/spec/install_spec.sh
+++ b/spec/install_spec.sh
@@ -99,6 +99,11 @@ It 'runs make install'
 When run bash -c "grep 'make install' '$SCRIPT'"
 The output should include 'make install'
 End
+
+It 'forwards HOST env var to make install'
+When run bash -c "grep 'HOST=\"\$HOST\" make install' '$SCRIPT'"
+The output should include 'HOST="$HOST" make install'
+End
 End
 
 Describe 'Docker support'


### PR DESCRIPTION
## Summary
- Propagate `HOST` env var from `install.sh` to `make install` so a single curl pipe can pin the host config.
- Lets fresh boxes boot with `HOST=kyber curl -fsSL .../install.sh | sh` instead of needing `hostnamectl set-hostname` first or a manual `git clone` + `make`.
- Adds spec coverage in `spec/install_spec.sh` for the new forwarding line.

## Test plan
- [x] `shellspec spec/install_spec.sh` (20 examples, 0 failures)
- [ ] `HOST=kyber curl -fsSL https://raw.githubusercontent.com/shunkakinoki/dotfiles/<branch>/install.sh | sh` on a fresh kyber box

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward the `HOST` env var from `install.sh` to `make install` so curl-pipe installs can pin the host config without setting the hostname first. Adds spec coverage for `HOST="$HOST" make install` and updates the README with `curl -fsSL .../install.sh | HOST={NAMED_HOST_HERE} sh` usage.

<sup>Written for commit 444f5c36115451000a5b4eefdd9adffb93936574. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

