### PR TITLE
feat: add yubikey-manager-qt GUI package

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -245,6 +245,7 @@ with pkgs;
   wtype
   xdg-desktop-portal-gtk
   yubikey-manager
+  yubikey-manager-qt
   yubioath-flutter
   yt-dlp
 ]


### PR DESCRIPTION
## Summary
- Add `yubikey-manager-qt` (YubiKey Manager GUI) to desktop packages

## Test plan
- [ ] Rebuild and launch `yubikey-manager-qt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `yubikey-manager-qt` to the Home Manager desktop packages to provide the YubiKey Manager GUI. Users can manage YubiKeys via a GUI alongside the existing `yubikey-manager` CLI.

<sup>Written for commit a652bcffbde1bda1badff944999f79b86429baab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

