### PR TITLE
fix: copy saved macOS screenshots to clipboard

### DIFF
--- a/home-manager/services/screenshot-clipboard/watch.sh
+++ b/home-manager/services/screenshot-clipboard/watch.sh
@@ -34,6 +34,9 @@ fswatch --event=Created --event=MovedTo --event=Renamed -0 "$DESKTOP_DIR" |
     "$DESKTOP_DIR/Screenshot "*.png | \
       "$DESKTOP_DIR/Screen Shot "*.png | \
       "$DESKTOP_DIR/"*_hyprshot.png)
+      # Native macOS captures can emit the filesystem event before the PNG is
+      # fully readable on large displays. Give the writer a brief head start.
+      sleep 1
       "$CLIPBOARD_COPY_IMAGE" "$path" || true
       ;;
     esac

--- a/nix-darwin/config/system.nix
+++ b/nix-darwin/config/system.nix
@@ -176,7 +176,7 @@
         location = "~/Desktop";
         save-selections = false;
         show-thumbnail = false;
-        target = "clipboard";
+        target = "file";
         type = "png";
       };
       screensaver = {

--- a/nix-darwin/config/system.nix
+++ b/nix-darwin/config/system.nix
@@ -176,7 +176,7 @@
         location = "~/Desktop";
         save-selections = false;
         show-thumbnail = false;
-        target = null;
+        target = "clipboard";
         type = "png";
       };
       screensaver = {


### PR DESCRIPTION
## Summary
- Keep native macOS screenshots saving as files on ~/Desktop
- Leave clipboard mirroring to the screenshot watcher service instead of making screencapture clipboard-only
- Add a short settle delay before copying watcher-detected screenshot files

## Verification
- shellspec spec/screenshot_clipboard_spec.sh spec/clipboard_copy_image_spec.sh
- nix eval --raw .#darwinConfigurations.aarch64-darwin.config.system.defaults.screencapture.target -> file
- nix eval --json .#darwinConfigurations.aarch64-darwin.config.home-manager.users.shunkakinoki.launchd.agents.screenshot-clipboard.enable -> true
- defaults read com.apple.screencapture target -> file
- direct live script test saved a PNG on Desktop and clipboard info reported PNG data

## Note
The currently loaded legacy LaunchAgent on this machine is com.shunkakinoki.screenshot-clipboard, not the repo-managed org.nix-community.home.screenshot-clipboard agent. The legacy script now works when run directly, but launchd still cannot enumerate Desktop files from that process; this looks like macOS privacy access for the stale manual agent rather than a screencapture target issue.
