### PR TITLE
fix(spec): align ssh config tests with settings format

### DIFF
--- a/spec/ssh_config_spec.sh
+++ b/spec/ssh_config_spec.sh
@@ -6,14 +6,14 @@ SSH_CONFIG_NIX="$PWD/home-manager/programs/ssh/default.nix"
 
 Describe 'kyber host'
 It 'uses the Tailscale DNS name instead of a stale tailnet IP'
-When run bash -c "grep 'hostname =' '$SSH_CONFIG_NIX' | grep kyber"
+When run bash -c "grep 'HostName =' '$SSH_CONFIG_NIX' | grep kyber"
 The output should include 'kyber.tail950b36.ts.net'
 The output should not include '100.74.174.97'
 End
 
 It 'pins the Codex-compatible SSH identity'
 When run cat "$SSH_CONFIG_NIX"
-The output should include 'identityFile = "~/.ssh/id_rsa"'
+The output should include 'IdentityFile = "~/.ssh/id_rsa"'
 The output should include 'IdentitiesOnly = "yes"'
 End
 End


### PR DESCRIPTION
## Summary
- PR #1877 migrated `home-manager/programs/ssh/default.nix` from `matchBlocks` (camelCase: `hostname`, `identityFile`) to `settings` (PascalCase: `HostName`, `IdentityFile`)
- `spec/ssh_config_spec.sh` still asserted the old camelCase strings, breaking the Shell workflow on main

## Test plan
- [x] `shellspec spec/ssh_config_spec.sh` passes locally (2 examples, 0 failures)
- [ ] Shell CI workflow passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `spec/ssh_config_spec.sh` to assert `HostName` and `IdentityFile` (PascalCase) to match the `settings` format in `home-manager/programs/ssh/default.nix`. Fixes failing Shell workflow tests on main.

<sup>Written for commit 46f0098aa0ea5882df1c30bed7c7630fedc7c4f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

