### PR TITLE
fix(openclaw,cliproxy): disable bonjour and ensure docker group

### DIFF
--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -1039,6 +1039,9 @@
           }
         }
       },
+      "bonjour": {
+        "enabled": false
+      },
       "diagnostics-otel": {
         "enabled": true
       },

--- a/home-manager/services/cliproxyapi/scripts/docker-start.sh
+++ b/home-manager/services/cliproxyapi/scripts/docker-start.sh
@@ -5,6 +5,14 @@
 # @bash@, @start_script@, @docker@ are substituted by pkgs.replaceVars.
 SCRIPT="@bash@/bin/bash @start_script@"
 
+# Ensure docker group exists and user is a member (non-NixOS)
+if ! getent group docker >/dev/null 2>&1; then
+  sudo groupadd docker 2>/dev/null || true
+fi
+if ! id -nG "$USER" | grep -qw docker; then
+  sudo usermod -aG docker "$USER" 2>/dev/null || true
+fi
+
 # Try docker directly first (works on NixOS or when user has docker group)
 if @docker@/bin/docker info >/dev/null 2>&1; then
   exec $SCRIPT


### PR DESCRIPTION
## Summary
- Disable bonjour plugin in `openclaw.tpl.json` — mDNS CIAO probing fails on kyber (no multicast), causing unhandled promise rejection crash loop that takes down the gateway every ~40s
- Ensure docker group exists and user is a member in cliproxyapi's `docker-start.sh` before attempting `sg docker` — fixes `sg: group 'docker' does not exist` on non-NixOS hosts like kyber

## Test plan
- [x] Openclaw gateway stays up with bonjour disabled (10 plugins, no crash)
- [x] Health endpoint returns 200
- [ ] Cliproxyapi starts after rebuild (needs `make switch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the `bonjour` plugin in `openclaw.tpl.json` to stop mDNS CIAO crash loops on networks without multicast and keep the gateway up. Ensure `docker-start.sh` creates the `docker` group and adds the user when missing, preventing "sg: group 'docker' does not exist" on non‑NixOS hosts.

<sup>Written for commit 708dc2edc11e589063ea2fa05499de621660d65c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

