### PR TITLE
fix: format fprintd-resume service arrays for treefmt

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -290,8 +290,16 @@ import ../../hosts/nixos {
         # Restart fprintd after resume so the device isn't stuck in "already claimed" state
         systemd.services.fprintd-resume = {
           description = "Restart fprintd after resume to clear stale device claims";
-          after = [ "suspend.target" "hibernate.target" "hybrid-sleep.target" ];
-          wantedBy = [ "suspend.target" "hibernate.target" "hybrid-sleep.target" ];
+          after = [
+            "suspend.target"
+            "hibernate.target"
+            "hybrid-sleep.target"
+          ];
+          wantedBy = [
+            "suspend.target"
+            "hibernate.target"
+            "hybrid-sleep.target"
+          ];
           serviceConfig = {
             Type = "oneshot";
             ExecStart = "${pkgs.systemd}/bin/systemctl restart fprintd.service";


### PR DESCRIPTION
## Summary
- Expand `after` and `wantedBy` arrays in `fprintd-resume` service to one-per-line format required by treefmt
- Fixes `nix-flake`, `nix-format`, and `nix-test` CI failures caused by unformatted arrays in d0a32ed6

## Test plan
- [ ] `nix-format-check` passes in CI
- [ ] `nix flake check` passes in CI
- [ ] `nix-test` passes in CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reformatted the `after` and `wantedBy` arrays in the `fprintd-resume` systemd service to the one-per-line style required by `treefmt`. This restores green CI by fixing failures in `nix-format-check`, `nix flake check`, and `nix-test`.

<sup>Written for commit 48bfccb537e31b121eb07871329bc4ae456c739d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

