### PR TITLE
chore(git): Open commit editor in normal mode

### DIFF
--- a/home-manager/programs/git/default.nix
+++ b/home-manager/programs/git/default.nix
@@ -16,7 +16,7 @@
           email = "shunkakinoki@gmail.com";
         };
         core = {
-          editor = "nvim";
+          editor = "nvim -c \"stopinsert\"";
           compression = -1;
           autocrlf = "input";
           whitespace = "trailing-space,space-before-tab";


### PR DESCRIPTION
## Summary
- Configure Git to launch Neovim with `stopinsert` for commit messages.
- Keeps `git commit` editor sessions in normal mode on entry.

## Test plan
- Not run; configuration-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open the Git commit editor in normal mode by setting the editor to `nvim -c "stopinsert"`. This makes `git commit` start outside insert mode for consistent editing.

<sup>Written for commit 00d8d8b5a349fb4e17ea288c0c4c426c1fee8f20. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1609?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

