### PR TITLE
fix(k3s): satisfy statix and clean up spec after #1738

### DIFF
--- a/config/k3s/default.nix
+++ b/config/k3s/default.nix
@@ -12,7 +12,7 @@ let
   # kubeconfig over Tailscale.
   galacticaAuthorizedKey = (import ../../named-hosts/pubkeys.nix).galactica;
   serverActivateScript = pkgs.replaceVars ./activate.sh {
-    galacticaAuthorizedKey = galacticaAuthorizedKey;
+    inherit galacticaAuthorizedKey;
   };
 in
 {

--- a/spec/activate_k3s_spec.sh
+++ b/spec/activate_k3s_spec.sh
@@ -61,11 +61,6 @@ When run bash -c "grep 'ensure_authorized_key' '$SCRIPT'"
 The output should include 'ensure_authorized_key'
 End
 
-It 'guards against unsubstituted placeholder'
-When run bash -c "grep -E '\\\"@\\\"\\*\\\"@\\\"' '$SCRIPT'"
-The output should include '@'
-End
-
 It 'uses fixed-string match against authorized_keys'
 When run bash -c "grep 'grep -qxF' '$SCRIPT'"
 The output should include 'grep -qxF'


### PR DESCRIPTION
## Summary

#1738 auto-merged before the slower checks completed, so two failures landed on main:

- `nix-lint` (statix): `galacticaAuthorizedKey = galacticaAuthorizedKey;` should use `inherit`.
- `shell-test`: a placeholder-guard grep test in `spec/activate_k3s_spec.sh` had over-escaped regex and shellspec marked it WARNED, which fails the suite. The behavior is already covered by a functional test in the same describe block, so just remove it.

## Test plan

- [x] `shellspec spec/activate_k3s_spec.sh` -> 15 examples, 0 failures
- [x] `statix check config/k3s/default.nix` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks CI after #1738 by fixing a `statix` lint and removing a redundant test in the k3s activation spec. Uses `inherit` for `galacticaAuthorizedKey` and drops an over-escaped grep test already covered elsewhere.

- **Bug Fixes**
  - Use `inherit galacticaAuthorizedKey;` in `config/k3s/default.nix` to satisfy `statix`.
  - Remove redundant placeholder-guard grep test from `spec/activate_k3s_spec.sh` to eliminate WARN and keep the suite green.

<sup>Written for commit e6f52109a8283bffef697554752b44a7c5ab816d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

