### PR TITLE
fix(dolt): only migrate dolt -> df when df is absent

### DIFF
--- a/home-manager/services/dolt/start.sh
+++ b/home-manager/services/dolt/start.sh
@@ -4,18 +4,17 @@ set -euo pipefail
 
 mkdir -p "@beadsDir@"
 
-if [ -d "@beadsDir@/dolt" ] && [ ! -L "@beadsDir@/dolt" ]; then
-  if [ -e "@beadsDir@/df" ]; then
-    echo "Refusing to migrate @beadsDir@/dolt because @beadsDir@/df already exists" >&2
-    exit 1
-  fi
-
+# Legacy migration: a `dolt` directory predates the rename to `df`.
+# Only migrate when `df` does not exist yet; once `df` is in place the
+# `dolt` directory is treated as its own (possibly external) database.
+if [ -d "@beadsDir@/dolt" ] && [ ! -L "@beadsDir@/dolt" ] && [ ! -e "@beadsDir@/df" ]; then
   mv -f "@beadsDir@/dolt" "@beadsDir@/df"
 fi
 
-# External databases (e.g. another repo's .beads/<dbname>) are mounted by the
-# user via plain symlinks under @beadsDir@/<dbname>. The server scans
-# @beadsDir@ at startup, so each symlinked DB becomes addressable by its name.
+# Additional databases (e.g. data shared with another repo) are managed by
+# the user as real directories under @beadsDir@/<dbname>. dolt sql-server
+# scans @beadsDir@ at startup and exposes each subdirectory as a database
+# by that name.
 
 exec "@dolt@/bin/dolt" sql-server \
   -H 127.0.0.1 \

--- a/spec/dolt_start_spec.sh
+++ b/spec/dolt_start_spec.sh
@@ -39,9 +39,9 @@ When run bash -c "grep 'mv -f' '$SCRIPT'"
 The output should include 'mv -f'
 End
 
-It 'refuses to overwrite an existing df directory'
-When run bash -c "grep 'Refusing to migrate' '$SCRIPT'"
-The output should include 'Refusing to migrate'
+It 'gates the migration on df not yet existing'
+When run bash -c "grep -- '-e \"@beadsDir@/df\"' '$SCRIPT'"
+The output should include '-e "@beadsDir@/df"'
 End
 
 It 'does not recreate the legacy dolt -> df symlink'


### PR DESCRIPTION
## Summary

- Follow-up to #1802. The previous start.sh refused to start with `Refusing to migrate ... because df already exists` whenever both a `df` directory and a `dolt` directory existed inside `~/dotfiles/.beads/`.
- That used to indicate a broken legacy state, but post-#1802 it is the expected steady state: `df` is dotfiles' own database, and `dolt` is now a separate user-managed directory (e.g. data shared with another repo).
- Gate the migration on `df` being absent; otherwise leave both directories in place. The migration still runs cleanly on machines that have not yet had `df` created.

## Test plan

- [x] `shellspec spec/dolt_start_spec.sh` (11/0)
- [x] `shellcheck home-manager/services/dolt/start.sh`
- [ ] `make switch` and confirm dolt starts when both `df/` and `dolt/` are real directories

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `dolt` startup by only migrating the legacy `dolt` directory to `df` when `df` doesn’t exist. If both `df/` and `dolt/` are present, startup proceeds and `dolt/` is treated as a separate database.

- **Bug Fixes**
  - Gate migration on `@beadsDir@/dolt` being a real dir and `@beadsDir@/df` being absent.
  - Remove the fatal “Refusing to migrate …” path; keep both dirs otherwise.
  - Update comments to reflect `dolt sql-server` exposes each subdirectory as a DB.
  - Adjust spec to assert the new migration guard.

<sup>Written for commit 138141b585459a4a8fed5c16558ee215d094fb98. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1803?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

