### PR TITLE
fix(ci): trim runner installs

### DIFF
--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -4,13 +4,14 @@
   lib,
   inputs,
   username,
+  isRunner ? false,
   ...
 }:
 let
   hmConfig = import ../config { inherit inputs; };
   modules = import ./modules;
   nix = import ./nix;
-  packages = import ./packages { inherit pkgs inputs; };
+  packages = import ./packages { inherit pkgs inputs isRunner; };
   programs = import ./programs {
     inherit config lib pkgs;
     sources = { };

--- a/home-manager/modules/uv-globals/default.nix
+++ b/home-manager/modules/uv-globals/default.nix
@@ -2,6 +2,7 @@
   config,
   pkgs,
   lib,
+  isRunner,
   ...
 }:
 let
@@ -9,14 +10,16 @@ let
 in
 {
   # Install uv global tools from pyproject.toml using home-manager activation
-  home.activation.installUvGlobals = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    export PATH=${pkgs.uv}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.yq}/bin:$PATH
-    ${lib.optionalString (!isDarwin) ''export SYSTEMCTL_BIN="${pkgs.systemd}/bin/systemctl"''}
-    $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./install-uv-globals.sh}"
-  '';
+  home.activation.installUvGlobals = lib.mkIf (!isRunner) (
+    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      export PATH=${pkgs.uv}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.yq}/bin:$PATH
+      ${lib.optionalString (!isDarwin) ''export SYSTEMCTL_BIN="${pkgs.systemd}/bin/systemctl"''}
+      $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./install-uv-globals.sh}"
+    ''
+  );
 
   # Run uv globals install after login (Linux only - systemd)
-  systemd.user.services = lib.mkIf (!isDarwin) {
+  systemd.user.services = lib.mkIf (!isDarwin && !isRunner) {
     install-uv-globals = {
       Unit = {
         Description = "Install uv global tools";

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   inputs,
+  isRunner ? false,
 }:
 let
   inherit (inputs.host) isDesktop isDev;
@@ -150,7 +151,6 @@ with pkgs;
   keychain
   libiconv
   libsecret
-  (if isDesktop then llama-cpp.override { vulkanSupport = true; } else llama-cpp)
   opencode
   openssl
   openssl.dev
@@ -165,6 +165,9 @@ with pkgs;
   xclip
   xdg-utils
   zlib
+]
+++ lib.optionals (stdenv.isLinux && !isRunner) [
+  (if isDesktop then llama-cpp.override { vulkanSupport = true; } else llama-cpp)
 ]
 ++ lib.optionals (stdenv.hostPlatform.system != "aarch64-linux") [
   qwen-code

--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -36,7 +36,7 @@ in
     {
       nixpkgs.pkgs = pkgs;
       home-manager.backupFileExtension = "hm-backup";
-      home-manager.extraSpecialArgs = { inherit inputs; };
+      home-manager.extraSpecialArgs = { inherit inputs isRunner; };
       home-manager.useGlobalPkgs = true;
       home-manager.sharedModules = [
         {
@@ -51,7 +51,12 @@ in
       ];
       home-manager.useUserPackages = true;
       home-manager.users."${username}" = import ../../home-manager {
-        inherit inputs username pkgs;
+        inherit
+          inputs
+          username
+          pkgs
+          isRunner
+          ;
         inherit (pkgs) lib;
         config = { };
       };

--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -140,11 +140,11 @@ let
     inputs.home-manager.nixosModules.home-manager
     {
       home-manager.backupFileExtension = "hm-backup";
-      home-manager.extraSpecialArgs = { inherit inputs; };
+      home-manager.extraSpecialArgs = { inherit inputs isRunner; };
       home-manager.useGlobalPkgs = true;
       home-manager.useUserPackages = true;
       home-manager.users."${username}" = import ../../home-manager {
-        inherit inputs username;
+        inherit inputs username isRunner;
         inherit (inputs.nixpkgs) lib;
         inherit pkgs;
         config = { };

--- a/named-hosts/galactica/default.nix
+++ b/named-hosts/galactica/default.nix
@@ -12,6 +12,7 @@ inputs.nix-darwin.lib.darwinSystem {
   modules = darwin-modules.modules ++ [
     {
       home-manager.extraSpecialArgs = {
+        isRunner = false;
         inputs = inputs // {
           host = (import ../../lib/host.nix) // {
             isGalactica = true;

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -19,6 +19,7 @@ home-manager.lib.homeManagerConfiguration {
   inherit pkgs;
   extraSpecialArgs = {
     inherit username pkgs;
+    isRunner = false;
     inputs = inputs // {
       host = (import ../../lib/host.nix) // {
         isKyber = true;

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -414,6 +414,7 @@ import ../../hosts/nixos {
         home-manager.backupFileExtension = "hm-backup";
         home-manager.extraSpecialArgs = {
           inherit pkgs;
+          isRunner = false;
           inputs = inputs // {
             host = (import ../../lib/host.nix) // {
               isDesktop = true;

--- a/named-hosts/pod/default.nix
+++ b/named-hosts/pod/default.nix
@@ -19,6 +19,7 @@ home-manager.lib.homeManagerConfiguration {
   inherit pkgs;
   extraSpecialArgs = {
     inherit username pkgs;
+    isRunner = false;
     inputs = inputs // {
       host = import ../../lib/host.nix;
     };


### PR DESCRIPTION
## Summary\n- pass the runner flag through Home Manager configs, including named-host overrides\n- skip runner uv-global activation/service installs\n- keep llama-cpp out of Linux runner package sets to avoid CUDA closure disk pressure\n\n## Verification\n- make nix-format-check\n- nix eval runner probes: no runner llama-cpp, no runner uv activation/service\n- nix eval darwin runner and galactica checks\n- make nix-test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trim CI runner installs to reduce disk and service overhead. Propagates an `isRunner` flag to skip `uv` globals and exclude `llama-cpp` from Linux runner packages.

- **Bug Fixes**
  - Pass `isRunner` through Home Manager, darwin/nixos hosts, and named hosts.
  - Disable `home.activation.installUvGlobals` and its systemd user service on runners.
  - Exclude `llama-cpp` on Linux runners to avoid CUDA closure disk pressure.

<sup>Written for commit 255edafd858bbd46a0d2a6c6487e137c96ff98c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

