### PR TITLE
fix: explicitly set host flags in all named-hosts

### DIFF
--- a/named-hosts/galactica/default.nix
+++ b/named-hosts/galactica/default.nix
@@ -11,6 +11,13 @@ inputs.nix-darwin.lib.darwinSystem {
   inherit (darwin-modules) specialArgs;
   modules = darwin-modules.modules ++ [
     {
+      home-manager.extraSpecialArgs = {
+        inputs = inputs // {
+          host = (import ../../lib/host.nix) // {
+            isGalactica = true;
+          };
+        };
+      };
       age.identityPaths = [ "/Users/${username}/.ssh/id_ed25519" ];
       age.secrets = builtins.mapAttrs (_: value: { inherit (value) file; }) (import ./secrets.nix);
       home-manager.users.${username} =

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -18,7 +18,12 @@ in
 home-manager.lib.homeManagerConfiguration {
   inherit pkgs;
   extraSpecialArgs = {
-    inherit inputs username pkgs;
+    inherit username pkgs;
+    inputs = inputs // {
+      host = (import ../../lib/host.nix) // {
+        isKyber = true;
+      };
+    };
   };
   modules = [
     agenix.homeManagerModules.default

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -393,6 +393,7 @@ import ../../hosts/nixos {
           inputs = inputs // {
             host = (import ../../lib/host.nix) // {
               isDesktop = true;
+              isMatic = true;
             };
           };
         };

--- a/named-hosts/pod/default.nix
+++ b/named-hosts/pod/default.nix
@@ -18,7 +18,10 @@ in
 home-manager.lib.homeManagerConfiguration {
   inherit pkgs;
   extraSpecialArgs = {
-    inherit inputs username pkgs;
+    inherit username pkgs;
+    inputs = inputs // {
+      host = import ../../lib/host.nix;
+    };
   };
   modules = [
     ../../home-manager/default.nix


### PR DESCRIPTION
## Summary
- `builtins.getEnv` returns empty in pure Nix eval, so host flags (isKyber, isGalactica, etc.) were always false
- Explicitly override host flags in each named-host's `extraSpecialArgs`, matching the pattern matic already used for `isDesktop`
- kyber: `isKyber = true`
- galactica: `isGalactica = true`
- matic: added `isMatic = true` alongside existing `isDesktop = true`
- pod: explicit host import (no host-specific flags needed)

## Test plan
- [ ] `home-manager switch --flake .#kyber` — k3s service activation now runs
- [ ] Verify `isKyber`-gated modules (k3s service, paperclip, openclaw) activate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly set host flags in each named host so host-gated modules work under pure Nix eval. `builtins.getEnv` returned empty, leaving flags false and disabling services like k3s on `kyber`.

- **Bug Fixes**
  - Override `home-manager.extraSpecialArgs.inputs.host` with `../../lib/host.nix` plus host-specific flags.
  - `kyber`: `isKyber = true`
  - `galactica`: `isGalactica = true`
  - `matic`: `isMatic = true` (keeps `isDesktop = true`)
  - `pod`: explicit host import, no flags needed

<sup>Written for commit 7ae05ce7cf9b4922091a7d817bbd7ad242c68ef8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

