### PR TITLE
feat(home-manager): auto-copy macOS screenshots to clipboard

### DIFF
--- a/home-manager/modules/local-scripts/clipboard-copy-image.sh
+++ b/home-manager/modules/local-scripts/clipboard-copy-image.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  printf 'usage: clipboard-copy-image FILE\n' >&2
+  exit 2
+fi
+
+file=$1
+
+if [[ ! -f $file ]]; then
+  printf 'clipboard-copy-image: file not found: %s\n' "$file" >&2
+  exit 1
+fi
+
+# macOS: AppleScript reads the file as «class PNGf» so receivers paste it as
+# an image. Piping PNG bytes through pbcopy would store them as text and
+# break image paste in Slack, Messages, browsers, etc.
+if command -v osascript >/dev/null 2>&1; then
+  escaped=${file//\\/\\\\}
+  escaped=${escaped//\"/\\\"}
+  osascript -e "set the clipboard to (read (POSIX file \"$escaped\") as «class PNGf»)"
+  exit 0
+fi
+
+if [[ -n ${WAYLAND_DISPLAY:-} ]] && command -v wl-copy >/dev/null 2>&1; then
+  wl-copy --type image/png <"$file"
+  exit 0
+fi
+
+if command -v xclip >/dev/null 2>&1; then
+  xclip -selection clipboard -t image/png -i "$file"
+  exit 0
+fi
+
+printf 'No image clipboard backend available\n' >&2
+exit 1

--- a/home-manager/modules/local-scripts/clipboard-copy-image.sh
+++ b/home-manager/modules/local-scripts/clipboard-copy-image.sh
@@ -16,11 +16,15 @@ fi
 
 # macOS: AppleScript reads the file as «class PNGf» so receivers paste it as
 # an image. Piping PNG bytes through pbcopy would store them as text and
-# break image paste in Slack, Messages, browsers, etc.
+# break image paste in Slack, Messages, browsers, etc. The path is passed as
+# a positional arg to a `run` handler so no shell interpolation reaches the
+# AppleScript source - this avoids quote/backslash/$(...) injection.
 if command -v osascript >/dev/null 2>&1; then
-  escaped=${file//\\/\\\\}
-  escaped=${escaped//\"/\\\"}
-  osascript -e "set the clipboard to (read (POSIX file \"$escaped\") as «class PNGf»)"
+  osascript \
+    -e 'on run {f}' \
+    -e 'set the clipboard to (read (POSIX file f) as «class PNGf»)' \
+    -e 'end run' \
+    "$file"
   exit 0
 fi
 

--- a/home-manager/modules/local-scripts/default.nix
+++ b/home-manager/modules/local-scripts/default.nix
@@ -4,6 +4,11 @@ _: {
     force = true;
     source = ./clipboard-copy.sh;
   };
+  home.file.".local/scripts/clipboard-copy-image" = {
+    executable = true;
+    force = true;
+    source = ./clipboard-copy-image.sh;
+  };
   home.file.".local/scripts/clipboard-paste" = {
     executable = true;
     force = true;

--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -26,6 +26,7 @@ let
   openclaw = ./openclaw;
   paperclip = ./paperclip;
   roborev = ./roborev;
+  screenshotClipboard = import ./screenshot-clipboard { inherit pkgs; };
   sshAgent = ./ssh-agent;
   tmuxSessionLogger = import ./tmux-session-logger { inherit pkgs; };
 in
@@ -50,6 +51,7 @@ in
   openclaw
   paperclip
   roborev
+  screenshotClipboard
   sshAgent
   tmuxSessionLogger
 ]

--- a/home-manager/services/screenshot-clipboard/default.nix
+++ b/home-manager/services/screenshot-clipboard/default.nix
@@ -24,4 +24,30 @@ in
       StandardErrorPath = "/tmp/screenshot-clipboard.error.log";
     };
   };
+
+  systemd.user.services.screenshot-clipboard = lib.mkIf pkgs.stdenv.isLinux {
+    Unit = {
+      Description = "Auto-copy screenshots to clipboard";
+      PartOf = [ "graphical-session.target" ];
+      After = [ "graphical-session.target" ];
+    };
+    Service = {
+      Type = "simple";
+      Environment = "PATH=${
+        lib.makeBinPath [
+          pkgs.bash
+          pkgs.coreutils
+          pkgs.fswatch
+          pkgs.wl-clipboard
+          pkgs.xclip
+        ]
+      }";
+      ExecStart = "${pkgs.bash}/bin/bash ${./watch.sh}";
+      Restart = "always";
+      RestartSec = 10;
+    };
+    Install = {
+      WantedBy = [ "graphical-session.target" ];
+    };
+  };
 }

--- a/home-manager/services/screenshot-clipboard/default.nix
+++ b/home-manager/services/screenshot-clipboard/default.nix
@@ -1,6 +1,8 @@
-{ pkgs, ... }:
+{ pkgs }:
+{ config, ... }:
 let
   inherit (pkgs) lib;
+  logDir = "${config.home.homeDirectory}/Library/Logs";
 in
 {
   launchd.agents.screenshot-clipboard = lib.mkIf pkgs.stdenv.isDarwin {
@@ -18,10 +20,15 @@ in
         }:/usr/bin:/bin";
       };
       RunAtLoad = true;
-      KeepAlive = true;
+      # Restart on crash/non-zero exit, but throttle to avoid a tight loop if
+      # a prereq (fswatch, helper script) is missing during early activation.
+      KeepAlive = {
+        SuccessfulExit = false;
+      };
+      ThrottleInterval = 30;
       ProcessType = "Background";
-      StandardOutPath = "/tmp/screenshot-clipboard.log";
-      StandardErrorPath = "/tmp/screenshot-clipboard.error.log";
+      StandardOutPath = "${logDir}/screenshot-clipboard.log";
+      StandardErrorPath = "${logDir}/screenshot-clipboard.error.log";
     };
   };
 
@@ -43,8 +50,8 @@ in
         ]
       }";
       ExecStart = "${pkgs.bash}/bin/bash ${./watch.sh}";
-      Restart = "always";
-      RestartSec = 10;
+      Restart = "on-failure";
+      RestartSec = 30;
     };
     Install = {
       WantedBy = [ "graphical-session.target" ];

--- a/home-manager/services/screenshot-clipboard/default.nix
+++ b/home-manager/services/screenshot-clipboard/default.nix
@@ -1,0 +1,27 @@
+{ pkgs, ... }:
+let
+  inherit (pkgs) lib;
+in
+{
+  launchd.agents.screenshot-clipboard = lib.mkIf pkgs.stdenv.isDarwin {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "${pkgs.bash}/bin/bash"
+        "${./watch.sh}"
+      ];
+      EnvironmentVariables = {
+        PATH = "${
+          lib.makeBinPath [
+            pkgs.fswatch
+          ]
+        }:/usr/bin:/bin";
+      };
+      RunAtLoad = true;
+      KeepAlive = true;
+      ProcessType = "Background";
+      StandardOutPath = "/tmp/screenshot-clipboard.log";
+      StandardErrorPath = "/tmp/screenshot-clipboard.error.log";
+    };
+  };
+}

--- a/home-manager/services/screenshot-clipboard/watch.sh
+++ b/home-manager/services/screenshot-clipboard/watch.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -eu
+
+DESKTOP_DIR="$HOME/Desktop"
+CLIPBOARD_COPY_IMAGE="$HOME/.local/scripts/clipboard-copy-image"
+
+if ! command -v fswatch >/dev/null 2>&1; then
+  echo "fswatch not found; screenshot-clipboard agent disabled" >&2
+  exit 1
+fi
+
+if [ ! -x "$CLIPBOARD_COPY_IMAGE" ]; then
+  echo "clipboard-copy-image not found at $CLIPBOARD_COPY_IMAGE" >&2
+  exit 1
+fi
+
+mkdir -p "$DESKTOP_DIR"
+
+echo "Watching $DESKTOP_DIR for screenshots..."
+
+# macOS writes screenshots atomically via a rename, so fswatch reports the
+# final path once writing has completed. The case glob matches both the
+# current default ("Screenshot ...") and the legacy ("Screen Shot ...")
+# filenames to keep working if locale or macOS version changes them.
+fswatch --event=Created --event=MovedTo --event=Renamed -0 "$DESKTOP_DIR" |
+  while IFS= read -r -d '' path; do
+    case "$path" in
+    *"/Screenshot "*.png | *"/Screen Shot "*.png)
+      "$CLIPBOARD_COPY_IMAGE" "$path" || true
+      ;;
+    esac
+  done

--- a/home-manager/services/screenshot-clipboard/watch.sh
+++ b/home-manager/services/screenshot-clipboard/watch.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -euo pipefail
 
 DESKTOP_DIR="$HOME/Desktop"
 CLIPBOARD_COPY_IMAGE="$HOME/.local/scripts/clipboard-copy-image"
@@ -21,6 +21,9 @@ echo "Watching $DESKTOP_DIR for screenshots..."
 
 # Screenshots are written atomically (macOS via rename, hyprshot via mv from
 # a temp path), so fswatch reports the final path once writing has finished.
+# fswatch on macOS uses FSEvents which is always recursive, so the patterns
+# are anchored to "$DESKTOP_DIR/" to ignore screenshots inside subfolders
+# (e.g. project directories) and only react to fresh top-level captures.
 # Patterns:
 #   - "Screenshot ..." / "Screen Shot ..." : macOS defaults (current / legacy)
 #   - "*_hyprshot.png"                     : hyprshot default name on Linux
@@ -28,7 +31,10 @@ echo "Watching $DESKTOP_DIR for screenshots..."
 fswatch --event=Created --event=MovedTo --event=Renamed -0 "$DESKTOP_DIR" |
   while IFS= read -r -d '' path; do
     case "$path" in
-    *"/Screenshot "*.png | *"/Screen Shot "*.png | *_hyprshot.png | *"/swappy-"*.png)
+    "$DESKTOP_DIR/Screenshot "*.png | \
+      "$DESKTOP_DIR/Screen Shot "*.png | \
+      "$DESKTOP_DIR/"*_hyprshot.png | \
+      "$DESKTOP_DIR/swappy-"*.png)
       "$CLIPBOARD_COPY_IMAGE" "$path" || true
       ;;
     esac

--- a/home-manager/services/screenshot-clipboard/watch.sh
+++ b/home-manager/services/screenshot-clipboard/watch.sh
@@ -19,14 +19,16 @@ mkdir -p "$DESKTOP_DIR"
 
 echo "Watching $DESKTOP_DIR for screenshots..."
 
-# macOS writes screenshots atomically via a rename, so fswatch reports the
-# final path once writing has completed. The case glob matches both the
-# current default ("Screenshot ...") and the legacy ("Screen Shot ...")
-# filenames to keep working if locale or macOS version changes them.
+# Screenshots are written atomically (macOS via rename, hyprshot via mv from
+# a temp path), so fswatch reports the final path once writing has finished.
+# Patterns:
+#   - "Screenshot ..." / "Screen Shot ..." : macOS defaults (current / legacy)
+#   - "*_hyprshot.png"                     : hyprshot default name on Linux
+#   - "swappy-*.png"                       : grim | swappy default name
 fswatch --event=Created --event=MovedTo --event=Renamed -0 "$DESKTOP_DIR" |
   while IFS= read -r -d '' path; do
     case "$path" in
-    *"/Screenshot "*.png | *"/Screen Shot "*.png)
+    *"/Screenshot "*.png | *"/Screen Shot "*.png | *_hyprshot.png | *"/swappy-"*.png)
       "$CLIPBOARD_COPY_IMAGE" "$path" || true
       ;;
     esac

--- a/home-manager/services/screenshot-clipboard/watch.sh
+++ b/home-manager/services/screenshot-clipboard/watch.sh
@@ -27,14 +27,13 @@ echo "Watching $DESKTOP_DIR for screenshots..."
 # Patterns:
 #   - "Screenshot ..." / "Screen Shot ..." : macOS defaults (current / legacy)
 #   - "*_hyprshot.png"                     : hyprshot default name on Linux
-#   - "swappy-*.png"                       : grim | swappy default name
+#     (HYPRSHOT_DIR is set to $HOME/Desktop in config/hyprland/hyprland.conf)
 fswatch --event=Created --event=MovedTo --event=Renamed -0 "$DESKTOP_DIR" |
   while IFS= read -r -d '' path; do
     case "$path" in
     "$DESKTOP_DIR/Screenshot "*.png | \
       "$DESKTOP_DIR/Screen Shot "*.png | \
-      "$DESKTOP_DIR/"*_hyprshot.png | \
-      "$DESKTOP_DIR/swappy-"*.png)
+      "$DESKTOP_DIR/"*_hyprshot.png)
       "$CLIPBOARD_COPY_IMAGE" "$path" || true
       ;;
     esac

--- a/nix-darwin/config/system.nix
+++ b/nix-darwin/config/system.nix
@@ -53,6 +53,11 @@
           "NSStatusItem VisibleCC Clock" = true;
           "NSStatusItem VisibleCC WiFi" = true;
         };
+        # Stage Manager: "Show windows from an application: All at Once"
+        # (false would be "One at a Time").
+        "com.apple.WindowManager" = {
+          AppWindowGroupingBehavior = true;
+        };
       };
       NSGlobalDomain = {
         AppleEnableMouseSwipeNavigateWithScrolls = null;

--- a/spec/clipboard_copy_image_spec.sh
+++ b/spec/clipboard_copy_image_spec.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'clipboard-copy-image.sh'
+SCRIPT="$PWD/home-manager/modules/local-scripts/clipboard-copy-image.sh"
+
+It 'exits with usage error when no args'
+When run bash "$SCRIPT"
+The status should equal 2
+The stderr should include 'usage:'
+End
+
+It 'exits with error when file does not exist'
+When run bash "$SCRIPT" /nonexistent/file.png
+The status should equal 1
+The stderr should include 'file not found'
+End
+
+Describe 'when osascript is available'
+setup() {
+  TEST_DIR=$(mktemp -d)
+  TEST_FILE="$TEST_DIR/test.png"
+  : >"$TEST_FILE"
+  mock_bin_setup osascript
+}
+cleanup() {
+  rm -rf "$TEST_DIR"
+  mock_bin_cleanup
+}
+Before 'setup'
+After 'cleanup'
+
+It 'uses osascript'
+When run bash "$SCRIPT" "$TEST_FILE"
+The status should be success
+End
+End
+
+Describe 'when wl-copy is available on Wayland'
+setup() {
+  TEST_DIR=$(mktemp -d)
+  TEST_FILE="$TEST_DIR/test.png"
+  : >"$TEST_FILE"
+  mock_bin_setup wl-copy
+  # Restrict PATH so osascript (higher priority) is hidden
+  local bash_dir
+  bash_dir="$(resolve_cmd_dir bash)"
+  export PATH="$MOCK_BIN:$bash_dir"
+  export WAYLAND_DISPLAY=wayland-0
+}
+cleanup() {
+  rm -rf "$TEST_DIR"
+  unset WAYLAND_DISPLAY
+  mock_bin_cleanup
+}
+Before 'setup'
+After 'cleanup'
+
+It 'uses wl-copy'
+When run bash "$SCRIPT" "$TEST_FILE"
+The status should be success
+End
+End
+
+Describe 'when xclip is available'
+setup() {
+  TEST_DIR=$(mktemp -d)
+  TEST_FILE="$TEST_DIR/test.png"
+  : >"$TEST_FILE"
+  mock_bin_setup xclip
+  local bash_dir
+  bash_dir="$(resolve_cmd_dir bash)"
+  export PATH="$MOCK_BIN:$bash_dir"
+  unset WAYLAND_DISPLAY
+}
+cleanup() {
+  rm -rf "$TEST_DIR"
+  mock_bin_cleanup
+}
+Before 'setup'
+After 'cleanup'
+
+It 'uses xclip'
+When run bash "$SCRIPT" "$TEST_FILE"
+The status should be success
+End
+End
+
+Describe 'when no clipboard backend is available'
+setup() {
+  TEST_DIR=$(mktemp -d)
+  TEST_FILE="$TEST_DIR/test.png"
+  : >"$TEST_FILE"
+  MOCK_BIN="$(mktemp -d)"
+  MOCK_ORIGINAL_PATH="${PATH:-}"
+  MOCK_ORIGINAL_WAYLAND="${WAYLAND_DISPLAY:-}"
+  ln -sf "$(command -v bash)" "$MOCK_BIN/bash"
+  ln -sf "$(command -v printf)" "$MOCK_BIN/printf" 2>/dev/null || true
+  export PATH="$MOCK_BIN"
+  unset WAYLAND_DISPLAY
+  export MOCK_BIN MOCK_ORIGINAL_PATH MOCK_ORIGINAL_WAYLAND
+}
+cleanup() {
+  export PATH="$MOCK_ORIGINAL_PATH"
+  if [ -n "$MOCK_ORIGINAL_WAYLAND" ]; then
+    export WAYLAND_DISPLAY="$MOCK_ORIGINAL_WAYLAND"
+  fi
+  rm -rf "$TEST_DIR" "$MOCK_BIN"
+  unset MOCK_BIN MOCK_ORIGINAL_PATH MOCK_ORIGINAL_WAYLAND
+}
+Before 'setup'
+After 'cleanup'
+
+It 'exits with error'
+When run bash "$SCRIPT" "$TEST_FILE"
+The status should be failure
+The stderr should include 'No image clipboard backend available'
+End
+End
+End

--- a/spec/clipboard_copy_image_spec.sh
+++ b/spec/clipboard_copy_image_spec.sh
@@ -49,9 +49,9 @@ setup() {
   export WAYLAND_DISPLAY=wayland-0
 }
 cleanup() {
+  mock_bin_cleanup
   rm -rf "$TEST_DIR"
   unset WAYLAND_DISPLAY
-  mock_bin_cleanup
 }
 Before 'setup'
 After 'cleanup'
@@ -74,8 +74,8 @@ setup() {
   unset WAYLAND_DISPLAY
 }
 cleanup() {
-  rm -rf "$TEST_DIR"
   mock_bin_cleanup
+  rm -rf "$TEST_DIR"
 }
 Before 'setup'
 After 'cleanup'

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -81,6 +81,14 @@ It 'has spec file for home-manager/services/code-syncer/sync.sh'
 The path "spec/code_syncer_spec.sh" should be exist
 End
 
+It 'has spec file for home-manager/modules/local-scripts/clipboard-copy-image.sh'
+The path "spec/clipboard_copy_image_spec.sh" should be exist
+End
+
+It 'has spec file for home-manager/services/screenshot-clipboard/watch.sh'
+The path "spec/screenshot_clipboard_spec.sh" should be exist
+End
+
 It 'has spec file for home-manager/services/docker-postgres/start-postgres.sh'
 The path "spec/docker_postgres_spec.sh" should be exist
 End
@@ -404,6 +412,7 @@ home-manager/modules/bin-shells/activate.sh
 home-manager/modules/cargo-globals/install-cargo-globals.sh
 home-manager/modules/local-binaries/sync-local-binaries.sh
 home-manager/modules/local-scripts/clipboard-copy.sh
+home-manager/modules/local-scripts/clipboard-copy-image.sh
 home-manager/modules/local-scripts/clipboard-paste.sh
 home-manager/modules/local-scripts/decafinate.sh
 home-manager/modules/local-scripts/notify-local.sh
@@ -437,6 +446,7 @@ home-manager/services/cliproxyapi/scripts/keychain-sync.sh
 home-manager/services/cliproxyapi/scripts/start.sh
 home-manager/services/cliproxyapi/scripts/wrapper.sh
 home-manager/services/code-syncer/sync.sh
+home-manager/services/screenshot-clipboard/watch.sh
 home-manager/services/docker-postgres/start-postgres-wrapper.sh
 home-manager/services/docker-postgres/start-postgres.sh
 home-manager/services/docker/docker-setup.sh

--- a/spec/screenshot_clipboard_spec.sh
+++ b/spec/screenshot_clipboard_spec.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'screenshot-clipboard/watch.sh'
+SCRIPT="$PWD/home-manager/services/screenshot-clipboard/watch.sh"
+
+It 'is syntactically valid bash'
+When run bash -n "$SCRIPT"
+The status should be success
+End
+
+It 'matches macOS screenshot patterns'
+When run grep -F 'Screenshot ' "$SCRIPT"
+The status should be success
+The output should include 'Screenshot'
+End
+
+It 'matches hyprshot pattern'
+When run grep -F '_hyprshot.png' "$SCRIPT"
+The status should be success
+The output should include '_hyprshot.png'
+End
+
+It 'matches swappy pattern'
+When run grep -F 'swappy-' "$SCRIPT"
+The status should be success
+The output should include 'swappy-'
+End
+
+Describe 'when fswatch is missing'
+setup() {
+  TEMP_HOME=$(mktemp -d)
+  MOCK_BIN="$(mktemp -d)"
+  MOCK_ORIGINAL_PATH="${PATH:-}"
+  ln -sf "$(command -v bash)" "$MOCK_BIN/bash"
+  ln -sf "$(command -v mkdir)" "$MOCK_BIN/mkdir"
+  ln -sf "$(command -v command)" "$MOCK_BIN/command" 2>/dev/null || true
+  export PATH="$MOCK_BIN"
+  export HOME="$TEMP_HOME"
+  mkdir -p "$HOME/Desktop"
+  export MOCK_BIN MOCK_ORIGINAL_PATH TEMP_HOME
+}
+cleanup() {
+  export PATH="$MOCK_ORIGINAL_PATH"
+  rm -rf "$MOCK_BIN" "$TEMP_HOME"
+  unset MOCK_BIN MOCK_ORIGINAL_PATH TEMP_HOME
+}
+Before 'setup'
+After 'cleanup'
+
+It 'exits with error'
+When run bash "$SCRIPT"
+The status should be failure
+The stderr should include 'fswatch not found'
+End
+End
+
+Describe 'when clipboard-copy-image is missing'
+setup() {
+  TEMP_HOME=$(mktemp -d)
+  MOCK_BIN="$(mktemp -d)"
+  MOCK_ORIGINAL_PATH="${PATH:-}"
+  ln -sf "$(command -v bash)" "$MOCK_BIN/bash"
+  ln -sf "$(command -v mkdir)" "$MOCK_BIN/mkdir"
+  cat >"$MOCK_BIN/fswatch" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$MOCK_BIN/fswatch"
+  export PATH="$MOCK_BIN"
+  export HOME="$TEMP_HOME"
+  mkdir -p "$HOME/Desktop"
+  export MOCK_BIN MOCK_ORIGINAL_PATH TEMP_HOME
+}
+cleanup() {
+  export PATH="$MOCK_ORIGINAL_PATH"
+  rm -rf "$MOCK_BIN" "$TEMP_HOME"
+  unset MOCK_BIN MOCK_ORIGINAL_PATH TEMP_HOME
+}
+Before 'setup'
+After 'cleanup'
+
+It 'exits with error'
+When run bash "$SCRIPT"
+The status should be failure
+The stderr should include 'clipboard-copy-image not found'
+End
+End
+End

--- a/spec/screenshot_clipboard_spec.sh
+++ b/spec/screenshot_clipboard_spec.sh
@@ -9,22 +9,20 @@ When run bash -n "$SCRIPT"
 The status should be success
 End
 
-It 'matches macOS screenshot patterns'
-When run grep -F 'Screenshot ' "$SCRIPT"
+# Extract only the case-arm logic (between "case" and "esac") so the
+# assertions can't be satisfied by matching the documentation comments.
+It 'declares screenshot patterns in case-arm logic'
+When run awk '/case "\$path" in/,/esac/' "$SCRIPT"
 The status should be success
-The output should include 'Screenshot'
-End
-
-It 'matches hyprshot pattern'
-When run grep -F '_hyprshot.png' "$SCRIPT"
-The status should be success
+The output should include 'Screenshot '
+The output should include 'Screen Shot '
 The output should include '_hyprshot.png'
 End
 
-It 'matches swappy pattern'
-When run grep -F 'swappy-' "$SCRIPT"
+It 'anchors patterns to $DESKTOP_DIR to avoid subfolder matches'
+When run awk '/case "\$path" in/,/esac/' "$SCRIPT"
 The status should be success
-The output should include 'swappy-'
+The output should include '"$DESKTOP_DIR/'
 End
 
 Describe 'when fswatch is missing'


### PR DESCRIPTION
## Summary

- Adds a launchd user agent (`screenshot-clipboard`) that watches `~/Desktop` with `fswatch` and copies new screenshots into the clipboard
- Adds a `clipboard-copy-image` helper script next to the existing `clipboard-copy` / `clipboard-paste`, with backends for macOS (`osascript ... as «class PNGf»`), Wayland (`wl-copy`), and X11 (`xclip`)
- Adds shellspec coverage for the new script (usage error, missing file, each backend, no-backend fallback)

## Why

macOS has no native `com.apple.screencapture` setting that does both "save to file" and "copy to clipboard" at once - `target` is one of `file | clipboard | preview | mail`, mutually exclusive. This pairs with the existing `screencapture.location = "~/Desktop"` in `nix-darwin/config/system.nix` so every screenshot lands on Desktop and is immediately pasteable.

`pbcopy` alone is insufficient: piping PNG bytes through it stores them as text and breaks image paste in Slack, Messages, browsers, etc. The new script uses AppleScript to read the file as `«class PNGf»`, which is the only reliable native path.

## Conventions

- Follows the `home-manager/services/code-syncer/` pattern (Darwin-only `launchd.agents.<name>`, `fswatch` on PATH via `EnvironmentVariables`)
- All shell lives in external `.sh` files - passes `scripts/check-nix-inline-scripts.sh`
- `nixfmt` clean, `shfmt -i 2 -s` clean
- shellspec test added alongside the existing clipboard suite

## Test plan

- [x] `shellspec spec/clipboard_copy_image_spec.sh` -> 6/6 pass
- [x] `shellspec spec/clipboard_copy_spec.sh` -> 7/7 pass (no regression)
- [x] `bash scripts/check-nix-inline-scripts.sh` -> clean
- [x] `make nix-format` -> 0 files changed
- [ ] After `make switch`: take a screenshot with Cmd+Shift+4 and paste into Slack/Notes
- [ ] Verify `/tmp/screenshot-clipboard.log` shows the watch starting at login

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically copies new screenshots to the clipboard on macOS and Linux so you can paste them right away. Adds a `launchd` agent and a `systemd --user` service powered by `fswatch`, plus a cross‑platform `clipboard-copy-image` helper.

- **New Features**
  - `screenshot-clipboard`: Darwin `launchd` and Linux `systemd --user` watchers for `~/Desktop`; match macOS “Screenshot…/Screen Shot…” and Linux `*_hyprshot.png`; start on login; restart on failure with a 30s backoff; macOS logs to `~/Library/Logs/screenshot-clipboard*.log`.
  - `clipboard-copy-image` script: macOS uses `osascript` to set clipboard as «class PNGf» via a positional arg run handler; Wayland uses `wl-copy`; X11 uses `xclip`.
  - nix-darwin: persist Stage Manager “All at Once” (`AppWindowGroupingBehavior=true`).

- **Bug Fixes**
  - Hardened watcher: add `pipefail` so `fswatch` errors trigger restarts; anchor patterns to `$DESKTOP_DIR/` to ignore subfolder events.
  - Tests: restore PATH in cleanup; tighten assertions to only the case block via `awk`; drop inert `swappy-*.png` pattern.

<sup>Written for commit f578b4004c173c620f4425d5a95b4385842781fd. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1850?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

