### PR TITLE
feat(security): add iptables firewall for kyber host

### DIFF
--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -12,6 +12,7 @@ let
   codeSyncer = import ./code-syncer { inherit pkgs; };
   dolt = ./dolt;
   docker = import ./docker { inherit lib pkgs; };
+  firewall = ./firewall;
   dockerPostgres = ./docker-postgres;
   dotfilesUpdater = import ./dotfiles-updater { inherit pkgs; };
   gasTown = import ./gas-town { inherit pkgs; };
@@ -37,6 +38,7 @@ in
   dolt
   docker
   dockerPostgres
+  firewall
   dotfilesUpdater
   gasTown
   hermes

--- a/home-manager/services/firewall/activate.sh
+++ b/home-manager/services/firewall/activate.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CHAIN="kyber-firewall"
+PUBLIC_IF="eno1"
+
+SUDO_CMD=""
+if command -v sudo >/dev/null 2>&1; then
+  SUDO_CMD="sudo"
+elif [ -x /run/wrappers/bin/sudo ]; then
+  SUDO_CMD="/run/wrappers/bin/sudo"
+elif [ -x /usr/bin/sudo ]; then
+  SUDO_CMD="/usr/bin/sudo"
+elif command -v doas >/dev/null 2>&1; then
+  SUDO_CMD="doas"
+elif [ "$(id -u)" -ne 0 ]; then
+  echo "Firewall setup requires root privileges." >&2
+  exit 1
+fi
+
+run_root() {
+  if [ -n "$SUDO_CMD" ]; then
+    "$SUDO_CMD" "$@"
+  else
+    "$@"
+  fi
+}
+
+ipt() {
+  run_root @iptables@ "$@"
+}
+
+if ipt -L "$CHAIN" -n >/dev/null 2>&1; then
+  echo "Firewall chain $CHAIN already exists, skipping."
+  exit 0
+fi
+
+echo "Configuring iptables firewall on $PUBLIC_IF..."
+
+ipt -N "$CHAIN"
+
+# Allow established/related connections
+ipt -A "$CHAIN" -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+# Allow SSH
+ipt -A "$CHAIN" -p tcp --dport 22 -j ACCEPT
+
+# Drop everything else on public interface
+ipt -A "$CHAIN" -j DROP
+
+# Insert chain into INPUT for public interface only
+ipt -I INPUT 1 -i "$PUBLIC_IF" -j "$CHAIN"
+
+echo "Firewall enabled: only SSH (22) allowed on $PUBLIC_IF."
+echo "Tailscale, k3s, and Docker traffic unaffected (different interfaces)."

--- a/home-manager/services/firewall/default.nix
+++ b/home-manager/services/firewall/default.nix
@@ -1,0 +1,18 @@
+{
+  config,
+  lib,
+  pkgs,
+  inputs,
+  ...
+}:
+let
+  inherit (inputs) host;
+  activateScript = pkgs.replaceVars ./activate.sh {
+    iptables = "${pkgs.iptables}/bin/iptables";
+  };
+in
+lib.mkIf host.isKyber {
+  home.activation.setupFirewall = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${activateScript}"
+  '';
+}

--- a/spec/activate_firewall_spec.sh
+++ b/spec/activate_firewall_spec.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329,SC2016
+
+Describe 'home-manager/services/firewall/activate.sh'
+SCRIPT="$PWD/home-manager/services/firewall/activate.sh"
+
+Describe 'script properties'
+It 'uses bash shebang'
+When run bash -c "head -1 '$SCRIPT'"
+The output should include '#!/usr/bin/env bash'
+End
+
+It 'uses strict mode'
+When run bash -c "head -5 '$SCRIPT'"
+The output should include 'set -euo pipefail'
+End
+End
+
+Describe 'sudo detection'
+It 'checks for sudo command'
+When run bash -c "grep 'command -v sudo' '$SCRIPT'"
+The output should include 'command -v sudo'
+End
+
+It 'checks NixOS wrapper path'
+When run bash -c "grep '/run/wrappers/bin/sudo' '$SCRIPT'"
+The output should include '/run/wrappers/bin/sudo'
+End
+End
+
+Describe 'firewall configuration'
+It 'defines a custom iptables chain name'
+When run bash -c "grep 'CHAIN=' '$SCRIPT'"
+The output should include 'kyber-firewall'
+End
+
+It 'targets the public interface'
+When run bash -c "grep 'PUBLIC_IF=' '$SCRIPT'"
+The output should include 'eno1'
+End
+
+It 'allows established connections'
+When run bash -c "grep 'ESTABLISHED,RELATED' '$SCRIPT'"
+The output should include 'ESTABLISHED,RELATED'
+End
+
+It 'allows SSH on port 22'
+When run bash -c "grep 'dport 22' '$SCRIPT'"
+The output should include 'dport 22'
+End
+
+It 'drops other traffic'
+When run bash -c "grep -- '-j DROP' '$SCRIPT'"
+The output should include 'DROP'
+End
+
+It 'is idempotent by checking chain existence'
+When run bash -c "grep 'already exists' '$SCRIPT'"
+The output should include 'already exists'
+End
+
+It 'uses a nix-substituted iptables path'
+When run bash -c "grep '@iptables@' '$SCRIPT'"
+The output should include '@iptables@'
+End
+End
+End

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -304,6 +304,10 @@ It 'has spec file for home-manager/modules/bin-shells/activate.sh'
 The path "spec/activate_bin_shells_spec.sh" should be exist
 End
 
+It 'has spec file for home-manager/services/firewall/activate.sh'
+The path "spec/activate_firewall_spec.sh" should be exist
+End
+
 It 'has spec file for home-manager/services/hermes/activate.sh'
 The path "spec/activate_paperclip_openclaw_spec.sh" should be exist
 End
@@ -421,6 +425,7 @@ home-manager/modules/local-scripts/pushover-notify.sh
 home-manager/modules/local-scripts/tmux-bridge.sh
 home-manager/modules/npm-globals/install-npm-globals.sh
 home-manager/modules/secure-dotenv/secure-dotenv.sh
+home-manager/services/firewall/activate.sh
 home-manager/services/hermes/activate.sh
 home-manager/services/obsidian/obsidian-git-trigger.sh
 home-manager/services/obsidian/obsidian-headless.sh


### PR DESCRIPTION
## Summary
- Add iptables-based firewall for the kyber host, gated behind `isKyber`
- Only allows SSH (port 22) on the public interface (`eno1`)
- Tailscale, k3s pod/service, and Docker bridge traffic unaffected (different interfaces)
- Uses a dedicated `kyber-firewall` iptables chain with idempotent setup
- Nix-substituted iptables path via `replaceVars` for deterministic builds

## Context
Investigation of a xmrig cryptominer infection (June 14) revealed the machine had **no firewall** with multiple services bound to `0.0.0.0` on a public IP. The attack vector was an unauthenticated RCE endpoint on port 9119.

## Test plan
- [x] shellcheck passes
- [x] shellspec activate_firewall_spec.sh passes (11 examples)
- [x] shellspec coverage_spec.sh passes (88 examples)
- [ ] Verify `home-manager switch` applies firewall rules on kyber
- [ ] Verify SSH access still works after firewall activation
- [ ] Verify k3s workloads and Tailscale are unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `iptables` firewall for the Kyber host that blocks all inbound traffic on `eno1` except SSH to reduce public exposure. Tailscale, `k3s`, and Docker bridge traffic are unaffected; the activation is idempotent.

- New Features
  - New `kyber-firewall` chain applied only when `host.isKyber` via `home-manager` activation.
  - Rules: accept ESTABLISHED/RELATED, allow SSH (22), drop all else on `eno1`.
  - Deterministic builds via nix-substituted `iptables` path.
  - Added shellspec tests and coverage entries.

- Migration
  - Run `home-manager switch` on the Kyber host.
  - Confirm the public NIC is `eno1`; update the script if the interface differs.
  - Verify SSH access after activation.

<sup>Written for commit 4ef2a6857520db95101b1986a9fcdb0ba0cfd816. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

