### PR TITLE
fix(hyprland): remove deprecated dwindle pseudotile option

### DIFF
--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -94,7 +94,6 @@ general {
 }
 
 dwindle {
-    pseudotile = true
     preserve_split = true
 }
 


### PR DESCRIPTION
## Summary
- Removes `pseudotile = true` from the `dwindle` block in `hyprland.conf`
- The option no longer exists in newer Hyprland versions, causing a config error: `<dwindle:pseudotile? does not exist`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove deprecated `pseudotile` from the `dwindle` block in the Hyprland config to restore compatibility with newer Hyprland versions. Fixes the config error `dwindle:pseudotile? does not exist` on startup.

<sup>Written for commit 239ce41fa209956fc521a2208e72483df6163723. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1805?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

