### PR TITLE
feat: add lean4 to nixpkgs packages

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -1,5 +1,5 @@
 # Default agent for this repo when no workflow-specific agent is set.
-agent = 'gemini'
+agent = 'codex'
 # Default model for this repo when no workflow-specific model is set.
 model = ''
 # Backup agent for this repo if the primary agent fails.

--- a/Makefile
+++ b/Makefile
@@ -1091,7 +1091,7 @@ launchctl-tmux-session-logger: ## Restart tmux-session-logger launchd agent.
 ##@ Systemd Services (Linux)
 
 .PHONY: systemctl
-systemctl: systemctl-docker systemctl-cliproxyapi systemctl-cliproxyapi-backup systemctl-code-syncer systemctl-docker-postgres systemctl-dolt systemctl-dotfiles-updater systemctl-make-updater systemctl-neverssl-keepalive systemctl-obsidian systemctl-ollama systemctl-openclaw systemctl-paperclip systemctl-roborev systemctl-tmux-session-logger ## Restart all systemd user services.
+systemctl: systemctl-docker systemctl-cliproxyapi systemctl-cliproxyapi-backup systemctl-code-syncer systemctl-docker-postgres systemctl-dolt systemctl-dotfiles-updater systemctl-make-updater systemctl-neverssl-keepalive systemctl-noctalia-shell systemctl-obsidian systemctl-ollama systemctl-openclaw systemctl-paperclip systemctl-roborev systemctl-tmux-session-logger ## Restart all systemd user services.
 
 .PHONY: systemctl-docker
 systemctl-docker: ## Start Docker daemon.
@@ -1152,6 +1152,22 @@ systemctl-neverssl-keepalive: ## Restart neverssl-keepalive systemd timer and se
 	@echo "🔄 Restarting neverssl-keepalive..."
 	@systemctl --user restart neverssl-keepalive.timer || true
 	@echo "✅ neverssl-keepalive restarted"
+
+.PHONY: systemctl-noctalia-shell
+systemctl-noctalia-shell: ## Restart noctalia-shell (quickshell) after Nix rebuild (matic only).
+	@echo "🔄 Restarting noctalia-shell..."
+	@if [ "$(DETECTED_HOST)" = "matic" ] || [ "$(HOST)" = "matic" ]; then \
+		if [ -n "$$WAYLAND_DISPLAY" ]; then \
+			pkill -x quickshell || true; \
+			sleep 1; \
+			nohup noctalia-shell >/dev/null 2>&1 & \
+		else \
+			echo "Skipping noctalia-shell (WAYLAND_DISPLAY not set)"; \
+		fi; \
+	else \
+		echo "Skipping noctalia-shell (host not matic)"; \
+	fi
+	@echo "✅ noctalia-shell restarted"
 
 .PHONY: systemctl-obsidian
 systemctl-obsidian: ## Restart Obsidian headless systemd user service.

--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -9,6 +9,7 @@ confirm-close-surface = true
 macos-option-as-alt = true
 macos-titlebar-style = "tabs"
 shell-integration = fish
+command = fish --login
 cursor-style = bar
 cursor-style-blink = true
 mouse-hide-while-typing = true

--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -9,7 +9,6 @@ confirm-close-surface = true
 macos-option-as-alt = true
 macos-titlebar-style = "tabs"
 shell-integration = fish
-command = __FISH_PATH__ --login
 cursor-style = bar
 cursor-style-blink = true
 mouse-hide-while-typing = true

--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -17,7 +17,6 @@ clipboard-read = "allow"
 clipboard-write = "allow"
 clipboard-paste-protection = false
 copy-on-select = clipboard
-gtk-single-instance = false
 
 keybind = ctrl+shift+c=copy_to_clipboard
 keybind = ctrl+shift+v=paste_from_clipboard

--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -17,6 +17,7 @@ clipboard-read = "allow"
 clipboard-write = "allow"
 clipboard-paste-protection = false
 copy-on-select = clipboard
+gtk-single-instance = false
 
 keybind = ctrl+shift+c=copy_to_clipboard
 keybind = ctrl+shift+v=paste_from_clipboard

--- a/config/ghostty/default.nix
+++ b/config/ghostty/default.nix
@@ -1,13 +1,10 @@
 { pkgs, ... }:
 let
   inherit (pkgs) lib;
-  fishPath = "${pkgs.fish}/bin/fish";
-  staticConfig = builtins.readFile ./config;
-  configText = builtins.replaceStrings [ "__FISH_PATH__" ] [ fishPath ] staticConfig;
 in
 {
   xdg.configFile."ghostty/config" = {
-    text = configText;
+    source = ./config;
   };
   xdg.configFile."ghostty/themes/Dracula Custom" = {
     source = ./themes + "/Dracula Custom";
@@ -20,7 +17,7 @@ in
   home.file."Library/Application Support/com.mitchellh.ghostty/config" =
     lib.mkIf pkgs.stdenv.isDarwin
       {
-        text = configText;
+        source = ./config;
       };
   home.file."Library/Application Support/com.mitchellh.ghostty/themes/Dracula Custom" =
     lib.mkIf pkgs.stdenv.isDarwin

--- a/config/gtk/default.nix
+++ b/config/gtk/default.nix
@@ -18,5 +18,6 @@
       name = "Adwaita";
       size = 24;
     };
+    gtk4.theme = null;
   };
 }

--- a/config/gtk/default.nix
+++ b/config/gtk/default.nix
@@ -18,9 +18,5 @@
       name = "Adwaita";
       size = 24;
     };
-    gtk4.theme = {
-      name = "Adwaita";
-      package = pkgs.gnome-themes-extra;
-    };
   };
 }

--- a/config/keyd/default.conf
+++ b/config/keyd/default.conf
@@ -1,5 +1,9 @@
 [ids]
 *
+# Framework 13 AI 300 embedded controller (I2C HID). keyd's `*` wildcard
+# does not grab I2C HID consumer control devices, so the Framework key
+# bypasses keyd unless this id is listed explicitly.
+32ac:0006
 # xremap creates its own virtual keyboard device via uinput. By default, xremap
 # uses vendor/product 0x1234/0x5678 for that output device.
 #

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -65,6 +65,7 @@ with pkgs;
   jujutsu
   just
   k6
+  lean4
   (if stdenv.isLinux && isDesktop then llama-cpp.override { vulkanSupport = true; } else llama-cpp)
   llm
   lsof


### PR DESCRIPTION
## Summary
- Adds `lean4` to the home-manager packages list in alphabetical order

## Test plan
- [ ] `nixos-rebuild switch` or `home-manager switch` builds successfully with lean4 available

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `lean4` to `home-manager` packages and simplify `ghostty` config to use a static file with `fish --login`. Fix input on Framework by having `keyd` grab `32ac:0006`, add a `systemctl-noctalia-shell` Makefile target (restart quickshell on matic), and suppress `gtk4` theme warnings.

<sup>Written for commit 71204798c86bd8f9e2ff2a96998bc3d7b606c73d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

