### PR TITLE
fix(test): remove paperclip spec tests after service removal

### DIFF
--- a/spec/activate_paperclip_openclaw_spec.sh
+++ b/spec/activate_paperclip_openclaw_spec.sh
@@ -1,37 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2016,SC2329
 
-Describe 'home-manager/services/paperclip/activate.sh'
-SCRIPT="$PWD/home-manager/services/paperclip/activate.sh"
-
-It 'uses bash shebang'
-When run bash -c "head -1 '$SCRIPT'"
-The output should include '#!/usr/bin/env bash'
-End
-
-It 'creates /tmp/paperclip'
-When run bash -c "grep '/tmp/paperclip' '$SCRIPT'"
-The output should include '/tmp/paperclip'
-End
-
-It 'creates .paperclip directory'
-When run bash -c "grep '.paperclip' '$SCRIPT'"
-The output should include '.paperclip'
-End
-
-It 'sets restrictive permissions'
-When run bash -c "grep 'chmod 700' '$SCRIPT'"
-The output should include 'chmod 700'
-End
-End
-
-Describe 'home-manager/services/paperclip/default.nix'
-It 'quotes the home directory argument when invoking the helper'
-When run cat "$PWD/home-manager/services/paperclip/default.nix"
-The output should include '"${./activate.sh}" "${homeDir}"'
-End
-End
-
 Describe 'home-manager/services/openclaw/activate.sh'
 SCRIPT="$PWD/home-manager/services/openclaw/activate.sh"
 


### PR DESCRIPTION
## Summary

- Removes paperclip test cases from `spec/activate_paperclip_openclaw_spec.sh` that were added alongside the paperclip service
- The paperclip service was removed in #1926 (`fix(security): bind hermes dashboard to localhost, remove paperclip service`) but the corresponding spec tests were not cleaned up
- This caused the `shell-test` CI job to fail with 5 test failures

## Test plan

- [ ] `shell-test` CI job passes (no more paperclip spec failures)
- [ ] Remaining openclaw and hermes tests in the spec file continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed obsolete paperclip spec tests left after the service was removed, unblocking the `shell-test` job by eliminating 5 failures.

- **Bug Fixes**
  - Deleted paperclip test blocks from `spec/activate_paperclip_openclaw_spec.sh`.

<sup>Written for commit 042282eef63da3a3afd14ec0291e8b2bcb159377. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

