### PR TITLE
fix(hyprshell): migrate config to version 4

### DIFF
--- a/config/hyprshell/config.toml
+++ b/config/hyprshell/config.toml
@@ -1,8 +1,13 @@
-version = 3
+version = 4
 
 [windows]
 scale = 8.0
+items_per_row = 5
 
 [windows.switch]
 modifier = "super"
 key = "Tab"
+filter_by = ["current_monitor"]
+switch_workspaces = false
+exclude_workspaces = ""
+kill_key = "q"


### PR DESCRIPTION
## Summary
- Migrate hyprshell config from version 3 to version 4
- hyprshell 4.10.4 expects v4 but the file was pinned at v3; the daemon's auto-migration failed because home-manager deploys config as read-only Nix store symlinks, breaking the Super+Tab window switcher

## Test plan
- [ ] Rebuild NixOS/home-manager config
- [ ] Verify `hyprshell config check` shows no migration warning
- [ ] Confirm Super+Tab opens the window switcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate `hyprshell` config to version 4 so 4.10.4 reads it correctly and the Super+Tab window switcher works again with read-only configs. This replaces the failed auto-migration under home-manager symlinks.

- **Bug Fixes**
  - Set `version = 4`; added v4 switcher fields: `items_per_row=5`, `filter_by=["current_monitor"]`, `switch_workspaces=false`, `exclude_workspaces=""`, `kill_key="q"`.

- **Migration**
  - Rebuild NixOS/home-manager.
  - Run `hyprshell config check` (no migration warning).
  - Confirm Super+Tab opens the switcher.

<sup>Written for commit 7c4909eab01a297f446dd0317f79a15db2d05219. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

