### PR TITLE
fix(handy): hydrate ZAI_API_KEY into settings_store

### DIFF
--- a/config/handy/hydrate.sh
+++ b/config/handy/hydrate.sh
@@ -33,10 +33,15 @@ if [ -z "${OPENROUTER_API_KEY:-}" ]; then
   echo "Warning: OPENROUTER_API_KEY not set, Handy post-processing will be unauthenticated" >&2
 fi
 
+if [ -z "${ZAI_API_KEY:-}" ]; then
+  echo "Warning: ZAI_API_KEY not set, Handy Z.AI provider will be unauthenticated" >&2
+fi
+
 mkdir -p "$DEST_DIR"
 TMP="$(mktemp)"
 @sed@ \
   -e "s|__OPENROUTER_API_KEY__|${OPENROUTER_API_KEY:-}|g" \
+  -e "s|__ZAI_API_KEY__|${ZAI_API_KEY:-}|g" \
   "$TEMPLATE" >"$TMP"
 install -m 0600 "$TMP" "$DEST_DIR/settings_store.json"
 rm -f "$TMP"

--- a/config/handy/settings_store.template.json
+++ b/config/handy/settings_store.template.json
@@ -58,7 +58,7 @@
       "groq": "",
       "openai": "",
       "openrouter": "__OPENROUTER_API_KEY__",
-      "zai": ""
+      "zai": "__ZAI_API_KEY__"
     },
     "post_process_enabled": true,
     "post_process_models": {

--- a/config/handy/settings_store.tpl.json
+++ b/config/handy/settings_store.tpl.json
@@ -58,7 +58,7 @@
       "groq": "",
       "openai": "",
       "openrouter": "__OPENROUTER_API_KEY__",
-      "zai": ""
+      "zai": "__ZAI_API_KEY__"
     },
     "post_process_enabled": true,
     "post_process_models": {


### PR DESCRIPTION
## Summary
- Add `__ZAI_API_KEY__` placeholder to template (zai post-process provider)
- Substitute `ZAI_API_KEY` from `~/dotfiles/.env` in `hydrate.sh`
- Warn when `ZAI_API_KEY` is missing, matching the openrouter behavior

## Test plan
- [ ] `home-manager switch` writes the live `ZAI_API_KEY` into `~/Library/Application Support/com.pais.handy/settings_store.json`
- [ ] Z.AI provider in Handy authenticates without manual key entry

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hydrates ZAI_API_KEY into Handy’s settings_store at build time so the Z.AI provider authenticates without manual input. Adds a missing-key warning consistent with OpenRouter.

- **Bug Fixes**
  - Added __ZAI_API_KEY__ placeholder to both settings_store templates.
  - Updated hydrate.sh to substitute ZAI_API_KEY into settings_store.json.
  - Warn when ZAI_API_KEY is unset.

<sup>Written for commit ff950daa5632d38030db38141458c1fb6925d278. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1871?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

