### PR TITLE
feat(config): enable goals feature in codex configuration

### DIFF
--- a/config/codex/config.tpl.toml
+++ b/config/codex/config.tpl.toml
@@ -24,6 +24,7 @@ exec_permission_approvals = true
 external_migration = true
 fast_mode = false
 general_analytics = true
+goals = true
 guardian_approval = true
 image_generation = true
 in_app_browser = true


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enables the Goals feature in Codex by turning it on in the default config template. Sets `goals = true` in `config/codex/config.tpl.toml` so the feature is available by default.

<sup>Written for commit 1812e04e21d6c9a7b54ff1c5cf2523522528c16d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

