### PR TITLE
fix: restart fprintd after resume to fix lock screen fingerprint

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -287,6 +287,17 @@ import ../../hosts/nixos {
         systemd.services.greetd.after = [ "fprintd.service" ];
         systemd.services.greetd.wants = [ "fprintd.service" ];
 
+        # Restart fprintd after resume so the device isn't stuck in "already claimed" state
+        systemd.services.fprintd-resume = {
+          description = "Restart fprintd after resume to clear stale device claims";
+          after = [ "suspend.target" "hibernate.target" "hybrid-sleep.target" ];
+          wantedBy = [ "suspend.target" "hibernate.target" "hybrid-sleep.target" ];
+          serviceConfig = {
+            Type = "oneshot";
+            ExecStart = "${pkgs.systemd}/bin/systemctl restart fprintd.service";
+          };
+        };
+
         # Disk management
         services.gvfs.enable = true;
         services.udisks2.enable = true;

--- a/spec/matic_pam_fingerprint_spec.sh
+++ b/spec/matic_pam_fingerprint_spec.sh
@@ -11,4 +11,11 @@ The output should include 'max-tries = -1;'
 The output should include 'timeout = -1;'
 End
 
+It 'restarts fprintd after resume to clear stale device claims'
+When run bash -c "awk '/fprintd-resume = \\{/{in_svc=1} in_svc{print} in_svc && /^        \\};/{exit}' '$CONFIG'"
+The output should include 'Restart fprintd after resume'
+The output should include 'suspend.target'
+The output should include 'systemctl restart fprintd.service'
+End
+
 End


### PR DESCRIPTION
## Summary
- After suspend/resume, fprintd keeps a stale device claim (`ReleaseDevice failed: device is still busy`), causing fingerprint to silently disappear from the noctalia lock screen
- Adds a `fprintd-resume` oneshot systemd service that restarts fprintd after `suspend.target`/`hibernate.target`/`hybrid-sleep.target`
- Adds spec coverage for the new service

## Test plan
- [ ] `nixos-rebuild switch` succeeds
- [ ] Suspend and resume the laptop
- [ ] Verify `systemctl status fprintd-resume` shows it ran after resume
- [ ] Lock screen shows fingerprint auth option after resume
- [ ] `shellspec spec/matic_pam_fingerprint_spec.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restarts `fprintd` after resume to restore fingerprint auth on the lock screen. Adds a oneshot `systemd` service `fprintd-resume` triggered by `suspend.target`, `hibernate.target`, and `hybrid-sleep.target`, plus a spec that verifies the restart command.

<sup>Written for commit 3bd257edd13ce710b08e601283479a968ab3e4e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

