### PR TITLE
fix(noctalia): use external IPC for idle lock to capture blurred desktop

### DIFF
--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -271,7 +271,7 @@ in
         behavior.lock = {
           enabled = true;
           timeout = 300;
-          command = "noctalia:session lock";
+          command = "noctalia msg session lock";
         };
         behavior.screen-off.enabled = false;
         behavior.suspend.enabled = false;


### PR DESCRIPTION
## Summary
- Changed idle lock command from internal `noctalia:session lock` to external `noctalia msg session lock`
- The internal idle-to-lock path skips framebuffer capture, resulting in no blurred desktop background on the lockscreen
- External IPC goes through the same codepath as manual lock, which properly captures the screen before presenting the lock surface

## Test plan
- [ ] Rebuild and let idle timer fire on AC power
- [ ] Verify lockscreen shows blurred current desktop as background

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched idle lock to `noctalia msg session lock` so idle-triggered locking follows the external IPC path that captures the framebuffer. Fixes the missing blurred desktop background on the lock screen, matching manual lock behavior.

<sup>Written for commit 1b28cc613e4b54e565b60deff2c007cc04c4da3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

