### PR TITLE
chore(bun): make install defaults explicit with rationale

### DIFF
--- a/config/bun/bunfig.toml
+++ b/config/bun/bunfig.toml
@@ -1,3 +1,14 @@
 [install]
+# Supply-chain hygiene: only install packages published at least 7 days ago.
 minimumReleaseAge = 604800
+# Pin exact versions when adding deps (no `^` range prefix).
 exact = true
+# Install optionalDependencies. Required for platform-native binaries shipped
+# as optional deps (turbo, esbuild, oxlint napi bindings, etc). Previously
+# set to `false`, which silently broke fresh installs in monorepos that
+# depend on them — see https://github.com/shunkakinoki/dotfiles/pull/1840.
+optional = true
+# Block arbitrary postinstall scripts as a supply-chain defense. Projects
+# that legitimately need lifecycle scripts must opt in via their own
+# bunfig.toml.
+ignoreScripts = true


### PR DESCRIPTION
## Summary

Restores `optional` and `ignoreScripts` to the bun install config as **explicit values with inline comments** explaining their intent. Both currently fall back to bun's built-in defaults (as of #1840 which removed them); this PR doesn't change behavior, only documents it.

## Why

#1840 fixed a real bug: `optional = false` was silently breaking fresh installs in monorepos that ship platform-native binaries (`@turbo/darwin-arm64`, `@esbuild/*`, oxlint napi bindings, etc) as optionalDependencies. But the fix was a pure deletion — a future reader sees nothing about why those lines aren't there and could re-introduce the bad setting unaware.

Setting them explicitly:
- **`optional = true`** — matches bun's default, but signals "we deliberately want optionalDeps installed; do not flip this back to false."
- **`ignoreScripts = true`** — restores the prior supply-chain defense, also matching bun's *opposite* default. This was lost in #1840.

Net effect vs current main:
- `optional` behavior: unchanged (true either way).
- `ignoreScripts` behavior: changes from `false` (bun default) back to `true`. This re-enables the postinstall-script block that existed before #1840.

## Reviewer notes

- Inline comments link back to #1840 so the context survives.
- If a project legitimately needs lifecycle scripts, it can opt in via its own `bunfig.toml` (project bunfig overrides user-global for `ignoreScripts`, verified separately).
- Note: separate testing showed that `install.optional` from user-global bunfig wins over project bunfig (bun cascade quirk). So a project-level override of `optional = false` won't help — this user-level explicit value is the load-bearing one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Bun install defaults explicit in `config/bun/bunfig.toml` by setting `optional = true` and `ignoreScripts = true` with rationale comments. This keeps optional dependencies installing and restores the postinstall script block removed in #1840.

- **Migration**
  - If a project needs lifecycle scripts, set `install.ignoreScripts = false` in its project `bunfig.toml`.

<sup>Written for commit df86c0687912cfe1811ef23dbb5b19d910a0cc1f. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1841?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

