### PR TITLE
refactor(dolt): drop legacy dolt -> df symlink

### DIFF
--- a/home-manager/services/dolt/start.sh
+++ b/home-manager/services/dolt/start.sh
@@ -13,9 +13,9 @@ if [ -d "@beadsDir@/dolt" ] && [ ! -L "@beadsDir@/dolt" ]; then
   mv -f "@beadsDir@/dolt" "@beadsDir@/df"
 fi
 
-if [ -d "@beadsDir@/df" ]; then
-  ln -sfn df "@beadsDir@/dolt"
-fi
+# External databases (e.g. another repo's .beads/<dbname>) are mounted by the
+# user via plain symlinks under @beadsDir@/<dbname>. The server scans
+# @beadsDir@ at startup, so each symlinked DB becomes addressable by its name.
 
 exec "@dolt@/bin/dolt" sql-server \
   -H 127.0.0.1 \

--- a/spec/dolt_start_spec.sh
+++ b/spec/dolt_start_spec.sh
@@ -39,14 +39,14 @@ When run bash -c "grep 'mv -f' '$SCRIPT'"
 The output should include 'mv -f'
 End
 
-It 'symlinks dolt to df for backwards compatibility'
-When run bash -c "grep 'ln -sfn df' '$SCRIPT'"
-The output should include 'ln -sfn df'
-End
-
 It 'refuses to overwrite an existing df directory'
 When run bash -c "grep 'Refusing to migrate' '$SCRIPT'"
 The output should include 'Refusing to migrate'
+End
+
+It 'does not recreate the legacy dolt -> df symlink'
+When run bash -c "grep -c 'ln -sfn df' '$SCRIPT' || true"
+The output should equal '0'
 End
 End
 


### PR DESCRIPTION
## Summary

- The shared launchd dolt server uses `~/dotfiles/.beads/` as its data-dir, treating each subdirectory as a database.
- start.sh used to recreate `~/dotfiles/.beads/dolt -> df` on every launch as a backwards-compat alias from when bd defaulted to a `dolt` DB name.
- That symlink prevented any other repo (e.g.shun, whose bd config expects a database literally named `dolt`) from mounting itself onto the shared server, because `dolt` was always squatted by the dotfiles alias.
- Drop the alias. dotfiles continues to use its own `df` database (configured via `prefix: df` in its bd config); other repos can now manually symlink their `.beads/<dbname>` into `~/dotfiles/.beads/<dbname>` and the shared server will serve them after a restart.

## Test plan

- [x] `shellspec spec/dolt_start_spec.sh` (11/0)
- [x] `shellcheck home-manager/services/dolt/start.sh`
- [ ] `make switch` and confirm `bd status` works in dotfiles (DB `df`)
- [ ] Manually `ln -sfn <repo>/.beads/dolt ~/dotfiles/.beads/dolt` for another repo and confirm `bd status` works there

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the legacy dolt -> df symlink from the shared Dolt server startup so we don’t squat the dolt DB name. Dotfiles still uses the df database; other repos can now mount their own databases via symlinks.

- **Refactors**
  - Stop creating `dolt -> df` in `home-manager/services/dolt/start.sh`; keep the migration guard for a real `dolt` dir.
  - Update spec to assert the legacy symlink is not recreated.

- **Migration**
  - No change for dotfiles (uses `df`).
  - To serve another repo as `dolt`, symlink its `.beads/dolt` into `~/dotfiles/.beads/dolt` and restart the server.

<sup>Written for commit 860576ba5fdd19adbe1644fb3282c0c7bdc520a2. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1802?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

