### PR TITLE
fix(claude): remove tmux teammate mode causing dead panes

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -523,7 +523,6 @@
   },
   "skipDangerousModePermissionPrompt": true,
   "defaultMode": "bypassPermissions",
-  "teammateMode": "tmux",
   "hostOverrides": {
     "matic": {
       "enabledPlugins": {


### PR DESCRIPTION
## Summary
- Remove `teammateMode: "tmux"` from Claude Code settings
- This setting spawns subagents in new tmux panes via `claude --print`, but tmux panes don't inherit stdin from the spawner, so the prompt never reaches the child process
- Results in immediate `Pane is dead (status 1)` with `Error: Input must be provided either through stdin or as a prompt argument when using --print`
- Falls back to inline mode (default), which passes prompts in-process reliably

## Test plan
- [ ] Run Claude Code with Agent tool (subagent spawning) and confirm no dead panes
- [ ] Verify subagents complete their tasks inline without errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `teammateMode: "tmux"` from Claude settings to prevent dead panes caused by missing stdin to `claude --print`. Subagents now run inline (default), restoring reliable prompt handling.

- **Bug Fixes**
  - Eliminates "Pane is dead (status 1)" by not spawning subagents in `tmux` panes.
  - No functional loss; subagents execute inline without errors.

<sup>Written for commit b751347b9b20e8ae4cff3feacad072d0cf7a9d13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

