### PR TITLE
fix(nix-darwin): stop writing WindowManager defaults on every switch

### DIFF
--- a/nix-darwin/config/system.nix
+++ b/nix-darwin/config/system.nix
@@ -53,11 +53,6 @@
           "NSStatusItem VisibleCC Clock" = true;
           "NSStatusItem VisibleCC WiFi" = true;
         };
-        # Stage Manager: "Show windows from an application: All at Once"
-        # (false would be "One at a Time").
-        "com.apple.WindowManager" = {
-          AppWindowGroupingBehavior = true;
-        };
       };
       NSGlobalDomain = {
         AppleEnableMouseSwipeNavigateWithScrolls = null;
@@ -113,20 +108,6 @@
         "com.apple.trackpad.forceClick" = true;
         "com.apple.trackpad.scaling" = 3.0;
         "com.apple.trackpad.trackpadCornerClickBehavior" = null;
-      };
-      WindowManager = {
-        AppWindowGroupingBehavior = false;
-        AutoHide = false;
-        EnableStandardClickToShowDesktop = null;
-        EnableTiledWindowMargins = false;
-        EnableTilingByEdgeDrag = null;
-        EnableTilingOptionAccelerator = null;
-        EnableTopTilingByEdgeDrag = null;
-        GloballyEnabled = true;
-        HideDesktop = false;
-        StageManagerHideWidgets = false;
-        StandardHideDesktopIcons = null;
-        StandardHideWidgets = false;
       };
       controlcenter = {
         AirDrop = null;


### PR DESCRIPTION
## Summary
- Remove the `CustomUserPreferences."com.apple.WindowManager"` block and the typed `WindowManager` block from [nix-darwin/config/system.nix](nix-darwin/config/system.nix).
- These two blocks wrote conflicting values for `AppWindowGroupingBehavior` (`true` vs `false`) and rewrote `com.apple.WindowManager` prefs on every `darwin-rebuild switch`.
- Every `make switch` runs `activateSettings -u` via `system.activationScripts.postUserActivation`, which makes WindowManager reload its prefs and re-evaluate Stage Manager / window grouping. That shuffles window frames and wipes out Raycast window-management layouts (e.g. Last Three Fourths) on each rebuild.

## Notes
- Values already in the macOS prefs DB persist; this PR just stops re-writing them on every switch.
- Future WindowManager tweaks should be set manually via `defaults write com.apple.WindowManager ...`.

## Test plan
- [ ] `make build` succeeds.
- [ ] `make switch` succeeds and existing window layout (Raycast Last Three Fourths) survives the rebuild.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop `nix-darwin` from rewriting `com.apple.WindowManager` prefs on each switch to prevent Stage Manager resets and Raycast window layout loss. Removes the `CustomUserPreferences."com.apple.WindowManager"` and typed `WindowManager` blocks from `nix-darwin/config/system.nix`.

- **Bug Fixes**
  - Removed conflicting `AppWindowGroupingBehavior` values that reloaded settings via `activateSettings -u` on `make switch`.
  - Existing prefs remain; apply future tweaks with `defaults write com.apple.WindowManager ...`.

<sup>Written for commit fcec425aa1276db2aaed3bfaacf292e9ff60ed1d. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1853?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

