### PR TITLE
feat(noctalia): enable screen time, clean up keyd/xremap

### DIFF
--- a/config/keyd/app.conf
+++ b/config/keyd/app.conf
@@ -1,6 +1,2 @@
 # keyd-application-mapper normalizes classes/titles to lowercase
-# with punctuation collapsed to '-'. Slack's class becomes `slack`.
-[slack]
-leftmeta = layer(control)
-prog1 = layer(control)
-f13 = layer(control)
+# with punctuation collapsed to '-'.

--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -158,6 +158,7 @@ in
         font_family = "Noto Sans";
         clipboard_enabled = true;
         clipboard_auto_paste = "auto";
+        screen_time_enabled = true;
         animation = {
           enabled = true;
           speed = 3;

--- a/home-manager/modules/xremap/default.nix
+++ b/home-manager/modules/xremap/default.nix
@@ -95,8 +95,6 @@ let
     "code"
     "Code"
   ];
-  # Slack-specific Framework->Ctrl behavior is handled by keyd's
-  # application mapper on hosts that enable ~/.config/keyd/app.conf.
   slackRemap = globalRemap;
 in
 {


### PR DESCRIPTION
## Summary
- Enable noctalia screen time tracking (`screen_time_enabled = true`)
- Remove stale Slack keyd app.conf remapping (no longer needed)
- Remove orphaned xremap comment referencing keyd Slack mapper

## Test plan
- [ ] Rebuild NixOS config and verify noctalia screen time tab appears in control center
- [ ] Confirm keyd still works without the removed Slack-specific block

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable screen time in Noctalia by setting `screen_time_enabled = true`, and remove stale Slack-specific key mapping config. This surfaces the Screen Time tab and simplifies mappings by deleting the Slack block in `keyd` and the related xremap comment.

<sup>Written for commit b97a5284825a809c8ef4671cfa67d2e7aed088f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

