### PR TITLE
feat(nix): install grok, antigravity, bernstein via llm-agents.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,6 +25,64 @@
         "type": "github"
       }
     },
+    "blueprint": {
+      "inputs": {
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "llm-agents",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776249299,
+        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "blueprint",
+        "type": "github"
+      }
+    },
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": [
+          "llm-agents",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "llm-agents",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "llm-agents",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778446047,
+        "narHash": "sha256-oQvcadh2BCkrog+SGrG6YffKJrveYpjj3TdQJWaKhaM=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "f2bc12af1a6369648aac41041ceeaa0b866599c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
     "cachix": {
       "inputs": {
         "devenv": [
@@ -433,7 +491,7 @@
     "flake-parts_5": {
       "inputs": {
         "nixpkgs-lib": [
-          "neovim-nightly-overlay",
+          "llm-agents",
           "nixpkgs"
         ]
       },
@@ -454,6 +512,27 @@
     "flake-parts_6": {
       "inputs": {
         "nixpkgs-lib": [
+          "neovim-nightly-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_7": {
+      "inputs": {
+        "nixpkgs-lib": [
           "nur",
           "nixpkgs"
         ]
@@ -472,7 +551,7 @@
         "type": "github"
       }
     },
-    "flake-parts_7": {
+    "flake-parts_8": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
@@ -797,6 +876,31 @@
         "type": "github"
       }
     },
+    "llm-agents": {
+      "inputs": {
+        "blueprint": "blueprint",
+        "bun2nix": "bun2nix",
+        "flake-parts": "flake-parts_5",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems_3",
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1779586228,
+        "narHash": "sha256-0OpgH2IfQ0WcPlds47S6aqIEtF+YbQ6MZzKxMvaLEa4=",
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "rev": "2afb09845fe19a28ecf702a0587cc725f85814e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "type": "github"
+      }
+    },
     "mk-shell-bin": {
       "locked": {
         "lastModified": 1677004959,
@@ -814,7 +918,7 @@
     },
     "neovim-nightly-overlay": {
       "inputs": {
-        "flake-parts": "flake-parts_5",
+        "flake-parts": "flake-parts_6",
         "neovim-src": "neovim-src",
         "nixpkgs": [
           "nixpkgs"
@@ -1159,8 +1263,8 @@
           "noctalia-shell",
           "nixpkgs"
         ],
-        "systems": "systems_3",
-        "treefmt-nix": "treefmt-nix_2"
+        "systems": "systems_4",
+        "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
         "lastModified": 1778983195,
@@ -1199,7 +1303,7 @@
     },
     "nur": {
       "inputs": {
-        "flake-parts": "flake-parts_6",
+        "flake-parts": "flake-parts_7",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -1283,6 +1387,7 @@
         "flake-parts": "flake-parts_4",
         "foundry": "foundry",
         "home-manager": "home-manager_2",
+        "llm-agents": "llm-agents",
         "mk-shell-bin": "mk-shell-bin",
         "neovim-nightly-overlay": "neovim-nightly-overlay",
         "nix-darwin": "nix-darwin",
@@ -1296,7 +1401,7 @@
         "nixpkgs-unstable": "nixpkgs-unstable",
         "noctalia-shell": "noctalia-shell",
         "nur": "nur",
-        "treefmt-nix": "treefmt-nix_3",
+        "treefmt-nix": "treefmt-nix_4",
         "xremap": "xremap"
       }
     },
@@ -1354,6 +1459,21 @@
     },
     "systems_3": {
       "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_4": {
+      "locked": {
         "lastModified": 1689347949,
         "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
         "owner": "nix-systems",
@@ -1392,6 +1512,27 @@
     "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_3": {
+      "inputs": {
+        "nixpkgs": [
           "noctalia-shell",
           "noctalia-qs",
           "nixpkgs"
@@ -1411,7 +1552,7 @@
         "type": "github"
       }
     },
-    "treefmt-nix_3": {
+    "treefmt-nix_4": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
@@ -1434,7 +1575,7 @@
     "xremap": {
       "inputs": {
         "crane": "crane",
-        "flake-parts": "flake-parts_7",
+        "flake-parts": "flake-parts_8",
         "nixpkgs": [
           "nixpkgs"
         ],

--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,10 @@
       url = "github:noctalia-dev/noctalia-shell";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    llm-agents = {
+      url = "github:numtide/llm-agents.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/home-manager/nix/nix.nix
+++ b/home-manager/nix/nix.nix
@@ -22,10 +22,10 @@
         "https://yazi.cachix.org"
       ];
       extra-trusted-public-keys = [
-        "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
         "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
-        "cloudtide.cachix.org-1:9NZ1Mah2+u8cd/CmVffFV23z5uFNpZSrhfgTt5fuN/4="
         "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
+        "cloudtide.cachix.org-1:9NZ1Mah2+u8cd/CmVffFV23z5uFNpZSrhfgTt5fuN/4="
+        "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
         "yazi.cachix.org-1:Dcdz63NZKfvUCbDGngQDAZq6kOroIrFoyO064uvLh8k="
       ];
     };

--- a/home-manager/nix/nix.nix
+++ b/home-manager/nix/nix.nix
@@ -16,6 +16,7 @@
       ];
       extra-substituters = [
         "https://cache.garnix.io"
+        "https://cache.numtide.com"
         "https://cloudtide.cachix.org"
         "https://nix-community.cachix.org"
         "https://yazi.cachix.org"
@@ -24,6 +25,7 @@
         "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
         "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
         "cloudtide.cachix.org-1:9NZ1Mah2+u8cd/CmVffFV23z5uFNpZSrhfgTt5fuN/4="
+        "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
         "yazi.cachix.org-1:Dcdz63NZKfvUCbDGngQDAZq6kOroIrFoyO064uvLh8k="
       ];
     };

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -13,17 +13,16 @@ with pkgs;
 [
   inputs.agenix.packages.${stdenv.hostPlatform.system}.default
   pkgs.nur.repos.charmbracelet.crush
-  pkgs.llm-agents.antigravity
-  pkgs.llm-agents.bernstein
-  pkgs.llm-agents.grok
   act
   age
   aichat
+  pkgs.llm-agents.antigravity
   argocd
   ast-grep
   awscli
   azure-cli
   bat
+  pkgs.llm-agents.bernstein
   broot
   bun
   clipse
@@ -61,6 +60,7 @@ with pkgs;
   google-cloud-sdk
   gping
   grc
+  pkgs.llm-agents.grok
   htop
   httpie
   hyperfine

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -13,6 +13,9 @@ with pkgs;
 [
   inputs.agenix.packages.${stdenv.hostPlatform.system}.default
   pkgs.nur.repos.charmbracelet.crush
+  pkgs.llm-agents.antigravity
+  pkgs.llm-agents.bernstein
+  pkgs.llm-agents.grok
   act
   age
   aichat

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -33,6 +33,7 @@
     });
   })
   inputs.noctalia-shell.overlays.default
+  inputs.llm-agents.overlays.default
   (final: prev: {
     nightlyPkgs = import inputs.nixpkgs-nightly {
       inherit (prev) system config;

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -32,8 +32,8 @@
       '';
     });
   })
-  inputs.noctalia-shell.overlays.default
   inputs.llm-agents.overlays.default
+  inputs.noctalia-shell.overlays.default
   (final: prev: {
     nightlyPkgs = import inputs.nixpkgs-nightly {
       inherit (prev) system config;


### PR DESCRIPTION
## Summary

- Add `numtide/llm-agents.nix` as a flake input
- Register its default overlay (exposes `pkgs.llm-agents.*` without shadowing existing packages)
- Install `grok`, `antigravity` (CLI), and `bernstein` to home-manager
- Add `cache.numtide.com` substituter so binary cache is used instead of building from source

## Why

Pulls three agent CLIs into the declarative Nix config so they're managed alongside the rest of the toolchain.

## Notes for reviewer

- The `antigravity` package from `llm-agents.nix` is the CLI (installs as `agy` with an `antigravity` symlink). It is distinct from the existing Antigravity GUI app installed via Homebrew cask in [nix-darwin/config/homebrew.nix](nix-darwin/config/homebrew.nix) and there is no PATH conflict.
- The `llm-agents` default overlay only adds the `pkgs.llm-agents` attrset; it does not override existing `claude-code` / `codex` / `opencode` overrides from `nightlyPkgs` in [overlays/default.nix](overlays/default.nix).
- All three packages support `aarch64-darwin`, `aarch64-linux`, and `x86_64-linux` (the systems declared in `flake.nix`).

## Test plan

- [x] `nix flake lock --update-input llm-agents` succeeds
- [x] `nix eval .#darwinConfigurations.aarch64-darwin.config.home-manager.users.shunkakinoki.home.packages` resolves and includes `antigravity-1.0.1`, `bernstein-2.2.0`, `grok-0.1.218`
- [ ] `darwin-rebuild switch --flake .#aarch64-darwin` on local machine
- [ ] `grok --help`, `agy --help`, `bernstein --help` run after rebuild

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install `grok`, `antigravity` (CLI), and `bernstein` via `numtide/llm-agents.nix` and manage them with Home Manager. Add `cache.numtide.com` to use the binary cache and avoid local builds.

- **Dependencies**
  - Add `llm-agents` flake input and register `inputs.llm-agents.overlays.default` (exposes `pkgs.llm-agents.*` without overriding existing overlays).
  - Install `pkgs.llm-agents.{grok, antigravity (CLI `agy`), bernstein}` in `home.packages`; no conflict with the Homebrew Antigravity GUI app.
  - Add `https://cache.numtide.com` to `extra-substituters` with its public key to enable prebuilt binaries.
  - Sort package entries, overlay list, and align `extra-trusted-public-keys` order with `extra-substituters`.
  - Works on `aarch64-darwin`, `aarch64-linux`, and `x86_64-linux`.

<sup>Written for commit 33ebf73337ce2544dd09f03f6cfdd0be676976e6. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1844?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

