### PR TITLE
fix(nix): migrate to beamPackages and antigravity-cli

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -19,7 +19,7 @@ with pkgs;
   age
   aichat
   angle-grinder
-  pkgs.llm-agents.antigravity
+  pkgs.llm-agents.antigravity-cli
   argocd
   ast-grep
   awscli

--- a/home-manager/programs/elixir/default.nix
+++ b/home-manager/programs/elixir/default.nix
@@ -1,8 +1,8 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    elixir_1_19
+    beamPackages.elixir_1_19
     elixir-ls
-    erlang
+    beamPackages.erlang
   ];
 }


### PR DESCRIPTION
## Summary

Suppresses evaluation warnings during `make build` / `make switch`:

- `elixir_1_19` -> `beamPackages.elixir_1_19`
- `erlang` -> `beamPackages.erlang`
- `llm-agents.antigravity` -> `llm-agents.antigravity-cli` (upstream rename)

## Verification

`nix eval .#darwinConfigurations.galactica.system.drvPath` completes with no evaluation warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress Nix evaluation warnings by updating home-manager packages: `elixir_1_19` -> `beamPackages.elixir_1_19`, `erlang` -> `beamPackages.erlang`, and `llm-agents.antigravity` -> `llm-agents.antigravity-cli`.

<sup>Written for commit d08aa8ecd30cbb844be3248e8df07fb77f4fb935. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

