### PR TITLE
fix(nixos): pin resolv.conf to prevent DNS resolution failures

### DIFF
--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -32,11 +32,14 @@ let
       networking.enableIPv6 = false;
       networking.networkmanager.enable = true;
       networking.networkmanager.dns = "none";
-      networking.nameservers = [
-        "8.8.8.8"
-        "8.8.4.4"
-        "1.1.1.1"
-        "1.0.0.1"
+      networking.resolvconf.enable = false;
+      environment.etc."resolv.conf".text = lib.concatStringsSep "\n" [
+        "nameserver 8.8.8.8"
+        "nameserver 8.8.4.4"
+        "nameserver 1.1.1.1"
+        "nameserver 1.0.0.1"
+        "options edns0"
+        ""
       ];
 
       programs.fish.enable = true;


### PR DESCRIPTION
## Summary
- Disable `resolvconf` service and manage `/etc/resolv.conf` via `environment.etc` so DHCP lease renewals on public wifi cannot overwrite static nameservers
- Fixes intermittent `Could not resolve host: github.com` errors caused by resolvconf race condition during DHCP renewal

## Test plan
- [ ] `sudo nixos-rebuild switch`
- [ ] Verify `/etc/resolv.conf` is a symlink to `/etc/static/resolv.conf`
- [ ] Confirm DNS resolution survives wifi reconnect / DHCP renewal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins DNS config by disabling `resolvconf`, setting `networking.networkmanager.dns = "none"`, and managing `/etc/resolv.conf` via `environment.etc` with static nameservers. This prevents DHCP from overwriting DNS and fixes intermittent “Could not resolve host: github.com” errors.

<sup>Written for commit a38960285a099760120b649269429066817264db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

