### PR TITLE
chore: update neovim pack lock

### DIFF
--- a/home-manager/programs/neovim/nvim-pack-lock.json
+++ b/home-manager/programs/neovim/nvim-pack-lock.json
@@ -145,6 +145,10 @@
       "rev": "b3772adec8db61ba9098c5624a0823a77be3a23d",
       "src": "https://github.com/nvim-tree/nvim-tree.lua"
     },
+    "nvim-treesitter": {
+      "rev": "42fc28ba918343ebfd5565147a42a26580579482",
+      "src": "https://github.com/nvim-treesitter/nvim-treesitter"
+    },
     "nvim-treesitter-context": {
       "rev": "9a8e39993e3b895601bf8227124a48ea8268149e",
       "src": "https://github.com/nvim-treesitter/nvim-treesitter-context"


### PR DESCRIPTION
Updates neovim pack lock file with latest dependency changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a pinned lock entry for `nvim-treesitter` in `nvim-pack-lock.json`. This ensures consistent, reproducible Neovim plugin installs across machines.

<sup>Written for commit fc2b5f73feac9603e35ada05cb7e6500bf15a344. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

