### PR TITLE
feat: set KUBECONFIG in bash, zsh, and fish for Linux

### DIFF
--- a/config/k3s/default.nix
+++ b/config/k3s/default.nix
@@ -1,8 +1,12 @@
 {
+  config,
   lib,
   pkgs,
   ...
 }:
+let
+  kubeconfig = "${config.home.homeDirectory}/.kube/config";
+in
 {
   home.file.".config/k3s/config.yaml" = lib.mkIf pkgs.stdenv.isLinux {
     source = ./config.yaml;
@@ -16,6 +20,22 @@
     };
     force = true;
   };
+
+  home.sessionVariables = lib.mkIf pkgs.stdenv.isLinux {
+    KUBECONFIG = kubeconfig;
+  };
+
+  programs.bash.bashrcExtra = lib.mkIf pkgs.stdenv.isLinux ''
+    export KUBECONFIG="${kubeconfig}"
+  '';
+
+  programs.zsh.initExtra = lib.mkIf pkgs.stdenv.isLinux ''
+    export KUBECONFIG="${kubeconfig}"
+  '';
+
+  programs.fish.interactiveShellInit = lib.mkIf pkgs.stdenv.isLinux ''
+    set -gx KUBECONFIG "${kubeconfig}"
+  '';
 
   home.activation.k3s-config = lib.mkIf pkgs.stdenv.isLinux (
     lib.hm.dag.entryAfter [ "writeBoundary" ] ''

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -119,10 +119,6 @@ home-manager.lib.homeManagerConfiguration {
           set -gx GPG_TTY (tty)
         '';
 
-        home.sessionVariables = {
-          KUBECONFIG = "${config.home.homeDirectory}/.kube/config";
-        };
-
         # Enable XDG directories
         xdg.enable = true;
 


### PR DESCRIPTION
## Summary
- Set `KUBECONFIG=~/.kube/config` in bash, zsh, and fish via `config/k3s`
- Also set via `home.sessionVariables` for other tools
- Removed duplicate from kyber named-host

## Test plan
- [ ] `home-manager switch --flake .#kyber`, open new bash/zsh/fish shell
- [ ] `echo $KUBECONFIG` shows `~/.kube/config`
- [ ] `kubectl get nodes` works without prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes KUBECONFIG setup in `config/k3s` and exports it for `bash`, `zsh`, and `fish` on Linux. This makes `kubectl` work out of the box on all Linux hosts and removes host-specific config from `named-hosts/kyber`.

- New Features
  - Export `KUBECONFIG=${homeDirectory}/.kube/config` via `home.sessionVariables` and shell init for `bash`, `zsh`, and `fish` on Linux.

- Refactors
  - Moved `KUBECONFIG` from `named-hosts/kyber` into shared `config/k3s`; removed the duplicate setting.

<sup>Written for commit afd6c2ef5fff96b35cd71badffe03887086f2f39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

