### PR TITLE
chore(fish): Update fish functions and configuration

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -105,6 +105,7 @@
       v = "nvim";
 
       # Function-based abbreviations
+      caf = "_caf_function";
       cawxe = "_cawxe_function";
       cawxeh = "_cawxeh_function";
       caxe = "_caxe_function";
@@ -226,6 +227,7 @@
       })
       [
         "__tmux_bootstrap_default_session"
+        "_caf_function"
         "_cawxe_function"
         "_cawxeh_function"
         "_caxe_function"

--- a/home-manager/programs/fish/functions/__tmux_bootstrap_default_session.fish
+++ b/home-manager/programs/fish/functions/__tmux_bootstrap_default_session.fish
@@ -6,10 +6,11 @@ function __tmux_bootstrap_default_session --description "Create built-in tmux se
   # initializing before we build and attach. On a cold start, otherwise the
   # first new-session boots the server concurrently with the attach, freezing
   # the freshly-attached client (standalone `tpo` works only on a 2nd call).
-  tmux start-server 2>/dev/null
+  # Only warm for known sessions so an unknown name never touches tmux.
 
   switch $session_name
     case primary mobile desktop
+      tmux start-server 2>/dev/null
       tmux new-session -d -s $session_name -n btop
       if test $status -ne 0
         tmux has-session -t $session_name 2>/dev/null
@@ -30,6 +31,7 @@ function __tmux_bootstrap_default_session --description "Create built-in tmux se
       end
 
     case work
+      tmux start-server 2>/dev/null
       tmux new-session -d -s work -n editor
       if test $status -ne 0
         tmux has-session -t work 2>/dev/null

--- a/home-manager/programs/fish/functions/__tmux_bootstrap_default_session.fish
+++ b/home-manager/programs/fish/functions/__tmux_bootstrap_default_session.fish
@@ -2,6 +2,12 @@ function __tmux_bootstrap_default_session --description "Create built-in tmux se
   set -l session_name $argv[1]
   set -l dotfiles_root ~/dotfiles
 
+  # Warm the server first so config/plugins (continuum, resurrect) finish
+  # initializing before we build and attach. On a cold start, otherwise the
+  # first new-session boots the server concurrently with the attach, freezing
+  # the freshly-attached client (standalone `tpo` works only on a 2nd call).
+  tmux start-server 2>/dev/null
+
   switch $session_name
     case primary mobile desktop
       tmux new-session -d -s $session_name -n btop

--- a/home-manager/programs/fish/functions/_caf_function.fish
+++ b/home-manager/programs/fish/functions/_caf_function.fish
@@ -1,0 +1,48 @@
+function _caf_function --description "Keep the machine awake lid-closed (caffeinate / systemd-inhibit)"
+    set -l pid_file "$HOME/.local/state/caf.pid"
+
+    switch "$argv[1]"
+        case on
+            mkdir -p (dirname "$pid_file")
+            if test (uname) = Darwin
+                sudo pmset -a disablesleep 1
+                caffeinate -dimsu &
+            else
+                systemd-inhibit --what=handle-lid-switch:sleep:idle \
+                    --who=caf --why=caf --mode=block sleep infinity &
+            end
+            echo $last_pid >"$pid_file"
+            disown
+            echo "caf on: awake lid-closed (pid "(cat "$pid_file")")"
+        case off
+            if test (uname) = Darwin
+                sudo pmset -a disablesleep 0
+            end
+            if test -f "$pid_file"
+                kill (cat "$pid_file") 2>/dev/null
+                rm -f "$pid_file"
+            end
+            echo "caf off: normal sleep restored"
+        case status
+            if test (uname) = Darwin
+                pmset -g | string match -e disablesleep
+            else
+                systemd-inhibit --list 2>/dev/null | string match -e caf
+            end
+            if test -f "$pid_file"; and kill -0 (cat "$pid_file") 2>/dev/null
+                echo "caf active (pid "(cat "$pid_file")")"
+            else
+                echo "caf inactive"
+            end
+        case ''
+            # Toggle: active if the keeper pid is alive
+            if test -f "$pid_file"; and kill -0 (cat "$pid_file") 2>/dev/null
+                _caf_function off
+            else
+                _caf_function on
+            end
+        case '*'
+            echo "Usage: caf [on|off|status]"
+            return 1
+    end
+end

--- a/spec/fish/_caf_function_test.fish
+++ b/spec/fish/_caf_function_test.fish
@@ -1,0 +1,31 @@
+set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caf_function.fish
+
+# Isolate state so the pid file never touches the real HOME.
+set tmpdir (mktemp -d)
+set -x HOME $tmpdir
+
+# Stub system commands so no real sleep keeper or sudo is invoked.
+function uname
+    echo Linux
+end
+function systemd-inhibit
+    echo $argv
+end
+
+# ── unknown argument ──────────────────────────────────────
+_caf_function bogus >/dev/null 2>&1
+@test "unknown argument returns 1" $status = 1
+
+set usage (_caf_function bogus 2>&1)
+@test "unknown argument prints usage" (string match -q "*Usage: caf*" "$usage"; echo $status) = 0
+
+# ── status with no keeper running ─────────────────────────
+set out (_caf_function status 2>/dev/null)
+@test "status reports inactive without pid file" (string match -q "*caf inactive*" "$out"; echo $status) = 0
+
+# ── off with no keeper running ────────────────────────────
+_caf_function off >/dev/null 2>&1
+@test "off restores normal sleep" $status = 0
+
+rm -rf $tmpdir


### PR DESCRIPTION
Update fish shell function configurations in home-manager.

## Changes
- Update default.nix fish configuration
- Update __tmux_bootstrap_default_session function  
- Add _caf_function for new functionality

## Details
Modifies fish shell setup in home-manager to improve function configuration and add new shell utilities.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new fish “caf” utility to keep the machine awake and wire it into the config. Warm the tmux server during bootstrap to prevent client freezes on cold start; add tests for “caf” to validate usage and inactive-state handling.

- **New Features**
  - `_caf_function`: keeps the machine awake lid-closed using `pmset`/`caffeinate` (macOS) or `systemd-inhibit` (Linux); supports on/off/status/toggle and tracks PID at `~/.local/state/caf.pid`.
  - Adds `caf` abbreviation and loads `_caf_function` in `home-manager/programs/fish/default.nix`.
  - Tests for `caf`: check argument handling, usage output, and no-keeper behavior with isolated HOME and stubbed commands.

- **Bug Fixes**
  - `__tmux_bootstrap_default_session`: call `tmux start-server` before creating/attaching sessions to avoid freezes while plugins initialize.

<sup>Written for commit 800f5768012e776f72ec9d250ded09e5991971fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

