### PR TITLE
feat: disable Codex features

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -1,6 +1,6 @@
 suppress_unstable_features_warning = true
 web_search = "cached"
-model = "gpt-5.3-codex"
+model = "gpt-5.5"
 model_reasoning_effort = "xhigh"
 oss_provider = "lmstudio"
 
@@ -37,7 +37,7 @@ js_repl = true
 js_repl_tools_only = false
 memories = true
 multi_agent = true
-multi_agent_v2 = true
+multi_agent_v2 = false
 personality = true
 plugin_hooks = true
 plugins = true

--- a/config/codex/config.tpl.toml
+++ b/config/codex/config.tpl.toml
@@ -1,6 +1,6 @@
 suppress_unstable_features_warning = true
 web_search = "cached"
-model = "__GPT_CODEX__"
+model = "__GPT__"
 model_reasoning_effort = "xhigh"
 oss_provider = "lmstudio"
 
@@ -37,7 +37,7 @@ js_repl = true
 js_repl_tools_only = false
 memories = true
 multi_agent = true
-multi_agent_v2 = true
+multi_agent_v2 = false
 personality = true
 plugin_hooks = true
 plugins = true


### PR DESCRIPTION
Disable Codex features in config templates and update dotagents submodule.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Codex-specific behavior by switching the default model from `gpt-5.3-codex`/`__GPT_CODEX__` to `gpt-5.5`/`__GPT__` and turning off `multi_agent_v2`.
Updates applied to both Codex config and template files.

<sup>Written for commit 3dafe1e28a92c8cc2cad650c3b9dff51835a30ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

