### PR TITLE
fix(noctalia): lockscreen blur 0.4, tint 0.2

### DIFF
--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -260,8 +260,8 @@ in
         enabled = true;
         fingerprint = true;
         blurred_desktop = true;
-        blur_intensity = 40;
-        tint_intensity = 20;
+        blur_intensity = 0.4;
+        tint_intensity = 0.2;
       };
 
       lockscreen_widgets.enabled = true;


### PR DESCRIPTION
## Summary
- Set lockscreen `blur_intensity = 0.4` and `tint_intensity = 0.2` (0-1 range)

## Test plan
- [ ] Lock screen shows moderate blur with light tint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Noctalia lockscreen blur/tint to normalized 0–1 values: set blur_intensity to 0.4 and tint_intensity to 0.2. Restores the expected moderate blur with a light tint on the lock screen.

<sup>Written for commit 570833bac4d8030a1e0939270f57cf3be6984f2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

