### PR TITLE
fix(nixos): reorder DNS resolvers to prioritize Google over Cloudflare

### DIFF
--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -32,9 +32,10 @@ let
       networking.networkmanager.enable = true;
       networking.networkmanager.dns = "none";
       networking.nameservers = [
+        "8.8.8.8"
+        "8.8.4.4"
         "1.1.1.1"
         "1.0.0.1"
-        "8.8.8.8"
       ];
 
       programs.fish.enable = true;


### PR DESCRIPTION
## Summary
- Reorder `networking.nameservers` to put Google DNS (`8.8.8.8`, `8.8.4.4`) before Cloudflare (`1.1.1.1`, `1.0.0.1`)
- Cloudflare DNS port 53 is blocked on some networks, causing 5s+ timeouts before fallback - this was breaking RPC calls to `dev-nodes.sequence.app`
- Add `8.8.4.4` as second Google resolver for redundancy

## Test plan
- [ ] `sudo nixos-rebuild switch --flake .`
- [ ] Verify `/etc/resolv.conf` has `8.8.8.8` first
- [ ] `curl -s -m 5 -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' "https://dev-nodes.sequence.app/mainnet/0xhorizon31337"` succeeds without timeout

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered NixOS DNS resolvers to prioritize Google (`8.8.8.8`, added `8.8.4.4`) ahead of Cloudflare (`1.1.1.1`, `1.0.0.1`). Prevents 5s+ timeouts on networks blocking Cloudflare port 53 and restores reliable RPC calls to `dev-nodes.sequence.app`.

<sup>Written for commit b61b93927a1c338415fdb784daf28207adf4e7dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

