### PR TITLE
Add roborev to local binaries

### DIFF
--- a/.local-binaries.txt
+++ b/.local-binaries.txt
@@ -27,5 +27,6 @@
 ~/ghq/github.com/NousResearch/hermes-agent/.venv/bin/hermes-acp
 ~/ghq/github.com/nwiizo/ccswarm/target/release/ccswarm
 ~/ghq/github.com/openai/symphony/elixir/bin/symphony
+~/ghq/github.com/roborev-dev/roborev/bin/roborev
 ~/ghq/github.com/steveyegge/beads/bd
 ~/ghq/github.com/steveyegge/gastown/gt


### PR DESCRIPTION
Adds the roborev binary from https://github.com/roborev-dev/roborev to `.local-binaries.txt`.

The Makefile builds to `bin/roborev`, so the entry uses the standard ghq path with that location.

---
_Generated by [Claude Code](https://claude.ai/code/session_017BoiaYmdd1UG2g7RycRF17)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `roborev` to the local binaries list so it’s available in dev environments.
The entry points to `~/ghq/github.com/roborev-dev/roborev/bin/roborev`, matching the Makefile’s build output.

<sup>Written for commit 7a1a890077c830e4f32a6f8bcf369154524c48b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

