### PR TITLE
fix(matic): pin kernel to 6.17 for Falcon sensor compatibility

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -52,8 +52,8 @@ import ../../hosts/nixos {
           "tpm2-device=auto"
         ];
 
-        # Pin kernel to 6.18 for CrowdStrike Falcon compatibility (RFM on 6.19)
-        boot.kernelPackages = pkgs.linuxPackages_6_18;
+        # Pin kernel: Falcon sensor 7.31.0 lacks kernel module for 6.18+, RFM on 6.19
+        boot.kernelPackages = pkgs.linuxPackages_6_17;
 
         # Filesystem hardening
         boot.kernel.sysctl = {


### PR DESCRIPTION
## Summary
- Pin kernel from `linuxPackages_6_18` to `linuxPackages_6_17` to resolve `CS_PREVENTION_MISSING` on Falcon sensor 7.31.0-18410
- Falcon's prevention kernel module fails to load on 6.18.33

## Test plan
- [ ] `sudo nixos-rebuild switch` and reboot
- [ ] `sudo systemctl status falcon-sensor` shows active
- [ ] `sudo /opt/CrowdStrike/falconctl -g --rfm-state` shows not in RFM

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the matic host kernel to `linuxPackages_6_17` to keep CrowdStrike Falcon prevention active. Sensor 7.31.0-18410 fails to load its module on 6.18.33, causing CS_PREVENTION_MISSING.

- **Migration**
  - Rebuild and reboot: `sudo nixos-rebuild switch` then reboot.
  - Verify service: `sudo systemctl status falcon-sensor` is active.
  - Confirm not in RFM: `/opt/CrowdStrike/falconctl -g --rfm-state`.

<sup>Written for commit e4aefe8edf7cab172dd32db9ace4db0b7c645fd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

