### PR TITLE
fix(noctalia): replace inline writeShellScript with replaceVars for quit-all-apps

### DIFF
--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -9,11 +9,10 @@ let
     noctalia_shell = "${noctaliaShell}/bin/noctalia-shell";
     sleep = "${pkgs.coreutils}/bin/sleep";
   };
-  quitAllAppsScript = pkgs.writeShellScript "quit-all-apps" ''
-    ${pkgs.hyprland}/bin/hyprctl clients -j | ${pkgs.jq}/bin/jq -r '.[].address' | while read -r addr; do
-      ${pkgs.hyprland}/bin/hyprctl dispatch closewindow "address:$addr"
-    done
-  '';
+  quitAllAppsScript = pkgs.replaceVars ./quit-all-apps-launcher.sh {
+    hyprctl = "${pkgs.hyprland}/bin/hyprctl";
+    jq = "${pkgs.jq}/bin/jq";
+  };
 in
 {
   xdg.configFile."noctalia/colorschemes/Dracula-Custom/Dracula-Custom.json" = {
@@ -71,7 +70,7 @@ in
   xdg.desktopEntries.quit-all-apps = {
     name = "Quit All Apps";
     comment = "Close all open windows";
-    exec = "${quitAllAppsScript}";
+    exec = "${pkgs.bash}/bin/bash ${quitAllAppsScript}";
     terminal = false;
     categories = [ "Utility" ];
     icon = "application-exit";

--- a/config/noctalia/quit-all-apps-launcher.sh
+++ b/config/noctalia/quit-all-apps-launcher.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+@hyprctl@ clients -j | @jq@ -r '.[].address' | while read -r addr; do
+  @hyprctl@ dispatch closewindow "address:$addr"
+done

--- a/config/noctalia/quit-all-apps-launcher.sh
+++ b/config/noctalia/quit-all-apps-launcher.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 @hyprctl@ clients -j | @jq@ -r '.[].address' | while read -r addr; do
-  @hyprctl@ dispatch closewindow "address:$addr"
+  @hyprctl@ dispatch closewindow "address:$addr" || true
 done

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -407,6 +407,7 @@ config/k3s/activate.sh
 config/noctalia/ac-idle-inhibit.sh
 config/noctalia/lock-before-sleep.sh
 config/noctalia/quit-active-app.sh
+config/noctalia/quit-all-apps-launcher.sh
 config/noctalia/quit-all-apps.sh
 config/obsidian/activate.sh
 config/omp/activate.sh


### PR DESCRIPTION
## Summary

- Replaces the inline `pkgs.writeShellScript` for the quit-all-apps desktop entry with `pkgs.replaceVars` pointing to an external script file
- Creates `config/noctalia/quit-all-apps-launcher.sh` with `@hyprctl@` and `@jq@` placeholders
- Updates the desktop entry exec to use `${pkgs.bash}/bin/bash ${quitAllAppsScript}` pattern

## Test plan

- [x] `make shell-inline-check` passes locally
- Shell CI workflow should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the quit-all-apps launcher from inline `pkgs.writeShellScript` to an external `pkgs.replaceVars` script, and run it via `${pkgs.bash}/bin/bash`. Added `|| true` to tolerate `closewindow` errors and listed the script in `spec/coverage_spec.sh`; ensures deterministic `hyprctl`/`jq` paths and fixes the shell inline check/CI.

<sup>Written for commit 0bf69510346d875ca9d85676a2f5d05c3e81647e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

