### PR TITLE
feat(nix-darwin): raise kern.tty.ptmx_max to 4096

### DIFF
--- a/nix-darwin/services/default.nix
+++ b/nix-darwin/services/default.nix
@@ -6,8 +6,10 @@
 let
   nixGcModule = import ./nix-gc { inherit lib isRunner; };
   pmsetBatteryPolicyModule = import ./pmset-battery-policy { inherit lib isRunner pkgs; };
+  sysctlPtmxModule = import ./sysctl-ptmx { inherit lib isRunner; };
 in
 [
   nixGcModule
   pmsetBatteryPolicyModule
+  sysctlPtmxModule
 ]

--- a/nix-darwin/services/sysctl-ptmx/default.nix
+++ b/nix-darwin/services/sysctl-ptmx/default.nix
@@ -7,12 +7,18 @@ let
   # macOS default kern.tty.ptmx_max is 511. Electron apps (Claude, Cursor,
   # VS Code) leak PTYs over long sessions; once the cap is hit, new
   # terminals fail with `posix_openpt: Device not configured` (ENXIO).
-  ptmxMax = 4096;
+  #
+  # The XNU kernel rejects values above its hard ceiling with EINVAL
+  # (observed: 4096 rejected, 999 accepted). 999 is the historical XNU
+  # upper bound and the highest reliably-settable value across recent
+  # macOS releases. Errors are swallowed so a future kernel that tightens
+  # the bound further does not break activation.
+  ptmxMax = 999;
 in
 lib.mkIf (!isRunner) {
   launchd.daemons."com.shunkakinoki.sysctl-ptmx" = {
     script = ''
-      /usr/sbin/sysctl -w kern.tty.ptmx_max=${toString ptmxMax}
+      /usr/sbin/sysctl -w kern.tty.ptmx_max=${toString ptmxMax} || true
     '';
     serviceConfig = {
       RunAtLoad = true;

--- a/nix-darwin/services/sysctl-ptmx/default.nix
+++ b/nix-darwin/services/sysctl-ptmx/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  isRunner,
+  ...
+}:
+let
+  # macOS default kern.tty.ptmx_max is 511. Electron apps (Claude, Cursor,
+  # VS Code) leak PTYs over long sessions; once the cap is hit, new
+  # terminals fail with `posix_openpt: Device not configured` (ENXIO).
+  ptmxMax = 4096;
+in
+lib.mkIf (!isRunner) {
+  launchd.daemons."com.shunkakinoki.sysctl-ptmx" = {
+    script = ''
+      /usr/sbin/sysctl -w kern.tty.ptmx_max=${toString ptmxMax}
+    '';
+    serviceConfig = {
+      RunAtLoad = true;
+      KeepAlive = false;
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a `launchd` daemon that sets `kern.tty.ptmx_max=4096` at boot on every nix-darwin host
- Default macOS cap is 511; long-running Electron apps (Claude.app, Cursor, VS Code) leak PTYs and exhaust it, causing `posix_openpt: Device not configured` (ENXIO) when launching new terminals
- Observed in the wild: 527 active PTYs vs 511 cap, Claude.app alone holding 428 — VS Code terminal refused to start

## Implementation

- New module: `nix-darwin/services/sysctl-ptmx/default.nix`
- Wired into `nix-darwin/services/default.nix` alongside `nix-gc` and `pmset-battery-policy`
- Gated on `!isRunner` so CI runners skip it
- Runs `/usr/sbin/sysctl -w kern.tty.ptmx_max=4096` at load; one-shot, no `KeepAlive`

## Test plan

- [x] `nix flake check --no-build` passes for all darwin configs (galactica, runner, default)
- [x] `nixfmt` clean
- [ ] `darwin-rebuild switch` on a host, then `sysctl kern.tty.ptmx_max` returns `4096`
- [ ] Survives reboot (re-runs at launchd load)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the macOS PTY limit by setting `kern.tty.ptmx_max` to 999 on nix-darwin hosts to prevent terminal failures from PTY exhaustion. Avoids "posix_openpt: Device not configured" errors seen with long-running Electron apps like Claude, Cursor, and VS Code.

- **New Features**
  - Added `nix-darwin/services/sysctl-ptmx` launchd daemon to set `kern.tty.ptmx_max=999` at boot; one-shot (`RunAtLoad=true`, `KeepAlive=false`).
  - Respects the XNU ceiling (999) and swallows sysctl errors to tolerate future tighter caps.
  - Wired into `nix-darwin/services/default.nix`; disabled on CI via `!isRunner`.

<sup>Written for commit 9597a74f5e99c1a7d4e69435e60a5973360ecac6. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1857?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

