### PR TITLE
fix: drop archived yubikey-manager-qt package

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -245,7 +245,6 @@ with pkgs;
   wtype
   xdg-desktop-portal-gtk
   yubikey-manager
-  yubikey-manager-qt
   yubioath-flutter
   yt-dlp
 ]


### PR DESCRIPTION
## Problem

The Nix workflow is failing on `main`:

```
error: 'yubikey-manager-qt' has been removed due to being archived upstream.
Consider using 'yubioath-flutter' instead.
```

PR #1920 ("fix: remove archived yubikey-manager-qt") was meant to remove this package, but the squashed merge landed as an empty commit - the file change was lost, so `yubikey-manager-qt` remained in `home-manager/packages/default.nix`.

## Fix

Remove `yubikey-manager-qt` from the package list.

## Verification

Against the locked nixpkgs (`3497aa5`):
- `yubikey-manager` -> python3.13-yubikey-manager-5.8.0 (exists)
- `yubioath-flutter` -> yubioath-flutter-7.3.1 (exists, the recommended replacement)
- `yubikey-manager-qt` -> removed (archived upstream)

The oneshot/Restart lines in the CI trace were just the lazy assertion-evaluation stack, not a separate failure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove archived `yubikey-manager-qt` from `home-manager/packages/default.nix` to fix Nix evaluation failures on main. `yubikey-manager` and `yubioath-flutter` remain as supported packages.

<sup>Written for commit 794db556e7ec7a789b6cfda5d4243d4a9e9a7e3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

