### PR TITLE
fix(fish): add ~/.railway/bin to PATH

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -11,7 +11,7 @@
       # Local binaries should be available before login/interactive-only PATH setup.
       # ~/.bun/bin (real native bun) must precede the global node_modules/.bin so a
       # transitively hoisted `bun`/`bunx` npm stub can never shadow the real binary.
-      set -gx PATH $HOME/.bun/bin $HOME/.bun/install/global/node_modules/.bin $HOME/.cargo/bin $HOME/.local/bin $PATH
+      set -gx PATH $HOME/.bun/bin $HOME/.bun/install/global/node_modules/.bin $HOME/.cargo/bin $HOME/.local/bin $HOME/.railway/bin $PATH
 
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
       if test (uname) = "Linux"
@@ -50,6 +50,7 @@
       fish_add_path -p -m /nix/var/nix/profiles/default/bin
       fish_add_path -p -m ~/.nix-profile/bin
       fish_add_path -p -m /etc/profiles/per-user/${config.home.username}/bin
+      fish_add_path -p -m ~/.railway/bin
       fish_add_path -p -m ~/go/bin
       fish_add_path -p -m ~/.local/bin
       fish_add_path -p -m ~/.cargo/bin
@@ -75,6 +76,7 @@
       fish_add_path -p -m /nix/var/nix/profiles/default/bin
       fish_add_path -p -m ~/.nix-profile/bin
       fish_add_path -p -m /etc/profiles/per-user/${config.home.username}/bin
+      fish_add_path -p -m ~/.railway/bin
       fish_add_path -p -m ~/go/bin
       fish_add_path -p -m ~/.local/bin
       fish_add_path -p -m ~/.cargo/bin


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `~/.railway/bin` to PATH in `fish` Home Manager config so the Railway CLI is available in all shells.
Sets it early in PATH and adds `fish_add_path` on both Linux and macOS to avoid “command not found” after install.

<sup>Written for commit 52874aa9c2ba40fb466b4a36665b5dfdc986f54e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

