### PR TITLE
feat(caf): disable screen lock and idle timeout when active

### DIFF
--- a/home-manager/programs/fish/functions/_caf_function.fish
+++ b/home-manager/programs/fish/functions/_caf_function.fish
@@ -1,4 +1,4 @@
-function _caf_function --description "Keep the machine awake lid-closed (caffeinate / systemd-inhibit)"
+function _caf_function --description "Keep the machine awake lid-closed, screen-lock disabled (caffeinate / systemd-inhibit)"
     set -l pid_file "$HOME/.local/state/caf.pid"
 
     switch "$argv[1]"
@@ -13,7 +13,13 @@ function _caf_function --description "Keep the machine awake lid-closed (caffein
             end
             echo $last_pid >"$pid_file"
             disown
-            echo "caf on: awake lid-closed (pid "(cat "$pid_file")")"
+            if command -q noctalia-shell
+                noctalia-shell msg idleInhibitor enable 2>/dev/null
+            end
+            if test (uname) != Darwin
+                systemctl --user stop ac-idle-inhibit.service 2>/dev/null
+            end
+            echo "caf on: awake, screen lock disabled (pid "(cat "$pid_file")")"
         case off
             if test (uname) = Darwin
                 sudo pmset -a disablesleep 0
@@ -22,7 +28,13 @@ function _caf_function --description "Keep the machine awake lid-closed (caffein
                 kill (cat "$pid_file") 2>/dev/null
                 rm -f "$pid_file"
             end
-            echo "caf off: normal sleep restored"
+            if command -q noctalia-shell
+                noctalia-shell msg idleInhibitor disable 2>/dev/null
+            end
+            if test (uname) != Darwin
+                systemctl --user start ac-idle-inhibit.service 2>/dev/null
+            end
+            echo "caf off: normal sleep and screen lock restored"
         case status
             if test (uname) = Darwin
                 pmset -g | string match -e disablesleep

--- a/spec/fish/_caf_function_test.fish
+++ b/spec/fish/_caf_function_test.fish
@@ -12,6 +12,12 @@ end
 function systemd-inhibit
     echo $argv
 end
+function noctalia-shell
+    true
+end
+function systemctl
+    true
+end
 
 # ── unknown argument ──────────────────────────────────────
 _caf_function bogus >/dev/null 2>&1


### PR DESCRIPTION
## Summary
- `caf on` now also disables noctalia idle inhibitor (screen lock) and stops `ac-idle-inhibit.service` (battery dpms-off/suspend)
- `caf off` re-enables both
- Test stubs added for `noctalia-shell` and `systemctl` to prevent errors during fish tests

## Test plan
- [x] `make format` passes
- [x] `make fish-test` passes (all caf tests green)
- [ ] Run `caf on` and verify screen does not lock after idle timeout
- [ ] Run `caf off` and verify screen lock resumes
- [ ] Run `caf status` to confirm reporting still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `caf` so `on` disables screen lock and idle timeout (enables `noctalia-shell` idle inhibitor, stops user `ac-idle-inhibit.service`). `off` restores both; adds test stubs for `noctalia-shell` and `systemctl` to keep fish tests passing.

<sup>Written for commit e42fb01c19cfd760e4a11945df0e6a50f47cdb57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

