### PR TITLE
fix(bun): drop ignoreScripts and optional=false defaults

### DIFF
--- a/config/bun/bunfig.toml
+++ b/config/bun/bunfig.toml
@@ -1,5 +1,3 @@
 [install]
 minimumReleaseAge = 604800
 exact = true
-ignoreScripts = true
-optional = false


### PR DESCRIPTION
These globals broke worktree-style installs in monorepos that ship
platform-native binaries as optional deps (turbo, esbuild, oxlint
bindings, etc) or rely on lifecycle scripts to link them. Keeping
minimumReleaseAge and exact for supply-chain hygiene.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `ignoreScripts` and `optional = false` from `config/bun/bunfig.toml` to restore worktree installs in monorepos that ship platform-native optional deps (e.g., `turbo`, `esbuild`, `oxlint`) or rely on lifecycle scripts. Keep `minimumReleaseAge` and `exact` for supply-chain hygiene.

<sup>Written for commit 1193450f11cfc3643d9ad7b0c984d804e92a4135. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1840?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

