### PR TITLE
fix(fish): keep tmux session alive when layout step fails

### DIFF
--- a/home-manager/programs/fish/functions/__tmux_bootstrap_default_session.fish
+++ b/home-manager/programs/fish/functions/__tmux_bootstrap_default_session.fish
@@ -2,52 +2,44 @@ function __tmux_bootstrap_default_session --description "Create built-in tmux se
   set -l session_name $argv[1]
   set -l dotfiles_root ~/dotfiles
 
-  # Warm the server first so config/plugins (continuum, resurrect) finish
-  # initializing before we build and attach. On a cold start, otherwise the
-  # first new-session boots the server concurrently with the attach, freezing
-  # the freshly-attached client (standalone `tpo` works only on a 2nd call).
-  # Only warm for known sessions so an unknown name never touches tmux.
+  # `new-session -d` boots the server and blocks until the config (plugins) is
+  # fully sourced, so the caller's later attach never races a half-initialized
+  # server. The window layout that follows is best-effort: a transient failure
+  # on a cold/busy server must NOT destroy the session, otherwise `tpo` aborts
+  # with no tmux at all ("tmux doesn't start entirely"). As long as the session
+  # exists we return success so the caller attaches to whatever was built.
 
   switch $session_name
     case primary mobile desktop
-      tmux start-server 2>/dev/null
       tmux new-session -d -s $session_name -n btop
       if test $status -ne 0
+        # Lost a race / already exists: treat an existing session as success.
         tmux has-session -t $session_name 2>/dev/null
         return $status
       end
 
-      if not begin
-        tmux send-keys -t $session_name:0 btop C-m
-        and tmux new-window -c $dotfiles_root -t $session_name:1 -n dotfiles
-        and tmux split-window -c $dotfiles_root -t $session_name:1
-        and tmux select-layout -t $session_name:1 even-horizontal
-        and tmux new-window -t $session_name:2 -n $session_name
-        and tmux select-window -t $session_name:0
-        and tmux select-pane -t $session_name:0.0
-      end
-        tmux kill-session -t $session_name 2>/dev/null
-        return 1
-      end
+      tmux send-keys -t $session_name:0 btop C-m
+      tmux new-window -c $dotfiles_root -t $session_name:1 -n dotfiles
+      tmux split-window -c $dotfiles_root -t $session_name:1
+      tmux select-layout -t $session_name:1 even-horizontal
+      tmux new-window -t $session_name:2 -n $session_name
+      tmux select-window -t $session_name:0
+      tmux select-pane -t $session_name:0.0
+      return 0
 
     case work
-      tmux start-server 2>/dev/null
       tmux new-session -d -s work -n editor
       if test $status -ne 0
         tmux has-session -t work 2>/dev/null
         return $status
       end
 
-      if not begin
-        tmux send-keys -t work:0 nvim C-m
-        and tmux new-window -t work:1 -n shell
-        and tmux new-window -t work:2 -n work
-        and tmux select-window -t work:0
-        and tmux select-pane -t work:0.0
-      end
-        tmux kill-session -t work 2>/dev/null
-        return 1
-      end
+      tmux send-keys -t work:0 nvim C-m
+      tmux new-window -t work:1 -n shell
+      tmux new-window -t work:2 -n work
+      tmux select-window -t work:0
+      tmux select-pane -t work:0.0
+      return 0
 
     case '*'
       echo "Unknown built-in tmux session '$session_name'" >&2


### PR DESCRIPTION
## Problem

On a cold start (`tpo` from a plain shell, no tmux running), tmux would not start entirely — the user is dropped back to a plain shell with no session.

`__tmux_bootstrap_default_session` built the window layout as an all-or-nothing `and`-chain and ran `tmux kill-session` + `return 1` on **any** failure. On a cold/busy server a single transient hiccup in a cosmetic step (`split-window`, `select-layout`, ...) destroyed the entire session, so `_tpo_function` aborted and never attached.

The `tmux start-server` warm-up added previously was a no-op: with no session to keep it alive the server exits immediately, so the next `new-session` cold-starts a fresh server anyway (verified in isolation).

## Fix

- Session creation (`new-session -d`) is the only hard requirement; it already blocks until the config/plugins are fully sourced, so the later attach never races a half-initialized server.
- Window layout is now best-effort — a failing step no longer destroys the session or aborts the attach.
- `return 0` after a successful create guarantees the caller always attaches to whatever was built.
- Preserved the "session already exists ⇒ success" race handling.
- Removed the dead `tmux start-server` line.

Applies to the `primary`/`mobile`/`desktop` and `work` bootstraps.

## Testing

- Full fish test suite (`make fish-test`) passes.
- Manual stub verification: cosmetic step failure no longer triggers `kill-session` and the session survives (rc=0); `new-session` failure with no existing session returns nonzero; existing-session race returns success; unknown session rejected without touching tmux.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the `tmux` session alive on cold start by making layout steps best-effort, so `tpo` no longer drops back to a plain shell if a cosmetic command fails. Also removes the no-op `start-server` and ensures we always attach after a successful session create.

- **Bug Fixes**
  - Make `tmux new-session -d` the only hard requirement; remove `start-server` and avoid half-initialized attaches.
  - Run layout commands best-effort; don’t `kill-session` on failure; return success once a session exists so attach proceeds.
  - Preserve “session already exists” handling; applies to `primary`, `mobile`, `desktop`, and `work` bootstraps.

<sup>Written for commit 97609d7c6b91e27435c4d9b48f570f3b53de1bee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

