### PR TITLE
feat: add Infisical/agent-vault to local binaries

### DIFF
--- a/.local-binaries.txt
+++ b/.local-binaries.txt
@@ -21,6 +21,7 @@
 ~/ghq/github.com/Dicklesworthstone/slb/build/slb
 ~/ghq/github.com/Dicklesworthstone/ultimate_bug_scanner/ubs
 ~/ghq/github.com/GoogleCloudPlatform/scion/scion
+~/ghq/github.com/Infisical/agent-vault/agent-vault
 ~/ghq/github.com/MH4GF/tq/tq
 ~/ghq/github.com/NousResearch/hermes-agent/.venv/bin/hermes
 ~/ghq/github.com/NousResearch/hermes-agent/.venv/bin/hermes-agent


### PR DESCRIPTION
## Summary
- Add `~/ghq/github.com/Infisical/agent-vault/agent-vault` to `.local-binaries.txt`

## Test plan
- [x] Repo cloned via `ghq get`
- [x] `make build` succeeds (binary: 15M, `agent-vault version v0.20.1-6-gf645306-dirty`)

Note: web step needs `npm install --include=optional --minimum-release-age=0` first when the global `~/.npmrc` has `minimum-release-age` set, because the rollup native binary gets filtered out otherwise.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `~/ghq/github.com/Infisical/agent-vault/agent-vault` to `.local-binaries.txt` so the `agent-vault` binary is included in local binaries for easy access. Assumes the repo is cloned via `ghq` and built locally.

<sup>Written for commit 938562a9fe00ec686b2f8a93ef3f86c8d4089818. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1801?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

