### PR TITLE
fix: expose local tool bins to shell startup

### DIFF
--- a/home-manager/programs/bash/bash_env.sh
+++ b/home-manager/programs/bash/bash_env.sh
@@ -1,0 +1,20 @@
+# shellcheck shell=bash
+# Loaded by non-interactive bash through BASH_ENV.
+if [ -z "$BUN_INSTALL" ]; then
+  export BUN_INSTALL="$HOME/.bun"
+fi
+
+case ":$PATH:" in
+  *":$HOME/.local/bin:"*) ;;
+  *) export PATH="$HOME/.local/bin:$PATH" ;;
+esac
+
+case ":$PATH:" in
+  *":$HOME/.cargo/bin:"*) ;;
+  *) export PATH="$HOME/.cargo/bin:$PATH" ;;
+esac
+
+case ":$PATH:" in
+  *":$HOME/.bun/bin:"*) ;;
+  *) export PATH="$HOME/.bun/bin:$PATH" ;;
+esac

--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -4,6 +4,12 @@
     bash-language-server
   ];
 
+  home.file.".bash_env".source = ./bash_env.sh;
+
+  home.sessionVariables = {
+    BASH_ENV = "$HOME/.bash_env";
+  };
+
   programs.bash = {
     enable = true;
     enableCompletion = true;
@@ -72,8 +78,8 @@
       export PATH="$PATH:$HOME/go/bin"
       export PATH="/nix/var/nix/profiles/default/bin:$PATH"
       export PATH="$HOME/.nix-profile/bin:$PATH"
-      export PATH="$HOME/.cargo/bin:$PATH"
       export PATH="$HOME/.local/bin:$PATH"
+      export PATH="$HOME/.cargo/bin:$PATH"
       export PATH="$HOME/.local/scripts:$PATH"
       export PATH="$HOME/.bun/bin:$PATH"
       export PATH="/opt/homebrew/opt/postgresql@18/bin:$PATH"
@@ -86,6 +92,9 @@
     '';
 
     profileExtra = ''
+      # Local binaries should be present even before login shells source .bashrc.
+      export PATH="$HOME/.bun/bin:$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
+
       # Nix
       if [ -e ~/.nix-profile/etc/profile.d/nix.sh ]; then
         . ~/.nix-profile/etc/profile.d/nix.sh

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -8,6 +8,9 @@
   programs.fish = {
     enable = true;
     shellInit = ''
+      # Local binaries should be available before login/interactive-only PATH setup.
+      set -gx PATH $HOME/.bun/bin $HOME/.cargo/bin $HOME/.local/bin $PATH
+
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
       if test (uname) = "Linux"
           set -gx XDG_RUNTIME_DIR /run/user/(id -u)
@@ -46,8 +49,8 @@
       fish_add_path -p -m ~/.nix-profile/bin
       fish_add_path -p -m /etc/profiles/per-user/${config.home.username}/bin
       fish_add_path -p -m ~/go/bin
-      fish_add_path -p -m ~/.cargo/bin
       fish_add_path -p -m ~/.local/bin
+      fish_add_path -p -m ~/.cargo/bin
       fish_add_path -p -m ~/.local/scripts
       fish_add_path -p -m ~/.bun/bin
       fish_add_path -p -m /opt/homebrew/opt/postgresql@18/bin
@@ -68,8 +71,8 @@
       fish_add_path -p -m ~/.nix-profile/bin
       fish_add_path -p -m /etc/profiles/per-user/${config.home.username}/bin
       fish_add_path -p -m ~/go/bin
-      fish_add_path -p -m ~/.cargo/bin
       fish_add_path -p -m ~/.local/bin
+      fish_add_path -p -m ~/.cargo/bin
       fish_add_path -p -m ~/.local/scripts
       fish_add_path -p -m ~/.bun/bin
       fish_add_path -p -m /opt/homebrew/opt/postgresql@18/bin

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -31,6 +31,9 @@
           eval "$(/opt/homebrew/bin/brew shellenv)"
       fi
 
+      # Local binaries must be available to non-interactive zsh commands too.
+      export PATH="$HOME/.bun/bin:$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
+
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
       if [ "$(uname)" = "Linux" ]; then
           export XDG_RUNTIME_DIR="/run/user/$(id -u)"
@@ -65,8 +68,8 @@
       export PATH="$PATH:$HOME/go/bin"
       export PATH="/nix/var/nix/profiles/default/bin:$PATH"
       export PATH="$HOME/.nix-profile/bin:$PATH"
-      export PATH="$HOME/.cargo/bin:$PATH"
       export PATH="$HOME/.local/bin:$PATH"
+      export PATH="$HOME/.cargo/bin:$PATH"
       export PATH="$HOME/.local/scripts:$PATH"
       export PATH="$HOME/.bun/bin:$PATH"
       export PATH="/opt/homebrew/opt/postgresql@18/bin:$PATH"

--- a/spec/atuin_history_spec.sh
+++ b/spec/atuin_history_spec.sh
@@ -6,6 +6,8 @@ HOOK_SCRIPT="$PWD/config/claude/hooks/atuin-history.sh"
 CLAUDE_DEFAULT="$PWD/config/claude/default.nix"
 CLAUDE_SETTINGS="$PWD/config/claude/settings.json"
 BASH_CONFIG="$PWD/home-manager/programs/bash/default.nix"
+BASH_ENV_FILE="$PWD/home-manager/programs/bash/bash_env.sh"
+FISH_CONFIG="$PWD/home-manager/programs/fish/default.nix"
 ZSH_CONFIG="$PWD/home-manager/programs/zsh/default.nix"
 
 run_hook() {
@@ -104,6 +106,45 @@ It 'defines the zsh alias from envExtra so .zshenv sees it'
 When run bash -c "grep -F \"alias rm='gomi'\" '$ZSH_CONFIG'"
 The status should be success
 The output should include "alias rm='gomi'"
+End
+
+It 'adds local binaries to zsh envExtra for non-interactive commands'
+When run bash -c "grep -F 'export PATH=\"\$HOME/.bun/bin:\$HOME/.cargo/bin:\$HOME/.local/bin:\$PATH\"' '$ZSH_CONFIG'"
+The status should be success
+The output should include '.local/bin'
+The output should include '.bun/bin'
+The output should include '.cargo/bin'
+End
+
+It 'adds local binaries to bash profileExtra before bashrc'
+When run bash -c "grep -F 'export PATH=\"\$HOME/.bun/bin:\$HOME/.cargo/bin:\$HOME/.local/bin:\$PATH\"' '$BASH_CONFIG'"
+The status should be success
+The output should include '.local/bin'
+The output should include '.bun/bin'
+The output should include '.cargo/bin'
+End
+
+It 'configures BASH_ENV for plain non-interactive bash commands'
+When run bash -c "grep -F 'BASH_ENV = \"\$HOME/.bash_env\"' '$BASH_CONFIG' && grep -F 'home.file.\".bash_env\".source = ./bash_env.sh' '$BASH_CONFIG' && ! grep -F 'home.file.\".bash_env\".text' '$BASH_CONFIG'"
+The status should be success
+The output should include 'BASH_ENV'
+The output should include 'bash_env.sh'
+End
+
+It 'loads cargo, local, and bun bins from the bash non-interactive env file'
+When run bash -c "grep -F 'export PATH=\"\$HOME/.cargo/bin:\$PATH\"' '$BASH_ENV_FILE' && grep -F 'export PATH=\"\$HOME/.bun/bin:\$PATH\"' '$BASH_ENV_FILE' && grep -F 'export PATH=\"\$HOME/.local/bin:\$PATH\"' '$BASH_ENV_FILE'"
+The status should be success
+The output should include '.cargo/bin'
+The output should include '.bun/bin'
+The output should include '.local/bin'
+End
+
+It 'adds local binaries to fish shellInit before login-only setup'
+When run bash -c "grep -F 'set -gx PATH \$HOME/.bun/bin \$HOME/.cargo/bin \$HOME/.local/bin \$PATH' '$FISH_CONFIG'"
+The status should be success
+The output should include '.local/bin'
+The output should include '.bun/bin'
+The output should include '.cargo/bin'
 End
 End
 End

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -398,6 +398,7 @@ home-manager/services/qmd/activate.sh
 home-manager/modules/tailscale/activate-create-dirs.sh
 home-manager/modules/tailscale/activate-install-service.sh
 home-manager/modules/uv-globals/install-uv-globals.sh
+home-manager/programs/bash/bash_env.sh
 home-manager/programs/fnm/activate.sh
 home-manager/programs/neovim/activate-build-plugins.sh
 home-manager/programs/neovim/activate-copy-pack-lock.sh


### PR DESCRIPTION
## Changes
- Add user tool-bin paths in `bun -> cargo -> local` order: npm/Bun globals (`$HOME/.bun/bin`), Cargo globals (`$HOME/.cargo/bin`), and uv/local tools (`$HOME/.local/bin`) to zsh `envExtra` so they are emitted into `.zshenv`.
- Add the same tool-bin paths and order to bash `profileExtra` before login shells source `.bashrc`.
- Install `home-manager/programs/bash/bash_env.sh` as `$HOME/.bash_env` and export `BASH_ENV=$HOME/.bash_env` so plain non-interactive `bash -c` commands can load the same tool-bin paths.
- Add the same tool-bin paths and order to fish `shellInit` before login/interactive-only PATH setup.
- Add ShellSpec coverage for all three managed shell startup locations, the sourced bash `BASH_ENV` hook, and the new shell file coverage list entry.

## Actual Cause
Codex command execution starts a non-interactive zsh command shell. zsh always reads `.zshenv`, but it only reads `.zshrc` for interactive shells. This repo previously added user-installed tool paths in Home Manager interactive/login startup paths, so normal terminals could find tools while some Codex command shells could not.

`bd` itself was present at `/Users/shunkakinoki/.local/bin/bd`; Bun globals are present under `/Users/shunkakinoki/.bun/bin`; Cargo globals are under `/Users/shunkakinoki/.cargo/bin`. The failure was PATH startup scope, not missing installs.

Home Manager also generates these paths into `hm-session-vars.sh`, but that file is guarded by `__HM_SESS_VARS_SOURCED`. In the Codex process tree the guard was already set while PATH had been narrowed, so child command shells skipped rehydrating the session PATH. The shell-specific startup snippets make npm/Bun, Cargo, and uv/local global paths explicit where each shell actually reads them.

## Bash Note
Plain non-interactive bash does not read `.bashrc` or `.bash_profile`. The portable mechanism is the `BASH_ENV` environment variable, so this PR manages `$HOME/.bash_env` from a sibling `bash_env.sh` source file and exports `BASH_ENV` through Home Manager session variables for future sessions.

## Testing
- `make shell-test`
- `make shell-lint`
- `git diff --check`

Generated with Codex by GPT-5