### PR TITLE
style(noctalia): nixfmt default.nix to fix CI

### DIFF
--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -145,9 +145,29 @@ in
         capsule = true;
         capsule_opacity = 0.6;
         shadow = true;
-        start = [ "launcher" "clock" "cpu" "memory" "network_rx" "network_tx" "gpu" "active_window" ];
+        start = [
+          "launcher"
+          "clock"
+          "cpu"
+          "memory"
+          "network_rx"
+          "network_tx"
+          "gpu"
+          "active_window"
+        ];
         center = [ "workspaces" ];
-        end = [ "tray" "bluetooth" "network" "notification_history" "battery" "power_profile" "volume" "brightness" "dark_mode" "control_center" ];
+        end = [
+          "tray"
+          "bluetooth"
+          "network"
+          "notification_history"
+          "battery"
+          "power_profile"
+          "volume"
+          "brightness"
+          "dark_mode"
+          "control_center"
+        ];
       };
 
       widget.clock = {


### PR DESCRIPTION
## Summary
- `config/noctalia/default.nix` had unformatted array literals (`start`/`end` bar module lists), which failed `nix fmt --fail-on-change` (treefmt) on `main`.
- This cascaded: `nix-format`, `nix-flake`, `nix-test`, and `nix-darwin` were all failing because the `treefmt-check` derivation failed.
- Ran `nixfmt` on the file to match required formatting; no functional change.

## Test plan
- [x] `nixfmt --check config/noctalia/default.nix` passes
- [x] `nixfmt --check` on all `*.nix` files in repo passes
- [ ] CI green on this PR (Nix workflow)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Formatted `config/noctalia/default.nix` with `nixfmt` so `treefmt` passes and CI goes green. No functional changes.

<sup>Written for commit d253fca9c677111bd7fc258c1df7df0aba03a0dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/1998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

