### PR TITLE
feat(noctalia,ghostty): launcher entries, lockscreen blur, ctrl+q

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -45,6 +45,7 @@ keybind = ctrl+shift+minus=new_split:down
 keybind = ctrl+shift+z=toggle_split_zoom
 keybind = ctrl+shift+e=equalize_splits
 keybind = ctrl+shift+w=close_surface
+keybind = ctrl+q=quit
 
 # opensessions sidebar
 keybind = cmd+e=text:\x02\x14

--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -68,6 +68,78 @@ in
     force = true;
   };
 
+  xdg.desktopEntries.logout = {
+    name = "Log Out";
+    comment = "End the current session";
+    exec = "${noctalia}/bin/noctalia msg session logout";
+    terminal = false;
+    categories = [ "System" ];
+    icon = "system-log-out";
+  };
+
+  xdg.desktopEntries.suspend = {
+    name = "Suspend";
+    comment = "Put the system to sleep";
+    exec = "${noctalia}/bin/noctalia msg session suspend";
+    terminal = false;
+    categories = [ "System" ];
+    icon = "system-suspend";
+  };
+
+  xdg.desktopEntries.screenshot-region = {
+    name = "Screenshot Region";
+    comment = "Capture a screen region";
+    exec = "${noctalia}/bin/noctalia msg screenshot-region";
+    terminal = false;
+    categories = [ "Utility" ];
+    icon = "accessories-screenshot";
+  };
+
+  xdg.desktopEntries.do-not-disturb = {
+    name = "Toggle Do Not Disturb";
+    comment = "Toggle notification Do Not Disturb mode";
+    exec = "${noctalia}/bin/noctalia msg notification-dnd-toggle";
+    terminal = false;
+    categories = [ "Utility" ];
+    icon = "notifications-disabled";
+  };
+
+  xdg.desktopEntries.reboot = {
+    name = "Reboot";
+    comment = "Restart the system";
+    exec = "${noctalia}/bin/noctalia msg session reboot";
+    terminal = false;
+    categories = [ "System" ];
+    icon = "system-reboot";
+  };
+
+  xdg.desktopEntries.shut-down = {
+    name = "Shut Down";
+    comment = "Power off the system";
+    exec = "${noctalia}/bin/noctalia msg session shutdown";
+    terminal = false;
+    categories = [ "System" ];
+    icon = "system-shutdown";
+  };
+
+  xdg.desktopEntries.lock-screen = {
+    name = "Lock Screen";
+    comment = "Lock the session";
+    exec = "${noctalia}/bin/noctalia msg session lock";
+    terminal = false;
+    categories = [ "System" ];
+    icon = "system-lock-screen";
+  };
+
+  xdg.desktopEntries.toggle-dark-mode = {
+    name = "Toggle Dark Mode";
+    comment = "Switch between dark and light theme";
+    exec = "${noctalia}/bin/noctalia msg theme-mode-toggle";
+    terminal = false;
+    categories = [ "Utility" ];
+    icon = "weather-clear-night";
+  };
+
   xdg.desktopEntries.quit-all-apps = {
     name = "Quit All Apps";
     comment = "Close all open windows";
@@ -187,7 +259,11 @@ in
       lockscreen = {
         enabled = true;
         fingerprint = true;
+        blur = true;
+        blur_intensity = 40;
       };
+
+      lockscreen_widgets.enabled = true;
 
       idle = {
         behavior.lock = {


### PR DESCRIPTION
## Summary
- Add desktop entries to Noctalia launcher: Log Out, Suspend, Reboot, Shut Down, Lock Screen, Screenshot Region, Toggle Dark Mode, Toggle Do Not Disturb
- Enable lockscreen blur with widgets for frosted-glass effect over animated wallpaper
- Add `ctrl+q=quit` keybind to Ghostty

## Test plan
- [ ] Rebuild NixOS config
- [ ] Open launcher (Super+Space) and verify all new entries appear
- [ ] Test each launcher action (lock, dark mode toggle, DND, screenshot region)
- [ ] Lock screen and verify blur + login widget renders
- [ ] Verify ctrl+q quits Ghostty

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add system and utility entries to the `noctalia` launcher, enable a blurred lock screen with widgets, and add Ctrl+Q to quit in `ghostty`. Improves quick actions and lock screen polish.

- **New Features**
  - `noctalia` launcher: Log Out, Suspend, Reboot, Shut Down, Lock Screen, Screenshot Region, Toggle Dark Mode, Toggle Do Not Disturb.
  - Lock screen: enable blur (intensity 40) and widgets for a frosted-glass look over animated wallpaper.
  - `ghostty`: add Ctrl+Q keybind to quit.

<sup>Written for commit 9a8a5c1ec4ddb898a72caf633739ca02fc192b2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

