### PR TITLE
fix: repair sqlite3 native binding in ing

### DIFF
--- a/home-manager/modules/npm-globals/install-npm-globals.sh
+++ b/home-manager/modules/npm-globals/install-npm-globals.sh
@@ -36,6 +36,44 @@ if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
+repair_sqlite3_native_binding() {
+  local sqlite3_dir="${GLOBAL_MODULES}/sqlite3"
+  local global_install_dir="${HOME}/.bun/install/global"
+  local require_sqlite3='const sqlite3 = require("sqlite3"); if (!sqlite3.Database) process.exit(1);'
+
+  if [ ! -d "$sqlite3_dir" ]; then
+    return 0
+  fi
+
+  if command -v node &>/dev/null && (cd "$global_install_dir" && node -e "$require_sqlite3") >/dev/null 2>&1; then
+    echo "sqlite3 native binding already loadable"
+    return 0
+  fi
+
+  if ! command -v npm &>/dev/null; then
+    echo "npm not found, cannot rebuild sqlite3 native binding" >&2
+    return 1
+  fi
+
+  if ! command -v node &>/dev/null; then
+    echo "node not found, cannot verify sqlite3 native binding" >&2
+    return 1
+  fi
+
+  echo "Rebuilding sqlite3 native binding..."
+  if ! (cd "$sqlite3_dir" && npm run install --foreground-scripts); then
+    echo "sqlite3 native binding rebuild failed" >&2
+    return 1
+  fi
+
+  if ! (cd "$global_install_dir" && node -e "$require_sqlite3") >/dev/null 2>&1; then
+    echo "sqlite3 native binding is still not loadable after rebuild" >&2
+    return 1
+  fi
+
+  echo "sqlite3 native binding rebuilt"
+}
+
 echo "Installing npm global packages from package.json using bun..."
 cd "${HOME}/dotfiles"
 
@@ -153,5 +191,9 @@ for pkg in $(echo "$OVERRIDES" | jq -r 'keys[]' 2>/dev/null); do
     echo "Deduplicated nested $pkg: $nested"
   done
 done
+
+if ! repair_sqlite3_native_binding; then
+  echo "Warning: sqlite3 native binding repair failed" >&2
+fi
 
 echo "npm globals installation complete"

--- a/spec/npm_globals_spec.sh
+++ b/spec/npm_globals_spec.sh
@@ -187,6 +187,23 @@ The output should include 'find'
 End
 End
 
+Describe 'native addon repair'
+It 'has a sqlite3 native binding repair step'
+When run bash -c "grep 'repair_sqlite3_native_binding' '$SCRIPT'"
+The output should include 'repair_sqlite3_native_binding'
+End
+
+It 'runs the sqlite3 package install script with foreground output'
+When run bash -c "grep 'npm run install --foreground-scripts' '$SCRIPT'"
+The output should include 'npm run install --foreground-scripts'
+End
+
+It 'verifies sqlite3 can be loaded by node'
+When run bash -c "grep 'const sqlite3 = require' '$SCRIPT'"
+The output should include 'const sqlite3 = require'
+End
+End
+
 Describe 'stale global package pruning'
 setup() {
   TEMP_HOME=$(mktemp -d)


### PR DESCRIPTION
## Changes
- Add an ing repair step for the global sqlite3 native binding.
- Verify require("sqlite3") before and after running the package install script.
- Add ShellSpec coverage for the native addon repair hook.

## Testing
- shellspec spec/npm_globals_spec.sh
- make shell-check
- make shell-test
- make shell-inline-check
- bash home-manager/modules/npm-globals/install-npm-globals.sh
- curl http://127.0.0.1:3100/api/health

Generated with Codex by GPT-5.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs the global `sqlite3` native binding in ing to prevent crashes after `bun` global installs skip the addon build. The installer now rebuilds and verifies `sqlite3` when it exists but isn’t loadable.

- **Bug Fixes**
  - Added `repair_sqlite3_native_binding` to run `npm run install --foreground-scripts` and check `require("sqlite3")` before/after.
  - Emits clear warnings and continues if `npm`/`node` are missing or the rebuild still fails.
  - Added ShellSpec tests for the repair hook, foreground install, and load verification.

<sup>Written for commit 50c3f6142afe9cae4e338b322ecd0c0102c4807f. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1798?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

