### PR TITLE
feat: add beads dolt environment variables to dolt service

### DIFF
--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -17,6 +17,11 @@ let
   };
 in
 lib.mkIf enabled {
+  home.sessionVariables = {
+    BEADS_DOLT_SHARED_SERVER = "1";
+    BEADS_DOLT_SERVER_PORT = "3307";
+  };
+
   launchd.agents.dolt = lib.mkIf pkgs.stdenv.isDarwin {
     enable = true;
     config = {


### PR DESCRIPTION
This commit adds BEADS_DOLT_SHARED_SERVER and BEADS_DOLT_SERVER_PORT environment variables to the dolt service configuration in home-manager.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds BEADS_DOLT_SHARED_SERVER=1 and BEADS_DOLT_SERVER_PORT=3307 to the Dolt service via home.sessionVariables. Enables shared-server mode and pins the Dolt server port to 3307 for macOS launchd sessions.

<sup>Written for commit 50455d6b8efc495273a7cc4dc41f4413ce97c231. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1799?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

