### PR TITLE
fix(keyd): emit plain Ctrl+C/V for Framework+C/V, bypass xremap synthesis

### DIFF
--- a/config/keyd/default.conf
+++ b/config/keyd/default.conf
@@ -39,6 +39,13 @@ rightshift = capslock
 # Framework+Tab → Super+Tab for hyprshell window switcher
 tab = M-tab
 
+# Clipboard: emit plain Ctrl+C/V directly, bypassing xremap. Electron apps
+# (Slack) drop xremap's synthesized Hyper→Ctrl modifier swaps, so clipboard
+# keys must not go through that dance. Ghostty converts C-c/C-v to
+# C-S-c/C-S-v via its xremap keymap block.
+c = C-c
+v = C-v
+
 [cmd_hyper+control]
 # Framework+Ctrl+5 → terminal split in VS Code
 5 = C-5

--- a/home-manager/modules/xremap/default.nix
+++ b/home-manager/modules/xremap/default.nix
@@ -13,11 +13,14 @@ let
   ctrlPrefix = "C-";
   # "f" is excluded — passes through as Hyper+F for Hyprland fullscreen bind.
   # "l" is excluded — passes through as Hyper+L for Hyprland lock screen bind.
+  # "c"/"v" are excluded — keyd emits plain Ctrl+C/V for Framework+C/V directly,
+  # because Electron apps (Slack) drop xremap's synthesized Hyper→Ctrl modifier
+  # swaps. Hyper+C/V never reaches xremap.
+  # See: config/keyd/default.conf ([cmd_hyper] section)
   # See: config/hyprland/hyprland.conf (Window Management section, Lock Screen section)
   letters = [
     "a"
     "b"
-    "c"
     "d"
     "e"
     "g"
@@ -34,7 +37,6 @@ let
     "s"
     "t"
     "u"
-    "v"
     "w"
     "x"
     "y"
@@ -82,20 +84,6 @@ let
     );
   # Framework+key -> Ctrl+key for all apps (macOS-style shortcuts)
   globalRemap = mkRemap remapKeys;
-  # Terminal/editor clipboard convention: Framework+C/V -> Ctrl+Shift+C/V so
-  # copy/paste does not collide with SIGINT or app-specific bare Ctrl+C handlers.
-  terminalClipboardRemap = globalRemap // {
-    "C-c" = "C-Shift-c";
-    "${hyperPrefix}c" = "C-Shift-c";
-    "${hyperPrefix}v" = "C-Shift-v";
-  };
-  codeEditorAppIds = [
-    "cursor"
-    "Cursor"
-    "code"
-    "Code"
-  ];
-  slackRemap = globalRemap;
 in
 {
   config = lib.mkMerge [
@@ -113,28 +101,20 @@ in
           keypress_delay_ms = 10;
           keymap = [
             {
-              # Ghostty: Framework+C/V -> Ctrl+Shift+C/V (terminal convention: Ctrl+C = SIGINT)
+              # Ghostty: clipboard is Ctrl+Shift+C/V (terminal convention).
+              # keyd already collapsed Framework+C/V to plain Ctrl+C/V, so
+              # both Framework+C/V and bare Ctrl+C/V become copy/paste here.
               name = "Framework Command (Ghostty)";
               application.only = [ "com.mitchellh.ghostty" ];
-              remap = terminalClipboardRemap;
-            }
-            {
-              # Cursor/VS Code: standard Ctrl+C/V for copy/paste (not terminal-style Ctrl+Shift+C/V).
-              # The integrated terminal handles its own clipboard shortcuts internally.
-              name = "Framework Command (Code Editors)";
-              application.only = codeEditorAppIds;
-              remap = globalRemap;
-            }
-            {
-              # Slack: isolated block so modifier-leak / thread mark-as-read
-              # workarounds can be tuned without affecting other apps.
-              name = "Framework Command (Slack)";
-              application.only = [ "Slack" ];
-              remap = slackRemap;
+              remap = globalRemap // {
+                "C-c" = "C-Shift-c";
+                "C-v" = "C-Shift-v";
+              };
             }
             {
               # Global: no application filter — applies unconditionally so window detection
               # failures don't cause raw Hyper events to leak through to apps (e.g. Slack).
+              # Note: app ids are lowercase on Wayland ("slack", not "Slack").
               name = "Framework Command (Global)";
               remap = globalRemap;
             }


### PR DESCRIPTION
## Summary
- Framework+C/V in Slack (and other Electron apps) failed because xremap's synthesized Hyper->Ctrl modifier swap (release Alt+Shift+Super, press key, restore) gets dropped by Electron - the same issue keypress_delay_ms=10 (#1468) tried to patch
- keyd's cmd_hyper layer now emits plain Ctrl+C/V directly for Framework+C/V, so clipboard keys never need xremap synthesis and work deterministically in every app
- Ghostty keeps the terminal convention: its xremap block remaps the collapsed C-c/C-v to C-Shift-c/C-Shift-v, so both Framework+C/V and bare Ctrl+C/V copy/paste there
- Removed dead abstractions: terminalClipboardRemap, slackRemap, codeEditorAppIds, and the Slack/editor keymap blocks. The Slack block never matched (app id is lowercase "slack", config said "Slack") and both blocks were identical to the global fallback

## Test plan
- [ ] Rebuild (`make switch`) - keyd restarts via restartTriggers
- [ ] Slack: Framework+C/V copies/pastes
- [ ] Chrome: Framework+C/V copies/pastes
- [ ] Cursor/VS Code: Framework+C/V and Ctrl+C/V copy/paste
- [ ] Ghostty: Framework+C/V and Ctrl+Shift+C/V copy/paste

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Framework+C/V clipboard shortcuts in Electron apps by emitting plain Ctrl+C/V directly from `keyd`, bypassing `xremap`’s modifier-swap synthesis. `Ghostty` keeps the terminal convention via `xremap`, so both Framework+C/V and plain Ctrl+C/V copy/paste there.

- **Bug Fixes**
  - `keyd` `cmd_hyper` maps C/V to plain Ctrl+C/V to avoid Electron dropping synthesized swaps.
  - `Ghostty` remaps Ctrl+C/V to Ctrl+Shift+C/V, preserving terminal behavior.

- **Refactors**
  - Removed `terminalClipboardRemap`, `slackRemap`, `codeEditorAppIds`, and the Slack/editor keymap blocks (they duplicated the global remap).
  - Simplified app handling; rely on the global block (Wayland app ids are lowercase, e.g. "slack").

<sup>Written for commit 99553e4242b3ad52d6cfb1a3bbcfcb6c6085d5ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

