### PR TITLE
fix(hunk): inherit Dracula theme colors from ghostty config

### DIFF
--- a/config/hunk/config.toml
+++ b/config/hunk/config.toml
@@ -1,4 +1,4 @@
-theme = "auto"
+theme = "custom"
 mode = "auto"
 vcs = "git"
 watch = false
@@ -8,3 +8,17 @@ wrap_lines = false
 menu_bar = true
 agent_notes = true
 transparent_background = true
+
+[custom_theme]
+base = "catppuccin-mocha"
+label = "Ghostty Dracula"
+accent = "#bd93f9"
+panel = "#21222c"
+noteBorder = "#ff79c6"
+
+[custom_theme.syntax]
+keyword = "#ff79c6"
+string = "#f1fa8c"
+comment = "#6272a4"
+operator = "#8be9fd"
+variable = "#f8f8f2"


### PR DESCRIPTION
## Summary
- Set hunk custom theme inheriting from `catppuccin-mocha` with Dracula color overrides matching the ghostty `Dracula Custom` theme
- Colors pulled from `config/ghostty/themes/Dracula Custom`: accent (`#bd93f9` purple), panel (`#21222c` bg), noteBorder (`#ff79c6` pink), syntax highlighting (keyword/string/comment/operator/variable)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align Hunk with Ghostty’s Dracula Custom theme by switching to a `custom` theme based on `catppuccin-mocha` and applying matching overrides (accent, panel, note border, syntax). Fixes mismatched UI colors between Ghostty and Hunk.

<sup>Written for commit 7c85d7db2b71f09476f9507fe66ac25319a1d658. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

