### PR TITLE
feat(shell): prioritize bun global bin in bash/fish/zsh PATH

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -83,7 +83,6 @@ with pkgs;
   k6
   lean4
   lefthook
-  (if stdenv.isLinux && isDesktop then llama-cpp.override { vulkanSupport = true; } else llama-cpp)
   llm
   lnav
   lsof
@@ -151,6 +150,7 @@ with pkgs;
   keychain
   libiconv
   libsecret
+  (if isDesktop then llama-cpp.override { vulkanSupport = true; } else llama-cpp)
   opencode
   openssl
   openssl.dev

--- a/home-manager/programs/bash/bash_env.sh
+++ b/home-manager/programs/bash/bash_env.sh
@@ -18,3 +18,8 @@ case ":$PATH:" in
 *":$HOME/.bun/bin:"*) ;;
 *) export PATH="$HOME/.bun/bin:$PATH" ;;
 esac
+
+case ":$PATH:" in
+*":$HOME/.bun/install/global/node_modules/.bin:"*) ;;
+*) export PATH="$HOME/.bun/install/global/node_modules/.bin:$PATH" ;;
+esac

--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -84,6 +84,7 @@
       export PATH="$HOME/.bun/bin:$PATH"
       export PATH="/opt/homebrew/opt/postgresql@18/bin:$PATH"
       export PATH="/opt/homebrew/bin:$PATH"
+      export PATH="$HOME/.bun/install/global/node_modules/.bin:$PATH"
 
       # Worktrunk shell init
       if command -v wt >/dev/null 2>&1; then
@@ -93,7 +94,7 @@
 
     profileExtra = ''
       # Local binaries should be present even before login shells source .bashrc.
-      export PATH="$HOME/.bun/bin:$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
+      export PATH="$HOME/.bun/install/global/node_modules/.bin:$HOME/.bun/bin:$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
 
       # Nix
       if [ -e ~/.nix-profile/etc/profile.d/nix.sh ]; then

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -9,7 +9,7 @@
     enable = true;
     shellInit = ''
       # Local binaries should be available before login/interactive-only PATH setup.
-      set -gx PATH $HOME/.bun/bin $HOME/.cargo/bin $HOME/.local/bin $PATH
+      set -gx PATH $HOME/.bun/install/global/node_modules/.bin $HOME/.bun/bin $HOME/.cargo/bin $HOME/.local/bin $PATH
 
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
       if test (uname) = "Linux"
@@ -55,6 +55,7 @@
       fish_add_path -p -m ~/.bun/bin
       fish_add_path -p -m /opt/homebrew/opt/postgresql@18/bin
       fish_add_path -p -m /opt/homebrew/bin
+      fish_add_path -p -m ~/.bun/install/global/node_modules/.bin
     '';
     interactiveShellInit = ''
       source ${config.home.homeDirectory}/.config/fish/functions/_hm_load_env_file.fish
@@ -77,6 +78,7 @@
       fish_add_path -p -m ~/.bun/bin
       fish_add_path -p -m /opt/homebrew/opt/postgresql@18/bin
       fish_add_path -p -m /opt/homebrew/bin
+      fish_add_path -p -m ~/.bun/install/global/node_modules/.bin
       # Worktrunk shell init
       if type -q wt
         wt config shell init fish | source

--- a/home-manager/programs/ssh/default.nix
+++ b/home-manager/programs/ssh/default.nix
@@ -1,4 +1,4 @@
-_: {
+{ lib, ... }: {
   home.file.".ssh/rc" = {
     source = ./rc;
     force = true;
@@ -10,7 +10,7 @@ _: {
     settings = {
       "*" = {
         ServerAliveInterval = 60;
-        IdentityFile = [ "~/.ssh/id_ed25519" ];
+        IdentityFile = lib.mkForce [ "~/.ssh/id_ed25519" ];
         SetEnv = {
           TERM = "xterm-256color";
         };

--- a/home-manager/programs/ssh/default.nix
+++ b/home-manager/programs/ssh/default.nix
@@ -10,7 +10,7 @@ _: {
     settings = {
       "*" = {
         ServerAliveInterval = 60;
-        IdentityFile = "~/.ssh/id_ed25519";
+        IdentityFile = [ "~/.ssh/id_ed25519" ];
         SetEnv = {
           TERM = "xterm-256color";
         };
@@ -28,12 +28,12 @@ _: {
       "kyber" = {
         HostName = "kyber.tail950b36.ts.net";
         User = "ubuntu";
-        IdentityFile = "~/.ssh/id_rsa";
+        IdentityFile = [ "~/.ssh/id_rsa" ];
         IdentitiesOnly = "yes";
       };
       "github.com" = {
         ServerAliveInterval = 0;
-        IdentityFile = "~/.ssh/id_ed25519_github";
+        IdentityFile = [ "~/.ssh/id_ed25519_github" ];
         ControlMaster = "auto";
         ControlPath = "~/.ssh/github.sock";
         ControlPersist = "3m";

--- a/home-manager/programs/ssh/default.nix
+++ b/home-manager/programs/ssh/default.nix
@@ -1,4 +1,5 @@
-{ lib, ... }: {
+{ lib, ... }:
+{
   home.file.".ssh/rc" = {
     source = ./rc;
     force = true;

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -32,7 +32,7 @@
       fi
 
       # Local binaries must be available to non-interactive zsh commands too.
-      export PATH="$HOME/.bun/bin:$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
+      export PATH="$HOME/.bun/install/global/node_modules/.bin:$HOME/.bun/bin:$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
 
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
       if [ "$(uname)" = "Linux" ]; then
@@ -74,6 +74,7 @@
       export PATH="$HOME/.bun/bin:$PATH"
       export PATH="/opt/homebrew/opt/postgresql@18/bin:$PATH"
       export PATH="/opt/homebrew/bin:$PATH"
+      export PATH="$HOME/.bun/install/global/node_modules/.bin:$PATH"
 
       # FNM (Fast Node Manager) configuration
       ${

--- a/spec/atuin_history_spec.sh
+++ b/spec/atuin_history_spec.sh
@@ -111,18 +111,20 @@ The output should include "gomi"
 End
 
 It 'adds local binaries to zsh envExtra for non-interactive commands'
-When run bash -c "grep -F 'export PATH=\"\$HOME/.bun/bin:\$HOME/.cargo/bin:\$HOME/.local/bin:\$PATH\"' '$ZSH_CONFIG'"
+When run bash -c "grep -F 'export PATH=\"\$HOME/.bun/install/global/node_modules/.bin:\$HOME/.bun/bin:\$HOME/.cargo/bin:\$HOME/.local/bin:\$PATH\"' '$ZSH_CONFIG'"
 The status should be success
 The output should include '.local/bin'
 The output should include '.bun/bin'
+The output should include '.bun/install/global/node_modules/.bin'
 The output should include '.cargo/bin'
 End
 
 It 'adds local binaries to bash profileExtra before bashrc'
-When run bash -c "grep -F 'export PATH=\"\$HOME/.bun/bin:\$HOME/.cargo/bin:\$HOME/.local/bin:\$PATH\"' '$BASH_CONFIG'"
+When run bash -c "grep -F 'export PATH=\"\$HOME/.bun/install/global/node_modules/.bin:\$HOME/.bun/bin:\$HOME/.cargo/bin:\$HOME/.local/bin:\$PATH\"' '$BASH_CONFIG'"
 The status should be success
 The output should include '.local/bin'
 The output should include '.bun/bin'
+The output should include '.bun/install/global/node_modules/.bin'
 The output should include '.cargo/bin'
 End
 
@@ -142,11 +144,30 @@ The output should include '.local/bin'
 End
 
 It 'adds local binaries to fish shellInit before login-only setup'
-When run bash -c "grep -F 'set -gx PATH \$HOME/.bun/bin \$HOME/.cargo/bin \$HOME/.local/bin \$PATH' '$FISH_CONFIG'"
+When run bash -c "grep -F 'set -gx PATH \$HOME/.bun/install/global/node_modules/.bin \$HOME/.bun/bin \$HOME/.cargo/bin \$HOME/.local/bin \$PATH' '$FISH_CONFIG'"
 The status should be success
 The output should include '.local/bin'
 The output should include '.bun/bin'
+The output should include '.bun/install/global/node_modules/.bin'
 The output should include '.cargo/bin'
+End
+
+It 'prepends bun global node_modules/.bin after homebrew in bash initExtra so it wins on macOS'
+When run bash -c "awk '/export PATH=\"\\/opt\\/homebrew\\/bin:/{brew=NR} /export PATH=\"\\\$HOME\\/.bun\\/install\\/global\\/node_modules\\/.bin:/{bun=NR} END{ if (brew && bun && bun > brew) print \"ok\"; else print \"bad brew=\" brew \" bun=\" bun }' '$BASH_CONFIG'"
+The status should be success
+The output should eq 'ok'
+End
+
+It 'prepends bun global node_modules/.bin after homebrew in zsh initContent so it wins on macOS'
+When run bash -c "awk '/export PATH=\"\\/opt\\/homebrew\\/bin:/{brew=NR} /export PATH=\"\\\$HOME\\/.bun\\/install\\/global\\/node_modules\\/.bin:/{bun=NR} END{ if (brew && bun && bun > brew) print \"ok\"; else print \"bad brew=\" brew \" bun=\" bun }' '$ZSH_CONFIG'"
+The status should be success
+The output should eq 'ok'
+End
+
+It 'prepends bun global node_modules/.bin after homebrew in fish loginShellInit so it wins on macOS'
+When run bash -c "awk '/fish_add_path -p -m \\/opt\\/homebrew\\/bin/{brew=NR} /fish_add_path -p -m ~\\/.bun\\/install\\/global\\/node_modules\\/.bin/{bun=NR} END{ if (brew && bun && bun > brew) print \"ok\"; else print \"bad brew=\" brew \" bun=\" bun }' '$FISH_CONFIG'"
+The status should be success
+The output should eq 'ok'
 End
 End
 End

--- a/spec/ssh_config_spec.sh
+++ b/spec/ssh_config_spec.sh
@@ -13,7 +13,7 @@ End
 
 It 'pins the Codex-compatible SSH identity'
 When run cat "$SSH_CONFIG_NIX"
-The output should include 'IdentityFile = "~/.ssh/id_rsa"'
+The output should include 'IdentityFile = [ "~/.ssh/id_rsa" ]'
 The output should include 'IdentitiesOnly = "yes"'
 End
 End


### PR DESCRIPTION
## Summary

- Add `$HOME/.bun/install/global/node_modules/.bin` as the highest-priority PATH entry in bash, fish, and zsh
- Mirrors the existing pattern that prepends `~/.bun/bin`, so global packages installed via `bun install -g` resolve from the actual node_modules `.bin` directory first
- Updated locations: bash `bashrcExtra` + `profileExtra` + `bash_env.sh`, zsh `envExtra` + `initContent`, fish `shellInit` + `loginShellInit` + `interactiveShellInit`

## Test plan

- [ ] `nix flake check --no-build` passes
- [ ] After `make switch`, `echo $PATH` in each shell shows `~/.bun/install/global/node_modules/.bin` at the front
- [ ] Globally `bun add`-ed CLIs still resolve as expected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepends $HOME/.bun/install/global/node_modules/.bin to PATH with highest priority in bash, zsh, and fish so global `bun` CLIs resolve first across interactive and login shells. Mirrors ~/.bun/bin precedence and ensures it wins over /opt/homebrew/bin on macOS.

- **Bug Fixes**
  - Updated specs to assert the new PATH order and that bun globals win over Homebrew on macOS (bash/zsh/fish).
  - SSH config: switched `IdentityFile` to list type and forced `*` to use `~/.ssh/id_ed25519` with `lib.mkForce` to override `@home-manager` defaults.
  - Scoped `llama-cpp` Vulkan override to `isDesktop` for simpler platform handling.

- **Refactors**
  - Nixfmt the SSH module header.

<sup>Written for commit a8b993de00f53cf6644b8a75a9786de5cc7e14d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

