### PR TITLE
feat(noctalia): lid lock, AC-aware idle, 5min dimlock 10min suspend

### DIFF
--- a/config/noctalia/ac-idle-inhibit.sh
+++ b/config/noctalia/ac-idle-inhibit.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AC=/sys/class/power_supply/ACAD/online
+
+while true; do
+    if [ "$(cat "$AC" 2>/dev/null)" = "1" ]; then
+        systemd-inhibit --what=idle --why="On AC power" --mode=block sleep 20
+    else
+        sleep 20
+    fi
+done

--- a/config/noctalia/ac-idle-inhibit.sh
+++ b/config/noctalia/ac-idle-inhibit.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
+# Inhibit idle when on AC power so noctalia's idle timeouts only fire on battery.
+# Polls every 2s so AC state changes take effect well within the 5-min idle window.
 set -euo pipefail
 
 AC=/sys/class/power_supply/ACAD/online
 
 while true; do
-    if [ "$(cat "$AC" 2>/dev/null)" = "1" ]; then
-        systemd-inhibit --what=idle --why="On AC power" --mode=block sleep 20
-    else
-        sleep 20
-    fi
+  if [ "$(cat "$AC" 2>/dev/null)" = "1" ]; then
+    systemd-inhibit --what=idle --why="On AC power" --mode=block sleep 2
+  else
+    sleep 2
+  fi
 done

--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -9,6 +9,33 @@
     force = true;
   };
 
+  # Inhibit idle when plugged into AC; noctalia's idle timeouts apply on battery only.
+  systemd.user.services.ac-idle-inhibit = {
+    Unit = {
+      Description = "Inhibit idle when on AC power";
+      After = [ "graphical-session.target" ];
+      PartOf = [ "graphical-session.target" ];
+    };
+    Service = {
+      Type = "simple";
+      ExecStart =
+        let
+          script = pkgs.writeShellScript "ac-idle-inhibit" ''
+            while true; do
+              if [ "$(cat /sys/class/power_supply/ACAD/online 2>/dev/null)" = "1" ]; then
+                ${pkgs.systemd}/bin/systemd-inhibit --what=idle --why="On AC power" --mode=block ${pkgs.coreutils}/bin/sleep 20
+              else
+                ${pkgs.coreutils}/bin/sleep 20
+              fi
+            done
+          '';
+        in
+        "${script}";
+      Restart = "on-failure";
+    };
+    Install.WantedBy = [ "graphical-session.target" ];
+  };
+
   programs.noctalia-shell = {
     enable = true;
     package = inputs.noctalia-shell.packages.${pkgs.system}.default;
@@ -95,7 +122,9 @@
       wallpaper.enabled = false;
       idle = {
         enabled = true;
-        timeout = 300;
+        screenOffTimeout = 300;  # 5 min on battery
+        lockTimeout = 300;
+        suspendTimeout = 600;    # 10 min on battery
       };
       systemMonitor.enableDgpuMonitoring = true;
       colorSchemes.schedulingMode = "location";

--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -110,9 +110,9 @@
       wallpaper.enabled = false;
       idle = {
         enabled = true;
-        screenOffTimeout = 300;  # 5 min on battery
+        screenOffTimeout = 300; # 5 min on battery
         lockTimeout = 300;
-        suspendTimeout = 600;    # 10 min on battery
+        suspendTimeout = 600; # 10 min on battery
       };
       systemMonitor.enableDgpuMonitoring = true;
       colorSchemes.schedulingMode = "location";

--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -20,6 +20,7 @@
         capsuleOpacity = 0;
         widgets.left = [
           { id = "Launcher"; }
+          { id = "Workspaces"; }
           {
             id = "Clock";
             formatHorizontal = "yyyy/MM/dd HH:mm:ss";
@@ -44,12 +45,11 @@
           { id = "PowerProfile"; }
           { id = "Volume"; }
           { id = "Brightness"; }
-          { id = "Settings"; }
           { id = "ControlCenter"; }
         ];
       };
       ui = {
-        fontDefault = "JetBrainsMono Nerd Font";
+        fontDefault = "Noto Sans";
         fontFixed = "JetBrainsMono Nerd Font";
       };
       notifications = {
@@ -73,16 +73,29 @@
       colorSchemes.predefinedScheme = "Dracula-Custom";
       hooks = {
         enabled = true;
-        darkModeChange = ''if [ "$1" = "true" ]; then dconf write /org/gnome/desktop/interface/color-scheme "'prefer-dark'" && dconf write /org/gnome/desktop/interface/gtk-theme "'Adwaita-dark'"; else dconf write /org/gnome/desktop/interface/color-scheme "'prefer-light'" && dconf write /org/gnome/desktop/interface/gtk-theme "'Adwaita'"; fi'';
+        darkModeChange = ''
+          if [ "$1" = "true" ]; then
+            dconf write /org/gnome/desktop/interface/color-scheme "'prefer-dark'"
+            dconf write /org/gnome/desktop/interface/gtk-theme "'Adwaita-dark'"
+            dconf write /org/gnome/desktop/interface/icon-theme "'Adwaita'"
+          else
+            dconf write /org/gnome/desktop/interface/color-scheme "'prefer-light'"
+            dconf write /org/gnome/desktop/interface/gtk-theme "'Adwaita'"
+            dconf write /org/gnome/desktop/interface/icon-theme "'Adwaita'"
+          fi
+        '';
       };
       dock = {
         colorizeIcons = true;
         showLauncherIcon = true;
-        showDockIndicator = true;
+        showDockIndicator = false;
       };
       desktopWidgets.enabled = true;
       wallpaper.enabled = false;
-      idle.enabled = true;
+      idle = {
+        enabled = true;
+        timeout = 300;
+      };
       systemMonitor.enableDgpuMonitoring = true;
       colorSchemes.schedulingMode = "location";
       location.autoLocate = true;

--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -18,19 +18,7 @@
     };
     Service = {
       Type = "simple";
-      ExecStart =
-        let
-          script = pkgs.writeShellScript "ac-idle-inhibit" ''
-            while true; do
-              if [ "$(cat /sys/class/power_supply/ACAD/online 2>/dev/null)" = "1" ]; then
-                ${pkgs.systemd}/bin/systemd-inhibit --what=idle --why="On AC power" --mode=block ${pkgs.coreutils}/bin/sleep 20
-              else
-                ${pkgs.coreutils}/bin/sleep 20
-              fi
-            done
-          '';
-        in
-        "${script}";
+      ExecStart = "${pkgs.bash}/bin/bash ${./ac-idle-inhibit.sh}";
       Restart = "on-failure";
     };
     Install.WantedBy = [ "graphical-session.target" ];

--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -69,6 +69,7 @@
         compactLockScreen = true;
         autoStartAuth = true;
         allowPasswordWithFprintd = true;
+        lockOnSuspend = true;
       };
       colorSchemes.predefinedScheme = "Dracula-Custom";
       hooks = {

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -360,6 +360,7 @@ config/git-ai/activate.sh
 config/hyprland/scripts/record-screen.sh
 config/hyprland/scripts/toggle-terminal.sh
 config/k3s/activate.sh
+config/noctalia/ac-idle-inhibit.sh
 config/obsidian/activate.sh
 config/omp/activate.sh
 config/openclaw/hydrate.sh


### PR DESCRIPTION
## Summary

- Lock screen on lid close via `general.lockOnSuspend = true` (noctalia calls `lockAndSuspend()` instead of `suspend()`)
- Disable idle entirely on AC power via a systemd user service (`ac-idle-inhibit`) that holds a `systemd-inhibit --what=idle` lock while `/sys/class/power_supply/ACAD/online` reads `1`
- On battery: screen off + lock at 5 min (`screenOffTimeout`/`lockTimeout = 300`), suspend at 10 min (`suspendTimeout = 600`)
- Extracted AC inhibit script to `ac-idle-inhibit.sh` to satisfy `shell-inline-check`

## Test plan

- [ ] Closing lid locks screen
- [ ] No idle timeouts fire while plugged in
- [ ] Screen dims and locks at ~5 min on battery
- [ ] System suspends at ~10 min on battery
- [ ] `shell-inline-check` passes
- [ ] `shell-test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lock the session on lid close and make idle power-aware. On AC, idle is inhibited; on battery, the display turns off and locks at 5 minutes and the system suspends at 10 minutes.

- **New Features**
  - Enable `lockOnSuspend` to lock on lid close.
  - Add `systemd` user service `ac-idle-inhibit` that polls AC state every 2s and holds `systemd-inhibit` when online.
  - Set idle timeouts: `screenOffTimeout`/`lockTimeout` = 300s, `suspendTimeout` = 600s.
  - Minor UI tweaks in `noctalia`: add Workspaces widget, switch default font to Noto Sans, hide dock indicator, align GTK/icon themes with dark mode.

- **Bug Fixes**
  - Extract AC-inhibit logic to `ac-idle-inhibit.sh`, add coverage entry, and fix Nix formatting.

<sup>Written for commit ca98d82b7b5eb899e31581bff18a54afe9d4c55b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

