### PR TITLE
chore: add herdr to homebrew brews

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -72,6 +72,7 @@
       "grafana"
       "graphviz"
       "helm"
+      "herdr"
       "jjui"
       "kimi-cli"
       "kurtosis-cli"


### PR DESCRIPTION
Adds `herdr` (agent multiplexer for the terminal, homebrew-core 0.7.1) to the declarative homebrew brews list in `nix-darwin/config/homebrew.nix`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `herdr` to the declarative Homebrew brews in `nix-darwin/config/homebrew.nix` so it installs automatically via nix-darwin. Ensures the terminal agent multiplexer is available on all machines.

<sup>Written for commit 5b3a6a261b37ad5c826e6ac83588dcab2cb5ca3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

