### PR TITLE
fix(homebrew): trust non-official taps for Homebrew 6.0.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -660,11 +660,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779036909,
-        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
+        "lastModified": 1781761792,
+        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "56c666e108467d87d13508936aade6d567f2a501",
+        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
         "type": "github"
       },
       "original": {

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -15,16 +15,46 @@
       extraFlags = [ "--force" ];
     };
     taps = [
-      "anomalyco/tap"
-      "entireio/tap"
+      # Homebrew 6.0.0 enabled HOMEBREW_REQUIRE_TAP_TRUST by default, refusing
+      # to load formulae/casks from non-official taps unless explicitly trusted.
+      # Mark our non-official taps as trusted so activation can install them.
+      {
+        name = "anomalyco/tap";
+        trusted = true;
+      }
+      {
+        name = "entireio/tap";
+        trusted = true;
+      }
       "homebrew/cask"
-      "kurtosis-tech/tap"
-      "manaflow-ai/cmux"
-      "open-pencil/tap"
-      "oven-sh/bun"
-      "paradigmxyz/brew"
-      "planetscale/tap"
-      "steipete/tap"
+      {
+        name = "kurtosis-tech/tap";
+        trusted = true;
+      }
+      {
+        name = "manaflow-ai/cmux";
+        trusted = true;
+      }
+      {
+        name = "open-pencil/tap";
+        trusted = true;
+      }
+      {
+        name = "oven-sh/bun";
+        trusted = true;
+      }
+      {
+        name = "paradigmxyz/brew";
+        trusted = true;
+      }
+      {
+        name = "planetscale/tap";
+        trusted = true;
+      }
+      {
+        name = "steipete/tap";
+        trusted = true;
+      }
     ];
     brews = [
       "argo"


### PR DESCRIPTION
## Summary

Homebrew 6.0.0 (2026-06-11) enabled `HOMEBREW_REQUIRE_TAP_TRUST` by default, refusing to load formulae/casks from non-official taps unless explicitly trusted. This broke `brew bundle` activation with warnings like:

```
Warning: The following taps are not trusted:
  anomalyco/tap, entireio/tap, kurtosis-tech/tap, ...
Homebrew is currently ignoring formulae, casks and commands from these taps because tap trust is required.
```

## Changes

- Bump `nix-darwin` `56c666e` -> `a1fa429`, which adds the homebrew module `trusted` option (landed 2026-06-17) plus the Homebrew 6.0.0 bundle-CLI fixes.
- Mark all 9 non-official taps `trusted = true` in `nix-darwin/config/homebrew.nix`. `homebrew/cask` is left untouched (official taps are always trusted).

This emits `tap "...", trusted: true` in the generated Brewfile. `brew bundle` converts those into trust-store entries (`~/.config/homebrew/trust.json`) before fetching, so activation installs from them without prompting.

## Verification

- `nix eval .#darwinConfigurations.aarch64-darwin.config.homebrew.brewfile` renders the `trusted: true` tap lines and evaluates cleanly.
- `nixfmt --check` passes.

Not run here: `darwin-rebuild switch` (apply on the host to clear the warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `brew bundle` on Homebrew 6.0.0 by trusting non‑official taps so installs aren’t blocked. Updates `nix-darwin` to use the new tap `trusted` option and applies it to our taps to remove trust warnings.

<sup>Written for commit b042582ad0f2f85d3a37b5ba391427175c6923e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

