### PR TITLE
feat(hyprland): add Handy speech-to-text keybinds

### DIFF
--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -236,6 +236,12 @@ bind = $mod, B, exec, blueman-manager
 bind = $mod, A, exec, pavucontrol
 
 # =============================================================================
+# Handy speech-to-text
+# =============================================================================
+bind = ALT, SPACE, exec, handy --toggle-transcription
+bind = ALT SHIFT, SPACE, exec, handy --toggle-post-process
+
+# =============================================================================
 # Launcher & Clipboard
 # =============================================================================
 bind = CTRL ALT SHIFT SUPER, SPACE, exec, noctalia-shell ipc call launcher toggle


### PR DESCRIPTION
## Summary
- Add Alt+Space (transcribe) and Alt+Shift+Space (transcribe + post-process) keybinds
- Tauri global shortcuts don't work on Wayland, so bind via Hyprland calling `handy --toggle-transcription` / `--toggle-post-process` CLI IPC

## Test plan
- [x] `handy --toggle-transcription` triggers recording on running instance
- [ ] Alt+Space triggers transcription via Hyprland keybind

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Hyprland keybinds for Handy speech-to-text: Alt+Space starts transcription, Alt+Shift+Space starts transcription with post-process. Uses `handy` CLI IPC because `Tauri` global shortcuts don't work on Wayland.

<sup>Written for commit 41c40003028837bae63cf3e51ebfa352db6b91d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1869?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

