### PR TITLE
feat: add dcg config

### DIFF
--- a/config/dcg/activate.sh
+++ b/config/dcg/activate.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Copy dcg config (atomic writes break symlinks)
+# Usage: activate.sh <config_toml>
+set -euo pipefail
+CONFIG_TOML="$1"
+
+mkdir -p ~/.config/dcg/packs
+cp -f "$CONFIG_TOML" ~/.config/dcg/config.toml
+chmod 644 ~/.config/dcg/config.toml

--- a/config/dcg/config.toml
+++ b/config/dcg/config.toml
@@ -1,35 +1,33 @@
 [packs]
-custom_paths = [
-    "~/.config/dcg/packs/*.yaml",
-]
+custom_paths = ["~/.config/dcg/packs/*.yaml"]
 
 enabled = [
 
-    # CI/CD
-    "cicd.github_actions",
+  # CI/CD
+  "cicd.github_actions",
 
-    # database
-    "database.postgresql",
+  # database
+  "database.postgresql",
 
-    # Cloudflare
-    "cdn.cloudflare_workers",
-    "dns.cloudflare",
+  # Cloudflare
+  "cdn.cloudflare_workers",
+  "dns.cloudflare",
 
-    # Infrastructure
-    "infrastructure.terraform",
+  # Infrastructure
+  "infrastructure.terraform",
 
-    # Secrets management
-    "secrets.onepassword",
+  # Secrets management
+  "secrets.onepassword",
 
-    # System
-    "system.permissions",
-    "system.services",
+  # System
+  "system.permissions",
+  "system.services",
 
-    # Platform
-    "platform.github",
-    "platform.railway",
+  # Platform
+  "platform.github",
+  "platform.railway",
 
-    # Storage
-    "storage.gcs",
-    "storage.s3"
+  # Storage
+  "storage.gcs",
+  "storage.s3",
 ]

--- a/config/dcg/config.toml
+++ b/config/dcg/config.toml
@@ -3,31 +3,137 @@ custom_paths = ["~/.config/dcg/packs/*.yaml"]
 
 enabled = [
 
-  # CI/CD
-  "cicd.github_actions",
+  # API Gateway
+  "apigateway.apigee",
+  "apigateway.aws",
+  "apigateway.kong",
 
-  # database
-  "database.postgresql",
+  # Backup
+  "backup.borg",
+  "backup.rclone",
+  "backup.restic",
+  "backup.velero",
 
-  # Cloudflare
+  # CDN
   "cdn.cloudflare_workers",
+  "cdn.cloudfront",
+  "cdn.fastly",
+
+  # CI/CD
+  "cicd.circleci",
+  "cicd.github_actions",
+  "cicd.gitlab_ci",
+  "cicd.jenkins",
+
+  # Cloud
+  "cloud.aws",
+  "cloud.azure",
+  "cloud.gcp",
+
+  # Containers
+  "containers.compose",
+  "containers.docker",
+  "containers.podman",
+
+  # Core
+  "core.filesystem",
+  "core.git",
+
+  # Database
+  "database.mongodb",
+  "database.mysql",
+  "database.postgresql",
+  "database.redis",
+  "database.sqlite",
+  "database.supabase",
+
+  # DNS
   "dns.cloudflare",
+  "dns.generic",
+  "dns.route53",
+
+  # Email
+  "email.mailgun",
+  "email.postmark",
+  "email.sendgrid",
+  "email.ses",
+
+  # Feature Flags
+  "featureflags.flipt",
+  "featureflags.launchdarkly",
+  "featureflags.split",
+  "featureflags.unleash",
 
   # Infrastructure
+  "infrastructure.ansible",
+  "infrastructure.pulumi",
   "infrastructure.terraform",
 
-  # Secrets management
-  "secrets.onepassword",
+  # Kubernetes
+  "kubernetes.helm",
+  "kubernetes.kubectl",
+  "kubernetes.kustomize",
 
-  # System
-  "system.permissions",
-  "system.services",
+  # Load Balancer
+  "loadbalancer.elb",
+  "loadbalancer.haproxy",
+  "loadbalancer.nginx",
+  "loadbalancer.traefik",
+
+  # Messaging
+  "messaging.kafka",
+  "messaging.nats",
+  "messaging.rabbitmq",
+  "messaging.sqs_sns",
+
+  # Monitoring
+  "monitoring.datadog",
+  "monitoring.newrelic",
+  "monitoring.pagerduty",
+  "monitoring.prometheus",
+  "monitoring.splunk",
+
+  # Package Managers
+  "package_managers",
+
+  # Payment
+  "payment.braintree",
+  "payment.square",
+  "payment.stripe",
 
   # Platform
   "platform.github",
+  "platform.gitlab",
   "platform.railway",
 
+  # Remote
+  "remote.rsync",
+  "remote.scp",
+  "remote.ssh",
+
+  # Search
+  "search.algolia",
+  "search.elasticsearch",
+  "search.meilisearch",
+  "search.opensearch",
+
+  # Secrets
+  "secrets.aws_secrets",
+  "secrets.doppler",
+  "secrets.onepassword",
+  "secrets.vault",
+
   # Storage
+  "storage.azure_blob",
   "storage.gcs",
+  "storage.minio",
   "storage.s3",
+
+  # Strict Git
+  "strict_git",
+
+  # System
+  "system.disk",
+  "system.permissions",
+  "system.services",
 ]

--- a/config/dcg/config.toml
+++ b/config/dcg/config.toml
@@ -1,0 +1,35 @@
+[packs]
+custom_paths = [
+    "~/.config/dcg/packs/*.yaml",
+]
+
+enabled = [
+
+    # CI/CD
+    "cicd.github_actions",
+
+    # database
+    "database.postgresql",
+
+    # Cloudflare
+    "cdn.cloudflare_workers",
+    "dns.cloudflare",
+
+    # Infrastructure
+    "infrastructure.terraform",
+
+    # Secrets management
+    "secrets.onepassword",
+
+    # System
+    "system.permissions",
+    "system.services",
+
+    # Platform
+    "platform.github",
+    "platform.railway",
+
+    # Storage
+    "storage.gcs",
+    "storage.s3"
+]

--- a/config/dcg/default.nix
+++ b/config/dcg/default.nix
@@ -1,0 +1,6 @@
+{ lib, pkgs, ... }:
+{
+  home.activation.dcgConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${./config.toml}"
+  '';
+}

--- a/config/default.nix
+++ b/config/default.nix
@@ -12,6 +12,7 @@ in
   ./crush
   ./cursor
   ./claude
+  ./dcg
   ./direnv
   ./factory
   ./gemini

--- a/spec/activate_config_spec.sh
+++ b/spec/activate_config_spec.sh
@@ -55,6 +55,25 @@ The output should include 'SETTINGS_JSON'
 End
 End
 
+Describe 'config/dcg/activate.sh'
+SCRIPT="$PWD/config/dcg/activate.sh"
+
+It 'uses bash shebang'
+When run bash -c "head -1 '$SCRIPT'"
+The output should include '#!/usr/bin/env bash'
+End
+
+It 'creates packs directory'
+When run bash -c "grep 'mkdir -p' '$SCRIPT'"
+The output should include '.config/dcg/packs'
+End
+
+It 'copies config.toml'
+When run bash -c "grep 'CONFIG_TOML' '$SCRIPT'"
+The output should include 'CONFIG_TOML'
+End
+End
+
 Describe 'config/cursor/activate.sh'
 SCRIPT="$PWD/config/cursor/activate.sh"
 

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -228,6 +228,10 @@ It 'has spec file for config/codex/activate.sh'
 The path "spec/activate_config_spec.sh" should be exist
 End
 
+It 'has spec file for config/dcg/activate.sh'
+The path "spec/activate_config_spec.sh" should be exist
+End
+
 It 'has spec file for config/claude/activate.sh'
 The path "spec/activate_config_spec.sh" should be exist
 End
@@ -364,6 +368,7 @@ config/claude/hooks/atuin-history.sh
 config/claude/hooks/statusline.sh
 config/codex/activate.sh
 config/codex/hooks/atuin-history.sh
+config/dcg/activate.sh
 config/codex/hooks/notify.sh
 config/codex/hooks/pushover.sh
 config/codex/hooks/rtk-rewrite.sh


### PR DESCRIPTION
## Summary
- Add Destructive Command Guard (dcg) config to dotfiles
- Enables 14 safety packs: GitHub Actions, PostgreSQL, Cloudflare Workers/DNS, Terraform, 1Password, system permissions/services, GitHub, Railway, GCS, S3
- Uses activation script pattern (same as codex/claude) to handle atomic writes

## Test plan
- [ ] `home-manager switch` succeeds
- [ ] `dcg doctor` passes all checks
- [ ] `dcg test "DROP TABLE users"` is blocked by postgresql pack

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Destructive Command Guard (`dcg`) config and `home-manager` activation to block destructive commands across the stack. Enables all `dcg` packs (84 modules) with support for custom pack paths.

- **New Features**
  - Add `config.toml` with `custom_paths` and enable all 84 packs; add `activate.sh` + `home.activation.dcgConfig` to install to `~/.config/dcg/config.toml` (644); include `./dcg` in `config/default.nix`.
  - Add shell tests and coverage for `config/dcg/activate.sh`.

- **Migration**
  - Run `home-manager switch`.
  - Verify with `dcg doctor`; `dcg test "DROP TABLE users"` is blocked.

<sup>Written for commit f9e2841186eff373f0c5007c8c6e2f1e7785cd43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

