### PR TITLE
fix(tmux): prevent tpo hang by closing daemon pipe FDs

### DIFF
--- a/home-manager/programs/tmux/tmux.conf
+++ b/home-manager/programs/tmux/tmux.conf
@@ -148,7 +148,7 @@ set -g history-limit 2147483647
 # =============================================================================
 # Claude Code Agent Teams
 # =============================================================================
-run-shell ~/ghq/github.com/shunkakinoki/tmux-claude-teams/claude-teams.tmux
+run-shell "~/ghq/github.com/shunkakinoki/tmux-claude-teams/claude-teams.tmux >/dev/null 2>&1"
 
 # =============================================================================
 # TPM plugins


### PR DESCRIPTION
## Summary
- `run-shell ~/ghq/.../claude-teams.tmux` starts a daemon process that inherits tmux's pipe file descriptors
- The daemon runs indefinitely, so the pipe never closes and `run-shell` hangs forever during config sourcing
- This blocks `tmux new-session -d` in `_tpo_function`, making `tpo` stuck on cold tmux starts
- Fix: redirect stdout/stderr to `/dev/null` so the daemon inherits `/dev/null` FDs instead of the pipe

## Test plan
- [x] All 379 fish function tests pass (including tpo-specific tests 332-343)
- [ ] Kill tmux server, run `tpo` - should attach without hanging
- [ ] Verify claude-teams keybindings still work after attach


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSXJcojZL93gke3q9pdjQG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a cold-start hang in `tmux` by redirecting the Claude Teams daemon’s stdout/stderr to `/dev/null`, closing the `run-shell` pipe so `tpo` can start and attach normally.

- **Bug Fixes**
  - Update tmux config to run `~/ghq/github.com/shunkakinoki/tmux-claude-teams/claude-teams.tmux >/dev/null 2>&1`, ensuring the daemon inherits `/dev/null` FDs instead of tmux’s pipe.

<sup>Written for commit c15bc2220a71b0e2e2f985a7a41d360e3c13ffea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

