### PR TITLE
fix(falcon): preserve CrowdStrike OTA updates across reboots

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -52,8 +52,8 @@ import ../../hosts/nixos {
           "tpm2-device=auto"
         ];
 
-        # Pin kernel: Falcon sensor 7.31.0 lacks kernel module for 6.18+, RFM on 6.19
-        boot.kernelPackages = pkgs.linuxPackages_6_17;
+        # Pin kernel to 6.18 for CrowdStrike Falcon compatibility (RFM on 6.19)
+        boot.kernelPackages = pkgs.linuxPackages_6_18;
 
         # Filesystem hardening
         boot.kernel.sysctl = {

--- a/named-hosts/matic/falcon-init.sh
+++ b/named-hosts/matic/falcon-init.sh
@@ -10,14 +10,33 @@ fi
 
 install -d -m 0770 /opt/CrowdStrike
 
-# Update binaries from the nix store, but preserve runtime state files.
-# falconstore contains the Agent ID (AID) — if lost, the sensor re-registers
-# as a new host and consumes another license seat.
-@rsync@/bin/rsync -a --delete \
-  --exclude=falconstore \
-  --exclude=falconstore.bak \
-  --exclude=CsConfig \
-  "@falcon@/opt/CrowdStrike/" /opt/CrowdStrike/
+# CrowdStrike pushes OTA updates that write newer versioned binaries into
+# /opt/CrowdStrike/. Only rsync the packaged binaries when the installed
+# version is not newer than the package, otherwise the rsync clobbers the
+# update and the running sensor can't find its helper binaries (ENOENT).
+pkg_ver="@falcon@/opt/CrowdStrike/falconctl"
+installed_ver=/opt/CrowdStrike/falconctl
+need_sync=true
+
+if [ -x "$installed_ver" ]; then
+  pkg_build=$(readlink -f "$pkg_ver" | grep -oP '\d+$' || echo "0")
+  inst_build=$(readlink -f "$installed_ver" | grep -oP '\d+$' || echo "0")
+  if [ "$inst_build" -gt "$pkg_build" ] 2>/dev/null; then
+    echo "falcon-init: installed build $inst_build is newer than packaged $pkg_build, skipping rsync"
+    need_sync=false
+  fi
+fi
+
+if [ "$need_sync" = true ]; then
+  # Update binaries from the nix store, but preserve runtime state files.
+  # falconstore contains the Agent ID (AID) - if lost, the sensor re-registers
+  # as a new host and consumes another license seat.
+  @rsync@/bin/rsync -a --delete \
+    --exclude=falconstore \
+    --exclude=falconstore.bak \
+    --exclude=CsConfig \
+    "@falcon@/opt/CrowdStrike/" /opt/CrowdStrike/
+fi
 
 chown -R root:root /opt/CrowdStrike
 


### PR DESCRIPTION
## Summary
- CrowdStrike cloud pushed OTA update (18410 -> 19004) but `falcon-init.sh` rsync'd old binaries back on boot, causing `CS_PREVENTION_MISSING`
- Init script now compares build numbers and skips rsync when installed version is newer
- Reverts kernel pin from 6.17 back to 6.18 (#1898 was a misdiagnosis - the kernel was never the issue)

## Root cause
Audit logs showed `falcon-sensor-bpf19004` failing to exec `/opt/CrowdStrike/falcon-fxpredict` (ENOENT) because the rsync restored 18410-versioned symlinks over the OTA-updated 19004 binaries.

## Test plan
- [ ] `sudo nixos-rebuild switch`
- [ ] `sudo systemctl restart falcon-sensor`
- [ ] Verify `CS_PREVENTION_MISSING` resolves in Drata/Falcon console

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents CrowdStrike Falcon OTA updates from being overwritten on reboot by skipping rsync when a newer build is already installed. Also reverts the kernel pin to 6.18 for sensor compatibility and resolves CS_PREVENTION_MISSING.

- **Bug Fixes**
  - `falcon-init.sh`: compare installed vs packaged build numbers via `falconctl` and skip rsync when installed is newer, preserving OTA updates (e.g., 19004).
  - Kernel pin set to 6.18 (6.19 remains RFM) to align with Falcon sensor support.

<sup>Written for commit e7386a42624f938d79c05be89effedc165262375. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

