### PR TITLE
fix(scripts): add build flag support to skip Makefile for local binaries

### DIFF
--- a/.local-binaries.txt
+++ b/.local-binaries.txt
@@ -2,6 +2,8 @@
 # Add one binary path per line
 # Lines starting with # are comments
 # Use path:alias to create a symlink with a custom name (e.g., ~/path/to/pi:pir)
+# Use path#flag1,flag2 to set build flags. Supported flags:
+#   nomake - skip Makefile and fall through to Cargo/go.mod/pyproject
 # Dependencies (lib-only repos) must appear before the binaries that need them
 
 # cass dependencies (pull + build before cass itself)
@@ -21,7 +23,7 @@
 ~/ghq/github.com/Dicklesworthstone/slb/build/slb
 ~/ghq/github.com/Dicklesworthstone/ultimate_bug_scanner/ubs
 ~/ghq/github.com/GoogleCloudPlatform/scion/scion
-~/ghq/github.com/Infisical/agent-vault/agent-vault
+~/ghq/github.com/Infisical/agent-vault/agent-vault#nomake
 ~/ghq/github.com/MH4GF/tq/tq
 ~/ghq/github.com/NousResearch/hermes-agent/.venv/bin/hermes
 ~/ghq/github.com/NousResearch/hermes-agent/.venv/bin/hermes-agent

--- a/scripts/update-local-binaries.sh
+++ b/scripts/update-local-binaries.sh
@@ -125,6 +125,7 @@ find_build_dir() {
 build_repo() {
   local repo_dir="$1"
   local binary_path="${2:-}"
+  local flags="${3:-}"
   local repo_name
   repo_name="$(get_repo_name "$repo_dir")"
 
@@ -149,7 +150,11 @@ build_repo() {
     (cd "$repo_dir" && git submodule update --init --recursive 2>&1) || true
   fi
 
-  if [ -f "$build_dir/Makefile" ]; then
+  # Honor `nomake` flag: skip Makefile detection and fall through to native
+  # build systems (Cargo/go.mod/pyproject). Useful when a repo's `make build`
+  # target pulls in heavyweight steps (e.g. a frontend bundle) that the local
+  # binary does not need.
+  if [ -f "$build_dir/Makefile" ] && [[ ",$flags," != *,nomake,* ]]; then
     # Use mise exec if mise.toml present to ensure correct tool versions
     local make_cmd="make"
     if [ -f "$build_dir/mise.toml" ] && command -v mise >/dev/null 2>&1; then
@@ -260,6 +265,7 @@ WRAPPER
 # Update a single repo
 update_repo() {
   local binary_path="$1"
+  local flags="${2:-}"
   local repo_dir
   repo_dir="$(get_repo_dir "$binary_path")"
   local repo_name
@@ -343,7 +349,7 @@ update_repo() {
   fi
 
   # Build
-  if build_repo "$repo_dir" "$binary_path"; then
+  if build_repo "$repo_dir" "$binary_path" "$flags"; then
     log_info "  ✅ $repo_name updated successfully"
     SUCCESSES+=("$repo_name")
   else
@@ -417,6 +423,15 @@ main() {
       continue
     fi
 
+    # Strip optional build-flag suffix (path[:alias]#flag1,flag2)
+    local flags=""
+    case "$line" in
+    *\#*)
+      flags="${line##*#}"
+      line="${line%#*}"
+      ;;
+    esac
+
     # Strip optional alias suffix (path:alias)
     case "$line" in
     *:*) line="${line%:*}" ;;
@@ -432,7 +447,7 @@ main() {
     seen_repos[$repo_dir]=1
 
     # Update repo (continue on failure)
-    update_repo "$line" || true
+    update_repo "$line" "$flags" || true
 
   done <"$CONFIG_FILE"
 


### PR DESCRIPTION
## Summary

- Parse optional `#flag` suffix in `.local-binaries.txt` entries to control build behavior per-binary.
- Add `nomake` flag that skips `Makefile` detection and falls through to Cargo/go.mod/pyproject.
- Apply `nomake` to `Infisical/agent-vault` so its build no longer runs the web frontend bundle.

## Why

`Infisical/agent-vault`'s `make build` target depends on `web` (npm ci + Vite build). On macOS arm64 this currently fails with:

```
Error: Cannot find module @rollup/rollup-darwin-arm64. npm has a bug related to
optional dependencies (https://github.com/npm/cli/issues/4828).
```

The local `agent-vault` binary only needs the Go CLI — the embed of `webdist` already has stale contents from a prior build, so `go build .` works fine. Detection now skips `make` for this repo and uses the Go path directly.

## Usage

```
~/path/to/binary                            # default: auto-detect
~/path/to/binary:alias                      # symlink alias
~/path/to/binary#nomake                     # skip Makefile
~/path/to/binary:alias#nomake,flag2         # combine
```

## Test plan

- [x] `bash -n scripts/update-local-binaries.sh` (syntax)
- [x] `bash scripts/update-local-binaries.sh agent-vault` succeeds (previously failed at `make web`)
- [x] Full run: 21 successful incl. agent-vault. The two remaining failures (`frankensearch`, `tq`) are unrelated upstream issues
- [x] Existing `path:alias` parsing for `pi:pir` unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add build flag support to local binary updates and apply `#nomake` to `Infisical/agent-vault` to skip its `Makefile` web build. This fixes macOS arm64 failures caused by `@rollup/rollup-darwin-arm64` optional dependency issues.

- **New Features**
  - Parse optional `#flag1,flag2` in `.local-binaries.txt` and pass flags through the build pipeline.
  - `nomake` flag bypasses `Makefile` and falls back to native build systems (Cargo/Go/Python). Applied to `Infisical/agent-vault` so it builds via `go build` without the web frontend.

<sup>Written for commit 09efcbcea7b33cb49e64c65712442856c36fba00. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1812?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

