### PR TITLE
fix: stop managing macOS screenshot defaults

### DIFF
--- a/home-manager/services/screenshot-clipboard/watch.sh
+++ b/home-manager/services/screenshot-clipboard/watch.sh
@@ -41,16 +41,18 @@ wait_until_stable() {
   done
 }
 
-# Screenshots are written atomically (macOS via rename, hyprshot via mv from
-# a temp path), so fswatch reports the final path once writing has finished.
-# fswatch on macOS uses FSEvents which is always recursive, so the patterns
-# are anchored to "$DESKTOP_DIR/" to ignore screenshots inside subfolders
-# (e.g. project directories) and only react to fresh top-level captures.
+# fswatch event filters are backend-specific; on macOS FSEvents can report
+# screenshot writes with combined flags that do not pass --event filters. Watch
+# all events and keep the stable filename filtering here instead.
+#
+# fswatch on macOS uses FSEvents which is always recursive, so the patterns are
+# anchored to "$DESKTOP_DIR/" to ignore screenshots inside subfolders (e.g.
+# project directories) and only react to fresh top-level captures.
 # Patterns:
 #   - "Screenshot ..." / "Screen Shot ..." : macOS defaults (current / legacy)
 #   - "*_hyprshot.png"                     : hyprshot default name on Linux
 #     (HYPRSHOT_DIR is set to $HOME/Desktop in config/hyprland/hyprland.conf)
-fswatch --event=Created --event=MovedTo --event=Renamed -0 "$DESKTOP_DIR" |
+fswatch -0 "$DESKTOP_DIR" |
   while IFS= read -r -d '' path; do
     case "$path" in
     "$DESKTOP_DIR/Screenshot "*.png | \

--- a/nix-darwin/config/system.nix
+++ b/nix-darwin/config/system.nix
@@ -42,10 +42,6 @@
           askForPasswordDelay = 0;
           idleTime = 600;
         };
-        "com.apple.screencapture" = {
-          location = "/Users/${username}/Desktop";
-          type = "png";
-        };
       };
       CustomUserPreferences = {
         "com.apple.controlcenter" = {
@@ -173,11 +169,11 @@
       screencapture = {
         disable-shadow = null;
         include-date = null;
-        location = "/Users/${username}/Desktop";
-        save-selections = false;
-        show-thumbnail = false;
+        location = null;
+        save-selections = null;
+        show-thumbnail = null;
         target = null;
-        type = "png";
+        type = null;
       };
       screensaver = {
         askForPassword = true;


### PR DESCRIPTION
## Summary
- remove the remaining custom `com.apple.screencapture` defaults
- leave all nix-darwin `system.defaults.screencapture` keys unmanaged so macOS uses native save behavior
- remove backend-specific `fswatch --event` filters so screenshot file events are seen on macOS FSEvents

## Verification
- `git diff --check`
- `nix eval --json .#darwinConfigurations.galactica.config.system.defaults.screencapture`
- reset live `com.apple.screencapture` prefs and verified `/usr/sbin/screencapture -x ~/Desktop/test.png` writes to Desktop
- ran the patched watcher script against a fresh Desktop screenshot and verified clipboard reports `PNGf`