### PR TITLE
fix: increase inotify limits in docker-setup for container file watchers

### DIFF
--- a/home-manager/services/docker/setup-docker.sh
+++ b/home-manager/services/docker/setup-docker.sh
@@ -47,6 +47,26 @@ if [ "$NEEDS_RELOAD" = true ]; then
   sudo "$SYSTEMCTL" daemon-reload
 fi
 
+# Ensure inotify limits are high enough for Docker containers (e.g. cliproxyapi file watchers)
+DESIRED_INOTIFY_INSTANCES=1024
+CURRENT_INOTIFY_INSTANCES=$(cat /proc/sys/fs/inotify/max_user_instances 2>/dev/null || echo 0)
+CURRENT_USERNS_INSTANCES=$(cat /proc/sys/user/max_inotify_instances 2>/dev/null || echo 0)
+if [ "$CURRENT_INOTIFY_INSTANCES" -lt "$DESIRED_INOTIFY_INSTANCES" ]; then
+  echo "Increasing fs.inotify.max_user_instances to $DESIRED_INOTIFY_INSTANCES..."
+  echo "$DESIRED_INOTIFY_INSTANCES" | sudo "$TEE" /proc/sys/fs/inotify/max_user_instances >/dev/null
+fi
+if [ "$CURRENT_USERNS_INSTANCES" -lt "$DESIRED_INOTIFY_INSTANCES" ]; then
+  echo "Increasing user.max_inotify_instances to $DESIRED_INOTIFY_INSTANCES..."
+  echo "$DESIRED_INOTIFY_INSTANCES" | sudo "$TEE" /proc/sys/user/max_inotify_instances >/dev/null
+fi
+# Persist sysctl across reboots
+SYSCTL_CONF="/etc/sysctl.d/99-docker-inotify.conf"
+SYSCTL_CONTENT="fs.inotify.max_user_instances = $DESIRED_INOTIFY_INSTANCES"
+if [ ! -f "$SYSCTL_CONF" ] || ! "$GREP" -qF "$SYSCTL_CONTENT" "$SYSCTL_CONF" 2>/dev/null; then
+  echo "Persisting inotify sysctl settings..."
+  printf '%s\n%s\n' "$SYSCTL_CONTENT" "user.max_inotify_instances = $DESIRED_INOTIFY_INSTANCES" | sudo "$TEE" "$SYSCTL_CONF" >/dev/null
+fi
+
 # Start or restart Docker as needed
 if ! "$SYSTEMCTL" is-active --quiet docker 2>/dev/null; then
   echo "Starting Docker daemon..."


### PR DESCRIPTION
## Summary
- The cliproxyapi container was crash-looping with `failed to create watcher: too many open files` because the default `max_user_instances` of 128 was too low for Docker container file watchers
- Raises both `fs.inotify.max_user_instances` and `user.max_inotify_instances` to 1024 at runtime in `docker-setup`
- Persists the setting via `/etc/sysctl.d/99-docker-inotify.conf` for reboots

## Test plan
- [x] Verified cliproxyapi container starts and returns HTTP 200 on `/healthz` after increasing limits
- [x] Confirmed the fix resolves the 265+ restart crash loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops cliproxyapi crash loops by raising inotify watcher limits in Docker setup. Increases both kernel params to 1024 and persists them to survive reboots.

- **Bug Fixes**
  - Set fs.inotify.max_user_instances and user.max_inotify_instances to 1024 at runtime in the setup script.
  - Persist settings via /etc/sysctl.d/99-docker-inotify.conf.

<sup>Written for commit 22750be6057467e0d801ea27623983ac1c77aaa5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

