### PR TITLE
fix(codex): install real native binary for aliased optional deps

### DIFF
--- a/home-manager/modules/npm-globals/install-npm-globals.sh
+++ b/home-manager/modules/npm-globals/install-npm-globals.sh
@@ -262,10 +262,54 @@ if [ -n "$OPTIONAL_DEPS" ]; then
     else
       continue
     fi
-    if [ -d "${GLOBAL_MODULES}/${dep}" ]; then
-      echo "$dep already installed, skipping"
-      continue
+    val="${entry#*=}"
+    # Resolve the spec to install and the exact version we expect on disk.
+    # For plain semver ranges (claude-code pattern) bun resolves latest, so we
+    # can't predict the version; want_ver stays empty and presence alone is fine.
+    spec="$dep"
+    want_ver=""
+    if [[ $val == npm:* ]]; then
+      # Aliased native binary (codex pattern): npm:@openai/codex@<ver>.
+      # These packages are PUBLISHED as <base>@<ver>-<platform-suffix> (e.g.
+      # @openai/codex@0.142.5-darwin-arm64) and only that suffixed tarball
+      # carries the vendor binary. A bare <base>@<ver> pin (no suffix) silently
+      # reinstalls the generic JS wrapper under the platform dir name -- no
+      # binary -- and the CLI dies with "Missing optional dependency". So we
+      # reconstruct the suffixed spec here regardless of how package.json pins it.
+      alias_spec="${val#npm:}"     # @openai/codex@0.142.2
+      base_name="${alias_spec%@*}" # @openai/codex
+      base_ver="${alias_spec##*@}" # 0.142.2 (fallback if parent not installed)
+      # Prefer the ACTUALLY INSTALLED parent version so the binary always matches
+      # the wrapper even when the package.json pins have drifted behind it.
+      base_pj="${GLOBAL_MODULES}/${base_name}/package.json"
+      if [ -f "$base_pj" ]; then
+        installed_base=$(jq -r '.version // empty' "$base_pj" 2>/dev/null || true)
+        [ -n "$installed_base" ] && base_ver="$installed_base"
+      fi
+      suffix="${dep#"${base_name}"-}" # darwin-arm64
+      if [ -n "$suffix" ] && [ "$suffix" != "$dep" ]; then
+        want_ver="${base_ver}-${suffix}"
+      else
+        want_ver="$base_ver"
+      fi
+      spec="${dep}@npm:${base_name}@${want_ver}"
     fi
+    # Consider the dep installed only when its payload is REAL. Bun's transitive
+    # optional resolution can leave a phantom empty dir (passes -d, holds no
+    # binary), and a stale/wrong-suffix pin leaves the generic wrapper (wrong
+    # version). Both must be torn down and reinstalled, not skipped on -d alone.
+    dep_pj="${GLOBAL_MODULES}/${dep}/package.json"
+    if [ -f "$dep_pj" ]; then
+      have_ver=$(jq -r '.version // empty' "$dep_pj" 2>/dev/null || true)
+      if [ -z "$want_ver" ] || [ "$have_ver" = "$want_ver" ]; then
+        echo "$dep@${have_ver:-unknown} already installed, skipping"
+        continue
+      fi
+      echo "$dep@${have_ver:-unknown} installed, want $want_ver, reinstalling"
+    elif [ -d "${GLOBAL_MODULES}/${dep}" ]; then
+      echo "$dep present but empty (phantom dir), reinstalling"
+    fi
+    rm -rf "${GLOBAL_MODULES:?}/${dep}"
     # Bun's `bun add -g <pkg>` is a no-op if <pkg> is already in the global
     # package.json's optionalDependencies (it never materializes the dir).
     # Strip from optionalDependencies first so the add becomes a real install.
@@ -273,16 +317,12 @@ if [ -n "$OPTIONAL_DEPS" ]; then
       jq --arg dep "$dep" 'del(.optionalDependencies[$dep])' "$GLOBAL_PKG" >"${GLOBAL_PKG}.tmp" &&
         mv "${GLOBAL_PKG}.tmp" "$GLOBAL_PKG"
     fi
-    val="${entry#*=}"
-    # For npm aliases (codex pattern), pass the full <name>@<spec>. For plain
-    # semver ranges, omitting the version lets bun resolve latest.
-    if [[ $val == npm:* ]]; then
-      spec="${dep}@${val}"
-    else
-      spec="$dep"
-    fi
     echo "Installing platform-native: $spec"
     timeout 600 bun add --global "$spec" --minimum-release-age 0 2>/dev/null || echo "Install failed: $spec"
+    # Verify the payload actually materialized; bun can silently no-op.
+    if [ ! -f "${GLOBAL_MODULES}/${dep}/package.json" ]; then
+      echo "Warning: $dep still missing after install ($spec)" >&2
+    fi
   done <<<"$OPTIONAL_DEPS"
 fi
 

--- a/package.json
+++ b/package.json
@@ -87,12 +87,12 @@
     "@anthropic-ai/claude-code-linux-x64-musl": "^2.1.186",
     "@anthropic-ai/claude-code-win32-arm64": "^2.1.186",
     "@anthropic-ai/claude-code-win32-x64": "^2.1.186",
-    "@openai/codex-darwin-arm64": "npm:@openai/codex@0.142.2",
-    "@openai/codex-darwin-x64": "npm:@openai/codex@0.142.2",
-    "@openai/codex-linux-arm64": "npm:@openai/codex@0.142.2",
-    "@openai/codex-linux-x64": "npm:@openai/codex@0.142.2",
-    "@openai/codex-win32-arm64": "npm:@openai/codex@0.142.2",
-    "@openai/codex-win32-x64": "npm:@openai/codex@0.142.2"
+    "@openai/codex-darwin-arm64": "npm:@openai/codex@0.142.5-darwin-arm64",
+    "@openai/codex-darwin-x64": "npm:@openai/codex@0.142.5-darwin-x64",
+    "@openai/codex-linux-arm64": "npm:@openai/codex@0.142.5-linux-arm64",
+    "@openai/codex-linux-x64": "npm:@openai/codex@0.142.5-linux-x64",
+    "@openai/codex-win32-arm64": "npm:@openai/codex@0.142.5-win32-arm64",
+    "@openai/codex-win32-x64": "npm:@openai/codex@0.142.5-win32-x64"
   },
   "overrides": {
     "pino": "^9.14.0"

--- a/spec/npm_globals_spec.sh
+++ b/spec/npm_globals_spec.sh
@@ -366,4 +366,105 @@ When run bash -c "HOME='$TEMP_HOME' MOCK_LOG='$MOCK_LOG' PATH='$MOCK_BIN:$REAL_B
 The output should eq 'missing'
 End
 End
+
+Describe 'aliased native binary (codex pattern)'
+It 'reconstructs the platform suffix for aliased native deps'
+When run bash -c "grep 'want_ver=\"\${base_ver}-\${suffix}\"' '$SCRIPT'"
+The output should include 'want_ver'
+End
+
+It 'derives the native binary version from the installed parent'
+When run bash -c "grep 'installed_base' '$SCRIPT'"
+The output should include 'installed_base'
+End
+
+It 'reinstalls a phantom native dir instead of trusting -d'
+When run bash -c "grep 'phantom dir' '$SCRIPT'"
+The output should include 'phantom dir'
+End
+
+It 'warns when the payload did not materialize after install'
+When run bash -c "grep 'still missing after install' '$SCRIPT'"
+The output should include 'still missing after install'
+End
+End
+
+Describe 'aliased native binary self-heal integration'
+setup() {
+  TEMP_HOME=$(mktemp -d)
+  MOCK_BIN=$(mktemp -d)
+  MOCK_LOG="$TEMP_HOME/mock.log"
+  REAL_BIN_DIR="$(dirname "$(command -v jq)")"
+  REAL_SYSTEM_BIN_DIR="$(dirname "$(command -v mv)")"
+  : >"$MOCK_LOG"
+
+  GM="$TEMP_HOME/.bun/install/global/node_modules"
+  mkdir -p "$TEMP_HOME/dotfiles" "$TEMP_HOME/.bun/install/global" "$TEMP_HOME/.bun/bin"
+
+  os_tok=$(uname -s | tr '[:upper:]' '[:lower:]')
+  [ "$os_tok" = "darwin" ] || os_tok="linux"
+  cpu_tok=$(uname -m)
+  case "$cpu_tok" in arm64 | aarch64) cpu_tok=arm64 ;; *) cpu_tok=x64 ;; esac
+  NATIVE_DEP="codexcli-${os_tok}-${cpu_tok}"
+  # Wrapper is installed at 1.0.2 but the dotfiles optional pin is a stale,
+  # SUFFIX-LESS 1.0.0 alias (the bug). The script must ignore both and install
+  # the suffixed binary at the parent's actual version.
+  WANT_SPEC="${NATIVE_DEP}@npm:codexcli@1.0.2-${os_tok}-${cpu_tok}"
+  EXPECT_INSTALL="bun add --global ${WANT_SPEC}"
+
+  cat >"$TEMP_HOME/dotfiles/package.json" <<EOF
+{
+  "dependencies": { "codexcli": "^1.0.0" },
+  "optionalDependencies": { "${NATIVE_DEP}": "npm:codexcli@1.0.0" }
+}
+EOF
+
+  # Parent installed ahead of the pin, no optionalDependencies of its own so the
+  # parent-reinstall guard leaves it in place for the optional loop to read.
+  mkdir -p "$GM/codexcli"
+  cat >"$GM/codexcli/package.json" <<'EOF'
+{ "name": "codexcli", "version": "1.0.2" }
+EOF
+
+  cat >"$MOCK_BIN/timeout" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+shift
+if [ "${1:-}" = "bash" ] && [ "${2:-}" = "-c" ] && [ "${3:-}" = "exec 3<>/dev/tcp/1.1.1.1/53" ]; then
+  exit 0
+fi
+exec "$@"
+EOF
+  chmod +x "$MOCK_BIN/timeout"
+
+  cat >"$MOCK_BIN/bun" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'bun %s\n' "$*" >>"$MOCK_LOG"
+EOF
+  chmod +x "$MOCK_BIN/bun"
+}
+
+cleanup() {
+  rm -rf "$TEMP_HOME" "$MOCK_BIN"
+}
+
+Before 'setup'
+After 'cleanup'
+
+It 'installs the suffixed binary at the installed parent version despite a stale bare pin'
+When run bash -c "HOME='$TEMP_HOME' MOCK_LOG='$MOCK_LOG' PATH='$MOCK_BIN:$REAL_BIN_DIR:$REAL_SYSTEM_BIN_DIR:/usr/bin:/bin' bash '$SCRIPT' >/dev/null 2>&1; cat '$MOCK_LOG'"
+The output should include "$EXPECT_INSTALL"
+End
+
+It 'reinstalls a phantom empty native dir'
+When run bash -c "mkdir -p '$GM/$NATIVE_DEP'; HOME='$TEMP_HOME' MOCK_LOG='$MOCK_LOG' PATH='$MOCK_BIN:$REAL_BIN_DIR:$REAL_SYSTEM_BIN_DIR:/usr/bin:/bin' bash '$SCRIPT' >/dev/null 2>&1; cat '$MOCK_LOG'"
+The output should include "$EXPECT_INSTALL"
+End
+
+It 'skips a native dir already at the correct version'
+When run bash -c "mkdir -p '$GM/$NATIVE_DEP'; printf '{\"version\":\"1.0.2-${os_tok}-${cpu_tok}\"}' >'$GM/$NATIVE_DEP/package.json'; HOME='$TEMP_HOME' MOCK_LOG='$MOCK_LOG' PATH='$MOCK_BIN:$REAL_BIN_DIR:$REAL_SYSTEM_BIN_DIR:/usr/bin:/bin' bash '$SCRIPT' >/dev/null 2>&1; cat '$MOCK_LOG'"
+The output should not include "bun add --global $NATIVE_DEP"
+End
+End
 End


### PR DESCRIPTION
## Problem

Running \`codex\` failed with:

\`\`\`
Error: Missing optional dependency @openai/codex-darwin-arm64. Reinstall Codex: bun install -g @openai/codex@latest
\`\`\`

The wrapper (\`codex.js\`) resolves its native binary purely by path -
\`require.resolve('@openai/codex-darwin-arm64/package.json')\` then
\`vendor/aarch64-apple-darwin/bin/codex\`. "Missing" means that binary file
wasn't on disk.

Root cause: the \`@openai/codex-*\` optional pins were malformed.

| | version spec | tarball contents |
|---|---|---|
| Correct (codex's own optionalDependencies) | \`npm:@openai/codex@0.142.3-darwin-arm64\` | native \`vendor/.../bin/codex\` |
| Dotfiles pin (before) | \`npm:@openai/codex@0.142.2\` | the generic JS wrapper again - **no binary** |

The \`-<triple>\` version suffix was missing, so \`install-npm-globals.sh\`
faithfully installed the wrapper package under the platform dir name. The
subsequent \`-d\` presence check then cached the broken dir across every run.

## Fix

- **package.json**: pin the suffixed native packages (\`0.142.5-<triple>\`).
  A caret can't float a suffixed version (semver treats \`-darwin-arm64\` as a
  prerelease tag), so drift protection lives in the script instead.
- **install-npm-globals.sh** (drift-proof self-heal for the aliased pattern):
  - reconstruct the \`-<triple>\` suffix from the dep name, so even a
    suffix-less pin installs the real binary package;
  - derive the version from the **actually-installed parent**, so pin drift
    can never desync the binary from the wrapper;
  - treat a dep as installed only when \`package.json\` exists **and** the
    version matches - tear down phantom/wrong-version dirs instead of trusting
    bare \`-d\`;
  - warn if the payload still didn't materialize after install.
- **spec**: cover suffix reconstruction, parent-version derivation,
  phantom-dir reinstall, and correct-version skip.

## Testing

- \`make shell-lint\` - clean
- \`shellspec spec/npm_globals_spec.sh\` - 50 examples, 0 failures (7 new)

## Follow-up (not in this PR)

\`codex\` is declared in three places - bun global (package.json), the Homebrew
cask (\`homebrew.nix\`), and the nix overlay (\`overlays/default.nix\`). The bun
global wins on PATH. Consolidating to a single source would remove the
redundancy but is out of scope here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex CLI failures by installing the real platform-native `@openai/codex-*` binary instead of the generic wrapper. Pins suffixed native packages and updates the installer to reconstruct the platform suffix, align with the installed parent version, and self-heal broken installs.

- **Bug Fixes**
  - Reconstruct the `-<triple>` suffix for aliased optional deps.
  - Derive the native package version from the installed `@openai/codex` parent.
  - Treat installs as valid only if `package.json` exists and the version matches; remove phantom/wrong-version dirs.
  - Warn if the native payload is still missing after install.
  - Add shellspec coverage for suffix reconstruction, parent-version derivation, phantom-dir reinstall, and correct-version skip.

- **Dependencies**
  - Pin `@openai/codex-*` optional deps to `0.142.5-<triple>` suffixed versions.

<sup>Written for commit cbc9745d2154a0882365fcba31308bec702af04f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

