### PR TITLE
fix: resolve kubectl conflict between k3s and standalone package

### DIFF
--- a/home-manager/programs/k8s/default.nix
+++ b/home-manager/programs/k8s/default.nix
@@ -6,12 +6,14 @@
       k9s
       kind
       kubeconform
-      kubectl
       kubectx
       kubernetes-helm
       kustomize
     ]
     ++ lib.optionals stdenv.isLinux [
       k3s
+    ]
+    ++ lib.optionals (!stdenv.isLinux) [
+      kubectl
     ];
 }


### PR DESCRIPTION
## Summary
- k3s bundles its own kubectl binary, causing a Nix buildEnv collision with standalone `kubectl`
- Install `kubectl` only on non-Linux; on Linux, k3s provides it

## Test plan
- [ ] `home-manager switch --flake .#kyber` builds without collision
- [ ] `kubectl` is available via k3s on Linux
- [ ] macOS builds still get standalone `kubectl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve `kubectl` binary conflict by installing standalone `kubectl` only on non-Linux and relying on `k3s`’s bundled `kubectl` on Linux. This removes the Nix buildEnv collision and keeps macOS unaffected.

<sup>Written for commit c362155e80f922b7290b9f0ff8d4aad7b91fd42a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

