### PR TITLE
fix: docker-setup stale paths, paperclip missing env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1079,13 +1079,13 @@ launchctl-tmux-session-logger: ## Restart tmux-session-logger launchd agent.
 ##@ Systemd Services (Linux)
 
 .PHONY: systemctl
-systemctl: systemctl-docker-setup systemctl-cliproxyapi systemctl-cliproxyapi-backup systemctl-code-syncer systemctl-docker-postgres systemctl-dolt systemctl-dotfiles-updater systemctl-make-updater systemctl-neverssl-keepalive systemctl-obsidian systemctl-ollama systemctl-openclaw systemctl-paperclip systemctl-tmux-session-logger ## Restart all systemd user services.
+systemctl: systemctl-docker systemctl-cliproxyapi systemctl-cliproxyapi-backup systemctl-code-syncer systemctl-docker-postgres systemctl-dolt systemctl-dotfiles-updater systemctl-make-updater systemctl-neverssl-keepalive systemctl-obsidian systemctl-ollama systemctl-openclaw systemctl-paperclip systemctl-tmux-session-logger ## Restart all systemd user services.
 
-.PHONY: systemctl-docker-setup
-systemctl-docker-setup: ## Ensure Docker daemon, group, and user membership are configured.
-	@echo "🐳 Ensuring Docker is set up..."
+.PHONY: systemctl-docker
+systemctl-docker: ## Start Docker daemon.
+	@echo "🐳 Starting Docker..."
 	@docker-setup || true
-	@echo "✅ Docker setup complete"
+	@echo "✅ Docker started"
 
 .PHONY: systemctl-cliproxyapi
 systemctl-cliproxyapi: ## Restart cliproxyapi systemd user service.

--- a/home-manager/services/docker/setup-docker.sh
+++ b/home-manager/services/docker/setup-docker.sh
@@ -5,7 +5,8 @@
 set -euo pipefail
 
 # Define paths
-GROUPS_CMD=@shadow@/bin/groups
+GROUPS_CMD=@coreutils@/bin/groups
+GROUPADD=@shadow@/bin/groupadd
 GREP=@gnugrep@/bin/grep
 USERMOD=@shadow@/bin/usermod
 SYSTEMCTL=@systemd@/bin/systemctl
@@ -14,7 +15,13 @@ DIFF=@diffutils@/bin/diff
 DOCKER_SERVICE_FILE=@docker_service_file@
 SYSTEM_SERVICE=/etc/systemd/system/docker.service
 
-# Check if docker group exists and user is in it
+# Ensure docker group exists
+if ! getent group docker >/dev/null 2>&1; then
+  echo "Creating docker group..."
+  sudo "$GROUPADD" docker
+fi
+
+# Check if user is in docker group
 if ! "$GROUPS_CMD" | "$GREP" -q docker; then
   echo "Adding user to docker group..."
   sudo "$USERMOD" -aG docker "$USER"

--- a/home-manager/services/paperclip/default.nix
+++ b/home-manager/services/paperclip/default.nix
@@ -38,7 +38,7 @@ lib.mkIf host.isKyber {
       ];
       EnvironmentFile = [
         "${homeDir}/dotfiles/.env"
-        "${homeDir}/.paperclip/instances/default/.env"
+        "-%h/.paperclip/instances/default/.env"
       ];
       WorkingDirectory = "${homeDir}/.paperclip";
       StandardOutput = "append:/tmp/paperclip/paperclip.log";


### PR DESCRIPTION
## Summary
- Fix `setup-docker.sh`: use `coreutils` for `groups` binary (was incorrectly using `shadow` which doesn't have it), add explicit `groupadd` step to create docker group before adding user
- Make paperclip instance `.env` optional with `-` prefix so systemd doesn't fail when the file is absent
- Rename `systemctl-docker-setup` to `systemctl-docker`

## Test plan
- [ ] `docker-setup` creates group and starts daemon
- [ ] `make services` succeeds without paperclip failing on missing .env

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Docker setup to reliably start by creating the `docker` group if missing and using the correct `groups` binary. Make Paperclip resilient when the instance `.env` is absent, and rename the Makefile target to `systemctl-docker`.

- **Bug Fixes**
  - Docker: use `@coreutils@/bin/groups` (not `@shadow@/bin/groups`), create `docker` group with `groupadd` when missing, then add user if needed.
  - Paperclip: make instance `.env` optional via `-%h/.paperclip/instances/default/.env` so systemd doesn’t fail when the file is missing.

- **Migration**
  - Use `make systemctl-docker` instead of `systemctl-docker-setup`.

<sup>Written for commit ecb5ef3f5861b936f70c1a1a24c6fee371e16596. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

