### PR TITLE
fix(spec): disable SC2016 in screenshot_clipboard_spec

### DIFF
--- a/spec/screenshot_clipboard_spec.sh
+++ b/spec/screenshot_clipboard_spec.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2329
+# shellcheck disable=SC2329,SC2016
 
 Describe 'screenshot-clipboard/watch.sh'
 SCRIPT="$PWD/home-manager/services/screenshot-clipboard/watch.sh"


### PR DESCRIPTION
## Summary
- Shell workflow on main (run 26386574332) failed because shellcheck SC2016 fired on `spec/screenshot_clipboard_spec.sh` lines 15, 22, 23, 25.
- Single quotes in ShellSpec `It` descriptions, `When run awk` patterns, and `The output should include` assertions are intentional - they need to be literal, not expanded.
- Other spec files (e.g. `atuin_history_spec.sh`, `clipboard_paste_spec.sh`) already disable SC2016 alongside SC2329. Matched that convention.

## Test plan
- [ ] `make shell-check-dev` passes locally
- [ ] Shell workflow goes green on the PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable ShellCheck rule SC2016 in `spec/screenshot_clipboard_spec.sh` to allow literal single quotes and awk patterns, preventing false positives and unblocking CI. Matches other spec files that disable SC2016 alongside SC2329.

<sup>Written for commit 3142e14a6c90b66f2e6538ab116eb2c96b1cab50. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1852?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

