### PR TITLE
fix(noctalia): valid lockscreen blur and tint settings

### DIFF
--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -259,8 +259,9 @@ in
       lockscreen = {
         enabled = true;
         fingerprint = true;
-        blur = true;
+        blurred_desktop = true;
         blur_intensity = 40;
+        tint_intensity = 20;
       };
 
       lockscreen_widgets.enabled = true;


### PR DESCRIPTION
## Summary
- Replace invalid `blur` with `blurred_desktop` (captures desktop for lockscreen background)
- Add `blur_intensity = 40` and `tint_intensity = 20` (both validated)
- Remove invalid `blur` boolean that triggered config warning

## Test plan
- [ ] `noctalia config validate` shows no lockscreen warnings
- [ ] Lock screen shows blurred desktop background instead of pitch black

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix lockscreen config by replacing invalid `blur` with `blurred_desktop` and adding `blur_intensity = 40` and `tint_intensity = 20`. This removes config warnings and shows a blurred desktop background on the lock screen.

<sup>Written for commit e5e310d70f8de37cd5820bf4d88e5edfc5699cd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

