### PR TITLE
Remove wait step for PR head ref in workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,20 +63,6 @@ jobs:
               sudo mv "$file" "${file}.before-nix-darwin"
             fi
           done
-      - name: Wait for PR Head Ref
-        if: github.event_name == 'pull_request'
-        run: |
-          for attempt in 1 2 3 4 5 6; do
-            if git ls-remote --exit-code origin "refs/pull/${{ github.event.pull_request.number }}/head"; then
-              exit 0
-            fi
-
-            echo "PR head ref is not available yet; retrying in 10s (attempt ${attempt}/6)."
-            sleep 10
-          done
-
-          echo "PR head ref refs/pull/${{ github.event.pull_request.number }}/head is unavailable."
-          exit 1
       - name: Run Install Command
         run: |
           curl -fsSL https://raw.githubusercontent.com/shunkakinoki/dotfiles/${{ github.sha }}/install.sh | sh


### PR DESCRIPTION
Removed the step that waits for the PR head ref to be available before proceeding.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the PR head ref wait step from `.github/workflows/e2e.yml` to eliminate redundant polling and speed up e2e runs. GitHub provides the PR head ref when the job starts, so the loop caused delays and occasional flakiness.

<sup>Written for commit 2b0c8932374e17a7e480cb7587d5e654e63aac29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

