### PR TITLE
Declare Docker log rotation for Kyber

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -54,3 +54,5 @@ issue-prefix: df
 # Keep bd status checks on the SQL probe path instead of PID-file auto-start.
 dolt.auto-start: "false"
 dolt.idle-timeout: "0"
+
+sync.remote: "git+https://github.com/shunkakinoki/dotfiles.git"

--- a/home-manager/services/docker/daemon.json
+++ b/home-manager/services/docker/daemon.json
@@ -1,0 +1,7 @@
+{
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "100m",
+    "max-file": "3"
+  }
+}

--- a/home-manager/services/docker/default.nix
+++ b/home-manager/services/docker/default.nix
@@ -9,6 +9,9 @@ let
     )
   );
 
+  # Docker daemon defaults installed on Linux hosts.
+  dockerDaemonFile = pkgs.writeText "daemon.json" (builtins.readFile ./daemon.json);
+
   # Script to ensure user is in docker group and system docker is running
   setupDockerScript = pkgs.writeShellScript "setup-docker" (
     builtins.readFile (
@@ -21,6 +24,7 @@ let
           diffutils
           ;
         docker_service_file = dockerServiceFile;
+        docker_daemon_file = dockerDaemonFile;
       }
     )
   );

--- a/home-manager/services/docker/setup-docker.sh
+++ b/home-manager/services/docker/setup-docker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Ensures the user is in the docker group and the system Docker daemon is running.
-# @shadow@, @gnugrep@, @systemd@, @coreutils@, @docker_service_file@, @diffutils@
+# @shadow@, @gnugrep@, @systemd@, @coreutils@, @docker_service_file@, @docker_daemon_file@, @diffutils@
 # are substituted by pkgs.replaceVars.
 set -euo pipefail
 
@@ -11,9 +11,14 @@ GREP=@gnugrep@/bin/grep
 USERMOD=@shadow@/bin/usermod
 SYSTEMCTL=@systemd@/bin/systemctl
 TEE=@coreutils@/bin/tee
+MKDIR=@coreutils@/bin/mkdir
+INSTALL=@coreutils@/bin/install
 DIFF=@diffutils@/bin/diff
 DOCKER_SERVICE_FILE=@docker_service_file@
+DOCKER_DAEMON_FILE=@docker_daemon_file@
 SYSTEM_SERVICE=/etc/systemd/system/docker.service
+DOCKER_CONFIG_DIR=/etc/docker
+DOCKER_DAEMON_CONFIG="$DOCKER_CONFIG_DIR/daemon.json"
 
 # Ensure docker group exists
 if ! getent group docker >/dev/null 2>&1; then
@@ -30,17 +35,35 @@ fi
 
 # Always ensure the service file is up to date (Nix GC can invalidate store paths)
 NEEDS_RELOAD=false
+NEEDS_RESTART=false
 if [ ! -f "$SYSTEM_SERVICE" ]; then
   echo "Installing Docker systemd service..."
   # shellcheck disable=SC2024
   sudo "$TEE" "$SYSTEM_SERVICE" >/dev/null <"$DOCKER_SERVICE_FILE"
   sudo "$SYSTEMCTL" enable docker
   NEEDS_RELOAD=true
+  NEEDS_RESTART=true
 elif ! "$DIFF" -q "$DOCKER_SERVICE_FILE" "$SYSTEM_SERVICE" >/dev/null 2>&1; then
   echo "Updating Docker systemd service (Nix store paths changed)..."
   # shellcheck disable=SC2024
   sudo "$TEE" "$SYSTEM_SERVICE" >/dev/null <"$DOCKER_SERVICE_FILE"
   NEEDS_RELOAD=true
+  NEEDS_RESTART=true
+fi
+
+if [ ! -d "$DOCKER_CONFIG_DIR" ]; then
+  echo "Creating Docker daemon config directory..."
+  sudo "$MKDIR" -p "$DOCKER_CONFIG_DIR"
+fi
+
+if [ ! -f "$DOCKER_DAEMON_CONFIG" ]; then
+  echo "Installing Docker daemon config..."
+  sudo "$INSTALL" -m 0644 "$DOCKER_DAEMON_FILE" "$DOCKER_DAEMON_CONFIG"
+  NEEDS_RESTART=true
+elif ! "$DIFF" -q "$DOCKER_DAEMON_FILE" "$DOCKER_DAEMON_CONFIG" >/dev/null 2>&1; then
+  echo "Updating Docker daemon config..."
+  sudo "$INSTALL" -m 0644 "$DOCKER_DAEMON_FILE" "$DOCKER_DAEMON_CONFIG"
+  NEEDS_RESTART=true
 fi
 
 if [ "$NEEDS_RELOAD" = true ]; then
@@ -72,8 +95,8 @@ if ! "$SYSTEMCTL" is-active --quiet docker 2>/dev/null; then
   echo "Starting Docker daemon..."
   sudo "$SYSTEMCTL" start docker
   echo "Docker daemon started"
-elif [ "$NEEDS_RELOAD" = true ]; then
-  echo "Restarting Docker daemon (service file updated)..."
+elif [ "$NEEDS_RESTART" = true ]; then
+  echo "Restarting Docker daemon (configuration updated)..."
   sudo "$SYSTEMCTL" restart docker
   echo "Docker daemon restarted"
 else

--- a/home-manager/services/paperclip/default.nix
+++ b/home-manager/services/paperclip/default.nix
@@ -8,6 +8,16 @@
 let
   inherit (inputs) host;
   homeDir = config.home.homeDirectory;
+  paperclipNoDockerBin = pkgs.runCommand "paperclip-no-docker-bin" { } ''
+        mkdir -p "$out/bin"
+        cat >"$out/bin/docker" <<'EOF'
+    #!${pkgs.bash}/bin/bash
+    echo "Docker is disabled for the Paperclip service; use the declarative Kyber runtime instead." >&2
+    exit 127
+    EOF
+        chmod +x "$out/bin/docker"
+        ln -s "$out/bin/docker" "$out/bin/docker-compose"
+  '';
 in
 # Only enable on kyber (server host)
 lib.mkIf host.isKyber {
@@ -34,7 +44,8 @@ lib.mkIf host.isKyber {
         "PAPERCLIP_DEPLOYMENT_MODE=authenticated"
         "PAPERCLIP_ALLOWED_HOSTNAMES=paperclip.shunkakinoki.com,172.17.0.1"
         "BETTER_AUTH_URL=https://paperclip.shunkakinoki.com"
-        "PATH=${homeDir}/.local/bin:${homeDir}/.bun/bin:${homeDir}/.nix-profile/bin:${homeDir}/.local/share/pnpm:${homeDir}/.local/share/fnm/current/bin:${homeDir}/.npm-global/bin:/usr/local/bin:/usr/bin:/bin"
+        "DOCKER_HOST=unix:///run/paperclip-docker-disabled.sock"
+        "PATH=${paperclipNoDockerBin}/bin:${homeDir}/.local/bin:${homeDir}/.bun/bin:${homeDir}/.nix-profile/bin:${homeDir}/.local/share/pnpm:${homeDir}/.local/share/fnm/current/bin:${homeDir}/.npm-global/bin:/usr/local/bin:/usr/bin:/bin"
       ];
       EnvironmentFile = [
         "${homeDir}/dotfiles/.env"


### PR DESCRIPTION
## Summary
- add a declarative Docker daemon daemon.json with json-file log rotation capped at 100m x 3 files
- have the Docker setup script install/update /etc/docker/daemon.json and restart Docker when service or daemon config changes
- harden the Kyber Paperclip systemd service so Docker/Compose calls fail inside the service environment

## Verification
- make format shell-lint nix-format-check
- make nix-lint
- git diff --check

## Notes
- Kyber investigation found the large storage usage came primarily from stopped Paperclip Docker Compose containers with unbounded json-file logs, including a 129G Temporal log and a 21G Postgres log.
- This PR prevents recurrence declaratively. Live eviction/removal of old stopped containers should still be done deliberately on Kyber after this rolls out.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Docker daemon log rotation on Kyber to cap `json-file` logs at 100 MB × 3, preventing disk bloat. Also hardens the Paperclip systemd service to block `docker`/`docker-compose` calls inside the service.

- **New Features**
  - Installs `/etc/docker/daemon.json` with `"log-driver": "json-file"` and `"max-size": "100m", "max-file": "3"`.
  - Setup script now manages `daemon.json` and restarts Docker when service or daemon configs change.
  - Disables Docker inside the Paperclip service via a wrapper in `PATH` and `DOCKER_HOST` pointing to a disabled socket.

- **Migration**
  - After deploy, manually prune old stopped containers and large legacy logs on Kyber.

<sup>Written for commit b8e8e8802122ed92c57653ad819785eac2a31a11. Summary will update on new commits. <a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1858?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

