### PR TITLE
feat(noctalia): add quit-app and quit-all-apps scripts

### DIFF
--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -253,7 +253,7 @@ bind = $mod SHIFT, E, exec, noctalia-shell ipc call launcher emoji
 # =============================================================================
 bind = $mod, W, movetoworkspacesilent, special:minimized
 bind = $mod SHIFT, W, exec, hyprctl -j clients | jq -r '.[] | select(.workspace.name == "special:minimized") | .address' | xargs -I{} hyprctl dispatch movetoworkspacesilent e+0,address:{}
-bind = $mod, Q, killactive,
+bind = $mod, Q, exec, ~/.config/noctalia/scripts/quit-active-app.sh
 bind = $mod SHIFT, F, togglefloating,
 bind = CTRL ALT SHIFT SUPER, F, exec, hyprctl --batch "dispatch movetoworkspace empty; dispatch fullscreen 0"
 bind = SUPER CTRL, F, fullscreen, 1

--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -52,6 +52,26 @@ in
     Install.WantedBy = [ "sleep.target" ];
   };
 
+  xdg.configFile."noctalia/scripts/quit-active-app.sh" = {
+    source = ./quit-active-app.sh;
+    executable = true;
+    force = true;
+  };
+  xdg.configFile."noctalia/scripts/quit-all-apps.sh" = {
+    source = ./quit-all-apps.sh;
+    executable = true;
+    force = true;
+  };
+
+  xdg.desktopEntries.quit-all-apps = {
+    name = "Quit All Apps";
+    comment = "Close all open windows";
+    exec = "${pkgs.bash}/bin/bash -c '\"$HOME/.config/noctalia/scripts/quit-all-apps.sh\"'";
+    terminal = false;
+    categories = [ "Utility" ];
+    icon = "application-exit";
+  };
+
   programs.noctalia-shell = {
     enable = true;
     package = noctaliaShell;

--- a/config/noctalia/quit-active-app.sh
+++ b/config/noctalia/quit-active-app.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+class=$(hyprctl activewindow -j | jq -r '.class')
+if [ -z "$class" ] || [ "$class" = "null" ]; then
+  exit 0
+fi
+hyprctl clients -j | jq -r --arg c "$class" '.[] | select(.class == $c) | .address' | while read -r addr; do
+  hyprctl dispatch closewindow "address:$addr"
+done

--- a/config/noctalia/quit-all-apps.sh
+++ b/config/noctalia/quit-all-apps.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+hyprctl clients -j | jq -r '.[].address' | while read -r addr; do
+  hyprctl dispatch closewindow "address:$addr"
+done

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -406,6 +406,8 @@ config/k3s/activate-client.sh
 config/k3s/activate.sh
 config/noctalia/ac-idle-inhibit.sh
 config/noctalia/lock-before-sleep.sh
+config/noctalia/quit-active-app.sh
+config/noctalia/quit-all-apps.sh
 config/obsidian/activate.sh
 config/omp/activate.sh
 config/openclaw/hydrate.sh

--- a/spec/noctalia_quit_active_app_spec.sh
+++ b/spec/noctalia_quit_active_app_spec.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016,SC2329
+
+Describe 'config/noctalia/quit-active-app.sh'
+SCRIPT="$PWD/config/noctalia/quit-active-app.sh"
+
+It 'uses bash strict mode'
+When run bash -c "head -5 '$SCRIPT'"
+The output should include 'set -euo pipefail'
+End
+
+It 'queries the active window class via hyprctl'
+When run bash -c "cat '$SCRIPT'"
+The output should include 'hyprctl activewindow -j'
+The output should include "jq -r '.class'"
+End
+
+It 'closes all windows matching the active class'
+When run bash -c "cat '$SCRIPT'"
+The output should include 'hyprctl clients -j'
+The output should include 'hyprctl dispatch closewindow'
+End
+
+End

--- a/spec/noctalia_quit_all_apps_spec.sh
+++ b/spec/noctalia_quit_all_apps_spec.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016,SC2329
+
+Describe 'config/noctalia/quit-all-apps.sh'
+SCRIPT="$PWD/config/noctalia/quit-all-apps.sh"
+
+It 'uses bash strict mode'
+When run bash -c "head -5 '$SCRIPT'"
+The output should include 'set -euo pipefail'
+End
+
+It 'closes all open windows via hyprctl'
+When run bash -c "cat '$SCRIPT'"
+The output should include 'hyprctl clients -j'
+The output should include 'hyprctl dispatch closewindow'
+End
+
+End


### PR DESCRIPTION
## Summary
- Add `quit-active-app.sh` - closes all windows of the focused app's class (macOS Cmd+Q behavior)
- Add `quit-all-apps.sh` - closes every open window, searchable via Noctalia launcher desktop entry
- Rebind `Super+Q` from `killactive` (single window) to quit-active-app (all windows of same class)

## Test plan
- [ ] `make shell-test` passes (2 pre-existing failures unchanged)
- [ ] `make shell-lint` passes
- [ ] `make format` passes
- [ ] Super+Q closes all windows of the focused app
- [ ] "Quit All Apps" appears in Noctalia launcher search and closes everything

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `quit-active-app.sh` and `quit-all-apps.sh` to make quitting apps faster; `Super+Q` now quits all windows of the focused app. Adds a "Quit All Apps" launcher entry to close everything at once.

- **New Features**
  - `quit-active-app.sh`: closes all windows of the focused app (macOS Cmd+Q behavior).
  - `quit-all-apps.sh`: closes every open window; added desktop entry "Quit All Apps" in Noctalia.
  - Hyprland: rebind `Super+Q` from `killactive` to `~/.config/noctalia/scripts/quit-active-app.sh`.

<sup>Written for commit 7f60ce18bb8f08c0d77ec5115a7e00ae68935993. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

