### PR TITLE
fix(noctalia): improve bar visibility

### DIFF
--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -54,10 +54,11 @@ in
         capsuleOpacity = 0;
         widgets.left = [
           { id = "Launcher"; }
-          { id = "Workspaces"; }
           {
             id = "Clock";
             formatHorizontal = "yyyy/MM/dd HH:mm:ss";
+            formatVertical = "HH mm ss - dd MM";
+            tooltipFormat = "yyyy/MM/dd HH:mm:ss";
           }
           {
             id = "SystemMonitor";
@@ -67,8 +68,21 @@ in
           { id = "ActiveWindow"; }
           { id = "MediaMini"; }
         ];
+        widgets.center = [
+          {
+            id = "Workspace";
+            labelMode = "index";
+            showApplications = true;
+            showApplicationsHover = false;
+            showBadge = true;
+            unfocusedIconsOpacity = 0.55;
+          }
+        ];
         widgets.right = [
-          { id = "Tray"; }
+          {
+            id = "Tray";
+            drawerEnabled = false;
+          }
           { id = "Bluetooth"; }
           { id = "Network"; }
           { id = "NotificationHistory"; }

--- a/spec/noctalia_bar_spec.sh
+++ b/spec/noctalia_bar_spec.sh
@@ -9,4 +9,30 @@ When run bash -c "awk '/widgets.right = \\[/{in_right=1} in_right && /id =/ { gs
 The output should include 'Brightness DarkMode ControlCenter'
 End
 
+It 'shows tray items inline instead of hiding them in the drawer'
+When run bash -c "awk '/id = \"Tray\";/{in_tray=1} in_tray && /drawerEnabled = false;/{print; exit}' '$CONFIG'"
+The output should include 'drawerEnabled = false;'
+End
+
+It 'does not duplicate the workspace widget on the left bar'
+When run bash -c "awk '/widgets.left = \\[/{in_left=1} in_left && /id =/ {print} in_left && /^        \\];/{exit}' '$CONFIG'"
+The output should not include 'Workspace'
+End
+
+It 'shows applications inside the centered numbered workspace widget'
+When run bash -c "awk '/widgets.center = \\[/{in_center=1} in_center && /^        \\];/{exit} in_center{print}' '$CONFIG'"
+The output should include 'labelMode = "index";'
+The output should include 'showApplications = true;'
+The output should include 'showApplicationsHover = false;'
+The output should include 'showBadge = true;'
+The output should include 'unfocusedIconsOpacity = 0.55;'
+End
+
+It 'keeps seconds visible in clock formats'
+When run bash -c "awk '/id = \"Clock\";/{in_clock=1} in_clock && /^          }/{exit} in_clock{print}' '$CONFIG'"
+The output should include 'formatHorizontal = "yyyy/MM/dd HH:mm:ss";'
+The output should include 'formatVertical = "HH mm ss - dd MM";'
+The output should include 'tooltipFormat = "yyyy/MM/dd HH:mm:ss";'
+End
+
 End


### PR DESCRIPTION
## Changes
- Show Noctalia tray items inline instead of hiding them in the drawer.
- Keep seconds visible in the clock's horizontal, vertical, and tooltip formats.
- Move the native app-enabled `Workspace` widget to the center bar section so it does not duplicate the left bar, while preserving numbered workspace badges.

## Testing
- `shellspec spec/noctalia_bar_spec.sh`
- `nix-instantiate --parse config/noctalia/default.nix >/dev/null`
- `make nix-switch SUDO='sudo -n'` activation verified through `home-manager-skakinoki.service`
- Restarted Noctalia and verified the new instance loaded configuration without workspace widget errors.

Generated with Codex.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Noctalia bar visibility by showing tray items inline, keeping seconds on the clock, and centering the Workspace widget to avoid duplication.

- **Bug Fixes**
  - Tray now shows items inline (`drawerEnabled = false`) instead of hiding them in a drawer.
  - Clock keeps seconds in horizontal, vertical, and tooltip formats.
  - Moved native app-enabled Workspace widget to the center; preserves numbered badges and removes duplicate on the left.

<sup>Written for commit 48a1755cca34b05336dd9a487648050f0a19ef06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

