### PR TITLE
fix(ssh): route kyber through tailscale dns

### DIFF
--- a/home-manager/programs/ssh/default.nix
+++ b/home-manager/programs/ssh/default.nix
@@ -37,8 +37,12 @@ _: {
         };
       };
       "kyber" = {
-        hostname = "100.74.174.97";
+        hostname = "kyber.tail950b36.ts.net";
         user = "ubuntu";
+        identityFile = "~/.ssh/id_rsa";
+        extraOptions = {
+          IdentitiesOnly = "yes";
+        };
       };
       "github.com" = {
         serverAliveInterval = 0;

--- a/spec/ssh_config_spec.sh
+++ b/spec/ssh_config_spec.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'home-manager/programs/ssh/default.nix'
+SSH_CONFIG_NIX="$PWD/home-manager/programs/ssh/default.nix"
+
+Describe 'kyber host'
+It 'uses the Tailscale DNS name instead of a stale tailnet IP'
+When run bash -c "grep 'hostname =' '$SSH_CONFIG_NIX' | grep kyber"
+The output should include 'kyber.tail950b36.ts.net'
+The output should not include '100.74.174.97'
+End
+
+It 'pins the Codex-compatible SSH identity'
+When run cat "$SSH_CONFIG_NIX"
+The output should include 'identityFile = "~/.ssh/id_rsa"'
+The output should include 'IdentitiesOnly = "yes"'
+End
+End
+End


### PR DESCRIPTION
## Summary
- Update the managed Kyber SSH alias to use Tailscale DNS instead of the stale tailnet IP
- Pin the RSA identity and IdentitiesOnly for Codex's discovered SSH connection
- Add a ShellSpec regression for the managed Kyber SSH block

## Verification
- shellspec spec/ssh_config_spec.sh
- shellcheck spec/ssh_config_spec.sh
- nixfmt --check home-manager/programs/ssh/default.nix
- ssh -G kyber | rg '^(hostname|user|port|identityfile|identitiesonly) '
- ssh -o BatchMode=yes -o ConnectTimeout=8 kyber hostname

Note: make shell-test currently fails on pre-existing rtk rewrite / coverage-list issues outside this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route the managed Kyber SSH host through Tailscale DNS and pin the RSA identity for reliable resolution and auth. Adds a ShellSpec regression test for the managed `kyber` SSH block.

- **Bug Fixes**
  - Use `kyber.tail950b36.ts.net` instead of a stale tailnet IP.
  - Set `identityFile = "~/.ssh/id_rsa"` and `IdentitiesOnly = "yes"` for Codex compatibility.
  - Add ShellSpec to assert the DNS hostname and identity settings.

<sup>Written for commit aab253d1413c46106f2b5cd6c3225921cd50a0d4. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1796?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

