### PR TITLE
fix(npm-globals): install platform-native binaries for claude-code and codex

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -70,6 +70,16 @@
         "vite-plus": "^0.1.24",
         "xcodebuildmcp": "^2.6.2",
       },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-code-darwin-arm64": "^2.1.162",
+        "@anthropic-ai/claude-code-darwin-x64": "^2.1.162",
+        "@anthropic-ai/claude-code-linux-arm64": "^2.1.162",
+        "@anthropic-ai/claude-code-linux-arm64-musl": "^2.1.162",
+        "@anthropic-ai/claude-code-linux-x64": "^2.1.162",
+        "@anthropic-ai/claude-code-linux-x64-musl": "^2.1.162",
+        "@anthropic-ai/claude-code-win32-arm64": "^2.1.162",
+        "@anthropic-ai/claude-code-win32-x64": "^2.1.162",
+      },
     },
   },
   "trustedDependencies": [

--- a/home-manager/modules/npm-globals/install-npm-globals.sh
+++ b/home-manager/modules/npm-globals/install-npm-globals.sh
@@ -177,6 +177,87 @@ if [ -n "$OVERRIDES" ]; then
   fi
 fi
 
+# Install platform-matching optionalDependencies (e.g. claude-code-darwin-arm64).
+# Bun's transitive-optional resolution silently drops these when the parent's
+# postinstall is blocked by ignoreScripts, so we install the matching variant
+# directly. MUST run after the overrides `bun install` above, which prunes
+# optional deps. Filter by os-arch[-libc] suffix in the package name.
+OPTIONAL_DEPS=$(jq -r '.optionalDependencies // {} | to_entries[] | "\(.key)=\(.value)"' "$PACKAGE_JSON" 2>/dev/null || true)
+if [ -n "$OPTIONAL_DEPS" ]; then
+  PLATFORM_OS=""
+  case "$(uname -s)" in
+    Darwin) PLATFORM_OS="darwin" ;;
+    Linux) PLATFORM_OS="linux" ;;
+    *) PLATFORM_OS="$(uname -s | tr '[:upper:]' '[:lower:]')" ;;
+  esac
+  PLATFORM_ARCH=""
+  case "$(uname -m)" in
+    arm64 | aarch64) PLATFORM_ARCH="arm64" ;;
+    x86_64) PLATFORM_ARCH="x64" ;;
+    *) PLATFORM_ARCH="$(uname -m)" ;;
+  esac
+  PLATFORM_SUFFIX="${PLATFORM_OS}-${PLATFORM_ARCH}"
+  PLATFORM_MUSL_SUFFIX="${PLATFORM_SUFFIX}-musl"
+
+  while IFS= read -r entry; do
+    dep="${entry%%=*}"
+    [ -z "$dep" ] && continue
+    # Match exact platform variant. Skip musl on darwin/win32.
+    if [[ "$dep" == *"-${PLATFORM_SUFFIX}" ]]; then
+      :
+    elif [ "$PLATFORM_OS" = "linux" ] && [[ "$dep" == *"-${PLATFORM_MUSL_SUFFIX}" ]]; then
+      # Only install musl variant on actual musl systems (NixOS uses glibc by default).
+      if ! ldd --version 2>&1 | grep -qi musl; then
+        continue
+      fi
+    else
+      continue
+    fi
+    if [ -d "${GLOBAL_MODULES}/${dep}" ]; then
+      echo "$dep already installed, skipping"
+      continue
+    fi
+    # Bun's `bun add -g <pkg>` is a no-op if <pkg> is already in the global
+    # package.json's optionalDependencies (it never materializes the dir).
+    # Strip from optionalDependencies first so the add becomes a real install.
+    if [ -f "$GLOBAL_PKG" ] && jq -e --arg dep "$dep" '.optionalDependencies | has($dep)' "$GLOBAL_PKG" >/dev/null 2>&1; then
+      jq --arg dep "$dep" 'del(.optionalDependencies[$dep])' "$GLOBAL_PKG" >"${GLOBAL_PKG}.tmp" &&
+        mv "${GLOBAL_PKG}.tmp" "$GLOBAL_PKG"
+    fi
+    val="${entry#*=}"
+    # For npm aliases (codex pattern), pass the full <name>@<spec>. For plain
+    # semver ranges, omitting the version lets bun resolve latest.
+    if [[ "$val" == npm:* ]]; then
+      spec="${dep}@${val}"
+    else
+      spec="$dep"
+    fi
+    echo "Installing platform-native: $spec"
+    timeout 600 bun add --global "$spec" --minimum-release-age 0 2>/dev/null || echo "Install failed: $spec"
+  done <<<"$OPTIONAL_DEPS"
+fi
+
+# Strip non-matching platform-variant entries from global optionalDependencies.
+# Bun lists them but never materializes them (os/cpu mismatch), so they just
+# accumulate and clutter the global package.json across runs.
+if [ -f "$GLOBAL_PKG" ]; then
+  STALE_OPTIONAL=$(jq -r '.optionalDependencies // {} | keys[]?' "$GLOBAL_PKG" 2>/dev/null || true)
+  if [ -n "$STALE_OPTIONAL" ]; then
+    while IFS= read -r dep; do
+      [ -z "$dep" ] && continue
+      if ! jq -e --arg dep "$dep" '.dependencies | has($dep)' "$GLOBAL_PKG" >/dev/null 2>&1; then
+        jq --arg dep "$dep" 'del(.optionalDependencies[$dep])' "$GLOBAL_PKG" >"${GLOBAL_PKG}.tmp" &&
+          mv "${GLOBAL_PKG}.tmp" "$GLOBAL_PKG"
+      fi
+    done <<<"$STALE_OPTIONAL"
+  fi
+  # Drop the optionalDependencies key entirely if now empty.
+  if [ "$(jq -r '.optionalDependencies // {} | length' "$GLOBAL_PKG" 2>/dev/null)" = "0" ]; then
+    jq 'del(.optionalDependencies)' "$GLOBAL_PKG" >"${GLOBAL_PKG}.tmp" &&
+      mv "${GLOBAL_PKG}.tmp" "$GLOBAL_PKG"
+  fi
+fi
+
 # Deduplicate overridden packages from nested node_modules
 # Bun can install the same package at both top-level and nested locations.
 # When packages use Symbols (like pino), two copies create incompatible

--- a/home-manager/modules/npm-globals/install-npm-globals.sh
+++ b/home-manager/modules/npm-globals/install-npm-globals.sh
@@ -186,15 +186,15 @@ OPTIONAL_DEPS=$(jq -r '.optionalDependencies // {} | to_entries[] | "\(.key)=\(.
 if [ -n "$OPTIONAL_DEPS" ]; then
   PLATFORM_OS=""
   case "$(uname -s)" in
-    Darwin) PLATFORM_OS="darwin" ;;
-    Linux) PLATFORM_OS="linux" ;;
-    *) PLATFORM_OS="$(uname -s | tr '[:upper:]' '[:lower:]')" ;;
+  Darwin) PLATFORM_OS="darwin" ;;
+  Linux) PLATFORM_OS="linux" ;;
+  *) PLATFORM_OS="$(uname -s | tr '[:upper:]' '[:lower:]')" ;;
   esac
   PLATFORM_ARCH=""
   case "$(uname -m)" in
-    arm64 | aarch64) PLATFORM_ARCH="arm64" ;;
-    x86_64) PLATFORM_ARCH="x64" ;;
-    *) PLATFORM_ARCH="$(uname -m)" ;;
+  arm64 | aarch64) PLATFORM_ARCH="arm64" ;;
+  x86_64) PLATFORM_ARCH="x64" ;;
+  *) PLATFORM_ARCH="$(uname -m)" ;;
   esac
   PLATFORM_SUFFIX="${PLATFORM_OS}-${PLATFORM_ARCH}"
   PLATFORM_MUSL_SUFFIX="${PLATFORM_SUFFIX}-musl"
@@ -203,9 +203,9 @@ if [ -n "$OPTIONAL_DEPS" ]; then
     dep="${entry%%=*}"
     [ -z "$dep" ] && continue
     # Match exact platform variant. Skip musl on darwin/win32.
-    if [[ "$dep" == *"-${PLATFORM_SUFFIX}" ]]; then
+    if [[ $dep == *"-${PLATFORM_SUFFIX}" ]]; then
       :
-    elif [ "$PLATFORM_OS" = "linux" ] && [[ "$dep" == *"-${PLATFORM_MUSL_SUFFIX}" ]]; then
+    elif [ "$PLATFORM_OS" = "linux" ] && [[ $dep == *"-${PLATFORM_MUSL_SUFFIX}" ]]; then
       # Only install musl variant on actual musl systems (NixOS uses glibc by default).
       if ! ldd --version 2>&1 | grep -qi musl; then
         continue
@@ -227,7 +227,7 @@ if [ -n "$OPTIONAL_DEPS" ]; then
     val="${entry#*=}"
     # For npm aliases (codex pattern), pass the full <name>@<spec>. For plain
     # semver ranges, omitting the version lets bun resolve latest.
-    if [[ "$val" == npm:* ]]; then
+    if [[ $val == npm:* ]]; then
       spec="${dep}@${val}"
     else
       spec="$dep"

--- a/package.json
+++ b/package.json
@@ -76,6 +76,22 @@
     "vite-plus": "^0.1.24",
     "xcodebuildmcp": "^2.6.2"
   },
+  "optionalDependencies": {
+    "@anthropic-ai/claude-code-darwin-arm64": "^2.1.162",
+    "@anthropic-ai/claude-code-darwin-x64": "^2.1.162",
+    "@anthropic-ai/claude-code-linux-arm64": "^2.1.162",
+    "@anthropic-ai/claude-code-linux-arm64-musl": "^2.1.162",
+    "@anthropic-ai/claude-code-linux-x64": "^2.1.162",
+    "@anthropic-ai/claude-code-linux-x64-musl": "^2.1.162",
+    "@anthropic-ai/claude-code-win32-arm64": "^2.1.162",
+    "@anthropic-ai/claude-code-win32-x64": "^2.1.162",
+    "@openai/codex-darwin-arm64": "npm:@openai/codex@0.136.0-darwin-arm64",
+    "@openai/codex-darwin-x64": "npm:@openai/codex@0.136.0-darwin-x64",
+    "@openai/codex-linux-arm64": "npm:@openai/codex@0.136.0-linux-arm64",
+    "@openai/codex-linux-x64": "npm:@openai/codex@0.136.0-linux-x64",
+    "@openai/codex-win32-arm64": "npm:@openai/codex@0.136.0-win32-arm64",
+    "@openai/codex-win32-x64": "npm:@openai/codex@0.136.0-win32-x64"
+  },
   "overrides": {
     "pino": "9.14.0"
   },


### PR DESCRIPTION
## Summary

`claude --version` was stuck at 2.1.140 and `codex --version` at 0.130.0 even after `bun add -g` reported newer versions. Root cause: both packages ship native binaries via `optionalDependencies`, and bun's transitive optional resolution silently drops them when the parent's `postinstall` is blocked by `ignoreScripts = true` in `~/.bunfig.toml`.

## Changes

- **`package.json`**: add all platform variants under `optionalDependencies` as a cross-platform manifest. Claude-code uses real platform packages (`@anthropic-ai/claude-code-darwin-arm64` etc.); codex uses npm aliases (`@openai/codex-darwin-arm64` → `npm:@openai/codex@0.136.0-darwin-arm64`).
- **`install-npm-globals.sh`**: detect current OS/arch, filter to the matching platform variant, and install it as a direct global dep. Strips from global `optionalDependencies` first (bun bug: `bun add -g <pkg>` no-ops when `<pkg>` is already in optionalDeps). Cleans up stale non-matching variants across runs. Handles both plain semver and npm-alias specs.

## Why not transitive optionalDeps

Bun's `optional = true` should fetch matching variants automatically, but empirically doesn't in our global install when the parent has `postinstall` and global bunfig has `ignoreScripts = true`. The new variants would also be blocked by `minimumReleaseAge = 604800` because claude-code releases multiple times per day — the curated install passes `--minimum-release-age 0` to bypass the age gate for these vetted packages.

## Test plan

- [x] `bash home-manager/modules/npm-globals/install-npm-globals.sh` on darwin-arm64
- [x] `claude --version` returns 2.1.162
- [x] `codex --version` returns 0.136.0
- [x] Global `package.json` has matching variants in `.dependencies`, no stale entries in `.optionalDependencies`
- [ ] Run on a Linux host (NixOS) to verify `linux-x64`/`linux-arm64` selection works

Closes the version-drift issue observed locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes global installs of platform-native binaries for `@anthropic-ai/claude-code` and `@openai/codex` by directly installing the correct OS/arch variant. Prevents version drift when Bun skips transitive optional deps with `ignoreScripts = true`; also formats the installer script with `shfmt`.

- **Bug Fixes**
  - Add all platform variants to `optionalDependencies` as a cross-platform manifest.
  - Update `install-npm-globals.sh` to detect OS/arch and install the matching variant with `bun add -g`, removing it from global `optionalDependencies` first.
  - Clean stale non-matching variants from the global `package.json`.
  - Support both semver and `npm:` alias specs, and pass `--minimum-release-age 0` for these vetted packages.
  - Format the installer with `shfmt` for consistency.

- **Migration**
  - Rerun `home-manager/modules/npm-globals/install-npm-globals.sh` on each host to install the correct binary.

<sup>Written for commit c816b9bfe317c24b3e2d769edfd0a37b5fcc1cb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

