### PR TITLE
feat(dolt): persist beads_global to GitHub on every dolt commit

### DIFF
--- a/home-manager/services/dolt/backup-dolt-main.sh
+++ b/home-manager/services/dolt/backup-dolt-main.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# @git@, @mirrorDir@, @remoteUrl@, @userEmail@ are substituted by pkgs.replaceVars.
+# `bd` is resolved via PATH (user-installed in ~/.local/bin).
+#
+# Triggered by launchd/systemd when the dolt manifest changes. Exports the
+# full beads_global database to JSONL and pushes it to refs/heads/main of
+# the beads GitHub repo so the data renders in the GitHub UI. Dolt's native
+# git+https push only writes refs/dolt/data, which GitHub does not render.
+
+set -euo pipefail
+
+MIRROR="@mirrorDir@"
+REMOTE="@remoteUrl@"
+GIT="@git@/bin/git"
+USER_EMAIL="@userEmail@"
+
+export PATH="/etc/profiles/per-user/${USER}/bin:${HOME}/.nix-profile/bin:${HOME}/.local/bin:/run/current-system/sw/bin:/usr/bin:/bin"
+
+if ! command -v bd >/dev/null 2>&1; then
+  echo "bd not on PATH; cannot export beads database" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "${MIRROR}")"
+
+if [ ! -d "${MIRROR}/.git" ]; then
+  "${GIT}" clone --depth 1 "${REMOTE}" "${MIRROR}"
+fi
+
+cd "${MIRROR}"
+"${GIT}" fetch --depth 1 origin main
+"${GIT}" reset --hard origin/main
+
+bd --global export --all >issues.jsonl.tmp
+mv issues.jsonl.tmp issues.jsonl
+
+if "${GIT}" diff --quiet -- issues.jsonl; then
+  echo "no JSONL changes; skipping commit"
+  exit 0
+fi
+
+"${GIT}" add issues.jsonl
+"${GIT}" \
+  -c "user.name=beads-backup" \
+  -c "user.email=${USER_EMAIL}" \
+  commit -m "chore(beads): refresh issues.jsonl snapshot"
+"${GIT}" push origin main

--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -10,12 +10,20 @@ let
   homeDir = config.home.homeDirectory;
   repoDir = "${homeDir}/dotfiles";
   beadsDir = "${repoDir}/.beads";
+  doltManifest = "${beadsDir}/beads_global/.dolt/noms/manifest";
+  mirrorDir = "${homeDir}/.cache/beads-jsonl-mirror";
+  remoteUrl = "https://github.com/shunkakinoki/beads";
+  userEmail = "shunkakinoki@gmail.com";
   enabled = isKyber || isGalactica;
   # 1.86+ adds the git+https:// remote scheme used by the beads_global GitHub backup.
   doltMinVersion = "1.86";
   startScript = pkgs.replaceVars ./start.sh {
     inherit beadsDir;
     inherit (pkgs) dolt;
+  };
+  backupScript = pkgs.replaceVars ./backup-dolt-main.sh {
+    inherit mirrorDir remoteUrl userEmail;
+    inherit (pkgs) git;
   };
 in
 lib.mkIf enabled {
@@ -46,6 +54,27 @@ lib.mkIf enabled {
     };
   };
 
+  # Mirror the live beads_global DB to refs/heads/main as JSONL so the data
+  # is visible in the GitHub UI (Dolt's native push only writes refs/dolt/data).
+  # Triggered by manifest changes inside dolt's noms store; throttled to avoid
+  # hammering on rapid writes.
+  launchd.agents.dolt-backup-main = lib.mkIf pkgs.stdenv.isDarwin {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "${pkgs.bash}/bin/bash"
+        "${backupScript}"
+      ];
+      WatchPaths = [ doltManifest ];
+      ThrottleInterval = 60;
+      RunAtLoad = false;
+      KeepAlive = false;
+      WorkingDirectory = repoDir;
+      StandardOutPath = "/tmp/dolt-backup-main.log";
+      StandardErrorPath = "/tmp/dolt-backup-main.error.log";
+    };
+  };
+
   systemd.user.services.dolt = lib.mkIf pkgs.stdenv.isLinux {
     Unit = {
       Description = "Dolt SQL server for dotfiles beads";
@@ -57,6 +86,30 @@ lib.mkIf enabled {
       Restart = "always";
       RestartSec = 5;
       WorkingDirectory = repoDir;
+    };
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
+
+  systemd.user.services.dolt-backup-main = lib.mkIf pkgs.stdenv.isLinux {
+    Unit = {
+      Description = "Push beads_global JSONL snapshot to GitHub main";
+    };
+    Service = {
+      Type = "oneshot";
+      ExecStart = "${pkgs.bash}/bin/bash ${backupScript}";
+      WorkingDirectory = repoDir;
+    };
+  };
+
+  systemd.user.paths.dolt-backup-main = lib.mkIf pkgs.stdenv.isLinux {
+    Unit = {
+      Description = "Watch dolt manifest and trigger JSONL backup";
+    };
+    Path = {
+      PathChanged = doltManifest;
+      Unit = "dolt-backup-main.service";
     };
     Install = {
       WantedBy = [ "default.target" ];

--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -11,12 +11,21 @@ let
   repoDir = "${homeDir}/dotfiles";
   beadsDir = "${repoDir}/.beads";
   enabled = isKyber || isGalactica;
+  # 1.86+ adds the git+https:// remote scheme used by the beads_global GitHub backup.
+  doltMinVersion = "1.86";
   startScript = pkgs.replaceVars ./start.sh {
     inherit beadsDir;
     inherit (pkgs) dolt;
   };
 in
 lib.mkIf enabled {
+  assertions = [
+    {
+      assertion = lib.versionAtLeast pkgs.dolt.version doltMinVersion;
+      message = "pkgs.dolt is ${pkgs.dolt.version}; needs >= ${doltMinVersion} for git+https push (beads_global GitHub backup). Run 'nix flake update nixpkgs-unstable'.";
+    }
+  ];
+
   home.sessionVariables = {
     BEADS_DOLT_SHARED_SERVER = "1";
     BEADS_DOLT_SERVER_PORT = "3307";

--- a/spec/backup_dolt_main_spec.sh
+++ b/spec/backup_dolt_main_spec.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'home-manager/services/dolt/backup-dolt-main.sh'
+SCRIPT="$PWD/home-manager/services/dolt/backup-dolt-main.sh"
+
+Describe 'script properties'
+It 'uses bash shebang'
+When run bash -c "head -1 '$SCRIPT'"
+The output should include '#!/usr/bin/env bash'
+End
+
+It 'uses strict mode'
+When run bash -c "grep 'set -euo pipefail' '$SCRIPT'"
+The output should include 'set -euo pipefail'
+End
+
+It 'passes bash syntax check after stripping placeholders'
+When run bash -c "sed 's|@[A-Za-z_][A-Za-z0-9_]*@|/usr|g' '$SCRIPT' | bash -n"
+The status should be success
+End
+End
+
+Describe 'placeholder substitutions'
+It 'references @git@'
+When run bash -c "grep '@git@' '$SCRIPT'"
+The output should include '@git@'
+End
+
+It 'references @mirrorDir@'
+When run bash -c "grep '@mirrorDir@' '$SCRIPT'"
+The output should include '@mirrorDir@'
+End
+
+It 'references @remoteUrl@'
+When run bash -c "grep '@remoteUrl@' '$SCRIPT'"
+The output should include '@remoteUrl@'
+End
+
+It 'references @userEmail@'
+When run bash -c "grep '@userEmail@' '$SCRIPT'"
+The output should include '@userEmail@'
+End
+End
+
+Describe 'preflight checks'
+It 'requires bd on PATH'
+When run bash -c "grep 'command -v bd' '$SCRIPT'"
+The output should include 'command -v bd'
+End
+
+It 'extends PATH for Nix profiles and user-local bins'
+When run bash -c "grep 'export PATH=' '$SCRIPT'"
+The output should include '.nix-profile/bin'
+End
+End
+
+Describe 'mirror checkout management'
+It 'creates the mirror parent directory'
+When run bash -c "grep 'mkdir -p' '$SCRIPT'"
+The output should include 'mkdir -p'
+End
+
+It 'clones the remote when the mirror is missing'
+When run bash -c "grep 'clone --depth 1' '$SCRIPT'"
+The output should include 'clone --depth 1'
+End
+
+It 'resets the mirror to origin/main before exporting'
+When run bash -c "grep 'reset --hard origin/main' '$SCRIPT'"
+The output should include 'reset --hard origin/main'
+End
+End
+
+Describe 'export and push'
+It 'exports the full beads dataset'
+When run bash -c "grep -- 'bd --global export --all' '$SCRIPT'"
+The output should include 'bd --global export --all'
+End
+
+It 'writes to a temporary file before renaming'
+When run bash -c "grep 'issues.jsonl.tmp' '$SCRIPT'"
+The output should include 'issues.jsonl.tmp'
+End
+
+It 'skips commit when JSONL is unchanged'
+When run bash -c "grep -- 'diff --quiet' '$SCRIPT'"
+The output should include 'diff --quiet'
+End
+
+It 'commits with a chore prefix'
+When run bash -c "grep -- 'chore(beads)' '$SCRIPT'"
+The output should include 'chore(beads)'
+End
+
+It 'pushes to origin main'
+When run bash -c "grep 'push origin main' '$SCRIPT'"
+The output should include 'push origin main'
+End
+End
+
+End

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -201,6 +201,10 @@ It 'has spec file for home-manager/services/dolt/start.sh'
 The path "spec/dolt_start_spec.sh" should be exist
 End
 
+It 'has spec file for home-manager/services/dolt/backup-dolt-main.sh'
+The path "spec/backup_dolt_main_spec.sh" should be exist
+End
+
 It 'has spec file for home-manager/services/k3s/activate.sh'
 The path "spec/k3s_service_activate_spec.sh" should be exist
 End
@@ -438,6 +442,7 @@ home-manager/services/docker-postgres/start-postgres.sh
 home-manager/services/docker/docker-setup.sh
 home-manager/services/docker/setup-docker.sh
 home-manager/services/dolt/start.sh
+home-manager/services/dolt/backup-dolt-main.sh
 home-manager/services/dotfiles-updater/update.sh
 home-manager/services/gas-town/start.sh
 home-manager/services/k3s/activate.sh


### PR DESCRIPTION
## Summary
- Assert `pkgs.dolt >= 1.86` so the home-manager dolt service can use the git+https remote scheme that backs up `beads_global` to refs/dolt/data.
- Add a second launchd/systemd-path agent (`dolt-backup-main`) that watches the dolt manifest and pushes a JSONL snapshot of the live DB to `refs/heads/main` of the beads repo, so the data renders in the GitHub UI (the native dolt push only writes `refs/dolt/data`, which GitHub does not render).
- Trigger: launchd `WatchPaths` on `~/dotfiles/.beads/beads_global/.dolt/noms/manifest` with `ThrottleInterval = 60`; systemd `path` unit with `PathChanged` for the Linux equivalent.
- Payload: `bd --global export --all > issues.jsonl`, then `git diff --quiet`-gated commit and push.
- Mirror checkout lives at `~/.cache/beads-jsonl-mirror`.

## Test plan
- [x] `shellcheck` clean for `home-manager/services/dolt/backup-dolt-main.sh` and `spec/backup_dolt_main_spec.sh`
- [x] `shellspec` full suite: 1520 examples, 0 failures (new spec adds 17 examples; coverage spec updated)
- [x] `nix fmt` no changes
- [x] Verified on galactica: launchd-managed dolt is now 1.86.6 and `dolt push origin main` returns "Everything up-to-date" against the existing `refs/dolt/data` remote
- [ ] Verify after `make switch` that `dolt-backup-main` agent loads and produces an `issues.jsonl` push on the next dolt commit