### PR TITLE
feat(herdr): add config.toml and herdrd remote function

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -23,6 +23,7 @@ in
   ./gomi
   ./ghostty
   ./handy
+  ./herdr
   ./hermes
   ./iterm2
   ./hammerspoon

--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -1,0 +1,269 @@
+# herdr configuration
+# Place this file at ~/.config/herdr/config.toml
+#
+# All settings below are set to their built-in defaults (theme = dracula) and
+# left uncommented so they are easy to edit. Run `herdr server reload-config`
+# after changing values. Override/template blocks (theme.custom, custom sound
+# files, custom commands) stay commented because they need real values.
+
+# Show first-run notification setup on startup.
+# Default is true; set false once you've completed onboarding.
+onboarding = false
+
+[theme]
+# Built-in themes: catppuccin, terminal, tokyo-night, dracula, nord,
+#                  gruvbox, one-dark, solarized, kanagawa, rose-pine,
+#                  vesper
+name = "dracula"
+
+# Follow host terminal light/dark appearance and switch Herdr UI themes.
+# Existing manual behavior is unchanged unless this is true.
+auto_switch = false
+dark_name = "dracula"
+light_name = "catppuccin-latte"
+
+# Override individual color tokens on top of the base theme.
+# Accepts: hex (#rrggbb), named colors, rgb(r,g,b), or panel_bg = "reset"
+# [theme.custom]
+# panel_bg = "reset"
+# accent = "#bd93f9"
+# red = "#ff5555"
+# green = "#50fa7b"
+
+[terminal]
+# Executable used for new interactive panes.
+# Empty means $SHELL, then /bin/sh.
+default_shell = ""
+
+# Startup mode for new interactive pane shells: "auto", "login", or "non_login".
+# "auto" uses login shells on macOS and keeps the current behavior elsewhere.
+shell_mode = "auto"
+
+# CWD policy for new panes, tabs, and workspaces when no explicit --cwd is provided.
+# Use "follow" to inherit the source pane/workspace, "home" for $HOME,
+# "current" for Herdr's process directory, or a fixed path such as "~/Projects".
+new_cwd = "follow"
+
+[update]
+# Update channel used by background version checks and `herdr update`.
+# Use "stable" for normal releases or "preview" for opt-in preview builds.
+channel = "stable"
+
+# Check herdr.dev for new Herdr versions in the background.
+version_check = true
+
+# Check herdr.dev for remote agent-detection manifest updates in the background.
+manifest_check = true
+
+[keys]
+# Prefix key to enter prefix mode (default: "ctrl+b")
+# Examples: "ctrl+b", "f12", "esc", "-"
+# Action bindings use explicit syntax: "prefix+n" requires the prefix;
+# "ctrl+alt+n" is a direct terminal-mode shortcut.
+# Accepted key syntax: plain keys, ctrl/shift/alt/cmd/super modifiers, and special keys like enter/tab/esc/left/right/up/down.
+# Named punctuation such as minus, comma, ampersand, plus, and backtick is also accepted.
+# Most reliable direct bindings are ctrl+letter, function keys, and explicit modified chords.
+# alt+..., cmd/super, and punctuation-with-modifiers may depend on your terminal/tmux setup.
+prefix = "ctrl+b"
+
+# Prefix-mode actions
+help = "prefix+?"
+settings = "prefix+s"
+detach = "prefix+q"
+reload_config = "prefix+shift+r"
+open_notification_target = "prefix+o"
+workspace_picker = "prefix+w"
+goto = "prefix+g"
+new_workspace = "prefix+shift+n"
+new_worktree = "prefix+shift+g"
+open_worktree = ""    # optional, unset by default
+remove_worktree = ""  # optional, unset by default; opens confirmation
+rename_workspace = "prefix+shift+w"
+close_workspace = "prefix+shift+d"
+previous_workspace = "" # optional, unset by default
+next_workspace = ""     # optional, unset by default
+previous_agent = ""     # optional, unset by default
+next_agent = ""         # optional, unset by default
+focus_agent = ""        # optional indexed binding, e.g. "prefix+alt+1..9"
+remote_image_paste = "ctrl+v" # only active in herdr --remote; empty disables raw-key image paste
+new_tab = "prefix+c"
+rename_tab = "prefix+shift+t"
+previous_tab = "prefix+p"
+next_tab = "prefix+n"
+switch_tab = "prefix+1..9"
+switch_workspace = ""   # optional indexed binding, e.g. "prefix+shift+1..9"
+close_tab = "prefix+shift+x"
+rename_pane = "prefix+shift+p"
+edit_scrollback = "prefix+e"
+focus_pane_left = "prefix+h"
+focus_pane_down = "prefix+j"
+focus_pane_up = "prefix+k"
+focus_pane_right = "prefix+l"
+cycle_pane_next = "prefix+tab"
+cycle_pane_previous = "prefix+shift+tab"
+last_pane = ""          # optional, unset by default; bind e.g. "prefix+tab" for global back-and-forth
+split_vertical = "prefix+v"
+split_horizontal = "prefix+minus"
+close_pane = "prefix+x"
+zoom = "prefix+z"       # legacy alias: fullscreen
+resize_mode = "prefix+r"
+toggle_sidebar = "prefix+b"
+
+# Navigate-mode movement. These local shortcuts win while navigate mode is open.
+# They are independent from focus_pane_*. Do not include prefix+, esc, enter, tab, or 1..9 here.
+navigate_workspace_up = "up"
+navigate_workspace_down = "down"
+navigate_pane_left = "h"      # left arrow always focuses the pane to the left
+navigate_pane_down = "j"
+navigate_pane_up = "k"
+navigate_pane_right = "l"     # right arrow always focuses the pane to the right
+
+# Custom commands use the same binding syntax.
+# type = "shell" runs detached in the background.
+# type = "pane" opens a temporary pane and closes it when the command exits.
+# [[keys.command]]
+# key = "prefix+alt+g"
+# type = "pane"
+# command = "lazygit"
+
+# Legacy indexed shortcut config is still parsed for compatibility.
+# Prefer switch_tab, switch_workspace, and focus_agent for new configs.
+[keys.indexed]
+tabs = ""       # e.g. "ctrl" makes ctrl+1..9 switch tabs directly
+workspaces = "" # e.g. "ctrl+shift" makes ctrl+shift+1..9 switch workspaces directly
+agents = ""     # e.g. "alt" makes alt+1..9 focus agent rows directly
+
+[worktrees]
+directory = "~/.herdr/worktrees"
+
+[ui]
+# Sidebar width (auto-scaled based on workspace names, this sets the default)
+sidebar_width = 26
+
+# Minimum sidebar width when expanded (columns)
+sidebar_min_width = 18
+
+# Maximum sidebar width when expanded (columns)
+sidebar_max_width = 36
+
+# Terminal width at or below which Herdr uses the mobile single-column layout.
+# Increase this for foldables, tablets, or wide phone terminals.
+mobile_width_threshold = 64
+
+# Capture mouse input for Herdr's mouse UI.
+# Set false to let the terminal handle normal clicks, such as Cmd-clicking URLs.
+# Pane apps like lazygit and btop can still receive mouse when they request it.
+mouse_capture = true
+
+# Optional modifier that forwards right-click hold/drag gestures to pane apps instead of opening Herdr's pane menu.
+# Empty/off disables this. Shift is intentionally unsupported because terminals commonly reserve Shift+mouse.
+right_click_passthrough_modifier = ""
+
+# Force a full redraw when the outer terminal regains focus.
+# Set false to reduce visible flashing when switching back to Herdr.
+# Trade-off: rare host terminal surface corruption may persist until the next full redraw.
+redraw_on_focus_gained = true
+
+# Pane scrollback lines to scroll per mouse wheel notch.
+mouse_scroll_lines = 3
+
+# Ask for confirmation before closing a workspace
+confirm_close = true
+
+# Ask for a tab name before creating a new tab.
+# Set false to create tabs immediately with generated names.
+prompt_new_tab_name = true
+
+# Draw borders around split panes.
+pane_borders = true
+
+# Keep split panes visually separated instead of sharing divider borders.
+pane_gaps = true
+
+# Show detected/reported agent labels in split pane borders when no manual pane name is set.
+show_agent_labels_on_pane_borders = false
+
+# Agent panel ordering: "spaces" (grouped by space) or "priority" (attention queue).
+# "workspaces" is accepted as an alias for "spaces".
+agent_panel_sort = "spaces"
+
+# Accent color for highlights, borders, and navigation UI.
+# Accepts: hex (#89b4fa), named colors (cyan, blue, magenta), or rgb(r,g,b)
+accent = "cyan"
+
+# Background notification popup delivery
+[ui.toast]
+# off = disable pop-up notifications
+# herdr = show in-app toasts
+# terminal = ask the outer terminal to show a desktop notification
+# system = ask the OS notification service directly
+delivery = "off"
+delay_seconds = 1
+
+[ui.toast.herdr]
+position = "bottom-right"
+
+[ui.toast.clipboard]
+enabled = true
+position = "bottom-center"
+
+# Play sounds when agents change state in background workspaces
+[ui.sound]
+enabled = false
+# Optional custom mp3 sound files. Relative paths are resolved from this config file's directory.
+# path = "sounds/notification.mp3"   # one mp3 file for all sound notifications
+# done_path = "sounds/done.mp3"      # overrides only finished notifications
+# request_path = "sounds/request.mp3" # overrides only needs-attention notifications
+
+# Per-agent overrides: default | on | off
+# By default, droid is muted.
+[ui.sound.agents]
+droid = "off"
+
+[session]
+# Resume supported AI-agent panes into their native conversation sessions after
+# a Herdr server restart. Requires official integrations that report session refs.
+resume_agents_on_restore = true
+
+[remote]
+# Whether herdr manages the ssh config used for the `herdr --remote` bridge.
+# When true (default), herdr runs the bridge ssh through a generated config that
+# includes your ~/.ssh/config first and adds ServerAliveInterval/
+# ServerAliveCountMax as a fallback (so any keepalive you set yourself still
+# wins) to survive idle network/NAT timeouts. Set false to run plain ssh against
+# your ssh config unchanged — this does not force keepalive off, it only stops
+# herdr from adding its own.
+manage_ssh_config = true
+
+[experimental]
+# Allow launching herdr from inside a herdr-managed pane.
+allow_nested = false
+# Experimental local Kitty graphics rendering for attached clients.
+# Requires a Kitty graphics-compatible outer terminal.
+kitty_graphics = false
+# Save recent pane screen history across full server restarts.
+pane_history = true
+# While prefix mode is active, temporarily switch the macOS host input
+# source to an ASCII-capable keyboard layout so prefix commands register
+# even when a CJK IME is active, then restore the previous input source
+# when prefix mode exits. macOS only; best-effort. Default: false.
+switch_ascii_input_source_in_prefix = false
+# Expose the focused pane's cursor to the outer terminal so macOS input
+# methods keep tracking the candidate window when TUIs paint their own
+# cursor (Claude Code, pi, codex). Trade-off: extra cursor visible for
+# apps that hide it without painting a replacement (vim normal mode, etc.).
+reveal_hidden_cursor_for_cjk_ime = false
+# Optional allow-list: only reveal for focused panes whose detected agent
+# matches one of these names. Empty means apply to any focused pane.
+# If the list contains no valid names, the reveal does not apply.
+# Accepted: pi, claude, codex, gemini, cursor, devin, cline, opencode,
+# copilot, kimi, kiro, droid, amp, grok, hermes, kilo, qodercli, qoder.
+cjk_ime_agents = []
+# Cursor shape rendered when reveal_hidden_cursor_for_cjk_ime is true.
+# Values: block, steady_block (default), underline, steady_underline, bar, steady_bar.
+cjk_ime_cursor_shape = "steady_block"
+
+[advanced]
+# Maximum scrollback buffer size in bytes retained per pane terminal.
+# Matches Ghostty's default scrollback-limit behavior.
+scrollback_limit_bytes = 300000000

--- a/config/herdr/default.nix
+++ b/config/herdr/default.nix
@@ -1,0 +1,6 @@
+_: {
+  home.file.".config/herdr/config.toml" = {
+    source = ./config.toml;
+    force = true;
+  };
+}

--- a/home-manager/modules/npm-globals/install-npm-globals.sh
+++ b/home-manager/modules/npm-globals/install-npm-globals.sh
@@ -262,10 +262,54 @@ if [ -n "$OPTIONAL_DEPS" ]; then
     else
       continue
     fi
-    if [ -d "${GLOBAL_MODULES}/${dep}" ]; then
-      echo "$dep already installed, skipping"
-      continue
+    val="${entry#*=}"
+    # Resolve the spec to install and the exact version we expect on disk.
+    # For plain semver ranges (claude-code pattern) bun resolves latest, so we
+    # can't predict the version; want_ver stays empty and presence alone is fine.
+    spec="$dep"
+    want_ver=""
+    if [[ $val == npm:* ]]; then
+      # Aliased native binary (codex pattern): npm:@openai/codex@<ver>.
+      # These packages are PUBLISHED as <base>@<ver>-<platform-suffix> (e.g.
+      # @openai/codex@0.142.5-darwin-arm64) and only that suffixed tarball
+      # carries the vendor binary. A bare <base>@<ver> pin (no suffix) silently
+      # reinstalls the generic JS wrapper under the platform dir name -- no
+      # binary -- and the CLI dies with "Missing optional dependency". So we
+      # reconstruct the suffixed spec here regardless of how package.json pins it.
+      alias_spec="${val#npm:}"     # @openai/codex@0.142.2
+      base_name="${alias_spec%@*}" # @openai/codex
+      base_ver="${alias_spec##*@}" # 0.142.2 (fallback if parent not installed)
+      # Prefer the ACTUALLY INSTALLED parent version so the binary always matches
+      # the wrapper even when the package.json pins have drifted behind it.
+      base_pj="${GLOBAL_MODULES}/${base_name}/package.json"
+      if [ -f "$base_pj" ]; then
+        installed_base=$(jq -r '.version // empty' "$base_pj" 2>/dev/null || true)
+        [ -n "$installed_base" ] && base_ver="$installed_base"
+      fi
+      suffix="${dep#"${base_name}"-}" # darwin-arm64
+      if [ -n "$suffix" ] && [ "$suffix" != "$dep" ]; then
+        want_ver="${base_ver}-${suffix}"
+      else
+        want_ver="$base_ver"
+      fi
+      spec="${dep}@npm:${base_name}@${want_ver}"
     fi
+    # Consider the dep installed only when its payload is REAL. Bun's transitive
+    # optional resolution can leave a phantom empty dir (passes -d, holds no
+    # binary), and a stale/wrong-suffix pin leaves the generic wrapper (wrong
+    # version). Both must be torn down and reinstalled, not skipped on -d alone.
+    dep_pj="${GLOBAL_MODULES}/${dep}/package.json"
+    if [ -f "$dep_pj" ]; then
+      have_ver=$(jq -r '.version // empty' "$dep_pj" 2>/dev/null || true)
+      if [ -z "$want_ver" ] || [ "$have_ver" = "$want_ver" ]; then
+        echo "$dep@${have_ver:-unknown} already installed, skipping"
+        continue
+      fi
+      echo "$dep@${have_ver:-unknown} installed, want $want_ver, reinstalling"
+    elif [ -d "${GLOBAL_MODULES}/${dep}" ]; then
+      echo "$dep present but empty (phantom dir), reinstalling"
+    fi
+    rm -rf "${GLOBAL_MODULES:?}/${dep}"
     # Bun's `bun add -g <pkg>` is a no-op if <pkg> is already in the global
     # package.json's optionalDependencies (it never materializes the dir).
     # Strip from optionalDependencies first so the add becomes a real install.
@@ -273,16 +317,12 @@ if [ -n "$OPTIONAL_DEPS" ]; then
       jq --arg dep "$dep" 'del(.optionalDependencies[$dep])' "$GLOBAL_PKG" >"${GLOBAL_PKG}.tmp" &&
         mv "${GLOBAL_PKG}.tmp" "$GLOBAL_PKG"
     fi
-    val="${entry#*=}"
-    # For npm aliases (codex pattern), pass the full <name>@<spec>. For plain
-    # semver ranges, omitting the version lets bun resolve latest.
-    if [[ $val == npm:* ]]; then
-      spec="${dep}@${val}"
-    else
-      spec="$dep"
-    fi
     echo "Installing platform-native: $spec"
     timeout 600 bun add --global "$spec" --minimum-release-age 0 2>/dev/null || echo "Install failed: $spec"
+    # Verify the payload actually materialized; bun can silently no-op.
+    if [ ! -f "${GLOBAL_MODULES}/${dep}/package.json" ]; then
+      echo "Warning: $dep still missing after install ($spec)" >&2
+    fi
   done <<<"$OPTIONAL_DEPS"
 fi
 

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -143,6 +143,7 @@
       grwxeh = "_grwxeh_function";
       grxe = "_grxe_function";
       grxeh = "_grxeh_function";
+      herdrd = "_herdrd_function";
       hme = "_hm_load_env_file";
       icg = "_install_cargo_globals_function";
       ing = "_install_npm_globals_function";
@@ -268,6 +269,7 @@
         "_grwxeh_function"
         "_grxe_function"
         "_grxeh_function"
+        "_herdrd_function"
         "_hm_load_env_file"
         "_llm_update_function"
         "_kyber_function"

--- a/home-manager/programs/fish/functions/_herdrd_function.fish
+++ b/home-manager/programs/fish/functions/_herdrd_function.fish
@@ -1,0 +1,3 @@
+function _herdrd_function --description "Attach to herdr running on remote Kyber over SSH"
+  herdr --remote kyber $argv
+end

--- a/package.json
+++ b/package.json
@@ -87,12 +87,12 @@
     "@anthropic-ai/claude-code-linux-x64-musl": "^2.1.186",
     "@anthropic-ai/claude-code-win32-arm64": "^2.1.186",
     "@anthropic-ai/claude-code-win32-x64": "^2.1.186",
-    "@openai/codex-darwin-arm64": "npm:@openai/codex@0.142.2",
-    "@openai/codex-darwin-x64": "npm:@openai/codex@0.142.2",
-    "@openai/codex-linux-arm64": "npm:@openai/codex@0.142.2",
-    "@openai/codex-linux-x64": "npm:@openai/codex@0.142.2",
-    "@openai/codex-win32-arm64": "npm:@openai/codex@0.142.2",
-    "@openai/codex-win32-x64": "npm:@openai/codex@0.142.2"
+    "@openai/codex-darwin-arm64": "npm:@openai/codex@0.142.5-darwin-arm64",
+    "@openai/codex-darwin-x64": "npm:@openai/codex@0.142.5-darwin-x64",
+    "@openai/codex-linux-arm64": "npm:@openai/codex@0.142.5-linux-arm64",
+    "@openai/codex-linux-x64": "npm:@openai/codex@0.142.5-linux-x64",
+    "@openai/codex-win32-arm64": "npm:@openai/codex@0.142.5-win32-arm64",
+    "@openai/codex-win32-x64": "npm:@openai/codex@0.142.5-win32-x64"
   },
   "overrides": {
     "pino": "^9.14.0"

--- a/spec/npm_globals_spec.sh
+++ b/spec/npm_globals_spec.sh
@@ -366,4 +366,105 @@ When run bash -c "HOME='$TEMP_HOME' MOCK_LOG='$MOCK_LOG' PATH='$MOCK_BIN:$REAL_B
 The output should eq 'missing'
 End
 End
+
+Describe 'aliased native binary (codex pattern)'
+It 'reconstructs the platform suffix for aliased native deps'
+When run bash -c "grep 'want_ver=\"\${base_ver}-\${suffix}\"' '$SCRIPT'"
+The output should include 'want_ver'
+End
+
+It 'derives the native binary version from the installed parent'
+When run bash -c "grep 'installed_base' '$SCRIPT'"
+The output should include 'installed_base'
+End
+
+It 'reinstalls a phantom native dir instead of trusting -d'
+When run bash -c "grep 'phantom dir' '$SCRIPT'"
+The output should include 'phantom dir'
+End
+
+It 'warns when the payload did not materialize after install'
+When run bash -c "grep 'still missing after install' '$SCRIPT'"
+The output should include 'still missing after install'
+End
+End
+
+Describe 'aliased native binary self-heal integration'
+setup() {
+  TEMP_HOME=$(mktemp -d)
+  MOCK_BIN=$(mktemp -d)
+  MOCK_LOG="$TEMP_HOME/mock.log"
+  REAL_BIN_DIR="$(dirname "$(command -v jq)")"
+  REAL_SYSTEM_BIN_DIR="$(dirname "$(command -v mv)")"
+  : >"$MOCK_LOG"
+
+  GM="$TEMP_HOME/.bun/install/global/node_modules"
+  mkdir -p "$TEMP_HOME/dotfiles" "$TEMP_HOME/.bun/install/global" "$TEMP_HOME/.bun/bin"
+
+  os_tok=$(uname -s | tr '[:upper:]' '[:lower:]')
+  [ "$os_tok" = "darwin" ] || os_tok="linux"
+  cpu_tok=$(uname -m)
+  case "$cpu_tok" in arm64 | aarch64) cpu_tok=arm64 ;; *) cpu_tok=x64 ;; esac
+  NATIVE_DEP="codexcli-${os_tok}-${cpu_tok}"
+  # Wrapper is installed at 1.0.2 but the dotfiles optional pin is a stale,
+  # SUFFIX-LESS 1.0.0 alias (the bug). The script must ignore both and install
+  # the suffixed binary at the parent's actual version.
+  WANT_SPEC="${NATIVE_DEP}@npm:codexcli@1.0.2-${os_tok}-${cpu_tok}"
+  EXPECT_INSTALL="bun add --global ${WANT_SPEC}"
+
+  cat >"$TEMP_HOME/dotfiles/package.json" <<EOF
+{
+  "dependencies": { "codexcli": "^1.0.0" },
+  "optionalDependencies": { "${NATIVE_DEP}": "npm:codexcli@1.0.0" }
+}
+EOF
+
+  # Parent installed ahead of the pin, no optionalDependencies of its own so the
+  # parent-reinstall guard leaves it in place for the optional loop to read.
+  mkdir -p "$GM/codexcli"
+  cat >"$GM/codexcli/package.json" <<'EOF'
+{ "name": "codexcli", "version": "1.0.2" }
+EOF
+
+  cat >"$MOCK_BIN/timeout" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+shift
+if [ "${1:-}" = "bash" ] && [ "${2:-}" = "-c" ] && [ "${3:-}" = "exec 3<>/dev/tcp/1.1.1.1/53" ]; then
+  exit 0
+fi
+exec "$@"
+EOF
+  chmod +x "$MOCK_BIN/timeout"
+
+  cat >"$MOCK_BIN/bun" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'bun %s\n' "$*" >>"$MOCK_LOG"
+EOF
+  chmod +x "$MOCK_BIN/bun"
+}
+
+cleanup() {
+  rm -rf "$TEMP_HOME" "$MOCK_BIN"
+}
+
+Before 'setup'
+After 'cleanup'
+
+It 'installs the suffixed binary at the installed parent version despite a stale bare pin'
+When run bash -c "HOME='$TEMP_HOME' MOCK_LOG='$MOCK_LOG' PATH='$MOCK_BIN:$REAL_BIN_DIR:$REAL_SYSTEM_BIN_DIR:/usr/bin:/bin' bash '$SCRIPT' >/dev/null 2>&1; cat '$MOCK_LOG'"
+The output should include "$EXPECT_INSTALL"
+End
+
+It 'reinstalls a phantom empty native dir'
+When run bash -c "mkdir -p '$GM/$NATIVE_DEP'; HOME='$TEMP_HOME' MOCK_LOG='$MOCK_LOG' PATH='$MOCK_BIN:$REAL_BIN_DIR:$REAL_SYSTEM_BIN_DIR:/usr/bin:/bin' bash '$SCRIPT' >/dev/null 2>&1; cat '$MOCK_LOG'"
+The output should include "$EXPECT_INSTALL"
+End
+
+It 'skips a native dir already at the correct version'
+When run bash -c "mkdir -p '$GM/$NATIVE_DEP'; printf '{\"version\":\"1.0.2-${os_tok}-${cpu_tok}\"}' >'$GM/$NATIVE_DEP/package.json'; HOME='$TEMP_HOME' MOCK_LOG='$MOCK_LOG' PATH='$MOCK_BIN:$REAL_BIN_DIR:$REAL_SYSTEM_BIN_DIR:/usr/bin:/bin' bash '$SCRIPT' >/dev/null 2>&1; cat '$MOCK_LOG'"
+The output should not include "bun add --global $NATIVE_DEP"
+End
+End
 End


### PR DESCRIPTION
## Summary
- Add `config/herdr/` with a fully-verbose `config.toml` (Dracula theme, matching ghostty/zellij/fish) seeded from `herdr --default-config`, wired via home-manager
- Add `herdrd` fish abbr -> `_herdrd_function` that attaches to herdr on remote kyber (`herdr --remote kyber`), mirroring the existing `kyberd`/`kyberm` pattern
- Register `./herdr` in `config/default.nix`

## Non-default settings
- `onboarding = false`
- `theme.name = "dracula"`
- `ui.sound.enabled = false`
- `experimental.pane_history = true`
- `advanced.scrollback_limit_bytes = 300000000` (300MB)

## Apply
Rebuild home-manager, then `herdr server reload-config`.

herdr is already present in `nix-darwin/config/homebrew.nix`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Herdr config managed by home-manager and a `fish` shortcut to attach to the remote Kyber session. Also fixes global installs of aliased native `@openai/codex-*` packages to ensure the correct platform binary is installed, with tests.

- New Features
  - Add `config/herdr/config.toml` (Dracula theme, onboarding off, sound off, `experimental.pane_history = true`, `advanced.scrollback_limit_bytes = 300000000`), managed via home-manager.
  - Register `./herdr` in `config/default.nix` and add `herdrd` (`_herdrd_function`) to run `herdr --remote kyber`.
  - Apply: rebuild home-manager, then run `herdr server reload-config`.

- Bug Fixes
  - Fix aliased native binary installs for `@openai/codex-*`: reconstruct the `-<os>-<arch>` suffix, match the installed wrapper’s version, and reinstall phantom/wrong-version dirs.
  - Pin `package.json` to suffixed versions `0.142.5-<triple>`.
  - Add specs covering suffix reconstruction, parent-version derivation, phantom-dir reinstall, and correct-version skip.

<sup>Written for commit 88107c8a1270a98f2d458d5737006f671d716dd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

