### PR TITLE
fix(openclaw): migrate legacy streaming config and create missing dirs

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -920,7 +920,9 @@
       "reactionNotifications": "all",
       "reactionLevel": "extensive",
       "replyToMode": "first",
-      "streaming": "partial"
+      "streaming": {
+        "mode": "partial"
+      }
     },
     "whatsapp": {
       "dmPolicy": "pairing",

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -920,7 +920,9 @@
       "reactionNotifications": "all",
       "reactionLevel": "extensive",
       "replyToMode": "first",
-      "streaming": "partial"
+      "streaming": {
+        "mode": "partial"
+      }
     },
     "whatsapp": {
       "dmPolicy": "pairing",

--- a/home-manager/services/openclaw/activate.sh
+++ b/home-manager/services/openclaw/activate.sh
@@ -6,4 +6,7 @@ HOME_DIR="$1"
 
 mkdir -p /tmp/openclaw
 mkdir -p "$HOME_DIR/.openclaw"
+mkdir -p "$HOME_DIR/.openclaw/plugins"
+mkdir -p "$HOME_DIR/.openclaw/agents/main/sessions"
+mkdir -p "$HOME_DIR/.openclaw/credentials"
 chmod 700 "$HOME_DIR/.openclaw"


### PR DESCRIPTION
## Summary
- Migrated legacy `"streaming": "partial"` (scalar) to the new object form `"streaming": { "mode": "partial" }` in both `openclaw.template.json` and `openclaw.tpl.json` — required by newer openclaw versions
- Added `mkdir -p` for `plugins`, `agents/main/sessions`, and `credentials` directories in `activate.sh` — openclaw doctor flagged these as CRITICAL missing dirs

## Test plan
- [x] Verified gateway starts without config errors after changes
- [x] Health endpoint returns 200
- [x] `openclaw doctor` no longer reports legacy config keys or missing plugin path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes gateway startup failures by migrating the legacy streaming config and creating required directories. Prevents exit code 78 (CONFIG) and clears `openclaw doctor` criticals.

- **Bug Fixes**
  - Migrate `"streaming": "partial"` to `"streaming": { "mode": "partial" }` in `config/openclaw/openclaw.template.json` and `config/openclaw/openclaw.tpl.json`.
  - Create required dirs in `home-manager/services/openclaw/activate.sh`: `~/.openclaw/plugins`, `~/.openclaw/agents/main/sessions`, `~/.openclaw/credentials`.

<sup>Written for commit a99abda3fa3b7618e57bb2fad805eb4fe1b7bfce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

