### PR TITLE
chore(ollama): disable on isMatic to skip ROCm build

### DIFF
--- a/home-manager/services/ollama/default.nix
+++ b/home-manager/services/ollama/default.nix
@@ -6,29 +6,31 @@
 }:
 let
   inherit (inputs.host) isGalactica isMatic;
-  enabled = isGalactica || isMatic;
+  # isMatic disabled: ROCm build takes too long; re-enable when pre-built cache is available
+  # enabled = isGalactica || isMatic;
+  enabled = isGalactica;
 
   # Per-host ollama package:
   #   AMD GPU (ROCm): ollama-rocm (matic)
   #   NVIDIA GPU (CUDA): ollama-cuda
   #   CPU fallback: ollama
   ollamaPackage =
-    if isMatic then
-      pkgs.ollama-rocm
+    # if isMatic then
+    #   pkgs.ollama-rocm
     # else if isNvidiaHost then pkgs.ollama-cuda
-    else
-      pkgs.ollama;
+    # else
+    pkgs.ollama;
 
   ollamaEnv =
-    if isMatic then
-      [
-        "OLLAMA_HOST=127.0.0.1"
-        "HSA_OVERRIDE_GFX_VERSION=11.5.0"
-      ]
-    else
-      [
-        "OLLAMA_HOST=127.0.0.1"
-      ];
+    # if isMatic then
+    #   [
+    #     "OLLAMA_HOST=127.0.0.1"
+    #     "HSA_OVERRIDE_GFX_VERSION=11.5.0"
+    #   ]
+    # else
+    [
+      "OLLAMA_HOST=127.0.0.1"
+    ];
 in
 lib.mkIf enabled {
   home.packages = [ ollamaPackage ];


### PR DESCRIPTION
## Summary

- Comment out isMatic-specific ollama paths (`ollama-rocm` package, `HSA_OVERRIDE_GFX_VERSION` env) to avoid lengthy ROCm compilation
- Ollama remains enabled on isGalactica (CPU fallback package)
- All isMatic code is commented, not removed, for easy re-enablement when a pre-built cache is available

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Ollama on `isMatic` to skip long ROCm builds. Comment out `ollama-rocm` and `HSA_OVERRIDE_GFX_VERSION`; keep CPU `ollama` enabled on `isGalactica`; leave `isMatic` paths commented for easy re-enable.

<sup>Written for commit 34b751252f32b61927a450118bb2ac1ad9df016b. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1804?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

