### PR TITLE
feat(shell): use macos-trash for rm on darwin

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -24,6 +24,7 @@ exec_permission_approvals = true
 external_migration = true
 fast_mode = false
 general_analytics = true
+goals = true
 guardian_approval = true
 image_generation = true
 in_app_browser = true

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -103,6 +103,9 @@ with pkgs;
   zellij
   zoxide
 ]
+++ lib.optionals stdenv.isDarwin [
+  darwin.trash
+]
 ++ lib.optionals stdenv.isLinux [
   atop
   below

--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -44,7 +44,7 @@
     shellAliases = {
       copy = "clipboard-copy";
       paste = "clipboard-paste";
-      rm = "gomi";
+      rm = if pkgs.stdenv.isDarwin then "trash" else "gomi";
     };
 
     bashrcExtra = ''

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -99,7 +99,7 @@
       lzg = "lazygit";
       ompc = "omp commit";
       ompcp = "omp commit --push";
-      rm = "gomi";
+      rm = if pkgs.stdenv.isDarwin then "trash" else "gomi";
       v = "nvim";
 
       # Function-based abbreviations

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -57,7 +57,7 @@
       # Define aliases in .zshenv so non-interactive zsh invocations can use them.
       alias copy='clipboard-copy'
       alias paste='clipboard-paste'
-      alias rm='gomi'
+      alias rm='${if pkgs.stdenv.isDarwin then "trash" else "gomi"}'
     '';
 
     initContent = ''

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -67,6 +67,7 @@
       "sshpass"
       "temporal"
       "tmux"
+      "trash"
       "watchexec"
       "yt-dlp"
     ];

--- a/spec/atuin_history_spec.sh
+++ b/spec/atuin_history_spec.sh
@@ -103,9 +103,11 @@ The output should include 'shopt -s expand_aliases'
 End
 
 It 'defines the zsh alias from envExtra so .zshenv sees it'
-When run bash -c "grep -E \"alias rm='\\\$\\{if pkgs.stdenv.isDarwin then \\\"trash\\\" else \\\"gomi\\\"\" '$ZSH_CONFIG'"
+When run bash -c "grep -F \"alias rm='\" '$ZSH_CONFIG'"
 The status should be success
 The output should include "alias rm="
+The output should include "trash"
+The output should include "gomi"
 End
 
 It 'adds local binaries to zsh envExtra for non-interactive commands'

--- a/spec/atuin_history_spec.sh
+++ b/spec/atuin_history_spec.sh
@@ -103,9 +103,9 @@ The output should include 'shopt -s expand_aliases'
 End
 
 It 'defines the zsh alias from envExtra so .zshenv sees it'
-When run bash -c "grep -F \"alias rm='gomi'\" '$ZSH_CONFIG'"
+When run bash -c "grep -E \"alias rm='\\\$\\{if pkgs.stdenv.isDarwin then \\\"trash\\\" else \\\"gomi\\\"\" '$ZSH_CONFIG'"
 The status should be success
-The output should include "alias rm='gomi'"
+The output should include "alias rm="
 End
 
 It 'adds local binaries to zsh envExtra for non-interactive commands'


### PR DESCRIPTION
## Summary
- Add `trash` (Homebrew) and `darwin.trash` (nixpkgs) on darwin so the `rm` alias picks the macOS-native trash CLI.
- Conditionally alias `rm` to `trash` on darwin and keep `gomi` on linux (fish/bash/zsh).
- Update spec/atuin_history_spec.sh to match the new conditional zsh alias.

## Why
gomi auto-renames on collision via `name_1`, `name_2`, ..., but the loop checks via `os.Stat` and then creates with `O_EXCL`. An orphaned `.trashinfo` (info exists, files/ entry missing or vice versa) defeats the loop and gomi errors with `failed to create info file: ... file exists`. gomi has no config knob for collision strategy. macOS `trash` calls Finder via AppleScript, hits `~/.Trash`, and Finder handles duplicates natively (`request-host 2.ts`, etc.).

## Test plan
- [ ] `darwin-rebuild switch` on macOS, confirm `rm <file>` moves to `~/.Trash` and duplicates auto-rename
- [ ] `home-manager switch` on linux, confirm `rm` still resolves to `gomi`
- [ ] `shellspec spec/atuin_history_spec.sh` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On macOS, `rm` now sends files to the system Trash via `trash`; Linux keeps `gomi`. This avoids duplicate-name errors on macOS, fixes the zsh alias test for the conditional alias, and enables `goals` in the Codex config.

- **Dependencies**
  - Added `darwin.trash` to Home Manager packages on Darwin.
  - Added Homebrew `trash` in `nix-darwin` brew packages.

<sup>Written for commit ba1d3c87fc2ccdd0a43533ec92aef38fe71f8b1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

