### PR TITLE
fix: use absolute path for sudo in k3s activation

### DIFF
--- a/home-manager/services/k3s/default.nix
+++ b/home-manager/services/k3s/default.nix
@@ -11,18 +11,19 @@ let
 in
 lib.mkIf (pkgs.stdenv.isLinux && host.isKyber) {
   home.activation.setupK3s = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    SUDO="/usr/bin/sudo"
     if ! ${pkgs.diffutils}/bin/diff -q "${serviceFile}" /etc/systemd/system/k3s.service >/dev/null 2>&1; then
-      $DRY_RUN_CMD sudo cp "${serviceFile}" /etc/systemd/system/k3s.service
-      $DRY_RUN_CMD sudo ${pkgs.systemd}/bin/systemctl daemon-reload
-      $DRY_RUN_CMD sudo ${pkgs.systemd}/bin/systemctl enable --now k3s
+      $DRY_RUN_CMD $SUDO cp "${serviceFile}" /etc/systemd/system/k3s.service
+      $DRY_RUN_CMD $SUDO ${pkgs.systemd}/bin/systemctl daemon-reload
+      $DRY_RUN_CMD $SUDO ${pkgs.systemd}/bin/systemctl enable --now k3s
     fi
 
     K3S_KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
     KUBE_DIR="${config.home.homeDirectory}/.kube"
     if [ -f "$K3S_KUBECONFIG" ]; then
       $DRY_RUN_CMD mkdir -p "$KUBE_DIR"
-      $DRY_RUN_CMD sudo cp "$K3S_KUBECONFIG" "$KUBE_DIR/config"
-      $DRY_RUN_CMD sudo chown "$(id -u):$(id -g)" "$KUBE_DIR/config"
+      $DRY_RUN_CMD $SUDO cp "$K3S_KUBECONFIG" "$KUBE_DIR/config"
+      $DRY_RUN_CMD $SUDO chown "$(id -u):$(id -g)" "$KUBE_DIR/config"
       $DRY_RUN_CMD chmod 600 "$KUBE_DIR/config"
     fi
   '';


### PR DESCRIPTION
## Summary
- Nix activation environment doesn't have `sudo` in PATH
- Use `/usr/bin/sudo` explicitly in the k3s service activation script

## Test plan
- [ ] `home-manager switch --flake .#kyber` completes without `sudo: command not found`
- [ ] k3s service is installed and started

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use absolute `/usr/bin/sudo` in the `k3s` Home Manager activation script because the Nix activation PATH lacks `sudo`. This prevents "sudo: command not found" and ensures service install/reload/enable and kubeconfig copy run correctly.

<sup>Written for commit dce36a58a386bdd591103af402898ebf11961f64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

