### PR TITLE
fix(neovim): add tree-sitter CLI to dev shell for parser builds

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -5,6 +5,7 @@
     pkgs.nodejs
     pkgs.bun
     pkgs.neovim
+    pkgs.tree-sitter
     pkgs.shellcheck
     pkgs.shellspec
     pkgs.gnumake


### PR DESCRIPTION
## Problem

The `Lua` workflow (`lua-neovim` job → `make lua-check-neovim-dev`) fails on main:

```
vim.schedule callback: vim/_core/system:340: ENOENT: no such file or directory (cmd): 'tree-sitter'
```

Since #1935 / #1936, Neovim treesitter parsers are managed by [tree-sitter-manager.nvim](https://github.com/romus204/tree-sitter-manager.nvim), which shells out to the `tree-sitter` CLI at startup to build the `ensure_installed` parsers. The Nix dev shell (`devenv.nix`) used by CI does not provide `tree-sitter`, so every parser build throws `ENOENT`, and the headless config check trips on `Error in command line:`.

`tree-sitter` is already in `home-manager/packages/default.nix`, so the user's real machine works; only the CI dev shell was missing it.

## Fix

Add `pkgs.tree-sitter` to the `devenv.nix` dev shell so the parser builds find the CLI (git + gcc are already present).

## Note

The separate `Upgrade` workflow failure is unrelated — it originates in the `dotagents` submodule's `.ruler/ruler.toml` (`[global]` table rejected by newer ruler). Out of scope for this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `pkgs.tree-sitter` to the `devenv.nix` dev shell so Neovim Treesitter parsers can build in CI. Fixes ENOENT errors in the `lua-neovim` job.

<sup>Written for commit da5e3a4642be952baa550230b29653687d387dc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

