### PR TITLE
fix: restore k3s CI checks

### DIFF
--- a/config/k3s/default.nix
+++ b/config/k3s/default.nix
@@ -15,8 +15,7 @@ in
 
   home.file.".config/k3s/k3s.service" = lib.mkIf pkgs.stdenv.isLinux {
     source = pkgs.replaceVars ./k3s.service {
-      inherit (pkgs) coreutils;
-      k3s = pkgs.k3s;
+      inherit (pkgs) coreutils k3s;
     };
     force = true;
   };
@@ -29,7 +28,7 @@ in
     export KUBECONFIG="${kubeconfig}"
   '';
 
-  programs.zsh.initExtra = lib.mkIf pkgs.stdenv.isLinux ''
+  programs.zsh.initContent = lib.mkIf pkgs.stdenv.isLinux ''
     export KUBECONFIG="${kubeconfig}"
   '';
 

--- a/home-manager/services/k3s/activate.sh
+++ b/home-manager/services/k3s/activate.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Install the generated k3s service and sync kubeconfig for the current user.
+# @diff@ and @systemctl@ are substituted by pkgs.replaceVars.
+set -euo pipefail
+
+SERVICE_FILE="$1"
+KUBE_DIR="$2"
+SYSTEM_SERVICE="/etc/systemd/system/k3s.service"
+K3S_KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
+
+sudo_cmd=()
+if command -v sudo >/dev/null 2>&1; then
+  sudo_cmd=(sudo)
+elif [ -x /run/wrappers/bin/sudo ]; then
+  sudo_cmd=(/run/wrappers/bin/sudo)
+elif [ -x /usr/bin/sudo ]; then
+  sudo_cmd=(/usr/bin/sudo)
+fi
+
+run() {
+  if [ -n "${DRY_RUN_CMD:-}" ]; then
+    # shellcheck disable=SC2086
+    $DRY_RUN_CMD "$@"
+  else
+    "$@"
+  fi
+}
+
+run_sudo() {
+  run "${sudo_cmd[@]}" "$@"
+}
+
+require_sudo() {
+  if [ "${#sudo_cmd[@]}" -eq 0 ]; then
+    echo "Warning: sudo not found, skipping k3s system setup" >&2
+    return 1
+  fi
+}
+
+if [ -f "$SERVICE_FILE" ] && ! @diff@ -q "$SERVICE_FILE" "$SYSTEM_SERVICE" >/dev/null 2>&1; then
+  require_sudo || exit 0
+  run_sudo cp "$SERVICE_FILE" "$SYSTEM_SERVICE"
+  run_sudo @systemctl@ daemon-reload
+  run_sudo @systemctl@ enable --now k3s
+fi
+
+if [ -f "$K3S_KUBECONFIG" ]; then
+  run mkdir -p "$KUBE_DIR"
+  require_sudo || exit 0
+  run_sudo cp "$K3S_KUBECONFIG" "$KUBE_DIR/config"
+  run_sudo chown "$(id -u):$(id -g)" "$KUBE_DIR/config"
+  run chmod 600 "$KUBE_DIR/config"
+fi

--- a/home-manager/services/k3s/default.nix
+++ b/home-manager/services/k3s/default.nix
@@ -7,24 +7,17 @@
 }:
 let
   inherit (inputs) host;
-  serviceFile = "${config.home.homeDirectory}/.config/k3s/k3s.service";
+  homeDir = config.home.homeDirectory;
+  setupScript = pkgs.replaceVars ./activate.sh {
+    diff = "${pkgs.diffutils}/bin/diff";
+    systemctl = "${pkgs.systemd}/bin/systemctl";
+  };
+  serviceFile = "${homeDir}/.config/k3s/k3s.service";
 in
 lib.mkIf (pkgs.stdenv.isLinux && host.isKyber) {
   home.activation.setupK3s = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    SUDO="/usr/bin/sudo"
-    if ! ${pkgs.diffutils}/bin/diff -q "${serviceFile}" /etc/systemd/system/k3s.service >/dev/null 2>&1; then
-      $DRY_RUN_CMD $SUDO cp "${serviceFile}" /etc/systemd/system/k3s.service
-      $DRY_RUN_CMD $SUDO ${pkgs.systemd}/bin/systemctl daemon-reload
-      $DRY_RUN_CMD $SUDO ${pkgs.systemd}/bin/systemctl enable --now k3s
-    fi
-
-    K3S_KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
-    KUBE_DIR="${config.home.homeDirectory}/.kube"
-    if [ -f "$K3S_KUBECONFIG" ]; then
-      $DRY_RUN_CMD mkdir -p "$KUBE_DIR"
-      $DRY_RUN_CMD $SUDO cp "$K3S_KUBECONFIG" "$KUBE_DIR/config"
-      $DRY_RUN_CMD $SUDO chown "$(id -u):$(id -g)" "$KUBE_DIR/config"
-      $DRY_RUN_CMD chmod 600 "$KUBE_DIR/config"
-    fi
+    ${pkgs.bash}/bin/bash "${setupScript}" \
+      "${serviceFile}" \
+      "${homeDir}/.kube"
   '';
 }

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -196,6 +196,10 @@ End
 It 'has spec file for home-manager/services/dolt/start.sh'
 The path "spec/dolt_start_spec.sh" should be exist
 End
+
+It 'has spec file for home-manager/services/k3s/activate.sh'
+The path "spec/k3s_service_activate_spec.sh" should be exist
+End
 It 'has spec file for nix-darwin/services/pmset-battery-policy/power-policy.sh'
 The path "spec/pmset_battery_policy_spec.sh" should be exist
 End
@@ -417,6 +421,7 @@ home-manager/services/docker/setup-docker.sh
 home-manager/services/dolt/start.sh
 home-manager/services/dotfiles-updater/update.sh
 home-manager/services/gas-town/start.sh
+home-manager/services/k3s/activate.sh
 home-manager/services/make-updater/update.sh
 home-manager/services/neverssl-keepalive/keepalive.sh
 hosts/darwin/activate-remove-backups.sh

--- a/spec/k3s_service_activate_spec.sh
+++ b/spec/k3s_service_activate_spec.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'home-manager/services/k3s/activate.sh'
+SCRIPT="$PWD/home-manager/services/k3s/activate.sh"
+
+Describe 'script properties'
+It 'uses bash shebang'
+When run bash -c "head -1 '$SCRIPT'"
+The output should include '#!/usr/bin/env bash'
+End
+
+It 'uses strict mode'
+When run bash -c "grep 'set -euo pipefail' '$SCRIPT'"
+The output should include 'set -euo pipefail'
+End
+End
+
+Describe 'sudo detection'
+It 'checks for sudo command'
+When run bash -c "grep 'command -v sudo' '$SCRIPT'"
+The output should include 'command -v sudo'
+End
+
+It 'checks NixOS wrapper path'
+When run bash -c "grep '/run/wrappers/bin/sudo' '$SCRIPT'"
+The output should include '/run/wrappers/bin/sudo'
+End
+
+It 'warns when sudo is unavailable'
+When run bash -c "grep 'sudo not found' '$SCRIPT'"
+The output should include 'sudo not found'
+End
+End
+
+Describe 'k3s setup'
+It 'installs the generated systemd service'
+When run bash -c "grep '/etc/systemd/system/k3s.service' '$SCRIPT'"
+The output should include '/etc/systemd/system/k3s.service'
+End
+
+It 'reloads and enables k3s'
+When run bash -c "grep 'enable --now k3s' '$SCRIPT'"
+The output should include 'enable --now k3s'
+End
+
+It 'syncs kubeconfig into the user kube directory'
+When run bash -c "grep '/etc/rancher/k3s/k3s.yaml' '$SCRIPT'"
+The output should include '/etc/rancher/k3s/k3s.yaml'
+End
+
+It 'preserves dry-run command handling'
+When run bash -c "grep 'DRY_RUN_CMD' '$SCRIPT'"
+The output should include 'DRY_RUN_CMD'
+End
+End
+End


### PR DESCRIPTION
## Summary

- Move the kyber k3s Home Manager activation shell into an external script so shell-inline-check passes again.
- Add ShellSpec coverage and coverage-list registration for the new k3s service activation script.
- Fix the current Statix W04 failure in config/k3s/default.nix by using inherit (pkgs) coreutils k3s.
- Replace the deprecated zsh initExtra hook with initContent for the k3s KUBECONFIG export.

## Verification

- make shell-inline-check
- make shell-check-dev
- make shell-test-dev
- make nix-format-check
- make nix-lint
- make nix-test
