### PR TITLE
fix(fish): unify tmux session-attach pattern across t{p,d,m,w}o

### DIFF
--- a/home-manager/programs/fish/functions/_tdo_function.fish
+++ b/home-manager/programs/fish/functions/_tdo_function.fish
@@ -1,17 +1,19 @@
 function _tdo_function --description "Attach to tmux desktop session"
-  if tmux has-session -t desktop 2>/dev/null
-    if test -n "$TMUX"
-      tmux detach-client
+  if test -n "$TMUX"
+    set -l current (tmux display-message -p '#S' 2>/dev/null)
+    if test "$current" = desktop
+      return 0
     end
-    tmux attach-session -t desktop
-  else
+  end
+
+  if not tmux has-session -t desktop 2>/dev/null
     __tmux_bootstrap_default_session desktop
     or return 1
+  end
 
-    if test -n "$TMUX"
-      tmux switch-client -t desktop
-    else
-      tmux attach-session -t desktop
-    end
+  if test -n "$TMUX"
+    tmux switch-client -t desktop
+  else
+    tmux attach-session -t desktop
   end
 end

--- a/home-manager/programs/fish/functions/_tmo_function.fish
+++ b/home-manager/programs/fish/functions/_tmo_function.fish
@@ -1,17 +1,19 @@
 function _tmo_function --description "Attach to tmux mobile session"
-  if tmux has-session -t mobile 2>/dev/null
-    if test -n "$TMUX"
-      tmux detach-client
+  if test -n "$TMUX"
+    set -l current (tmux display-message -p '#S' 2>/dev/null)
+    if test "$current" = mobile
+      return 0
     end
-    tmux attach-session -t mobile
-  else
+  end
+
+  if not tmux has-session -t mobile 2>/dev/null
     __tmux_bootstrap_default_session mobile
     or return 1
+  end
 
-    if test -n "$TMUX"
-      tmux switch-client -t mobile
-    else
-      tmux attach-session -t mobile
-    end
+  if test -n "$TMUX"
+    tmux switch-client -t mobile
+  else
+    tmux attach-session -t mobile
   end
 end

--- a/home-manager/programs/fish/functions/_tpo_function.fish
+++ b/home-manager/programs/fish/functions/_tpo_function.fish
@@ -1,17 +1,19 @@
 function _tpo_function --description "Attach to tmux primary session"
-  if tmux has-session -t primary 2>/dev/null
-    if test -n "$TMUX"
-      tmux detach-client
+  if test -n "$TMUX"
+    set -l current (tmux display-message -p '#S' 2>/dev/null)
+    if test "$current" = primary
+      return 0
     end
-    tmux attach-session -t primary
-  else
+  end
+
+  if not tmux has-session -t primary 2>/dev/null
     __tmux_bootstrap_default_session primary
     or return 1
+  end
 
-    if test -n "$TMUX"
-      tmux switch-client -t primary
-    else
-      tmux attach-session -t primary
-    end
+  if test -n "$TMUX"
+    tmux switch-client -t primary
+  else
+    tmux attach-session -t primary
   end
 end

--- a/home-manager/programs/fish/functions/_two_function.fish
+++ b/home-manager/programs/fish/functions/_two_function.fish
@@ -1,4 +1,11 @@
 function _two_function --description "Attach to tmux work session"
+  if test -n "$TMUX"
+    set -l current (tmux display-message -p '#S' 2>/dev/null)
+    if test "$current" = work
+      return 0
+    end
+  end
+
   if tmux has-session -t work 2>/dev/null
     if test -n "$TMUX"
       tmux switch-client -t work

--- a/spec/fish/_tdo_function_test.fish
+++ b/spec/fish/_tdo_function_test.fish
@@ -50,4 +50,21 @@ _tdo_function
 
 @test "existing session attaches" (grep -c "attach-session -t desktop" $log2) -ge 1
 
-rm -f $log1 $log_inside $log2
+# ── already inside desktop → no-op ────────────────────────
+set log4 (mktemp)
+set -gx TMUX /tmp/tmux-desktop-test
+function tmux
+    if test "$argv[1]" = display-message
+        echo desktop
+        return 0
+    end
+    echo $argv >> $log4
+end
+
+_tdo_function
+
+@test "already inside desktop skips attach" (grep -c "attach-session" $log4) -eq 0
+@test "already inside desktop skips switch-client" (grep -c "switch-client" $log4) -eq 0
+@test "already inside desktop skips bootstrap" (grep -c "new-session" $log4) -eq 0
+
+rm -f $log1 $log_inside $log2 $log4

--- a/spec/fish/_tmo_function_test.fish
+++ b/spec/fish/_tmo_function_test.fish
@@ -50,4 +50,21 @@ _tmo_function
 
 @test "existing session attaches" (grep -c "attach-session -t mobile" $log2) -ge 1
 
-rm -f $log1 $log_inside $log2
+# ── already inside mobile → no-op ─────────────────────────
+set log4 (mktemp)
+set -gx TMUX /tmp/tmux-mobile-test
+function tmux
+    if test "$argv[1]" = display-message
+        echo mobile
+        return 0
+    end
+    echo $argv >> $log4
+end
+
+_tmo_function
+
+@test "already inside mobile skips attach" (grep -c "attach-session" $log4) -eq 0
+@test "already inside mobile skips switch-client" (grep -c "switch-client" $log4) -eq 0
+@test "already inside mobile skips bootstrap" (grep -c "new-session" $log4) -eq 0
+
+rm -f $log1 $log_inside $log2 $log4

--- a/spec/fish/_tpo_function_test.fish
+++ b/spec/fish/_tpo_function_test.fish
@@ -50,4 +50,21 @@ _tpo_function
 
 @test "existing session attaches" (grep -c "attach-session -t primary" $log3) -ge 1
 
-rm -f $log1 $log2 $log3
+# ── already inside primary → no-op ────────────────────────
+set log4 (mktemp)
+set -gx TMUX /tmp/tmux-primary-test
+function tmux
+    if test "$argv[1]" = display-message
+        echo primary
+        return 0
+    end
+    echo $argv >> $log4
+end
+
+_tpo_function
+
+@test "already inside primary skips attach" (grep -c "attach-session" $log4) -eq 0
+@test "already inside primary skips switch-client" (grep -c "switch-client" $log4) -eq 0
+@test "already inside primary skips bootstrap" (grep -c "new-session" $log4) -eq 0
+
+rm -f $log1 $log2 $log3 $log4

--- a/spec/fish/_two_function_test.fish
+++ b/spec/fish/_two_function_test.fish
@@ -74,4 +74,21 @@ _two_function
 
 @test "existing work session attaches" (grep -c "attach-session -t work" $log2) -ge 1
 
-rm -f $log_restore $log $log2
+# ── already inside work → no-op ───────────────────────────
+set log4 (mktemp)
+set -gx TMUX /tmp/tmux-work-test
+function tmux
+    if test "$argv[1]" = display-message
+        echo work
+        return 0
+    end
+    echo $argv >> $log4
+end
+
+_two_function
+
+@test "already inside work skips attach" (grep -c "attach-session" $log4) -eq 0
+@test "already inside work skips switch-client" (grep -c "switch-client" $log4) -eq 0
+@test "already inside work skips bootstrap" (grep -c "new-session" $log4) -eq 0
+
+rm -f $log_restore $log $log2 $log4


### PR DESCRIPTION
## Summary

- Fix `tpo`/`tdo`/`tmo` hang when invoked from inside the same target session: removed broken `detach-client` + `attach-session` pair (you can't `attach-session` from inside tmux). Replaced with the existing `switch-client`/`attach-session` pattern selected by `$TMUX`.
- Add no-op early-return guard to all four (`tpo`, `tdo`, `tmo`, `two`) so re-running while already in the target session is a quiet no-op rather than a wasted tmux call.
- `two` keeps its tmux-resurrect restore path; `tpo`/`tdo`/`tmo` deliberately don't grow that logic - those sessions are intentionally simple.

## Test plan

- [x] `fishtape spec/fish/_t{po,do,mo,wo,ss}*_test.fish` - 52/52 passing
- [x] Added "already inside session" no-op tests for all four functions
- [ ] Manual: `tpo` from outside tmux bootstraps + attaches
- [ ] Manual: `tpo` from inside `primary` returns silently
- [ ] Manual: `tpo` from inside another session switches client

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hangs when running `tpo`/`tdo`/`tmo` from inside their target tmux session and unifies session attach behavior across `tpo`, `tdo`, `tmo`, and `two`.

- **Bug Fixes**
  - Replace broken `detach-client` + `attach-session` with `switch-client` when inside tmux to avoid hangs.
  - Add early return to all four functions to no-op if already in the target session.

- **Refactors**
  - Standardize flow: if session missing, bootstrap it; then `switch-client` when `$TMUX` is set, otherwise `attach-session`.
  - Keep `two`’s tmux-resurrect restore path; `tpo`/`tdo`/`tmo` stay simple.

<sup>Written for commit 85ec8bc1ede62154d54da09c58e7f1ca5427e828. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

