### PR TITLE
fix(handy): switch keyboard implementation to tauri

### DIFF
--- a/config/handy/settings_store.template.json
+++ b/config/handy/settings_store.template.json
@@ -40,7 +40,7 @@
     "external_script_path": null,
     "extra_recording_buffer_ms": 0,
     "history_limit": 9999999,
-    "keyboard_implementation": "handy_keys",
+    "keyboard_implementation": "tauri",
     "lazy_stream_close": true,
     "log_level": "debug",
     "model_unload_timeout": "never",

--- a/config/handy/settings_store.tpl.json
+++ b/config/handy/settings_store.tpl.json
@@ -40,7 +40,7 @@
     "external_script_path": null,
     "extra_recording_buffer_ms": 0,
     "history_limit": 9999999,
-    "keyboard_implementation": "handy_keys",
+    "keyboard_implementation": "tauri",
     "lazy_stream_close": true,
     "log_level": "debug",
     "model_unload_timeout": "never",


### PR DESCRIPTION
## Summary
- Switch Handy `keyboard_implementation` from `handy_keys` to `tauri`
- `handy_keys` uses `rdev grab()` which exclusively locks evdev devices, conflicting with `keyd` and `xremap` (causes `EBUSY` error loop)
- `tauri` uses Tauri's global shortcut system which coexists with other input grabbers

## Test plan
- [x] Handy starts without `rdev grab error` in logs
- [x] Shortcuts initialized successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Handy’s keyboard implementation from `handy_keys` to `tauri` to avoid evdev lock conflicts (EBUSY) with tools like `keyd` and `xremap`. Updates the default config so shortcuts use Tauri global shortcuts and can coexist with other input grabbers.

<sup>Written for commit e3fb28948bab6f4a0cdb57ecb10ea6e97c7a9751. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1868?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

