### PR TITLE
feat(hermes): declarative gateway deps via uv dependency group

### DIFF
--- a/config/hermes/hydrate.sh
+++ b/config/hermes/hydrate.sh
@@ -59,7 +59,7 @@ if [ -z "$CLIPROXY_API_KEY" ]; then
   CLIPROXY_API_KEY="$(read_secret "${SECRETS_DIR}/cliproxy-key")"
 fi
 
-TELEGRAM_TOKEN="${TELEGRAM_TOKEN:-$(read_secret "${SECRETS_DIR}/telegram-token")}"
+TELEGRAM_TOKEN="${HERMES_TELEGRAM_TOKEN:-${TELEGRAM_TOKEN:-$(read_secret "${SECRETS_DIR}/telegram-token")}}"
 GATEWAY_TOKEN="${HERMES_GATEWAY_TOKEN:-${GATEWAY_TOKEN:-$(read_secret "${SECRETS_DIR}/gateway-token")}}"
 WHATSAPP_ALLOW_FROM="${WHATSAPP_ALLOW_FROM:-$(read_secret "${SECRETS_DIR}/whatsapp-allow-from")}"
 

--- a/home-manager/services/hermes/activate.sh
+++ b/home-manager/services/hermes/activate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Create Hermes directories with correct permissions
+# Create Hermes directories and install runtime deps
 # Usage: activate.sh <home_dir>
 set -euo pipefail
 HOME_DIR="$1"
@@ -11,3 +11,11 @@ mkdir -p "$HOME_DIR/.hermes/memories"
 mkdir -p "$HOME_DIR/.hermes/skills"
 mkdir -p "$HOME_DIR/.hermes/cron"
 chmod 700 "$HOME_DIR/.hermes"
+
+# Install hermes gateway runtime deps from pyproject.toml dependency group
+HERMES_VENV="$HOME_DIR/ghq/github.com/NousResearch/hermes-agent/.venv"
+if [ -d "$HERMES_VENV" ]; then
+  uv pip install --python "$HERMES_VENV/bin/python" \
+    --group hermes \
+    --project "$HOME_DIR/dotfiles" 2>/dev/null || true
+fi

--- a/home-manager/services/hermes/default.nix
+++ b/home-manager/services/hermes/default.nix
@@ -41,4 +41,30 @@ lib.mkIf host.isKyber {
       WantedBy = [ "default.target" ];
     };
   };
+
+  systemd.user.services.hermes-dashboard = {
+    Unit = {
+      Description = "Hermes dashboard";
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
+      StartLimitIntervalSec = 300;
+      StartLimitBurst = 10;
+    };
+    Service = {
+      Type = "simple";
+      ExecStart = "${homeDir}/.local/bin/hermes dashboard --host 0.0.0.0 --port 9119 --no-open --insecure";
+      Restart = "always";
+      RestartSec = "5s";
+      Environment = [
+        "HOME=${homeDir}"
+        "PATH=${homeDir}/.local/bin:${homeDir}/.nix-profile/bin:/usr/local/bin:/usr/bin:/bin"
+      ];
+      WorkingDirectory = "${homeDir}/.hermes";
+      StandardOutput = "append:/tmp/hermes/hermes-dashboard.log";
+      StandardError = "append:/tmp/hermes/hermes-dashboard.log";
+    };
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,11 @@ tools = [
   "vllm>=0.20.0",
   "vllm-mlx>=0.2.9",
 ]
+# Hermes gateway runtime deps - installed into hermes venv via uv pip install
+hermes = [
+  "python-telegram-bot[webhooks]>=22.6,<23",
+  "croniter>=6.0.0,<7",
+]
 
 [tool.uv]
 exclude-newer = "1 week"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ tools = [
 hermes = [
   "python-telegram-bot[webhooks]>=22.6,<23",
   "croniter>=6.0.0,<7",
+  "fastapi[standard]>=0.115.0",
+  "uvicorn>=0.30.0",
 ]
 
 [tool.uv]


### PR DESCRIPTION
## Summary
- Add `hermes` dependency group to `pyproject.toml` with `python-telegram-bot[webhooks]` and `croniter`
- Update `home-manager/services/hermes/activate.sh` to install deps into hermes venv at activation time via `uv pip install --group hermes`
- Renovate will track version updates for these deps

## Test plan
- [x] `uv pip install --group hermes` installs correctly into hermes venv
- [x] `make shell-test` passes (1397 examples, 0 failures)
- [ ] Verify hermes-gateway starts without "not installed" warnings after activation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Hermes gateway runtime deps declarative via a `hermes` uv group with auto-install on activation, and add a `hermes-dashboard` service. Prefer a dedicated `HERMES_TELEGRAM_TOKEN`; Renovate tracks versions to avoid missing-deps warnings.

- **New Features**
  - Added `hermes-dashboard` systemd user service (port 9119, `--insecure` for k3s).
  - `HERMES_TELEGRAM_TOKEN` is now used for the Telegram bot, with fallback to `TELEGRAM_TOKEN`/secrets.

- **Dependencies**
  - `hermes` group in `pyproject.toml`: `python-telegram-bot[webhooks]>=22.6,<23`, `croniter>=6.0.0,<7`, `fastapi[standard]>=0.115.0`, `uvicorn>=0.30.0`.
  - Activation installs the group into the Hermes venv using `uv pip` with the venv’s Python.

<sup>Written for commit 7a9f18896bc119fcdd492f0e0bd9b30161f8c96f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

