### PR TITLE
fix: set KUBECONFIG env var on kyber

### DIFF
--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -119,6 +119,10 @@ home-manager.lib.homeManagerConfiguration {
           set -gx GPG_TTY (tty)
         '';
 
+        home.sessionVariables = {
+          KUBECONFIG = "${config.home.homeDirectory}/.kube/config";
+        };
+
         # Enable XDG directories
         xdg.enable = true;
 


### PR DESCRIPTION
## Summary
- k3s-bundled kubectl defaults to `/etc/rancher/k3s/k3s.yaml` (root-only)
- Set `KUBECONFIG=~/.kube/config` via `home.sessionVariables` on kyber

## Test plan
- [ ] After switch + new shell, `kubectl get nodes` works without `KUBECONFIG=` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the KUBECONFIG env var on kyber to use ~/.kube/config so kubectl no longer points to the root-only k3s default. kubectl now works without a KUBECONFIG= prefix.

- **Bug Fixes**
  - Set `home.sessionVariables.KUBECONFIG` to `${config.home.homeDirectory}/.kube/config` in `named-hosts/kyber/default.nix`.

<sup>Written for commit be87e35bc9e94bb2b8497e168bdcc683670d958e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

