### PR TITLE
chore: upgrade

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -24,7 +24,6 @@ exec_permission_approvals = true
 external_migration = true
 fast_mode = false
 general_analytics = true
-goals = true
 guardian_approval = true
 image_generation = true
 in_app_browser = true


### PR DESCRIPTION
Automated upgrade

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the deprecated `goals` setting from `config/codex/config.toml` to align with the upgraded config schema. This cleans up an unused flag and avoids warnings in newer builds.

<sup>Written for commit b00c57044522b75bd03b3abd66b45768ad39fcfc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

