### PR TITLE
fix: set hyprland configType to hyprlang explicitly

### DIFF
--- a/config/hyprland/default.nix
+++ b/config/hyprland/default.nix
@@ -6,6 +6,7 @@
   wayland.windowManager.hyprland = {
     enable = true;
     package = pkgs.hyprland;
+    configType = "hyprlang";
     systemd.enable = false;
     extraConfig = ''
       exec-once = noctalia-shell


### PR DESCRIPTION
## Summary
- Explicitly set `wayland.windowManager.hyprland.configType = "hyprlang"` to silence the deprecation warning introduced in stateVersion 26.05
- The default changed from `hyprlang` to `lua` - this preserves existing behavior

## Test plan
- [ ] `nix build` completes without the `configType` warning

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly set `wayland.windowManager.hyprland.configType` to `hyprlang` to silence the 26.05 deprecation warning and preserve current behavior. The upstream default switched to `lua`, this keeps our config unchanged.

<sup>Written for commit 86c905fe1fc0e0425f391093c2934b5a5a097f7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

