### PR TITLE
fix(handy): start hidden, autostart on, auto-submit off

### DIFF
--- a/config/handy/settings_store.template.json
+++ b/config/handy/settings_store.template.json
@@ -5,9 +5,9 @@
     "append_trailing_space": false,
     "audio_feedback": true,
     "audio_feedback_volume": 1.0,
-    "auto_submit": true,
+    "auto_submit": false,
     "auto_submit_key": "enter",
-    "autostart_enabled": false,
+    "autostart_enabled": true,
     "bindings": {
       "cancel": {
         "current_binding": "escape",
@@ -89,7 +89,7 @@
     "selected_output_device": null,
     "show_tray_icon": true,
     "sound_theme": "marimba",
-    "start_hidden": false,
+    "start_hidden": true,
     "translate_to_english": false,
     "typing_tool": "auto",
     "update_checks_enabled": true,

--- a/config/handy/settings_store.tpl.json
+++ b/config/handy/settings_store.tpl.json
@@ -5,9 +5,9 @@
     "append_trailing_space": false,
     "audio_feedback": true,
     "audio_feedback_volume": 1.0,
-    "auto_submit": true,
+    "auto_submit": false,
     "auto_submit_key": "enter",
-    "autostart_enabled": false,
+    "autostart_enabled": true,
     "bindings": {
       "cancel": {
         "current_binding": "escape",
@@ -89,7 +89,7 @@
     "selected_output_device": null,
     "show_tray_icon": true,
     "sound_theme": "marimba",
-    "start_hidden": false,
+    "start_hidden": true,
     "translate_to_english": false,
     "typing_tool": "auto",
     "update_checks_enabled": true,


### PR DESCRIPTION
## Summary
- `auto_submit`: true -> false
- `autostart_enabled`: false -> true
- `start_hidden`: false -> true

Sync Handy template defaults with current live config.

## Test plan
- [ ] `home-manager switch` re-hydrates `settings_store.json`
- [ ] Handy launches on login, starts hidden, does not auto-submit transcripts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync Handy template defaults with the live config: autostart enabled, start hidden, and auto-submit disabled. Handy now launches on login quietly and requires manual submit.

- **Migration**
  - Run `home-manager switch` to re-hydrate `settings_store.json`.

<sup>Written for commit 69ec26e3b334d8068053702fad7019fb528963bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1870?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

