### PR TITLE
feat: add gcx Grafana Cloud CLI

### DIFF
--- a/home-manager/programs/grafana/default.nix
+++ b/home-manager/programs/grafana/default.nix
@@ -1,6 +1,7 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
+    gcx
     grafana-alloy
     grafana-loki
   ];


### PR DESCRIPTION
## Summary\n- add the Grafana Cloud CLI (gcx) to the Grafana Home Manager package module\n\n## Validation\n- make nix-format-check\n- make build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `gcx` (Grafana Cloud CLI) to the Grafana Home Manager module so the CLI is installed alongside other Grafana tools for cloud management tasks.

<sup>Written for commit 9d1d88c6f404eef405bf88615874a30cd6de16b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

