### PR TITLE
feat: add Handy speech-to-text for NixOS desktop hosts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,6 +52,32 @@
     },
     "bun2nix": {
       "inputs": {
+        "flake-parts": "flake-parts_5",
+        "import-tree": "import-tree",
+        "nixpkgs": [
+          "handy",
+          "nixpkgs"
+        ],
+        "systems": "systems_3",
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1770895533,
+        "narHash": "sha256-v3QaK9ugy9bN9RXDnjw0i2OifKmz2NnKM82agtqm/UY=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "c843f477b15f51151f8c6bcc886954699440a6e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "2.0.8",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
+    "bun2nix_2": {
+      "inputs": {
         "flake-parts": [
           "llm-agents",
           "flake-parts"
@@ -490,17 +516,14 @@
     },
     "flake-parts_5": {
       "inputs": {
-        "nixpkgs-lib": [
-          "llm-agents",
-          "nixpkgs"
-        ]
+        "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
         "type": "github"
       },
       "original": {
@@ -512,7 +535,7 @@
     "flake-parts_6": {
       "inputs": {
         "nixpkgs-lib": [
-          "neovim-nightly-overlay",
+          "llm-agents",
           "nixpkgs"
         ]
       },
@@ -533,6 +556,27 @@
     "flake-parts_7": {
       "inputs": {
         "nixpkgs-lib": [
+          "neovim-nightly-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_8": {
+      "inputs": {
+        "nixpkgs-lib": [
           "nur",
           "nixpkgs"
         ]
@@ -551,9 +595,9 @@
         "type": "github"
       }
     },
-    "flake-parts_8": {
+    "flake-parts_9": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_2"
+        "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
         "lastModified": 1765835352,
@@ -834,6 +878,27 @@
         "type": "github"
       }
     },
+    "handy": {
+      "inputs": {
+        "bun2nix": "bun2nix",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779509116,
+        "narHash": "sha256-oRNI7iORPGZOrJc42u2tZLNEcP853mNliibDZRMV9s0=",
+        "owner": "cjpais",
+        "repo": "Handy",
+        "rev": "10a4c31b361722602676105a641a0ddb2fc7612d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cjpais",
+        "repo": "Handy",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -876,16 +941,31 @@
         "type": "github"
       }
     },
+    "import-tree": {
+      "locked": {
+        "lastModified": 1763762820,
+        "narHash": "sha256-ZvYKbFib3AEwiNMLsejb/CWs/OL/srFQ8AogkebEPF0=",
+        "owner": "vic",
+        "repo": "import-tree",
+        "rev": "3c23749d8013ec6daa1d7255057590e9ca726646",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vic",
+        "repo": "import-tree",
+        "type": "github"
+      }
+    },
     "llm-agents": {
       "inputs": {
         "blueprint": "blueprint",
-        "bun2nix": "bun2nix",
-        "flake-parts": "flake-parts_5",
+        "bun2nix": "bun2nix_2",
+        "flake-parts": "flake-parts_6",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_3",
-        "treefmt-nix": "treefmt-nix_2"
+        "systems": "systems_4",
+        "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
         "lastModified": 1779586228,
@@ -918,7 +998,7 @@
     },
     "neovim-nightly-overlay": {
       "inputs": {
-        "flake-parts": "flake-parts_6",
+        "flake-parts": "flake-parts_7",
         "neovim-src": "neovim-src",
         "nixpkgs": [
           "nixpkgs"
@@ -1138,6 +1218,21 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
+        "lastModified": 1769909678,
+        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "72716169fe93074c333e8d0173151350670b824c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_3": {
+      "locked": {
         "lastModified": 1765674936,
         "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
         "owner": "nix-community",
@@ -1263,8 +1358,8 @@
           "noctalia-shell",
           "nixpkgs"
         ],
-        "systems": "systems_4",
-        "treefmt-nix": "treefmt-nix_3"
+        "systems": "systems_5",
+        "treefmt-nix": "treefmt-nix_4"
       },
       "locked": {
         "lastModified": 1778983195,
@@ -1303,7 +1398,7 @@
     },
     "nur": {
       "inputs": {
-        "flake-parts": "flake-parts_7",
+        "flake-parts": "flake-parts_8",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -1386,6 +1481,7 @@
         "devenv": "devenv",
         "flake-parts": "flake-parts_4",
         "foundry": "foundry",
+        "handy": "handy",
         "home-manager": "home-manager_2",
         "llm-agents": "llm-agents",
         "mk-shell-bin": "mk-shell-bin",
@@ -1401,7 +1497,7 @@
         "nixpkgs-unstable": "nixpkgs-unstable",
         "noctalia-shell": "noctalia-shell",
         "nur": "nur",
-        "treefmt-nix": "treefmt-nix_4",
+        "treefmt-nix": "treefmt-nix_5",
         "xremap": "xremap"
       }
     },
@@ -1474,6 +1570,21 @@
     },
     "systems_4": {
       "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_5": {
+      "locked": {
         "lastModified": 1689347949,
         "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
         "owner": "nix-systems",
@@ -1512,6 +1623,28 @@
     "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
+          "handy",
+          "bun2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770228511,
+        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_3": {
+      "inputs": {
+        "nixpkgs": [
           "llm-agents",
           "nixpkgs"
         ]
@@ -1530,7 +1663,7 @@
         "type": "github"
       }
     },
-    "treefmt-nix_3": {
+    "treefmt-nix_4": {
       "inputs": {
         "nixpkgs": [
           "noctalia-shell",
@@ -1552,7 +1685,7 @@
         "type": "github"
       }
     },
-    "treefmt-nix_4": {
+    "treefmt-nix_5": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
@@ -1575,7 +1708,7 @@
     "xremap": {
       "inputs": {
         "crane": "crane",
-        "flake-parts": "flake-parts_8",
+        "flake-parts": "flake-parts_9",
         "nixpkgs": [
           "nixpkgs"
         ],

--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,10 @@
       url = "github:numtide/llm-agents.nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    handy = {
+      url = "github:cjpais/Handy";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -35,6 +35,15 @@ in
       inputs.agenix.homeManagerModules.default
       inputs.xremap.homeManagerModules.default
       inputs.noctalia-shell.homeModules.default
+    ]
+    ++ lib.optionals (pkgs.stdenv.isLinux && inputs.host.isDesktop) [
+      inputs.handy.homeManagerModules.default
+      {
+        services.handy = {
+          enable = true;
+          package = inputs.handy.packages.${pkgs.stdenv.hostPlatform.system}.handy;
+        };
+      }
     ];
 
   home.username = username;

--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -6,6 +6,7 @@
   username,
   hostname ? "x86_64-linux",
   isRunner ? false,
+  isDesktop ? false,
   system ? "x86_64-linux",
   stateVersion ? "24.11",
   userExtraGroups ? [ ],
@@ -160,5 +161,14 @@ inputs.nixpkgs.lib.nixosSystem {
     { nixpkgs.pkgs = pkgs; }
     baseModule
   ]
-  ++ (if modules == null then genericModules else modules);
+  ++ (if modules == null then genericModules else modules)
+  ++ inputs.nixpkgs.lib.optionals isDesktop [
+    inputs.handy.nixosModules.default
+    {
+      programs.handy = {
+        enable = true;
+        package = inputs.handy.packages.${system}.handy;
+      };
+    }
+  ];
 }

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -9,6 +9,7 @@ in
 import ../../hosts/nixos {
   inherit inputs username;
   hostname = "matic";
+  isDesktop = true;
   userExtraGroups = [
     "input"
     "video"
@@ -364,6 +365,7 @@ import ../../hosts/nixos {
           openssl
           zlib
         ];
+
       }
     )
 


### PR DESCRIPTION
## Summary
- Adds [Handy](https://github.com/cjpais/Handy) (offline speech-to-text) as a flake input
- NixOS module (udev + system package) applied to all `isDesktop` hosts via shared builder
- Home Manager module (systemd autostart service) applied to all `isDesktop` Linux hosts
- Introduces `isDesktop` parameter to `hosts/nixos/default.nix` shared builder (default `false`)

## Test plan
- [x] `nix eval .#nixosConfigurations.matic.config.programs.handy.enable` returns `true`
- [x] Non-desktop hosts (viper, x86_64-linux) unaffected
- [x] `nix fmt` passes
- [ ] `make build && make switch` on matic

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds offline speech-to-text on NixOS desktops using `github:cjpais/Handy`, with autostart on login and udev integration. Introduces an `isDesktop` flag so only desktop hosts get it; servers are unchanged.

- **New Features**
  - Add `handy` flake input and wire NixOS/Home Manager modules.
  - Enable `programs.handy` (with udev rules and package) when `isDesktop = true`.
  - Start `services.handy` as a user `systemd` service on Linux desktops.
  - Set `isDesktop = true` for `matic`.

- **Migration**
  - For desktop hosts, set `isDesktop = true` in the shared NixOS builder to enable Handy.

<sup>Written for commit a653b1f0191eb19ea1c21a7c2159449ad4e473f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1867?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

