### PR TITLE
feat(local-scripts): make slb and ulb work cross-shell

### DIFF
--- a/.local-binaries.txt
+++ b/.local-binaries.txt
@@ -18,7 +18,7 @@
 ~/ghq/github.com/Dicklesworthstone/mcp_agent_mail/am
 ~/ghq/github.com/Dicklesworthstone/ntm/ntm
 ~/ghq/github.com/Dicklesworthstone/pi_agent_rust/target/release/pi:pir
-~/ghq/github.com/Dicklesworthstone/slb/build/slb
+~/ghq/github.com/Dicklesworthstone/slb/build/slb:slbutton
 ~/ghq/github.com/Dicklesworthstone/ultimate_bug_scanner/ubs
 ~/ghq/github.com/GoogleCloudPlatform/scion/scion
 ~/ghq/github.com/MH4GF/tq/tq

--- a/home-manager/modules/local-scripts/default.nix
+++ b/home-manager/modules/local-scripts/default.nix
@@ -24,6 +24,16 @@ _: {
     force = true;
     source = ./pushover-notify.sh;
   };
+  home.file.".local/scripts/slb" = {
+    executable = true;
+    force = true;
+    source = ./slb.sh;
+  };
+  home.file.".local/scripts/ulb" = {
+    executable = true;
+    force = true;
+    source = ./ulb.sh;
+  };
   home.file.".local/scripts/tmux-bridge" = {
     executable = true;
     force = true;

--- a/home-manager/modules/local-scripts/slb.sh
+++ b/home-manager/modules/local-scripts/slb.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec bash "$HOME/dotfiles/home-manager/modules/local-binaries/sync-local-binaries.sh" "$@"

--- a/home-manager/modules/local-scripts/ulb.sh
+++ b/home-manager/modules/local-scripts/ulb.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec bash "$HOME/dotfiles/scripts/update-local-binaries.sh" "$@"


### PR DESCRIPTION
## Summary

- Adds `slb` and `ulb` wrapper scripts under `home-manager/modules/local-scripts/`, installed to `~/.local/scripts/` so they work in bash/zsh/fish (previously only fish via abbreviations).
- Renames the SLB binary alias in `.local-binaries.txt` from `slb` to `slbutton` to free up the name.
- Fish abbreviations (`slb`, `ulb`) continue to expand to the existing fish functions; non-fish shells now hit the wrappers and call the same underlying bash scripts.

## Test plan

- [ ] `home-manager switch` applies cleanly
- [ ] `rm ~/.local/bin/slb` (stale symlink to old SLB binary location)
- [ ] `slb` runs sync in bash, zsh, and fish
- [ ] `ulb` runs update in bash, zsh, and fish
- [ ] `slbutton` invokes the Simultaneous Launch Button binary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `slb` and `ulb` work in bash, zsh, and fish by installing small wrapper scripts under ~/.local/scripts. Rename the SLB binary alias to `slbutton` to free up `slb`.

- **New Features**
  - Add cross-shell wrappers for `slb` (sync) and `ulb` (update) that call the existing bash scripts.
  - Install wrappers via home-manager to `~/.local/scripts` as executables.
  - Fish abbreviations still expand as before; bash/zsh use the wrappers.

- **Migration**
  - Run: `home-manager switch`.
  - Remove stale symlink: `rm ~/.local/bin/slb`.
  - Use `slbutton` to run the Simultaneous Launch Button binary.

<sup>Written for commit ab5bcb6f12b8040780b63201b2eeed67eb82060b. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1607?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

