### PR TITLE
chore(brew): add container

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -68,6 +68,7 @@
       "cmake"
       "coder"
       "colima"
+      "container"
       "coreutils"
       "ffmpeg"
       "gemini-cli"


### PR DESCRIPTION
Add `container` to Homebrew brews in alphabetical order (after `colima`, before `coreutils`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `container` to the Homebrew packages in the nix-darwin config so it gets installed by default. Kept alphabetical order between `colima` and `coreutils`.

<sup>Written for commit 88007450929942fb2b2e20e641ca434753854e40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

