### PR TITLE
fix(fish): prevent hoisted bun npm stub from shadowing real native bun

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -9,7 +9,9 @@
     enable = true;
     shellInit = ''
       # Local binaries should be available before login/interactive-only PATH setup.
-      set -gx PATH $HOME/.bun/install/global/node_modules/.bin $HOME/.bun/bin $HOME/.cargo/bin $HOME/.local/bin $PATH
+      # ~/.bun/bin (real native bun) must precede the global node_modules/.bin so a
+      # transitively hoisted `bun`/`bunx` npm stub can never shadow the real binary.
+      set -gx PATH $HOME/.bun/bin $HOME/.bun/install/global/node_modules/.bin $HOME/.cargo/bin $HOME/.local/bin $PATH
 
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
       if test (uname) = "Linux"
@@ -52,10 +54,12 @@
       fish_add_path -p -m ~/.local/bin
       fish_add_path -p -m ~/.cargo/bin
       fish_add_path -p -m ~/.local/scripts
-      fish_add_path -p -m ~/.bun/bin
       fish_add_path -p -m /opt/homebrew/opt/postgresql@18/bin
       fish_add_path -p -m /opt/homebrew/bin
       fish_add_path -p -m ~/.bun/install/global/node_modules/.bin
+      # ~/.bun/bin last => frontmost, so the real native bun/bunx always win over
+      # any hoisted `bun` npm stub living in the global node_modules/.bin above.
+      fish_add_path -p -m ~/.bun/bin
     '';
     interactiveShellInit = ''
       source ${config.home.homeDirectory}/.config/fish/functions/_hm_load_env_file.fish
@@ -75,10 +79,12 @@
       fish_add_path -p -m ~/.local/bin
       fish_add_path -p -m ~/.cargo/bin
       fish_add_path -p -m ~/.local/scripts
-      fish_add_path -p -m ~/.bun/bin
       fish_add_path -p -m /opt/homebrew/opt/postgresql@18/bin
       fish_add_path -p -m /opt/homebrew/bin
       fish_add_path -p -m ~/.bun/install/global/node_modules/.bin
+      # ~/.bun/bin last => frontmost, so the real native bun/bunx always win over
+      # any hoisted `bun` npm stub living in the global node_modules/.bin above.
+      fish_add_path -p -m ~/.bun/bin
       # Worktrunk shell init
       if type -q wt
         wt config shell init fish | source


### PR DESCRIPTION
## Problem
`which bun` resolved to `~/.bun/install/global/node_modules/.bin/bun`, a symlink to `bun.exe` (a Windows placeholder stub, ~450 bytes). The `bun` npm package gets transitively hoisted into the global tree during `install-npm-globals`, and its `.bin/bun` shadowed the real native bun.

## Root cause
`home-manager/programs/fish/default.nix` ordered `~/.bun/install/global/node_modules/.bin` **ahead of** `~/.bun/bin` on PATH (both in `shellInit` and the `fish_add_path` blocks). Global CLIs are meant to be frontmost, but that also let a hoisted `bun`/`bunx` stub win over the real binary at `~/.bun/bin`.

## Fix
Re-prepend `~/.bun/bin` **last** (frontmost) so the real native bun/bunx always win, while global CLIs still resolve from the node_modules `.bin` behind it. Applied to `shellInit`, `loginShellInit`, and `interactiveShellInit`.

Also removed the corrupt stub from disk (`~/.bun/install/global/node_modules/bun` + its `.bin` symlinks); real bun (1.3.14) now resolves.

Requires `make switch` / home-manager rebuild to take effect in login shells.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PATH ordering in `fish` so the real native `bun`/`bunx` in ~/.bun/bin always win over a hoisted npm stub in ~/.bun/install/global/node_modules/.bin. This prevents calling the Windows stub and ensures the correct binary runs.

- **Bug Fixes**
  - Reordered PATH in shellInit so ~/.bun/bin precedes the global node_modules/.bin.
  - In login and interactive init, added ~/.bun/bin last via fish_add_path so it is frontmost at runtime.

- **Migration**
  - Run home-manager rebuild (e.g., `make switch`) to apply in new shells.

<sup>Written for commit baa7a5e48694a11a281b4b33973a92c9c46d080e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

