### PR TITLE
chore: bump bun packageManager to 1.3.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,6 +312,17 @@ bun-update: ## Update bun dependencies to latest and regenerate lock file.
 	@bun install
 	@echo "✅ bun dependencies updated"
 
+.PHONY: bun-version-set
+bun-version-set: ## Bump the packageManager bun version in package.json to latest.
+	@echo "📦 Bumping bun packageManager version to latest..."
+	@latest=$$(curl -fsSL https://registry.npmjs.org/bun/latest | jq -r '.version'); \
+		if [ -z "$$latest" ] || [ "$$latest" = "null" ]; then \
+			echo "❌ Failed to fetch latest bun version"; exit 1; \
+		fi; \
+		echo "   → bun@$$latest"; \
+		bun pm pkg set packageManager="bun@$$latest"
+	@echo "✅ bun packageManager version bumped"
+
 .PHONY: cargo-update
 cargo-update: ## Update Rust dependencies to latest and regenerate lock file.
 	@echo "🦀 Updating Cargo dependencies..."

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "bun@1.3.0",
+  "packageManager": "bun@1.3.14",
   "dependencies": {
     "@anthropic-ai/claude-code": "^2.1.143",
     "@augmentcode/auggie": "^0.27.2",


### PR DESCRIPTION
## Summary
- Add `bun-version-set` Makefile target that fetches the latest bun version from npm and updates `packageManager` via `bun pm pkg set`
- Run the target: `bun@1.3.0` -> `bun@1.3.14`

## Test plan
- [x] `make bun-version-set` runs cleanly and updates `package.json`
- [ ] CI passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `bun-version-set` Makefile target to auto-fetch the latest `bun` and update the `packageManager` field via `bun pm pkg set`. Ran it to bump `bun@1.3.0` to `bun@1.3.14`.

<sup>Written for commit 3525f9597c14170d3373cb141d71c9f4fd67c5e4. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1851?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

