### PR TITLE
fix(ci): free more disk space and add nix fallback for cache mismatches

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,12 @@ jobs:
         if: runner.os == 'Linux'
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
-          tool-cache: false
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Login to GHCR

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,12 @@ jobs:
         if: runner.os == 'Linux'
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
-          tool-cache: false
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
       - name: KVM Linux Virtualization
         if: runner.os == 'Linux'
         run: |
@@ -50,6 +55,7 @@ jobs:
             system-features = kvm
             max-jobs = auto
             cores = 0
+            fallback = true
       - name: Prepare System Files
         if: runner.os == 'macOS'
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,7 @@ RUN mkdir -p /etc/nix && \
     echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf && \
     echo "filter-syscalls = false" >> /etc/nix/nix.conf && \
     echo "sandbox = true" >> /etc/nix/nix.conf && \
+    echo "fallback = true" >> /etc/nix/nix.conf && \
     if [ -n "$GITHUB_TOKEN" ]; then \
       echo "access-tokens = github.com=$GITHUB_TOKEN" >> /etc/nix/nix.conf ; \
     fi

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ NIX_USERNAME := $(shell \
 		echo "$(shell whoami)"; \
 	fi)
 NIX_ENV := $(shell . ~/.nix-profile/etc/profile.d/nix.sh 2>/dev/null || . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh 2>/dev/null || command -v nix >/dev/null 2>&1 || echo "not_found")
-NIX_FLAGS := --extra-experimental-features 'flakes nix-command' --no-pure-eval --impure
+NIX_FLAGS := --extra-experimental-features 'flakes nix-command' --no-pure-eval --impure --fallback
 # Only add cache options when user is trusted or on Darwin/CI (avoids "ignoring untrusted substituter" warnings)
 ifeq ($(OS),Darwin)
 NIX_FLAGS += --option substituters "$(NIX_SUBSTITUTERS)" --option trusted-public-keys "$(NIX_TRUSTED_KEYS)"


### PR DESCRIPTION
## Summary

- Enable `tool-cache: true` and explicit category flags in `free-disk-space` action for both E2E and Docker workflows to reclaim ~5GB additional disk space (fixes `No space left on device` during nix build on Ubuntu)
- Add `--fallback` to `NIX_FLAGS` in Makefile and `fallback = true` to nix.conf in Dockerfile and E2E workflow, so nix builds from source when binary cache returns hash mismatches (fixes arm64 Docker build failure: `hash mismatch importing path .../cyrus-sasl-2.1.28-dev`)

## Test plan

- [ ] E2E (Ubuntu) job completes without disk space exhaustion
- [ ] Docker (linux/arm64) job completes without nix cache hash mismatch errors
- [ ] E2E (MacOS) and E2E (NixOS) jobs remain green
- [ ] Docker (linux/amd64) job remains green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Free up more disk space on Linux runners and add Nix fallback to fix CI build failures. This prevents “No space left on device” and handles cache hash mismatches, stabilizing E2E and Docker builds (including `linux/arm64`).

- **Bug Fixes**
  - E2E and Docker workflows: enable `tool-cache: true` and explicit categories in `jlumbroso/free-disk-space@v1.3.1` to reclaim ~5 GB.
  - Nix: set `fallback = true` in nix.conf (Dockerfile and E2E) and add `--fallback` to `NIX_FLAGS` in the Makefile so builds continue from source on cache mismatches.

<sup>Written for commit 0bd05d8ad14edeccc8e7d70f46cfe655c72d0605. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

