### PR TITLE
fix(gateway): update Tailscale configuration and change bind address to loopback

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -971,13 +971,17 @@
   },
   "gateway": {
     "mode": "local",
-    "bind": "lan",
+    "bind": "loopback",
+    "tailscale": {
+      "mode": "serve",
+      "resetOnExit": false
+    },
     "controlUi": {
       "allowedOrigins": [
         "http://localhost:18789",
         "http://127.0.0.1:18789",
         "https://openclaw.shunkakinoki.com",
-        "https://kyber.tail950b36.ts.net:18789"
+        "https://kyber.tail950b36.ts.net"
       ]
     },
     "auth": {

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -971,13 +971,17 @@
   },
   "gateway": {
     "mode": "local",
-    "bind": "lan",
+    "bind": "loopback",
+    "tailscale": {
+      "mode": "serve",
+      "resetOnExit": false
+    },
     "controlUi": {
       "allowedOrigins": [
         "http://localhost:18789",
         "http://127.0.0.1:18789",
         "https://openclaw.shunkakinoki.com",
-        "https://kyber.tail950b36.ts.net:18789"
+        "https://kyber.tail950b36.ts.net"
       ]
     },
     "auth": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Tightened gateway exposure and aligned Tailscale access. Gateway now binds to loopback, uses Tailscale serve mode, and allowed origins match the Tailscale HTTPS endpoint.

- **Bug Fixes**
  - Change bind from "lan" to "loopback" to keep the gateway local-only.
  - Add `gateway.tailscale` config: `mode: "serve"`, `resetOnExit: false` for stable Tailscale serving.
  - Update allowed origin from `https://kyber.tail950b36.ts.net:18789` to `https://kyber.tail950b36.ts.net` to match Tailscale HTTPS.

<sup>Written for commit ed126e5e8c6c6f9afb55dc0a3e69b8d66af0f485. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1855?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

