### PR TITLE
fix(noctalia): preserve app icon colors

### DIFF
--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -65,7 +65,10 @@ in
             showNetworkStats = true;
             showGpuTemp = true;
           }
-          { id = "ActiveWindow"; }
+          {
+            id = "ActiveWindow";
+            colorizeIcons = false;
+          }
           { id = "MediaMini"; }
         ];
         widgets.center = [
@@ -81,6 +84,7 @@ in
         widgets.right = [
           {
             id = "Tray";
+            colorizeIcons = false;
             drawerEnabled = false;
           }
           { id = "Bluetooth"; }

--- a/spec/noctalia_bar_spec.sh
+++ b/spec/noctalia_bar_spec.sh
@@ -10,8 +10,14 @@ The output should include 'Brightness DarkMode ControlCenter'
 End
 
 It 'shows tray items inline instead of hiding them in the drawer'
-When run bash -c "awk '/id = \"Tray\";/{in_tray=1} in_tray && /drawerEnabled = false;/{print; exit}' '$CONFIG'"
+When run bash -c "awk '/id = \"Tray\";/{in_tray=1} in_tray && /^          }/{exit} in_tray{print}' '$CONFIG'"
+The output should include 'colorizeIcons = false;'
 The output should include 'drawerEnabled = false;'
+End
+
+It 'keeps active window app icons uncolorized'
+When run bash -c "awk '/id = \"ActiveWindow\";/{in_active_window=1} in_active_window && /^          }/{exit} in_active_window{print}' '$CONFIG'"
+The output should include 'colorizeIcons = false;'
 End
 
 It 'does not duplicate the workspace widget on the left bar'


### PR DESCRIPTION
## Changes
- Set Noctalia `Tray.colorizeIcons = false` so tray icons do not use the themed shader.
- Set Noctalia `ActiveWindow.colorizeIcons = false` so the active-window app icon keeps its source colors instead of grayscale.
- Keep the tray drawer disabled so tray items remain inline.
- Extend the focused Noctalia bar spec to cover tray and active-window icon color settings.

## Testing
- `shellspec spec/noctalia_bar_spec.sh`
- `nix-instantiate --parse config/noctalia/default.nix >/dev/null`
- `git diff --check`

Generated with Codex.
