### PR TITLE
fix(test): add roborev to shell coverage spec

### DIFF
--- a/spec/activate_roborev_spec.sh
+++ b/spec/activate_roborev_spec.sh
@@ -1,0 +1,35 @@
+Describe 'home-manager/services/roborev/activate.sh'
+SCRIPT="$PWD/home-manager/services/roborev/activate.sh"
+
+It 'uses bash shebang'
+When run bash -c "head -1 '$SCRIPT'"
+The output should include '#!/usr/bin/env bash'
+End
+
+It 'creates the data directory'
+When run bash -c "grep 'mkdir' '$SCRIPT'"
+The output should include 'mkdir -p'
+End
+
+It 'sets restrictive permissions on data directory'
+When run bash -c "grep 'chmod' '$SCRIPT'"
+The output should include 'chmod 700'
+End
+End
+
+Describe 'home-manager/services/roborev/default.nix'
+It 'enables on galactica and matic only'
+When run bash -c "grep 'isGalactica || isMatic' '$PWD/home-manager/services/roborev/default.nix'"
+The output should include 'isGalactica || isMatic'
+End
+
+It 'runs roborev daemon run'
+When run bash -c "grep 'daemon' '$PWD/home-manager/services/roborev/default.nix'"
+The output should include '"daemon"'
+End
+
+It 'passes data dir to activate script'
+When run cat "$PWD/home-manager/services/roborev/default.nix"
+The output should include '"${./activate.sh}" "${dataDir}"'
+End
+End

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -405,6 +405,7 @@ home-manager/services/obsidian/obsidian-headless.sh
 home-manager/services/openclaw/activate.sh
 home-manager/services/paperclip/activate.sh
 home-manager/services/qmd/activate.sh
+home-manager/services/roborev/activate.sh
 home-manager/modules/tailscale/activate-create-dirs.sh
 home-manager/modules/tailscale/activate-install-service.sh
 home-manager/modules/uv-globals/install-uv-globals.sh


### PR DESCRIPTION
## Summary

- Adds `home-manager/services/roborev/activate.sh` to the `covered_scripts` list in `spec/coverage_spec.sh`
- Creates `spec/activate_roborev_spec.sh` with tests for the activate script and `default.nix`

The shell-test CI job has been failing since #1745 (roborev service) because the new `activate.sh` was not registered in the coverage spec.

## Test plan

- [ ] `shell-test` CI job passes
- [ ] `spec/activate_roborev_spec.sh` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers `home-manager/services/roborev/activate.sh` in the shell coverage list and adds tests for the activate script and `default.nix`. Fixes the failing `shell-test` CI job introduced with the roborev service.

<sup>Written for commit 6ee15c5f83ec66c44eeeede69228c6aeb6000e98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

