### PR TITLE
fix(nixos): disable IPv6 to prevent Nix daemon timeout

### DIFF
--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -29,6 +29,7 @@ let
     { lib, ... }:
     {
       networking.hostName = hostname;
+      networking.enableIPv6 = false;
       networking.networkmanager.enable = true;
       networking.networkmanager.dns = "none";
       networking.nameservers = [


### PR DESCRIPTION
Adds `networking.enableIPv6 = false` to the NixOS base module.

The machine has no global IPv6 connectivity (only link-local). Nix daemon tries the AAAA record for `channels.nixos.org` first, hits a 15s timeout, then falls back to IPv4. Disabling IPv6 forces immediate IPv4 resolution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable IPv6 in the NixOS base config to prevent Nix daemon AAAA lookup timeouts and force immediate IPv4. The host only has link-local IPv6, so this removes ~15s delays when contacting channels.nixos.org.

<sup>Written for commit 0fbc7e121f5452f3fb27bc28a2cd41ee339e8e83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

