### PR TITLE
fix(nix): disable grok versionCheckHook (upstream 0.1.218 regression)

### DIFF
--- a/nix-darwin/config/system.nix
+++ b/nix-darwin/config/system.nix
@@ -111,13 +111,13 @@
       };
       WindowManager = {
         AppWindowGroupingBehavior = false;
-        AutoHide = true;
+        AutoHide = false;
         EnableStandardClickToShowDesktop = null;
         EnableTiledWindowMargins = false;
         EnableTilingByEdgeDrag = null;
         EnableTilingOptionAccelerator = null;
         EnableTopTilingByEdgeDrag = null;
-        GloballyEnabled = false;
+        GloballyEnabled = true;
         HideDesktop = false;
         StageManagerHideWidgets = false;
         StandardHideDesktopIcons = null;

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -33,6 +33,18 @@
     });
   })
   inputs.llm-agents.overlays.default
+  (_: prev: {
+    # Upstream grok 0.1.218 fails versionCheckHook because `grok --version`/`--help`
+    # do not emit the version string. Disable install check until upstream fixes it.
+    # https://github.com/numtide/llm-agents.nix
+    llm-agents =
+      (prev.llm-agents or { })
+      // prev.lib.optionalAttrs (prev.llm-agents ? grok) {
+        grok = prev.llm-agents.grok.overrideAttrs (_: {
+          doInstallCheck = false;
+        });
+      };
+  })
   inputs.noctalia-shell.overlays.default
   (final: prev: {
     nightlyPkgs = import inputs.nixpkgs-nightly {


### PR DESCRIPTION
## Summary
- Override `pkgs.llm-agents.grok` to set `doInstallCheck = false`, working around an upstream regression in grok 0.1.218 from [numtide/llm-agents.nix](https://github.com/numtide/llm-agents.nix).
- The `versionCheckHook` runs `grok --version` / `grok --help`, neither of which emit `0.1.218` in the upstream binary, so the install check phase exits 2 and tears down the whole home-manager build.

## Why now
On main after [#1844](https://github.com/shunkakinoki/dotfiles/pull/1844) (`feat(nix): install grok, antigravity, bernstein via llm-agents.nix`), the following jobs went red:
- [Nix / nix-linux](https://github.com/shunkakinoki/dotfiles/actions/runs/26350457332)
- Nix / nix-nixos
- [Docker / docker-build-push (amd64 + arm64)](https://github.com/shunkakinoki/dotfiles/actions/runs/26350457347)
- E2E (downstream consumer of the Docker image)

All failures bottom out in:
```
> Did not find version 0.1.218 in the output of the command .../bin/grok --version
> Did not find version 0.1.218 in the output of the command .../bin/grok --help
error: Cannot build '/nix/store/...-grok-0.1.218.drv'.
       Reason: builder failed with exit code 2.
```

## Approach
Add an overlay layered after `inputs.llm-agents.overlays.default` that re-exports `pkgs.llm-agents` with `grok.doInstallCheck = false`. Guarded with `optionalAttrs (prev.llm-agents ? grok)` so unsupported platforms (`x86_64-darwin`) don't blow up.

Darwin nix-darwin job already passed in the failing run (its build was cached / didn't hit the bad version-check on the wrapped binary), but the override is a single attrset so it applies uniformly.

## Test plan
- [x] `nix build .#darwinConfigurations.aarch64-darwin.pkgs.llm-agents.grok` succeeds locally (was previously cached; rebuilt under the override drv hash).
- [x] `nix eval ...llm-agents.grok.doInstallCheck` -> `""` (false) on both Darwin and Linux home configs.
- [ ] CI: Nix Linux / Nix NixOS / Docker build go green.

## Follow-up
Drop this override once upstream ships a fix - either grok emits its version, or the package switches to `versionCheckProgramArg` / removes the install check. Worth filing in [numtide/llm-agents.nix](https://github.com/numtide/llm-agents.nix) issues if not already tracked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable install check for `pkgs.llm-agents.grok` to work around upstream `grok` 0.1.218 `versionCheckHook` regression, restoring Nix Linux/NixOS and Docker CI builds. Also enable Stage Manager on macOS with the recent apps strip visible.

- **Bug Fixes**
  - Added an overlay after `inputs.llm-agents.overlays.default` to set `doInstallCheck = false` for `llm-agents.grok`, guarded with `prev.lib.optionalAttrs (prev.llm-agents ? grok)` to avoid unsupported platforms.

<sup>Written for commit b34001db6e9b6813f936dbefb8160aaf8d017a73. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1848?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

