### PR TITLE
fix(xremap): use globalRemap for code editors instead of terminalClipboardRemap

### DIFF
--- a/home-manager/modules/xremap/default.nix
+++ b/home-manager/modules/xremap/default.nix
@@ -119,10 +119,11 @@ in
               remap = terminalClipboardRemap;
             }
             {
-              # Cursor/VS Code: terminal-style clipboard shortcut, not bare Ctrl+C.
+              # Cursor/VS Code: standard Ctrl+C/V for copy/paste (not terminal-style Ctrl+Shift+C/V).
+              # The integrated terminal handles its own clipboard shortcuts internally.
               name = "Framework Command (Code Editors)";
               application.only = codeEditorAppIds;
-              remap = terminalClipboardRemap;
+              remap = globalRemap;
             }
             {
               # Slack: isolated block so modifier-leak / thread mark-as-read


### PR DESCRIPTION
## Summary
- Code editors (Cursor/VS Code) were using `terminalClipboardRemap`, which remapped `Ctrl+C` -> `Ctrl+Shift+C` and `Framework+C/V` -> `Ctrl+Shift+C/V`
- This broke copy/paste since code editors use `Ctrl+C/V` natively (the `Ctrl+Shift+C/V` convention is only for terminal emulators)
- Switched code editors to `globalRemap` so Framework+C/V correctly becomes Ctrl+C/V and bare Ctrl+C/V passes through unmodified

## Test plan
- [ ] Rebuild NixOS config (`sudo nixos-rebuild switch --flake .`)
- [ ] Verify Framework+C/V works for copy/paste in Cursor/VS Code
- [ ] Verify Ctrl+C/V still works in Cursor/VS Code
- [ ] Verify Framework+C/V still maps to Ctrl+Shift+C/V in Ghostty

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes copy/paste in Cursor and VS Code by switching code editors from `terminalClipboardRemap` to `globalRemap` in `xremap`.

`Framework+C/V` now maps to `Ctrl+C/V` and bare `Ctrl+C/V` passes through; terminal emulators keep their `Ctrl+Shift+C/V` behavior.

<sup>Written for commit cef9f8ffe4138466d1518c25ff22652547cfdbaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

