### PR TITLE
fix(noctalia): lockscreen blur/tint intensity 0-1 range

### DIFF
--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -260,8 +260,8 @@ in
         enabled = true;
         fingerprint = true;
         blurred_desktop = true;
-        blur_intensity = 40;
-        tint_intensity = 20;
+        blur_intensity = 1.0;
+        tint_intensity = 1.0;
       };
 
       lockscreen_widgets.enabled = true;


### PR DESCRIPTION
## Summary
- Fix lockscreen `blur_intensity` and `tint_intensity` to use 0.0-1.0 range (was 40/20)
- Both set to max 1.0 to match the settings UI

## Test plan
- [ ] Lock screen shows full blur and tint effect

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Noctalia lockscreen to use the 0.0–1.0 intensity range. Set `blur_intensity` and `tint_intensity` to 1.0 for full effect, matching the settings UI.

<sup>Written for commit 15b75e6031459dd090faa26dbb05bdf04677746a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

