### PR TITLE
fix(k3s): manage cluster URL in Nix, rewrite kubeconfig client-side

### DIFF
--- a/config/k3s/activate-client.sh
+++ b/config/k3s/activate-client.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REMOTE_HOST="ubuntu@kyber.tail950b36.ts.net"
+KYBER_API_URL="@kyberApiUrl@"
+KYBER_HOST="@kyberHost@"
+KYBER_USER="@kyberUser@"
+REMOTE_HOST="${KYBER_USER}@${KYBER_HOST}"
 REMOTE_KUBECONFIG_PATH=".kube/config"
 LOCAL_KUBECONFIG="$HOME/.kube/config-kyber"
 
@@ -21,6 +24,11 @@ trap 'rm -f "$SCP_ERR"' EXIT
 if scp -o ConnectTimeout=5 -o BatchMode=yes \
   "${REMOTE_HOST}:${REMOTE_KUBECONFIG_PATH}" "$LOCAL_KUBECONFIG" 2>"$SCP_ERR"; then
   chmod 600 "$LOCAL_KUBECONFIG"
+  # Defense-in-depth: kyber's server activate rewrites the loopback URL,
+  # but if the synced file still points at 127.0.0.1 (e.g. activate did
+  # not run), force it to the Nix-managed cluster URL.
+  sed -i.bak "s|https://127.0.0.1:6443|${KYBER_API_URL}|g" "$LOCAL_KUBECONFIG"
+  rm -f "$LOCAL_KUBECONFIG.bak"
   echo "k3s-client: kubeconfig synced from ${REMOTE_HOST}"
 else
   echo "k3s-client: failed to fetch kubeconfig from ${REMOTE_HOST}" >&2

--- a/config/k3s/activate.sh
+++ b/config/k3s/activate.sh
@@ -60,12 +60,12 @@ fi
 
 K3S_KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
 REMOTE_KUBECONFIG="$HOME/.kube/config"
-TAILSCALE_DNS="kyber.tail950b36.ts.net"
+KYBER_API_URL="@kyberApiUrl@"
 
 if [ -f "$K3S_KUBECONFIG" ]; then
   mkdir -p "$HOME/.kube"
   $SUDO_CMD cat "$K3S_KUBECONFIG" |
-    sed "s|https://127.0.0.1:6443|https://${TAILSCALE_DNS}:6443|g" \
+    sed "s|https://127.0.0.1:6443|${KYBER_API_URL}|g" \
       >"$REMOTE_KUBECONFIG"
   chmod 600 "$REMOTE_KUBECONFIG"
 fi

--- a/config/k3s/default.nix
+++ b/config/k3s/default.nix
@@ -8,11 +8,21 @@
 let
   inherit (inputs.host) isKyber isGalactica;
   kubeconfig = "${config.home.homeDirectory}/.kube/config-kyber";
+  # Single source of truth for how the kyber k3s API is reached from
+  # other tailnet members. Both server-side and client-side activate
+  # scripts rewrite the kubeconfig server URL to this value, so kubectl
+  # works the same on every host.
+  kyberHost = "kyber.tail950b36.ts.net";
+  kyberUser = "ubuntu";
+  kyberApiUrl = "https://${kyberHost}:6443";
   # Authorize galactica on kyber so the client activation can scp the
   # kubeconfig over Tailscale.
   galacticaAuthorizedKey = (import ../../named-hosts/pubkeys.nix).galactica;
   serverActivateScript = pkgs.replaceVars ./activate.sh {
-    inherit galacticaAuthorizedKey;
+    inherit galacticaAuthorizedKey kyberApiUrl;
+  };
+  clientActivateScript = pkgs.replaceVars ./activate-client.sh {
+    inherit kyberApiUrl kyberHost kyberUser;
   };
 in
 {
@@ -52,7 +62,7 @@ in
 
   home.activation.k3s-client = lib.mkIf isGalactica (
     lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-client.sh}"
+      $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${clientActivateScript}"
     ''
   );
 }

--- a/spec/activate_k3s_client_spec.sh
+++ b/spec/activate_k3s_client_spec.sh
@@ -34,14 +34,19 @@ When run bash -c "grep 'scp' '$SCRIPT'"
 The output should include 'scp'
 End
 
-It 'targets the tailscale DNS host'
-When run bash -c "grep 'tail950b36.ts.net' '$SCRIPT'"
-The output should include 'tail950b36.ts.net'
+It 'sources the tailscale DNS from a Nix-templated placeholder'
+When run bash -c "grep '^KYBER_HOST=' '$SCRIPT'"
+The output should include '@kyberHost@'
 End
 
-It 'connects as the kyber ubuntu user'
-When run bash -c "grep 'REMOTE_HOST=' '$SCRIPT'"
-The output should include 'ubuntu@kyber.tail950b36.ts.net'
+It 'sources the remote ssh user from a Nix-templated placeholder'
+When run bash -c "grep '^KYBER_USER=' '$SCRIPT'"
+The output should include '@kyberUser@'
+End
+
+It 'composes REMOTE_HOST from the templated user and host'
+When run bash -c "grep '^REMOTE_HOST=' '$SCRIPT'"
+The output should include '${KYBER_USER}@${KYBER_HOST}'
 End
 
 It 'sets restrictive permissions on kubeconfig'
@@ -59,6 +64,49 @@ End
 It 'logs scp failures to stderr'
 When run bash -c "grep 'failed to fetch kubeconfig' '$SCRIPT'"
 The output should include 'failed to fetch kubeconfig'
+End
+End
+
+Describe 'server URL rewrite'
+It 'rewrites the loopback server URL to the Nix-managed cluster URL'
+When run bash -c "grep 'sed -i.bak' '$SCRIPT'"
+The output should include 'https://127.0.0.1:6443'
+The output should include 'KYBER_API_URL'
+End
+
+It 'sources the cluster URL from a Nix-templated placeholder'
+When run bash -c "grep '^KYBER_API_URL=' '$SCRIPT'"
+The output should include '@kyberApiUrl@'
+End
+
+It 'removes the sed backup file'
+When run bash -c "grep 'rm -f .*\.bak' '$SCRIPT'"
+The output should include '.bak'
+End
+
+rewrite_kubeconfig_function() {
+cat <<'BASH'
+rewrite_kubeconfig() {
+local file="$1"
+local url="$2"
+sed -i.bak "s|https://127.0.0.1:6443|${url}|g" "$file"
+rm -f "$file.bak"
+}
+BASH
+}
+
+It 'rewrites a sample kubeconfig server URL in place'
+When run bash -c '
+tmp=$(mktemp -d)
+cfg="$tmp/config"
+printf "clusters:\n- cluster:\n    server: https://127.0.0.1:6443\n  name: default\n" >"$cfg"
+'"$(rewrite_kubeconfig_function)"'
+rewrite_kubeconfig "$cfg" "https://kyber.tail950b36.ts.net:6443"
+grep -q "server: https://kyber.tail950b36.ts.net:6443" "$cfg" &&
+  ! grep -q "127.0.0.1" "$cfg" &&
+  test ! -e "$cfg.bak"
+'
+The status should be success
 End
 End
 End


### PR DESCRIPTION
## Summary
- Lift the kyber API URL, hostname, and ssh user into `config/k3s/default.nix` as a single source of truth
- Template them into both `activate.sh` (server, on kyber) and `activate-client.sh` (client, on galactica) via `pkgs.replaceVars`
- Have the client activate rewrite `https://127.0.0.1:6443` -> the Nix-managed cluster URL after scp, as defense-in-depth so kubectl from galactica works even when kyber's server activate has not (re-)run since the last k3s restart

## Why
The kubeconfig synced from kyber pointed at `https://127.0.0.1:6443` whenever kyber's server activate had not run after k3s last regenerated `/etc/rancher/k3s/k3s.yaml`. The previous design hardcoded `TAILSCALE_DNS` in shell on the server side only, so the client was forced to manually `sed` after each `make switch`. The URL now lives in Nix and is referenced by both scripts.

## Test plan
- [x] `shellcheck config/k3s/activate-client.sh config/k3s/activate.sh` passes
- [x] `shellspec spec/activate_k3s_client_spec.sh spec/activate_k3s_spec.sh` -> 30 examples, 0 failures
- [x] `nix flake check --no-build` evaluates `darwinConfigurations.galactica`
- [ ] After merge: `make switch` on galactica, then `kubectl get nodes` returns the kyber node without manual sed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes the kyber k3s API URL/host/user in Nix and adds a client-side kubeconfig rewrite so `kubectl` on galactica works even if kyber’s server activate hasn’t run.

- **Bug Fixes**
  - Define `kyberHost`, `kyberUser`, and `kyberApiUrl` in `config/k3s/default.nix`; template into `activate.sh` and `activate-client.sh` with `pkgs.replaceVars`.
  - Server: export kubeconfig with `${KYBER_API_URL}` instead of `127.0.0.1`.
  - Client: build `REMOTE_HOST` from templated user/host and rewrite `https://127.0.0.1:6443` to the Nix-managed URL after scp; remove `.bak`.
  - Tests: cover templated placeholders and the URL rewrite behavior.

<sup>Written for commit a0656fec09da305bcebed81dee1b938f9a6139f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

