### PR TITLE
fix(tmux): disable continuum auto-restore to stop tpo cold-start hang

### DIFF
--- a/config/karabiner/karabiner.json
+++ b/config/karabiner/karabiner.json
@@ -167,6 +167,16 @@
           }
         ]
       },
+      "devices": [
+        {
+          "identifiers": {
+            "is_keyboard": true,
+            "product_id": 22,
+            "vendor_id": 1278
+          },
+          "ignore": false
+        }
+      ],
       "virtual_hid_keyboard": {
         "keyboard_type_v2": "ansi"
       }

--- a/home-manager/modules/npm-globals/install-npm-globals.sh
+++ b/home-manager/modules/npm-globals/install-npm-globals.sh
@@ -74,6 +74,43 @@ repair_sqlite3_native_binding() {
   echo "sqlite3 native binding rebuilt"
 }
 
+repair_claude_code_native_binary() {
+  # @anthropic-ai/claude-code ships only a wrapper in bin/claude.exe; the real
+  # binary comes from a platform-native optionalDependency installed by its
+  # postinstall. The version-only skip above leaves a broken install in place
+  # when that optional dep is missing (e.g. after an `omit=optional` install),
+  # so reinstall to fetch the native binary.
+  local claude_dir="${GLOBAL_MODULES}/@anthropic-ai/claude-code"
+  local wanted
+
+  if [ ! -d "$claude_dir" ]; then
+    return 0
+  fi
+
+  if command -v claude &>/dev/null && claude --version >/dev/null 2>&1; then
+    echo "claude native binary already loadable"
+    return 0
+  fi
+
+  wanted=$(jq -r '.dependencies["@anthropic-ai/claude-code"] // empty' "$PACKAGE_JSON" 2>/dev/null || true)
+  [ -z "$wanted" ] && wanted="latest"
+
+  echo "Reinstalling @anthropic-ai/claude-code to fetch native binary..."
+  bun pm -g trust @anthropic-ai/claude-code 2>/dev/null || true
+  bun remove --global @anthropic-ai/claude-code 2>/dev/null || true
+  if ! timeout 600 bun add --global "@anthropic-ai/claude-code@${wanted}"; then
+    echo "claude-code reinstall failed" >&2
+    return 1
+  fi
+
+  if ! (command -v claude &>/dev/null && claude --version >/dev/null 2>&1); then
+    echo "claude native binary still not loadable after reinstall" >&2
+    return 1
+  fi
+
+  echo "claude native binary repaired"
+}
+
 echo "Installing npm global packages from package.json using bun..."
 cd "${HOME}/dotfiles"
 
@@ -194,6 +231,10 @@ done
 
 if ! repair_sqlite3_native_binding; then
   echo "Warning: sqlite3 native binding repair failed" >&2
+fi
+
+if ! repair_claude_code_native_binary; then
+  echo "Warning: claude-code native binary repair failed" >&2
 fi
 
 echo "npm globals installation complete"

--- a/home-manager/modules/npm-globals/install-npm-globals.sh
+++ b/home-manager/modules/npm-globals/install-npm-globals.sh
@@ -74,41 +74,45 @@ repair_sqlite3_native_binding() {
   echo "sqlite3 native binding rebuilt"
 }
 
-repair_claude_code_native_binary() {
-  # @anthropic-ai/claude-code ships only a wrapper in bin/claude.exe; the real
-  # binary comes from a platform-native optionalDependency installed by its
-  # postinstall. The version-only skip above leaves a broken install in place
-  # when that optional dep is missing (e.g. after an `omit=optional` install),
-  # so reinstall to fetch the native binary.
-  local claude_dir="${GLOBAL_MODULES}/@anthropic-ai/claude-code"
-  local wanted
+# Current-platform tokens used to recognise the native optionalDependency that
+# actually carries a package's binary (e.g. *-darwin-arm64, @esbuild/linux-x64).
+case "$(uname -s)" in
+Darwin) PLATFORM_OS="darwin" ;;
+Linux) PLATFORM_OS="linux" ;;
+*) PLATFORM_OS="" ;;
+esac
+case "$(uname -m)" in
+arm64 | aarch64) PLATFORM_CPU="arm64" ;;
+x86_64 | amd64) PLATFORM_CPU="x64" ;;
+*) PLATFORM_CPU="" ;;
+esac
 
-  if [ ! -d "$claude_dir" ]; then
-    return 0
-  fi
+# Returns 0 when a package declares a platform-native optionalDependency for the
+# current OS/CPU but that dependency is not installed. Many CLIs ship their real
+# binary this way; a version-only skip would otherwise leave such a package
+# "installed" yet non-functional (e.g. after an `omit=optional` install).
+missing_native_optional_dep() {
+  local dep="$1"
+  local pj="${GLOBAL_MODULES}/${dep}/package.json"
+  [ -f "$pj" ] || return 1
+  [ -n "$PLATFORM_OS" ] && [ -n "$PLATFORM_CPU" ] || return 1
 
-  if command -v claude &>/dev/null && claude --version >/dev/null 2>&1; then
-    echo "claude native binary already loadable"
-    return 0
-  fi
+  local opt_deps name matched=0 present=0
+  opt_deps=$(jq -r '.optionalDependencies // {} | keys[]' "$pj" 2>/dev/null || true)
+  [ -n "$opt_deps" ] || return 1
 
-  wanted=$(jq -r '.dependencies["@anthropic-ai/claude-code"] // empty' "$PACKAGE_JSON" 2>/dev/null || true)
-  [ -z "$wanted" ] && wanted="latest"
+  while IFS= read -r name; do
+    [ -z "$name" ] && continue
+    # Only weigh native deps targeting this platform.
+    case "$name" in
+    *"$PLATFORM_OS"*"$PLATFORM_CPU"* | *"$PLATFORM_CPU"*"$PLATFORM_OS"*) ;;
+    *) continue ;;
+    esac
+    matched=1
+    [ -d "${GLOBAL_MODULES}/${name}" ] && present=1
+  done <<<"$opt_deps"
 
-  echo "Reinstalling @anthropic-ai/claude-code to fetch native binary..."
-  bun pm -g trust @anthropic-ai/claude-code 2>/dev/null || true
-  bun remove --global @anthropic-ai/claude-code 2>/dev/null || true
-  if ! timeout 600 bun add --global "@anthropic-ai/claude-code@${wanted}"; then
-    echo "claude-code reinstall failed" >&2
-    return 1
-  fi
-
-  if ! (command -v claude &>/dev/null && claude --version >/dev/null 2>&1); then
-    echo "claude native binary still not loadable after reinstall" >&2
-    return 1
-  fi
-
-  echo "claude native binary repaired"
+  [ "$matched" -eq 1 ] && [ "$present" -eq 0 ]
 }
 
 echo "Installing npm global packages from package.json using bun..."
@@ -168,6 +172,14 @@ if [ -n "$DEPS" ]; then
     if [ -n "$installed_ver" ] && [ -n "$wanted_ver" ]; then
       min_ver=$(printf '%s\n%s\n' "$wanted_ver" "$installed_ver" | sort -V | head -n1)
       if [ "$min_ver" = "$wanted_ver" ]; then
+        # Version matches, but only skip if the native binary is actually
+        # present. Drop a broken install so the reinstall below refetches it.
+        if missing_native_optional_dep "$dep"; then
+          echo "$dep@$installed_ver installed but native binary missing, reinstalling"
+          rm -rf "${GLOBAL_MODULES:?}/${dep}"
+          MISSING+=("$dep")
+          continue
+        fi
         echo "$dep@$installed_ver already installed, skipping"
         continue
       fi
@@ -231,10 +243,6 @@ done
 
 if ! repair_sqlite3_native_binding; then
   echo "Warning: sqlite3 native binding repair failed" >&2
-fi
-
-if ! repair_claude_code_native_binary; then
-  echo "Warning: claude-code native binary repair failed" >&2
 fi
 
 echo "npm globals installation complete"

--- a/home-manager/programs/tmux/default.nix
+++ b/home-manager/programs/tmux/default.nix
@@ -25,7 +25,11 @@
       {
         plugin = continuum;
         extraConfig = ''
-          set -g @continuum-restore 'on'
+          # Auto-restore is intentionally off: it fires on every cold tmux
+          # server start, racing __tmux_bootstrap_default_session and freezing
+          # the freshly-attached client (e.g. on `tpo`). Restore is driven
+          # manually by `two`/_two_function for the `work` session only.
+          set -g @continuum-restore 'off'
           set -g @continuum-save-interval '3'
           set -g status-right "#[fg=colour250]#{?#{pane_current_command},#{pane_current_command},} #[fg=colour28]| #[fg=colour255]%Y/%m/%d %H:%M:%S #{continuum_status}"
           set -g status-right-length 60

--- a/spec/npm_globals_spec.sh
+++ b/spec/npm_globals_spec.sh
@@ -202,6 +202,21 @@ It 'verifies sqlite3 can be loaded by node'
 When run bash -c "grep 'const sqlite3 = require' '$SCRIPT'"
 The output should include 'const sqlite3 = require'
 End
+
+It 'has a claude-code native binary repair step'
+When run bash -c "grep 'repair_claude_code_native_binary' '$SCRIPT'"
+The output should include 'repair_claude_code_native_binary'
+End
+
+It 'reinstalls claude-code when its native binary is missing'
+When run bash -c "grep -A 30 'repair_claude_code_native_binary()' '$SCRIPT'"
+The output should include 'bun add --global'
+End
+
+It 'verifies the claude binary is runnable after repair'
+When run bash -c "grep 'claude --version' '$SCRIPT'"
+The output should include 'claude --version'
+End
 End
 
 Describe 'stale global package pruning'

--- a/spec/npm_globals_spec.sh
+++ b/spec/npm_globals_spec.sh
@@ -202,20 +202,92 @@ It 'verifies sqlite3 can be loaded by node'
 When run bash -c "grep 'const sqlite3 = require' '$SCRIPT'"
 The output should include 'const sqlite3 = require'
 End
-
-It 'has a claude-code native binary repair step'
-When run bash -c "grep 'repair_claude_code_native_binary' '$SCRIPT'"
-The output should include 'repair_claude_code_native_binary'
 End
 
-It 'reinstalls claude-code when its native binary is missing'
-When run bash -c "grep -A 30 'repair_claude_code_native_binary()' '$SCRIPT'"
-The output should include 'bun add --global'
+Describe 'native binary completeness'
+It 'detects a missing platform-native optionalDependency'
+When run bash -c "grep 'missing_native_optional_dep' '$SCRIPT'"
+The output should include 'missing_native_optional_dep'
 End
 
-It 'verifies the claude binary is runnable after repair'
-When run bash -c "grep 'claude --version' '$SCRIPT'"
-The output should include 'claude --version'
+It 'derives current OS and CPU tokens for native deps'
+When run bash -c "grep -E 'PLATFORM_OS=|PLATFORM_CPU=' '$SCRIPT'"
+The output should include 'PLATFORM_OS'
+End
+
+It 'inspects optionalDependencies of installed packages'
+When run bash -c "grep 'optionalDependencies' '$SCRIPT'"
+The output should include 'optionalDependencies'
+End
+
+It 'reinstalls a version-matched package whose native binary is missing'
+When run bash -c "grep 'installed but native binary missing' '$SCRIPT'"
+The output should include 'reinstalling'
+End
+End
+
+Describe 'native-binary reinstall integration'
+setup() {
+  TEMP_HOME=$(mktemp -d)
+  MOCK_BIN=$(mktemp -d)
+  MOCK_LOG="$TEMP_HOME/mock.log"
+  REAL_BIN_DIR="$(dirname "$(command -v jq)")"
+  REAL_SYSTEM_BIN_DIR="$(dirname "$(command -v mv)")"
+  : >"$MOCK_LOG"
+
+  GM="$TEMP_HOME/.bun/install/global/node_modules"
+  mkdir -p "$TEMP_HOME/dotfiles" "$TEMP_HOME/.bun/install/global" "$TEMP_HOME/.bun/bin"
+
+  cat >"$TEMP_HOME/dotfiles/package.json" <<'EOF'
+{
+  "dependencies": {
+    "nativecli": "^1.0.0"
+  }
+}
+EOF
+
+  # Installed at the wanted version, but its platform-native optionalDependency
+  # directory is absent -> must be reinstalled, not skipped.
+  os_tok=$(uname -s | tr 'A-Z' 'a-z'); [ "$os_tok" = "darwin" ] || os_tok="linux"
+  cpu_tok=$(uname -m); case "$cpu_tok" in arm64|aarch64) cpu_tok=arm64 ;; *) cpu_tok=x64 ;; esac
+  mkdir -p "$GM/nativecli"
+  cat >"$GM/nativecli/package.json" <<EOF
+{
+  "name": "nativecli",
+  "version": "1.0.0",
+  "optionalDependencies": { "nativecli-${os_tok}-${cpu_tok}": "1.0.0" }
+}
+EOF
+
+  cat >"$MOCK_BIN/timeout" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+shift
+if [ "${1:-}" = "bash" ] && [ "${2:-}" = "-c" ] && [ "${3:-}" = "exec 3<>/dev/tcp/1.1.1.1/53" ]; then
+  exit 0
+fi
+exec "$@"
+EOF
+  chmod +x "$MOCK_BIN/timeout"
+
+  cat >"$MOCK_BIN/bun" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'bun %s\n' "$*" >>"$MOCK_LOG"
+EOF
+  chmod +x "$MOCK_BIN/bun"
+}
+
+cleanup() {
+  rm -rf "$TEMP_HOME" "$MOCK_BIN"
+}
+
+Before 'setup'
+After 'cleanup'
+
+It 'reinstalls a package missing its platform-native binary'
+When run bash -c "HOME='$TEMP_HOME' MOCK_LOG='$MOCK_LOG' PATH='$MOCK_BIN:$REAL_BIN_DIR:$REAL_SYSTEM_BIN_DIR:/usr/bin:/bin' bash '$SCRIPT' >/dev/null 2>&1; cat '$MOCK_LOG'"
+The output should include 'bun add --global nativecli'
 End
 End
 


### PR DESCRIPTION
## Problem

`tpo` hangs on startup unless another tmux session already exists in another tab.

## Root cause

`@continuum-restore 'on'` races with `__tmux_bootstrap_default_session` on cold server start:

1. `tpo` → `_tpo_function` → with no `primary` session, runs `tmux new-session -d -s primary -n btop`, which **cold-starts the tmux server**.
2. On server start, continuum's `main()` hits `just_started_tmux_server` → launches `continuum_restore.sh &`, which (after a 1s sleep) restores the saved sessions, re-spawning `btop fish git` and restoring pane contents.
3. That background restore stomps on the session the bootstrap is simultaneously building; the foreground `tmux attach-session -t primary` lands on a session being rewritten under it → frozen screen.

When a session already exists in another tab, `tmux new-session` reuses the running server, so `just_started_tmux_server` is false → restore never fires → no race. This matches the symptom exactly.

## Fix

Set `@continuum-restore 'off'`. Restore is already driven manually by `two`/`_two_function` for the `work` session only (`_two_function.fish:33-34` invokes the resurrect restore script directly), so auto-restore is redundant there and harmful on `tpo`/`tdo`/`tmo`.

- `tpo`/`tdo`/`tmo` cold-start cleanly, no race, no hang.
- `two` is unaffected — it restores `work` itself.
- Saving still runs every 3 min, so `work` snapshots stay current.

## Test plan

- [ ] `home-manager switch`, then `tmux kill-server` once to drop the running server holding the old `on` value.
- [ ] Run `tpo` with no existing server → attaches cleanly, no hang.
- [ ] Run `two` → still restores the `work` session.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable tmux Continuum auto-restore (`@continuum-restore 'off'`) to stop `tpo` cold-start hangs; saves still run every 3 minutes and `two` keeps restoring `work` manually. Improve npm-globals to reinstall packages missing platform-native binaries (e.g., `@anthropic-ai/claude-code`) and enable the Karabiner keyboard device (vendor 1278, product 22).

<sup>Written for commit 7e1a603f4c4bcb9db16e1fda9d47f747d6167b7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

