### PR TITLE
feat: 4-layer secret leak prevention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# Secrets - Layer 1 (design): structurally exclude credential locations
+_credentials/
+*.local.md
+*.secret.md
+credentials*.md
+**/draft/
+
 # AI
 .aider.tags.cache.v4
 .claude

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -259,6 +259,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "$HOME/dotfiles/config/shared/hooks/secret-guard.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "git-ai checkpoint claude --hook-input stdin",
             "timeout": 15,
             "async": true

--- a/config/codex/hooks.json
+++ b/config/codex/hooks.json
@@ -21,6 +21,16 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/dotfiles/config/shared/hooks/secret-guard.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {

--- a/config/default.nix
+++ b/config/default.nix
@@ -18,6 +18,7 @@ in
   ./factory
   ./gemini
   ./git-ai
+  ./gitleaks
   ./gomi
   ./ghostty
   ./hermes

--- a/config/gitleaks/config.toml
+++ b/config/gitleaks/config.toml
@@ -1,0 +1,37 @@
+title = "dotfiles gitleaks config"
+
+# Extend the default gitleaks rules
+[extend]
+useDefault = true
+
+[[rules]]
+id = "japanese-password-field"
+description = "Detects Japanese password field patterns"
+regex = '''(?i)(パスワード|password|pw|pass)\s*[:：=]\s*["']?[A-Za-z0-9!@#$%^&*\-_=+]{6,}["']?'''
+
+[[rules]]
+id = "japanese-api-key-field"
+description = "Detects Japanese API key field patterns"
+regex = '''(?i)(APIキー|api[-_ ]?key|secret[-_ ]?key|access[-_ ]?token)\s*[:：=]\s*["']?[A-Za-z0-9!@#$%^&*\-_=+]{16,}["']?'''
+
+[allowlist]
+description = "Global allowlist for templates, examples, and known-safe dummies"
+paths = [
+  '''(.*?)\.template\.md$''',
+  '''(.*?)\.example$''',
+  '''\.env\.example$''',
+  '''docs/.*\.template\.md$''',
+  '''dotagents/.*''',
+  '''bun\.lock$''',
+  '''Cargo\.lock$''',
+  '''flake\.lock$''',
+  '''node_modules/.*''',
+  '''target/.*''',
+]
+regexes = [
+  '''DUMMY_PASSWORD''',
+  '''<your-password-here>''',
+  '''<PLACEHOLDER>''',
+  '''xxxxxxxxxxxxxxxx''',
+  '''example\.com''',
+]

--- a/config/gitleaks/default.nix
+++ b/config/gitleaks/default.nix
@@ -1,0 +1,8 @@
+{ config, ... }:
+{
+  # Gitleaks reads $GITLEAKS_CONFIG when run outside a repo with a local .gitleaks.toml.
+  home.file.".config/gitleaks/config.toml".source = ./config.toml;
+  home.sessionVariables = {
+    GITLEAKS_CONFIG = "${config.home.homeDirectory}/.config/gitleaks/config.toml";
+  };
+}

--- a/config/shared/hooks/secret-guard.sh
+++ b/config/shared/hooks/secret-guard.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Shared PreToolUse hook for Claude Code and Codex Write/Edit operations.
+# Blocks writes containing secrets detected by gitleaks.
+# See: https://zenn.dev/takna/articles/secret-leak-prevention-4-layer
+set -euo pipefail
+
+# Hook is supplementary, not primary defense. Skip silently if deps missing.
+command -v jq >/dev/null 2>&1 || exit 0
+command -v gitleaks >/dev/null 2>&1 || exit 0
+
+PAYLOAD=$(cat)
+
+# Extract content across Claude and Codex payload shapes (Write/Edit/MultiEdit).
+CONTENT=$(printf '%s' "$PAYLOAD" | jq -r '
+  .tool_input.content //
+  .tool_input.new_string //
+  .tool.input.content //
+  .tool.input.new_string //
+  .toolInput.content //
+  .toolInput.new_string //
+  (.tool_input.edits // [] | map(.new_string) | join("\n")) //
+  (.tool.input.edits // [] | map(.new_string) | join("\n")) //
+  empty
+' 2>/dev/null)
+
+[[ -z "$CONTENT" || "$CONTENT" == "null" ]] && exit 0
+
+TMP_DIR=$(mktemp -d -t secret-guard.XXXXXX)
+trap 'rm -rf "$TMP_DIR"' EXIT
+printf '%s' "$CONTENT" > "$TMP_DIR/payload.txt"
+
+CONFIG_ARG=()
+if [[ -f "$PWD/.gitleaks.toml" ]]; then
+  CONFIG_ARG=(--config "$PWD/.gitleaks.toml")
+elif [[ -n "${GITLEAKS_CONFIG:-}" && -f "$GITLEAKS_CONFIG" ]]; then
+  CONFIG_ARG=(--config "$GITLEAKS_CONFIG")
+elif [[ -f "$HOME/.config/gitleaks/config.toml" ]]; then
+  CONFIG_ARG=(--config "$HOME/.config/gitleaks/config.toml")
+fi
+
+if gitleaks dir "$TMP_DIR" "${CONFIG_ARG[@]}" --no-banner --redact >/dev/null 2>&1; then
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+secret-guard: Blocked Write/Edit due to detected secrets.
+- Move credentials to .gitignore'd paths (_credentials/, *.secret.md, etc.)
+- Use explicit placeholders like <PLACEHOLDER> or DUMMY_PASSWORD
+- See: https://zenn.dev/takna/articles/secret-leak-prevention-4-layer
+EOF
+exit 2

--- a/config/shared/hooks/secret-guard.sh
+++ b/config/shared/hooks/secret-guard.sh
@@ -23,16 +23,16 @@ CONTENT=$(printf '%s' "$PAYLOAD" | jq -r '
   empty
 ' 2>/dev/null)
 
-[[ -z "$CONTENT" || "$CONTENT" == "null" ]] && exit 0
+[[ -z $CONTENT || $CONTENT == "null" ]] && exit 0
 
 TMP_DIR=$(mktemp -d -t secret-guard.XXXXXX)
 trap 'rm -rf "$TMP_DIR"' EXIT
-printf '%s' "$CONTENT" > "$TMP_DIR/payload.txt"
+printf '%s' "$CONTENT" >"$TMP_DIR/payload.txt"
 
 CONFIG_ARG=()
 if [[ -f "$PWD/.gitleaks.toml" ]]; then
   CONFIG_ARG=(--config "$PWD/.gitleaks.toml")
-elif [[ -n "${GITLEAKS_CONFIG:-}" && -f "$GITLEAKS_CONFIG" ]]; then
+elif [[ -n ${GITLEAKS_CONFIG:-} && -f $GITLEAKS_CONFIG ]]; then
   CONFIG_ARG=(--config "$GITLEAKS_CONFIG")
 elif [[ -f "$HOME/.config/gitleaks/config.toml" ]]; then
   CONFIG_ARG=(--config "$HOME/.config/gitleaks/config.toml")

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -49,6 +49,7 @@ with pkgs;
   fzf-make
   gh
   git
+  gitleaks
   glance
   glow
   gnumake
@@ -66,6 +67,7 @@ with pkgs;
   just
   k6
   lean4
+  lefthook
   (if stdenv.isLinux && isDesktop then llama-cpp.override { vulkanSupport = true; } else llama-cpp)
   llm
   lsof

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,5 @@
+pre-commit:
+  parallel: true
+  commands:
+    gitleaks:
+      run: gitleaks git --staged --redact --verbose

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -382,6 +382,7 @@ config/copilot/hooks/rtk-rewrite.sh
 config/copilot/hooks/security.sh
 config/shared/hooks/block-gh-settings.sh
 config/shared/hooks/block-git-push.sh
+config/shared/hooks/secret-guard.sh
 config/cursor/activate.sh
 config/gemini/activate.sh
 config/git-ai/activate.sh


### PR DESCRIPTION
## Summary

Implements the 4-layer secret leak prevention pattern from https://zenn.dev/takna/articles/secret-leak-prevention-4-layer.

- **Layer 1 (design)**: `.gitignore` patterns for credential locations (`_credentials/`, `*.local.md`, `*.secret.md`, `credentials*.md`, `**/draft/`).
- **Layer 2 (pre-commit)**: `lefthook.yml` runs `gitleaks git --staged --redact --verbose`. Gitleaks config moved to `config/gitleaks/config.toml` and installed globally at `~/.config/gitleaks/config.toml` via home-manager; `GITLEAKS_CONFIG` env var is set so every repo picks up the same baseline without a per-repo `.gitleaks.toml`.
- **Layer 3 (push protection)**: server-side, enable manually per repo at Settings -> Advanced Security -> Secret Protection -> Push protection.
- **Layer 4 (AI hook)**: `config/shared/hooks/secret-guard.sh` is a shared PreToolUse hook wired into both Claude Code (`config/claude/settings.json`) and Codex (`config/codex/hooks.json`) for `Write|Edit|MultiEdit`. It extracts content from multiple payload shapes (Claude `tool_input.*`, Codex `tool.input.*`, plus MultiEdit `edits[].new_string`), runs gitleaks against the extracted content, and exits 2 to block on detection. Skips silently if `gitleaks`/`jq` are missing so it does not break before the next rebuild.

`gitleaks` and `lefthook` added to `home-manager/packages/default.nix`.

## Test plan

- [ ] `darwin-rebuild switch --flake .` installs `gitleaks` and `lefthook`
- [ ] `lefthook install` wires `.git/hooks/pre-commit` in this repo
- [ ] `echo 'AWS_SECRET_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE' | gitleaks stdin` flags
- [ ] Claude Code `Write` with a fake AWS key in content is blocked by `secret-guard.sh`
- [ ] Codex `Write` with the same payload is blocked
- [ ] Clean writes pass through (exit 0)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 4-layer secret leak prevention system across ignore rules, pre-commit checks, server push protection, and editor hooks. Also adds shell coverage for `secret-guard.sh` and formats the script.

- New Features
  - Layer 1: `.gitignore` excludes `_credentials/`, `*.local.md`, `*.secret.md`, `credentials*.md`, `**/draft/`.
  - Layer 2: Pre-commit via `lefthook` runs `gitleaks git --staged --redact --verbose`; global config at `~/.config/gitleaks/config.toml` via `home-manager` with custom rules and allowlist.
  - Layer 3: Push protection (server-side). Enable per repo in Settings > Advanced Security > Secret Protection.
  - Layer 4: `secret-guard.sh` hooks Claude Code and Codex Write/Edit/MultiEdit, scans payloads with `gitleaks`, exits 2 on findings; skips if `gitleaks`/`jq` missing.

- Dependencies
  - Added `gitleaks` and `lefthook` to `home-manager` packages.

<sup>Written for commit 6ffefd15cce987b3e79ec56de15dca93729cbb7d. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1811?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

