### PR TITLE
fix(k3s): scp kubeconfig as ubuntu user on kyber

### DIFF
--- a/config/k3s/activate-client.sh
+++ b/config/k3s/activate-client.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REMOTE_HOST="kyber.tail950b36.ts.net"
+REMOTE_HOST="ubuntu@kyber.tail950b36.ts.net"
 REMOTE_KUBECONFIG_PATH=".kube/config"
 LOCAL_KUBECONFIG="$HOME/.kube/config-kyber"
 

--- a/spec/activate_k3s_client_spec.sh
+++ b/spec/activate_k3s_client_spec.sh
@@ -39,6 +39,11 @@ When run bash -c "grep 'tail950b36.ts.net' '$SCRIPT'"
 The output should include 'tail950b36.ts.net'
 End
 
+It 'connects as the kyber ubuntu user'
+When run bash -c "grep 'REMOTE_HOST=' '$SCRIPT'"
+The output should include 'ubuntu@kyber.tail950b36.ts.net'
+End
+
 It 'sets restrictive permissions on kubeconfig'
 When run bash -c "grep 'chmod 600' '$SCRIPT'"
 The output should include 'chmod 600'


### PR DESCRIPTION
## Summary

Galactica's local user is `shunkakinoki`, kyber's is `ubuntu`. After #1738 / #1739 landed galactica's pubkey in kyber's `~ubuntu/.ssh/authorized_keys` (correct - that's the home-manager target user on kyber), but `activate-client.sh` still scp'd as galactica's local username and got `Permission denied (publickey)`.

Verified end-to-end on galactica with this branch: `bash config/k3s/activate-client.sh` now logs `kubeconfig synced from ubuntu@kyber.tail950b36.ts.net` and writes the file.

There's a separate unrelated issue with the kubeconfig still containing `https://127.0.0.1:6443` (server-side `sed` rewrite in `activate.sh` doesn't seem to have run) and a stale TLS cert that needs regen on kyber - both deferred from this PR per request.

## Test plan

- [x] `shellspec spec/activate_k3s_client_spec.sh` -> 10 examples, 0 failures
- [x] `shellcheck config/k3s/activate-client.sh` clean
- [x] Live run on galactica: sync succeeds with the new username

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix k3s client kubeconfig sync by scp'ing as ubuntu@kyber.tail950b36.ts.net. This matches the authorized_keys user and resolves Permission denied (publickey).

- **Bug Fixes**
  - Set REMOTE_HOST to ubuntu@kyber.tail950b36.ts.net in `activate-client.sh`.
  - Added a spec to assert the script connects as the ubuntu user.

<sup>Written for commit fa61ef6b7d687014c00f6f5eee015ee86af421b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

