### PR TITLE
chore: update

### DIFF
--- a/config/bun/bunfig.toml
+++ b/config/bun/bunfig.toml
@@ -1,0 +1,5 @@
+[install]
+minimumReleaseAge = 604800
+exact = true
+ignoreScripts = true
+optional = false

--- a/config/bun/default.nix
+++ b/config/bun/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   home.file.".bunfig.toml" = {
     source = ./bunfig.toml;
     force = true;

--- a/config/bun/default.nix
+++ b/config/bun/default.nix
@@ -1,4 +1,4 @@
-{ ... }:
+_:
 {
   home.file.".bunfig.toml" = {
     source = ./bunfig.toml;

--- a/config/bun/default.nix
+++ b/config/bun/default.nix
@@ -1,0 +1,7 @@
+{ ... }:
+{
+  home.file.".bunfig.toml" = {
+    source = ./bunfig.toml;
+    force = true;
+  };
+}

--- a/config/default.nix
+++ b/config/default.nix
@@ -5,6 +5,7 @@ in
 [
   ./aichat
   ./amp
+  ./bun
   ./ccs
   ./cliproxyapi
   ./codex
@@ -25,12 +26,14 @@ in
   ./karabiner
   ./llm
   ./mempalace
+  ./npm
   ./obsidian
   ./omp
   ./openclaw
   ./opencode
   ./paperclip
   ./pi
+  ./pnpm
   ./serena
   ./starship
   ./tmuxinator

--- a/config/noctalia/ac-idle-inhibit.sh
+++ b/config/noctalia/ac-idle-inhibit.sh
@@ -1,14 +1,25 @@
 #!/usr/bin/env bash
-# Inhibit idle when on AC power so noctalia's idle timeouts only fire on battery.
-# Polls every 2s so AC state changes take effect well within the 5-min idle window.
+# Inhibit Wayland idle when on AC power so noctalia's idle timeouts only fire on battery.
+# Manages a wlinhibit process that holds an idle-inhibit Wayland surface.
 set -euo pipefail
 
 AC=/sys/class/power_supply/ACAD/online
+INHIBIT_PID=""
+
+cleanup() { [ -n "$INHIBIT_PID" ] && kill "$INHIBIT_PID" 2>/dev/null; }
+trap cleanup EXIT
 
 while true; do
   if [ "$(cat "$AC" 2>/dev/null)" = "1" ]; then
-    systemd-inhibit --what=idle --why="On AC power" --mode=block sleep 2
+    if [ -z "$INHIBIT_PID" ] || ! kill -0 "$INHIBIT_PID" 2>/dev/null; then
+      wlinhibit &
+      INHIBIT_PID=$!
+    fi
   else
-    sleep 2
+    if [ -n "$INHIBIT_PID" ] && kill -0 "$INHIBIT_PID" 2>/dev/null; then
+      kill "$INHIBIT_PID" 2>/dev/null
+      INHIBIT_PID=""
+    fi
   fi
+  sleep 2
 done

--- a/config/noctalia/ac-idle-inhibit.sh
+++ b/config/noctalia/ac-idle-inhibit.sh
@@ -1,24 +1,30 @@
 #!/usr/bin/env bash
-# Inhibit Wayland idle when on AC power so noctalia's idle timeouts only fire on battery.
-# Manages a wlinhibit process that holds an idle-inhibit Wayland surface.
+# On battery: run swayidle for screen-off (5 min) and suspend (10 min).
+# On AC: stop swayidle so only noctalia's lock fires.
 set -euo pipefail
 
 AC=/sys/class/power_supply/ACAD/online
-INHIBIT_PID=""
+SWAYIDLE_PID=""
 
-cleanup() { [ -n "$INHIBIT_PID" ] && kill "$INHIBIT_PID" 2>/dev/null; }
+cleanup() { [ -n "$SWAYIDLE_PID" ] && kill "$SWAYIDLE_PID" 2>/dev/null; }
 trap cleanup EXIT
 
 while true; do
-  if [ "$(cat "$AC" 2>/dev/null)" = "1" ]; then
-    if [ -z "$INHIBIT_PID" ] || ! kill -0 "$INHIBIT_PID" 2>/dev/null; then
-      wlinhibit &
-      INHIBIT_PID=$!
+  ON_AC="$(cat "$AC" 2>/dev/null)"
+
+  if [ "$ON_AC" = "1" ]; then
+    if [ -n "$SWAYIDLE_PID" ] && kill -0 "$SWAYIDLE_PID" 2>/dev/null; then
+      kill "$SWAYIDLE_PID" 2>/dev/null
+      SWAYIDLE_PID=""
+      hyprctl dispatch dpms on
     fi
   else
-    if [ -n "$INHIBIT_PID" ] && kill -0 "$INHIBIT_PID" 2>/dev/null; then
-      kill "$INHIBIT_PID" 2>/dev/null
-      INHIBIT_PID=""
+    if [ -z "$SWAYIDLE_PID" ] || ! kill -0 "$SWAYIDLE_PID" 2>/dev/null; then
+      swayidle -w \
+        timeout 300 'hyprctl dispatch dpms off' \
+        resume 'hyprctl dispatch dpms on' \
+        timeout 600 'systemctl suspend' &
+      SWAYIDLE_PID=$!
     fi
   fi
   sleep 2

--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -25,6 +25,7 @@ in
     };
     Service = {
       Type = "simple";
+      PassEnvironment = "WAYLAND_DISPLAY";
       Environment = "PATH=${pkgs.wlinhibit}/bin";
       ExecStart = "${pkgs.bash}/bin/bash ${./ac-idle-inhibit.sh}";
       Restart = "on-failure";

--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -25,6 +25,7 @@ in
     };
     Service = {
       Type = "simple";
+      Environment = "PATH=${pkgs.wlinhibit}/bin";
       ExecStart = "${pkgs.bash}/bin/bash ${./ac-idle-inhibit.sh}";
       Restart = "on-failure";
     };

--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -16,17 +16,24 @@ in
     force = true;
   };
 
-  # Inhibit idle when plugged into AC; noctalia's idle timeouts apply on battery only.
+  # Screen-off and suspend on battery only; noctalia handles lock on both AC and battery.
   systemd.user.services.ac-idle-inhibit = {
     Unit = {
-      Description = "Inhibit idle when on AC power";
+      Description = "Screen-off and suspend on battery via swayidle";
       After = [ "graphical-session.target" ];
       PartOf = [ "graphical-session.target" ];
     };
     Service = {
       Type = "simple";
       PassEnvironment = "WAYLAND_DISPLAY";
-      Environment = "PATH=${pkgs.wlinhibit}/bin:${pkgs.coreutils}/bin";
+      Environment = "PATH=${
+        pkgs.lib.makeBinPath [
+          pkgs.swayidle
+          pkgs.hyprland
+          pkgs.coreutils
+          pkgs.systemd
+        ]
+      }";
       ExecStart = "${pkgs.bash}/bin/bash ${./ac-idle-inhibit.sh}";
       Restart = "on-failure";
     };
@@ -150,9 +157,9 @@ in
       wallpaper.enabled = false;
       idle = {
         enabled = true;
-        screenOffTimeout = 300; # 5 min on battery
+        screenOffTimeout = 0;
         lockTimeout = 300;
-        suspendTimeout = 600; # 10 min on battery
+        suspendTimeout = 0;
       };
       systemMonitor.enableDgpuMonitoring = true;
       colorSchemes.schedulingMode = "location";

--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -26,7 +26,7 @@ in
     Service = {
       Type = "simple";
       PassEnvironment = "WAYLAND_DISPLAY";
-      Environment = "PATH=${pkgs.wlinhibit}/bin";
+      Environment = "PATH=${pkgs.wlinhibit}/bin:${pkgs.coreutils}/bin";
       ExecStart = "${pkgs.bash}/bin/bash ${./ac-idle-inhibit.sh}";
       Restart = "on-failure";
     };

--- a/config/npm/default.nix
+++ b/config/npm/default.nix
@@ -1,0 +1,7 @@
+{ ... }:
+{
+  home.file.".npmrc" = {
+    source = ./npmrc;
+    force = true;
+  };
+}

--- a/config/npm/default.nix
+++ b/config/npm/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   home.file.".npmrc" = {
     source = ./npmrc;
     force = true;

--- a/config/npm/default.nix
+++ b/config/npm/default.nix
@@ -1,4 +1,4 @@
-{ ... }:
+_:
 {
   home.file.".npmrc" = {
     source = ./npmrc;

--- a/config/npm/npmrc
+++ b/config/npm/npmrc
@@ -1,0 +1,5 @@
+minimum-release-age=10080
+ignore-scripts=true
+save-exact=true
+omit=optional
+engine-strict=true

--- a/config/pnpm/default.nix
+++ b/config/pnpm/default.nix
@@ -1,5 +1,4 @@
-_:
-{
+_: {
   xdg.configFile."pnpm/rc" = {
     source = ./rc;
     force = true;

--- a/config/pnpm/default.nix
+++ b/config/pnpm/default.nix
@@ -1,4 +1,4 @@
-{ ... }:
+_:
 {
   xdg.configFile."pnpm/rc" = {
     source = ./rc;

--- a/config/pnpm/default.nix
+++ b/config/pnpm/default.nix
@@ -1,0 +1,7 @@
+{ ... }:
+{
+  xdg.configFile."pnpm/rc" = {
+    source = ./rc;
+    force = true;
+  };
+}

--- a/config/pnpm/rc
+++ b/config/pnpm/rc
@@ -1,0 +1,5 @@
+minimum-release-age=10080
+ignore-scripts=true
+save-exact=true
+omit=optional
+engine-strict=true


### PR DESCRIPTION
## Summary
- Fix idle behavior on AC power: screen now locks but stays on (no screen-off or suspend). On battery, screen-off at 5 min and suspend at 10 min via swayidle.
- Add global package manager security defaults (~/.npmrc, ~/.config/pnpm/rc, ~/.bunfig.toml): 7-day minimum release age, ignore install scripts, exact versions, omit optional deps, strict engines.

## Test plan
- [x] `make build` and `make switch` succeed
- [x] `ac-idle-inhibit` service running on AC (no swayidle spawned)
- [x] `~/.npmrc`, `~/.config/pnpm/rc`, `~/.bunfig.toml` deployed with correct content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Wayland idle behavior so the screen stays on when plugged in, while still locking. Adds hardened defaults for `npm`, `pnpm`, and `bun` to reduce supply-chain risk.

- **Bug Fixes**
  - Battery: `swayidle` handles screen-off (5m) and suspend (10m). AC: stop `swayidle` so only lock runs and screen stays on.
  - Service: pass `WAYLAND_DISPLAY`, set PATH for `swayidle`, `hyprctl`, and core utils; restart on failure.
  - Noctalia idle: `screenOffTimeout=0`, `suspendTimeout=0`, `lockTimeout=5m`.
  - Nix: replace empty pattern with `_`; format Nix files.

- **New Features**
  - Ship security defaults for `npm` (`~/.npmrc`), `pnpm` (`~/.config/pnpm/rc`), `bun` (`~/.bunfig.toml`).
  - Defaults: 7‑day min release age, ignore scripts, exact versions, omit optional, strict engines.

<sup>Written for commit f0d2e6257800134d6db0b8dacab19e3a598ae9a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

