### PR TITLE
fix(shell): update test to match bun PATH reorder from #2008

### DIFF
--- a/spec/atuin_history_spec.sh
+++ b/spec/atuin_history_spec.sh
@@ -144,7 +144,7 @@ The output should include '.local/bin'
 End
 
 It 'adds local binaries to fish shellInit before login-only setup'
-When run bash -c "grep -F 'set -gx PATH \$HOME/.bun/install/global/node_modules/.bin \$HOME/.bun/bin \$HOME/.cargo/bin \$HOME/.local/bin \$PATH' '$FISH_CONFIG'"
+When run bash -c "grep -F 'set -gx PATH \$HOME/.bun/bin \$HOME/.bun/install/global/node_modules/.bin \$HOME/.cargo/bin \$HOME/.local/bin \$PATH' '$FISH_CONFIG'"
 The status should be success
 The output should include '.local/bin'
 The output should include '.bun/bin'


### PR DESCRIPTION
## Summary
- PR #2008 reordered the fish `shellInit` PATH to put `~/.bun/bin` before `~/.bun/install/global/node_modules/.bin` so the real native bun binary always wins over hoisted npm stubs
- The shellspec test at `spec/atuin_history_spec.sh:147` still expected the old order, causing the Shell CI workflow to fail on every push to main
- Updated the grep pattern in the test to match the current fish config

## Test plan
- [ ] Shell CI workflow passes with the corrected test assertion

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update shellspec to match the fish PATH reorder introduced in #2008, placing ~/.bun/bin before ~/.bun/install/global/node_modules/.bin so the native `bun` binary takes precedence. Fixes the Shell CI failure by aligning the test with the current fish config.

<sup>Written for commit 6ed1da352a0f419f70589899263acb4edae28b8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

