### PR TITLE
feat: add Beekeeper Studio to dock

### DIFF
--- a/nix-darwin/config/dock.nix
+++ b/nix-darwin/config/dock.nix
@@ -26,6 +26,7 @@
       "/Applications/Claude.app"
       "/Applications/Conductor.app"
       "/Applications/OpenClaw.app"
+      "/Applications/Beekeeper Studio.app"
       "/Applications/Google Chrome.app"
       "/Applications/Docker.app"
       "/Applications/Docker.app/Contents/MacOS/Docker Desktop.app"


### PR DESCRIPTION
## Summary
- Add Beekeeper Studio to macOS dock, positioned between OpenClaw and Google Chrome

## Test plan
- [ ] Run `darwin-rebuild switch` and verify Beekeeper Studio appears in the dock between OpenClaw and Chrome

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Beekeeper Studio to the macOS Dock via `nix-darwin`, positioned between OpenClaw and Google Chrome. Changes take effect after running `darwin-rebuild switch`.

<sup>Written for commit af405631c1e32e56ae57a420f9ef23931684fbb6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

