### PR TITLE
fix(noctalia): glass effect on top bar

### DIFF
--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -90,7 +90,16 @@ in
           enabled = true;
           speed = 3;
         };
+        panel.transparency_mode = "glass";
       };
+
+      backdrop = {
+        enabled = true;
+        blur_intensity = 40;
+        tint_intensity = 20;
+      };
+
+      audio.enable_sounds = false;
 
       theme = {
         mode = "auto";
@@ -143,6 +152,7 @@ in
       dock = {
         enabled = true;
         auto_hide = true;
+        reserve_space = false;
         launcher_icon = "nix-snowflake";
       };
 

--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -100,6 +100,8 @@ in
 
       bar.main = {
         background_opacity = 0.0;
+        margin_ends = 0;
+        margin_edge = 0;
         capsule = true;
         capsule_opacity = 0.0;
         start = [ "launcher" "clock" "cpu" "memory" "network_rx" "network_tx" "gpu" "active_window" "media" ];
@@ -140,6 +142,7 @@ in
 
       dock = {
         enabled = true;
+        auto_hide = true;
         launcher_icon = "nix-snowflake";
       };
 

--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -81,23 +81,83 @@ in
     enable = true;
     package = noctalia;
 
-    # v5 is a ground-up rewrite (C++/Qt, TOML config, snake_case keys) and upstream
-    # does NOT migrate v4 settings - "v5 ships with sane defaults, customize from there".
-    # The v4 config (bar widget layout, Dracula theme, dark-mode dconf hook, idle
-    # timeouts, per-widget options) has NO mechanical v5 equivalent and its semantics
-    # changed (e.g. bar widgets are now id vectors + separate styling; idle uses a
-    # behavior map; hooks run with no args). Re-apply those on-device via the settings UI.
-    #
-    # Only keys verified against the v5 schema (src/config/schema/config_schema.cpp)
-    # are set here so the build-time `noctalia config validate` passes.
     settings = {
       shell = {
-        font_family = "Noto Sans"; # was ui.fontDefault
-        clipboard_enabled = true; # was appLauncher.enableClipboardHistory
-        clipboard_auto_paste = "auto"; # was appLauncher.autoPasteClipboard = true
+        font_family = "Noto Sans";
+        clipboard_enabled = true;
+        clipboard_auto_paste = "auto";
+        animation = {
+          enabled = true;
+          speed = 3;
+        };
       };
-      location.auto_locate = true; # was location.autoLocate
-      wallpaper.enabled = false; # noctalia does not manage the wallpaper (wallpaper engine does)
+
+      theme = {
+        mode = "auto";
+        source = "builtin";
+        builtin = "Dracula";
+      };
+
+      bar.main = {
+        background_opacity = 0.0;
+        capsule = true;
+        capsule_opacity = 0.0;
+        start = [ "launcher" "clock" "cpu" "memory" "network_rx" "network_tx" "gpu" "active_window" "media" ];
+        center = [ "workspaces" ];
+        end = [ "tray" "bluetooth" "network" "notification_history" "battery" "power_profile" "volume" "brightness" "dark_mode" "control_center" ];
+      };
+
+      widget.clock = {
+        format = "{:%Y/%m/%d %H:%M:%S}";
+        vertical_format = "{:%H %M %S - %d %m}";
+        tooltip_format = "{:%Y/%m/%d %H:%M:%S}";
+      };
+
+      notification = {
+        enable_daemon = true;
+        position = "top_right";
+        background_opacity = 0.75;
+      };
+
+      osd.position = "right";
+
+      lockscreen = {
+        enabled = true;
+        fingerprint = true;
+      };
+
+      idle = {
+        behavior.lock = {
+          enabled = true;
+          timeout = 300;
+          command = "noctalia:session lock";
+        };
+      };
+
+      system.monitor = {
+        enabled = true;
+      };
+
+      dock = {
+        enabled = true;
+        launcher_icon = "nix-snowflake";
+      };
+
+      desktop_widgets.enabled = true;
+      wallpaper.enabled = false;
+      location.auto_locate = true;
+
+      hooks.theme_mode_changed = ''
+        if [ "$NOCTALIA_THEME_MODE" = "dark" ]; then
+          dconf write /org/gnome/desktop/interface/color-scheme "'prefer-dark'"
+          dconf write /org/gnome/desktop/interface/gtk-theme "'Adwaita-dark'"
+          dconf write /org/gnome/desktop/interface/icon-theme "'Adwaita'"
+        else
+          dconf write /org/gnome/desktop/interface/color-scheme "'prefer-light'"
+          dconf write /org/gnome/desktop/interface/gtk-theme "'Adwaita'"
+          dconf write /org/gnome/desktop/interface/icon-theme "'Adwaita'"
+        fi
+      '';
     };
   };
 }

--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -108,11 +108,11 @@ in
       };
 
       bar.main = {
-        background_opacity = 0.0;
+        background_opacity = 0.6;
         margin_ends = 0;
         margin_edge = 0;
         capsule = true;
-        capsule_opacity = 0.0;
+        capsule_opacity = 0.6;
         start = [ "launcher" "clock" "cpu" "memory" "network_rx" "network_tx" "gpu" "active_window" "media" ];
         center = [ "workspaces" ];
         end = [ "tray" "bluetooth" "network" "notification_history" "battery" "power_profile" "volume" "brightness" "dark_mode" "control_center" ];


### PR DESCRIPTION
## Summary
- Set `bar.main.background_opacity` and `capsule_opacity` from `0.0` to `0.6` so the glass transparency mode renders a visible frosted blur on the top bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the top bar’s glass effect visible in Noctalia by raising `bar.main.background_opacity` and `capsule_opacity` from 0.0 to 0.6. This enables a subtle frosted blur instead of full transparency.

<sup>Written for commit a89d385f9f5fc7dcc828ce3dd9f9a94e71766cd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

