### PR TITLE
fix(noctalia): use writeShellScript for quit-all-apps desktop entry

### DIFF
--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -9,6 +9,11 @@ let
     noctalia_shell = "${noctaliaShell}/bin/noctalia-shell";
     sleep = "${pkgs.coreutils}/bin/sleep";
   };
+  quitAllAppsScript = pkgs.writeShellScript "quit-all-apps" ''
+    ${pkgs.hyprland}/bin/hyprctl clients -j | ${pkgs.jq}/bin/jq -r '.[].address' | while read -r addr; do
+      ${pkgs.hyprland}/bin/hyprctl dispatch closewindow "address:$addr"
+    done
+  '';
 in
 {
   xdg.configFile."noctalia/colorschemes/Dracula-Custom/Dracula-Custom.json" = {
@@ -66,7 +71,7 @@ in
   xdg.desktopEntries.quit-all-apps = {
     name = "Quit All Apps";
     comment = "Close all open windows";
-    exec = "${pkgs.bash}/bin/bash -c '\"$HOME/.config/noctalia/scripts/quit-all-apps.sh\"'";
+    exec = "${quitAllAppsScript}";
     terminal = false;
     categories = [ "Utility" ];
     icon = "application-exit";


### PR DESCRIPTION
## Summary
- The `quit-all-apps.desktop` Exec value contained reserved characters (`'` and unescaped `$`) that failed `desktop-file-validate`
- Replaced the `bash -c '...'` invocation with a `writeShellScript` derivation that produces a clean Nix store path with absolute references to `hyprctl` and `jq`

## Test plan
- [x] `make build` succeeds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the `quit-all-apps.desktop` Exec with a Nix `writeShellScript` that uses absolute paths for `hyprctl` and `jq`. This removes invalid quoting/unescaped `$`, passes `desktop-file-validate`, and makes the desktop entry reliable.

<sup>Written for commit 4d0d1ee043edbecc9a3767a6dfac1ff877b68cdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

