### PR TITLE
fix(home-manager): migrate SSH config from matchBlocks to settings

### DIFF
--- a/home-manager/programs/ssh/default.nix
+++ b/home-manager/programs/ssh/default.nix
@@ -7,51 +7,36 @@ _: {
     enable = true;
     enableDefaultConfig = false;
     includes = [ "~/.ssh/config.local" ];
-    matchBlocks = {
+    settings = {
       "*" = {
-        serverAliveInterval = 60;
-        identityFile = "~/.ssh/id_ed25519";
-        setEnv = {
+        ServerAliveInterval = 60;
+        IdentityFile = "~/.ssh/id_ed25519";
+        SetEnv = {
           TERM = "xterm-256color";
         };
-        sendEnv = [
-          "COLORTERM"
-        ];
-        extraOptions = {
-          IgnoreUnknown = "UseKeychain";
-          UseKeyChain = "yes";
-          # Enable post-quantum key exchange algorithms
-          # sntrup761x25519 is a hybrid post-quantum algorithm combining
-          # Streamlined NTRU Prime (sntrup761) with X25519
-          KexAlgorithms = "sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256";
-          # Prefer modern host key algorithms
-          HostKeyAlgorithms = "ssh-ed25519-cert-v01@openssh.com,ssh-ed25519,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-256";
-          # Prefer modern public key algorithms
-          PubkeyAcceptedAlgorithms = "ssh-ed25519-cert-v01@openssh.com,ssh-ed25519,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-256";
-        };
+        SendEnv = [ "COLORTERM" ];
+        IgnoreUnknown = "UseKeychain";
+        UseKeyChain = "yes";
+        KexAlgorithms = "sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256";
+        HostKeyAlgorithms = "ssh-ed25519-cert-v01@openssh.com,ssh-ed25519,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-256";
+        PubkeyAcceptedAlgorithms = "ssh-ed25519-cert-v01@openssh.com,ssh-ed25519,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-256";
       };
       "localhost" = {
-        extraOptions = {
-          UserKnownHostsFile = "/dev/null";
-          StrictHostKeyChecking = "false";
-        };
+        UserKnownHostsFile = "/dev/null";
+        StrictHostKeyChecking = "false";
       };
       "kyber" = {
-        hostname = "kyber.tail950b36.ts.net";
-        user = "ubuntu";
-        identityFile = "~/.ssh/id_rsa";
-        extraOptions = {
-          IdentitiesOnly = "yes";
-        };
+        HostName = "kyber.tail950b36.ts.net";
+        User = "ubuntu";
+        IdentityFile = "~/.ssh/id_rsa";
+        IdentitiesOnly = "yes";
       };
       "github.com" = {
-        serverAliveInterval = 0;
-        identityFile = "~/.ssh/id_ed25519_github";
-        extraOptions = {
-          ControlMaster = "auto";
-          ControlPath = "~/.ssh/github.sock";
-          ControlPersist = "3m";
-        };
+        ServerAliveInterval = 0;
+        IdentityFile = "~/.ssh/id_ed25519_github";
+        ControlMaster = "auto";
+        ControlPath = "~/.ssh/github.sock";
+        ControlPersist = "3m";
       };
     };
   };


### PR DESCRIPTION
## Summary
- Migrate `programs.ssh.matchBlocks` to `programs.ssh.settings` (upstream API)
- Flatten `extraOptions` into top-level directives using upstream PascalCase names
- Eliminates all 5 deprecation warnings from home-manager SSH module

## Test plan
- [x] `nix build --dry-run` passes with no SSH deprecation warnings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated SSH config to `programs.ssh.settings` in `home-manager` and flattened options to remove five deprecation warnings. No behavior changes.

- **Refactors**
  - Replaced `matchBlocks` with `settings` for all hosts.
  - Moved `extraOptions` into top-level directives (`IgnoreUnknown`, `UseKeyChain`, `KexAlgorithms`, etc.).
  - Switched to upstream PascalCase keys (e.g., `ServerAliveInterval`, `IdentityFile`, `HostName`, `User`).

<sup>Written for commit 1f051f0c2ac3cffcdcaffa75e65594023d0cb62c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

