### PR TITLE
feat(home-manager): add dev/observability CLIs and group into modules

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -121,6 +121,7 @@ with pkgs;
   trippy
   turso-cli
   uv
+  vector
   watchexec
   websocat
   wget

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -13,22 +13,27 @@ with pkgs;
 [
   inputs.agenix.packages.${stdenv.hostPlatform.system}.default
   pkgs.nur.repos.charmbracelet.crush
+  _1password-cli
   act
   age
   aichat
+  angle-grinder
   pkgs.llm-agents.antigravity
   argocd
   ast-grep
   awscli
   azure-cli
+  bandwhich
   bat
   pkgs.llm-agents.bernstein
   broot
   bun
+  choose
   clipse
   cmatrix
   cloudflared
   copybara
+  croc
   curl
   curlie
   cursor-cli
@@ -48,9 +53,12 @@ with pkgs;
   fd
   foundry-bin
   fswatch
+  fx
   fzf-make
   gh
+  gh-dash
   git
+  git-absorb
   gitleaks
   glance
   glow
@@ -61,10 +69,14 @@ with pkgs;
   gping
   grc
   pkgs.llm-agents.grok
+  gron
+  hexyl
   htop
   httpie
   hyperfine
   input-leap
+  iperf3
+  jnv
   jq
   jujutsu
   just
@@ -73,35 +85,44 @@ with pkgs;
   lefthook
   (if stdenv.isLinux && isDesktop then llama-cpp.override { vulkanSupport = true; } else llama-cpp)
   llm
+  lnav
   lsof
   mariadb
   mise
   mkcert
+  mtr
   navi
   ncdu
+  nmap
+  oha
+  opentelemetry-collector-contrib
   pingu
   pnpm
   postgresql_18
+  process-compose
   procs
+  rclone
+  restic
   ripgrep
   sccache
   sd
   shellcheck
   shellspec
+  sops
   speedtest-cli
   sqlite
-  stern
   tealdeer
+  termshark
+  tig
   tmuxinator
   tokei
   tree
   tree-sitter
+  trippy
   turso-cli
   uv
-  victorialogs
-  victoriametrics
-  victoriatraces
   watchexec
+  websocat
   wget
   yarn
   yazi

--- a/home-manager/programs/default.nix
+++ b/home-manager/programs/default.nix
@@ -23,6 +23,7 @@ let
   ghq = import ./ghq;
   git = import ./git;
   go = import ./go;
+  grafana = import ./grafana;
   haskell = import ./haskell;
   java = import ./java;
   k8s = import ./k8s;
@@ -39,6 +40,7 @@ let
   perl = import ./perl;
   php = import ./php;
   prometheus = import ./prometheus;
+  protobuf = import ./protobuf;
   python = import ./python;
   ruby = import ./ruby;
   rust = import ./rust;
@@ -48,6 +50,8 @@ let
   terraform = import ./terraform;
   tms = import ./tms;
   tmux = import ./tmux;
+  vector = import ./vector;
+  victoriametrics = import ./victoriametrics;
   yaml = import ./yaml;
   yazi = import ./yazi;
   zig = import ./zig;
@@ -74,6 +78,7 @@ in
   ghq
   git
   go
+  grafana
   haskell
   java
   k8s
@@ -90,6 +95,7 @@ in
   perl
   php
   prometheus
+  protobuf
   python
   ruby
   rust
@@ -99,6 +105,8 @@ in
   terraform
   tms
   tmux
+  vector
+  victoriametrics
   yaml
   yazi
   zig

--- a/home-manager/programs/default.nix
+++ b/home-manager/programs/default.nix
@@ -50,7 +50,6 @@ let
   terraform = import ./terraform;
   tms = import ./tms;
   tmux = import ./tmux;
-  vector = import ./vector;
   victoriametrics = import ./victoriametrics;
   yaml = import ./yaml;
   yazi = import ./yazi;
@@ -105,7 +104,6 @@ in
   terraform
   tms
   tmux
-  vector
   victoriametrics
   yaml
   yazi

--- a/home-manager/programs/grafana/default.nix
+++ b/home-manager/programs/grafana/default.nix
@@ -1,8 +1,7 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    opentofu
-    terraform
-    terraform-ls
+    grafana-alloy
+    grafana-loki
   ];
 }

--- a/home-manager/programs/k8s/default.nix
+++ b/home-manager/programs/k8s/default.nix
@@ -9,6 +9,7 @@
       kubectx
       kubernetes-helm
       kustomize
+      stern
     ]
     ++ lib.optionals stdenv.isLinux [
       k3s

--- a/home-manager/programs/protobuf/default.nix
+++ b/home-manager/programs/protobuf/default.nix
@@ -1,8 +1,9 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    opentofu
-    terraform
-    terraform-ls
+    buf
+    ghz
+    grpcurl
+    protobuf
   ];
 }

--- a/home-manager/programs/vector/default.nix
+++ b/home-manager/programs/vector/default.nix
@@ -1,8 +1,6 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    opentofu
-    terraform
-    terraform-ls
+    vector
   ];
 }

--- a/home-manager/programs/vector/default.nix
+++ b/home-manager/programs/vector/default.nix
@@ -1,6 +1,0 @@
-{ pkgs, ... }:
-{
-  home.packages = with pkgs; [
-    vector
-  ];
-}

--- a/home-manager/programs/victoriametrics/default.nix
+++ b/home-manager/programs/victoriametrics/default.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [
+    victorialogs
+    victoriametrics
+    victoriatraces
+  ];
+}


### PR DESCRIPTION
## What

Adds a batch of developer and observability CLI tooling to the home-manager config, organized library-specifically (cohesive vendor/ecosystem toolchains as `programs/` modules; unrelated single-vendor CLIs stay flat).

### New `programs/` modules
- **grafana** - `grafana-loki`, `grafana-alloy`
- **vector** - `vector`
- **protobuf** - `buf`, `ghz`, `grpcurl`, `protobuf`
- **victoriametrics** - `victorialogs`, `victoriametrics`, `victoriatraces` (moved from the flat list)

### Extended existing modules
- **k8s** - `+stern`
- **terraform** - `+opentofu`

### Flat additions to `packages/default.nix` (unrelated-vendor CLIs)
`_1password-cli, angle-grinder, bandwhich, choose, croc, fx, gh-dash, git-absorb, gron, hexyl, iperf3, jnv, lnav, mtr, nmap, oha, opentelemetry-collector-contrib, process-compose, rclone, restic, sops, termshark, tig, trippy, websocat`

## Why

The original ask was to install a set of CLIs (Loki / observability led). Organized per the repo convention: cohesive vendor or single-technology toolchains become `programs/<name>` modules (like the existing `k8s` / `prometheus` / `terraform`); unrelated single-vendor CLIs stay flat in `packages/default.nix`.

## Notes / decisions

- **Databases dropped** - duckdb, usql, pgcli, harlequin, pgweb, atlas, dbmate, goose, sqlc were considered but excluded (not in use).
- **`vmctl` not added** - nixpkgs `vmctl` is an NVMe/QEMU testing tool, not the VictoriaMetrics migration tool; the real `vmctl` already ships in the `victoriametrics` package.
- **Heavy daemons skipped** - tempo, mimir, pyroscope, consul, nomad, vault.

## Verification

- `nix fmt` - clean (0 changed)
- `nix-instantiate --parse` - all changed files OK
- `nix eval .#darwinConfigurations.aarch64-darwin.system.drvPath` - evaluates to a valid derivation (config builds)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds developer and observability CLIs to Home Manager and groups ecosystem tools into vendor modules. Extends `k8s` and `terraform`, and keeps `vector` flat in `packages`.

- **New Features**
  - New modules: `grafana` (`grafana-loki`, `grafana-alloy`), `protobuf` (`buf`, `ghz`, `grpcurl`, `protobuf`), `victoriametrics` (`victorialogs`, `victoriametrics`, `victoriatraces`).
  - Extended modules: `k8s` adds `stern`; `terraform` adds `opentofu`.
  - Standalone CLIs in `packages/default.nix`: `_1password-cli`, `angle-grinder`, `bandwhich`, `choose`, `croc`, `fx`, `gh-dash`, `git-absorb`, `gron`, `hexyl`, `iperf3`, `jnv`, `lnav`, `mtr`, `nmap`, `oha`, `opentelemetry-collector-contrib`, `process-compose`, `rclone`, `restic`, `sops`, `termshark`, `tig`, `trippy`, `vector`, `websocat`.

<sup>Written for commit 63082fbdb4d9fd4ccae8be6e2c6e8b2bb3912e10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

