### PR TITLE
fix(hyprland): bypass Ghostty D-Bus single-instance for keybinds

### DIFF
--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -218,7 +218,7 @@ layerrule = ignore_alpha 0.3, match:namespace ^(gtk-layer-shell)$
 # =============================================================================
 # App Launch Hotkeys
 # =============================================================================
-bind = $mod, T, exec, ghostty
+bind = $mod, T, exec, ghostty --gtk-single-instance=false
 bind = $mod SHIFT, T, exec, Telegram
 bind = $mod, G, exec, hyprctl clients -j | grep -q '"class": "google-chrome"' && hyprctl dispatch focuswindow class:google-chrome || google-chrome-stable
 bind = $mod, S, exec, slack
@@ -227,7 +227,7 @@ bind = $mod, V, exec, code
 bind = $mod, P, exec, gtk-launch 1password
 bind = $mod, M, exec, gtk-launch signal-desktop
 bind = $mod, D, exec, hyprctl clients -j | grep -q '"class": "discord"' && hyprctl dispatch focuswindow class:discord || discord
-bind = $mod, F, exec, ghostty -e yazi
+bind = $mod, F, exec, ghostty --gtk-single-instance=false -e yazi
 
 # =============================================================================
 # System GUIs (WiFi / Bluetooth / Audio)


### PR DESCRIPTION
## Summary
- Pass `--gtk-single-instance=false` to Ghostty in Super+T and Super+F keybinds
- Ghostty's D-Bus service file forces `--gtk-single-instance=true`, routing new launches to the existing primary instance which may have stale config after a Nix rebuild
- The CLI flag overrides this, ensuring each keybind spawns a fresh process with current config

## Test plan
- [x] Super+T opens a new Ghostty window with working fish shell
- [x] Super+F opens yazi in a new Ghostty window

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bypass `ghostty`’s D-Bus single-instance from Hyprland hotkeys so each launch opens a fresh window with the current config. Adds `--gtk-single-instance=false` to Super+T (`ghostty`) and Super+F (`ghostty -e yazi`).

<sup>Written for commit 65a51976eb3c39eb1a00f929962deef66a0d4cf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

