### PR TITLE
feat: add YubiKey support to matic host

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -244,6 +244,8 @@ with pkgs;
   wl-clipboard
   wtype
   xdg-desktop-portal-gtk
+  yubikey-manager
+  yubioath-flutter
   yt-dlp
 ]
 ++ lib.optionals isDev [

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -153,6 +153,10 @@ import ../../hosts/nixos {
         #     systemd-creds encrypt --name=gnome-keyring --with-key=tpm2+host \
         #     - /etc/credstore.encrypted/gnome-keyring.cred'
 
+        # YubiKey support
+        services.pcscd.enable = true;
+        services.udev.packages = [ pkgs.yubikey-personalization ];
+
         # Fingerprint authentication
         services.fprintd.enable = true;
         security.pam.services.greetd = {


### PR DESCRIPTION
## Summary
- Enable `pcscd` (smartcard daemon) for YubiKey CCID/smartcard mode
- Add `yubikey-personalization` udev rules for device detection
- Install `yubikey-manager` (ykman CLI) and `yubioath-flutter` (Yubico Authenticator GUI) as desktop packages

## Test plan
- [ ] Rebuild NixOS: `sudo nixos-rebuild switch --flake .#matic`
- [ ] Plug in YubiKey and verify `ykman info` shows device info
- [ ] Open Yubico Authenticator and confirm it detects the key

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add YubiKey support to the matic host by enabling `pcscd`, adding udev rules via `yubikey-personalization`, and installing `yubikey-manager` and `yubioath-flutter`. Users can manage their key with ykman and use Yubico Authenticator without extra setup.

<sup>Written for commit 4d64c31cfe1c9158a0aba2f063ead441c598df45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

