### PR TITLE
feat(clipboard): add Zellij support to OSC 52 fallback

### DIFF
--- a/home-manager/modules/local-scripts/clipboard-copy.sh
+++ b/home-manager/modules/local-scripts/clipboard-copy.sh
@@ -20,7 +20,7 @@ fi
 
 # OSC 52 fallback: works over SSH if the terminal supports it
 # (ghostty, iTerm2, kitty, alacritty, tmux, etc.)
-if [[ -t 1 ]] || [[ -n ${TMUX:-} ]] || [[ -n ${SSH_TTY:-} ]]; then
+if [[ -t 1 ]] || [[ -n ${TMUX:-} ]] || [[ -n ${ZELLIJ:-} ]] || [[ -n ${SSH_TTY:-} ]]; then
   data=$(base64 | tr -d '\n')
   printf '\033]52;c;%s\a' "$data"
   exit 0

--- a/spec/clipboard_copy_spec.sh
+++ b/spec/clipboard_copy_spec.sh
@@ -120,6 +120,46 @@ The output should start with $'\033]52;c;'
 End
 End
 
+Describe 'when no clipboard backend but ZELLIJ is set'
+setup() {
+  MOCK_BIN="$(mktemp -d)"
+  MOCK_ORIGINAL_PATH="${PATH:-}"
+  MOCK_ORIGINAL_WAYLAND="${WAYLAND_DISPLAY:-}"
+  MOCK_ORIGINAL_ZELLIJ="${ZELLIJ:-}"
+  # Symlink only the commands the script needs into MOCK_BIN to avoid
+  # leaking pbcopy/xclip/etc. from shared directories like /usr/bin
+  local cmd
+  for cmd in bash base64 tr printf; do
+    ln -sf "$(command -v "$cmd")" "$MOCK_BIN/$cmd"
+  done
+  export PATH="$MOCK_BIN"
+  unset WAYLAND_DISPLAY
+  export ZELLIJ=0
+  export MOCK_BIN MOCK_ORIGINAL_PATH MOCK_ORIGINAL_WAYLAND MOCK_ORIGINAL_ZELLIJ
+}
+cleanup() {
+  export PATH="$MOCK_ORIGINAL_PATH"
+  if [ -n "$MOCK_ORIGINAL_WAYLAND" ]; then
+    export WAYLAND_DISPLAY="$MOCK_ORIGINAL_WAYLAND"
+  fi
+  if [ -n "$MOCK_ORIGINAL_ZELLIJ" ]; then
+    export ZELLIJ="$MOCK_ORIGINAL_ZELLIJ"
+  else
+    unset ZELLIJ
+  fi
+  rm -rf "$MOCK_BIN"
+  unset MOCK_BIN MOCK_ORIGINAL_PATH MOCK_ORIGINAL_WAYLAND MOCK_ORIGINAL_ZELLIJ
+}
+Before 'setup'
+After 'cleanup'
+
+It 'uses OSC 52 escape sequence'
+When run bash "$SCRIPT" <<<"hello"
+The status should be success
+The output should start with $'\033]52;c;'
+End
+End
+
 Describe 'when no clipboard backend is available'
 setup() {
   MOCK_BIN="$(mktemp -d)"
@@ -128,7 +168,7 @@ setup() {
   MOCK_ORIGINAL_SSH_TTY="${SSH_TTY:-}"
   ln -sf "$(command -v bash)" "$MOCK_BIN/bash"
   export PATH="$MOCK_BIN"
-  unset WAYLAND_DISPLAY SSH_TTY TMUX
+  unset WAYLAND_DISPLAY SSH_TTY TMUX ZELLIJ
   export MOCK_BIN MOCK_ORIGINAL_PATH MOCK_ORIGINAL_WAYLAND MOCK_ORIGINAL_SSH_TTY
 }
 cleanup() {


### PR DESCRIPTION
## Summary
- Add `ZELLIJ` env var detection to clipboard-copy OSC 52 fallback
- Add test case for Zellij multiplexer environment
- Unset `ZELLIJ` in the "no backend" test to prevent false passes

## Test plan
- [ ] Verify `pwd | copy` works inside a Zellij session
- [ ] Verify existing clipboard backends (pbcopy, wl-copy, xclip, xsel) still take priority
- [ ] Run shellspec tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Zellij support to the OSC 52 clipboard fallback so copy works inside Zellij sessions when no native clipboard backend is available.

- **New Features**
  - Detect `ZELLIJ` in `clipboard-copy.sh` to enable OSC 52 fallback.
  - Tests: add a Zellij environment test; unset `ZELLIJ` in the "no backend" test to avoid false passes.

<sup>Written for commit 2bc99d5085a5055612c9a0549498a5d92a20cc21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

