### PR TITLE
fix(ssh): migrate galactica to programs.ssh.settings

### DIFF
--- a/named-hosts/galactica/default.nix
+++ b/named-hosts/galactica/default.nix
@@ -25,13 +25,10 @@ inputs.nix-darwin.lib.darwinSystem {
         {
           programs.ssh = {
             enable = true;
-            matchBlocks = {
+            settings = {
               "*" = {
-                identityFile = inputs.nixpkgs.lib.mkForce " ~/.ssh/id_rsa";
-                extraOptions = {
-                  AddKeysToAgent = "yes";
-                  UseKeychain = "yes";
-                };
+                AddKeysToAgent = "yes";
+                UseKeychain = "yes";
               };
             };
           };


### PR DESCRIPTION
## What

Migrate the galactica host SSH config from the deprecated `programs.ssh.matchBlocks` / `extraOptions` to `programs.ssh.settings`.

## Why

`make build && make switch` emitted two home-manager deprecation warnings:

```
programs.ssh.matchBlocks ... is deprecated. Use programs.ssh.settings.
programs.ssh.matchBlocks.*.extraOptions ... Move these OpenSSH options to programs.ssh.settings.* using upstream directive names.
```

`named-hosts/galactica/default.nix` was the only remaining user of `matchBlocks`.

## Changes

- `matchBlocks."*"` -> `settings."*"`
- `extraOptions.{AddKeysToAgent,UseKeychain}` flattened into `settings."*"` (upstream directive names)
- Dropped `identityFile = mkForce " ~/.ssh/id_rsa"`:
  - It had a leading space (` ~/.ssh/id_rsa`), so ssh resolved it to a nonexistent relative path and skipped it at runtime.
  - The base module (`home-manager/programs/ssh/default.nix`) already forces `settings."*".IdentityFile = ["~/.ssh/id_ed25519"]`. Keeping a second `mkForce` on the now-shared `settings."*".IdentityFile` would be a build-breaking conflict.
  - Net effect on the generated `~/.ssh/config` is unchanged: `IdentityFile ~/.ssh/id_ed25519`.

## Verification

- `make build` succeeds with no deprecation warnings and no mkForce conflict.
- Generated `Host *` block confirmed: `AddKeysToAgent yes`, `UseKeychain yes`, `IdentityFile ~/.ssh/id_ed25519`.
- `make format` (0 changes) and `make nix-lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the galactica host SSH config to `programs.ssh.settings` to remove home‑manager deprecation warnings. Net SSH behavior stays the same.

- **Refactors**
  - Replace `programs.ssh.matchBlocks` and `extraOptions` with `programs.ssh.settings`.
  - Flatten `AddKeysToAgent` and `UseKeychain` into `settings."*"`.
  - Drop broken `IdentityFile` override (leading space) to avoid `mkForce` conflict; base sets `~/.ssh/id_ed25519`.

<sup>Written for commit 799047cd5e5f3f21059fb2c68cfb318238b1f5b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

