### PR TITLE
fix(npm-globals): purge bun npm shim that breaks @railway/cli install

### DIFF
--- a/home-manager/modules/npm-globals/install-npm-globals.sh
+++ b/home-manager/modules/npm-globals/install-npm-globals.sh
@@ -115,6 +115,20 @@ missing_native_optional_dep() {
   [ "$matched" -eq 1 ] && [ "$present" -eq 0 ]
 }
 
+# Remove the npm "bun" wrapper package from global node_modules.
+# Some transitive deps pull in the "bun" npm package whose postinstall
+# downloads a bun binary. When that postinstall is skipped/fails, it leaves
+# a stub .bin/bun shim that shadows the real system bun, breaking every
+# subsequent postinstall that shells out to bun (e.g. @railway/cli).
+purge_bun_npm_shim() {
+  local gm="${HOME}/.bun/install/global/node_modules"
+  if [ -d "${gm}/bun" ]; then
+    rm -rf "${gm}/bun"
+    rm -f "${gm}/.bin/bun" "${gm}/.bin/bunx"
+    echo "Removed broken bun npm shim from global node_modules"
+  fi
+}
+
 echo "Installing npm global packages from package.json using bun..."
 cd "${HOME}/dotfiles"
 
@@ -153,6 +167,8 @@ if [ "${#STALE[@]}" -gt 0 ]; then
     rm -rf "${HOME}/.bun/install/global/node_modules/$dep"
   done
 fi
+
+purge_bun_npm_shim
 
 # Build list of packages that need installing or updating
 GLOBAL_MODULES="${HOME}/.bun/install/global/node_modules"
@@ -198,6 +214,7 @@ if [ "${#MISSING[@]}" -gt 0 ]; then
   echo "Installing ${#MISSING[@]} missing packages..."
   for dep in "${MISSING[@]}"; do
     timeout 600 bun add --global "$dep" 2>/dev/null || echo "Install failed: $dep"
+    purge_bun_npm_shim
   done
 else
   echo "All npm global packages already installed"
@@ -222,6 +239,7 @@ if [ -n "$OVERRIDES" ]; then
     jq --argjson overrides "$OVERRIDES" '.overrides = $overrides' "$GLOBAL_PKG" >"${GLOBAL_PKG}.tmp" &&
       mv "${GLOBAL_PKG}.tmp" "$GLOBAL_PKG"
     (cd "${HOME}/.bun/install/global" && bun install 2>/dev/null || true)
+    purge_bun_npm_shim
     echo "Applied dependency overrides to global install"
   fi
 fi
@@ -319,6 +337,7 @@ if [ -n "$OPTIONAL_DEPS" ]; then
     fi
     echo "Installing platform-native: $spec"
     timeout 600 bun add --global "$spec" --minimum-release-age 0 2>/dev/null || echo "Install failed: $spec"
+    purge_bun_npm_shim
     # Verify the payload actually materialized; bun can silently no-op.
     if [ ! -f "${GLOBAL_MODULES}/${dep}/package.json" ]; then
       echo "Warning: $dep still missing after install ($spec)" >&2

--- a/spec/npm_globals_spec.sh
+++ b/spec/npm_globals_spec.sh
@@ -187,6 +187,28 @@ The output should include 'find'
 End
 End
 
+Describe 'bun npm shim purge'
+  It 'defines a purge_bun_npm_shim function'
+    When run bash -c "grep 'purge_bun_npm_shim()' '$SCRIPT'"
+    The output should include 'purge_bun_npm_shim'
+  End
+
+  It 'removes the bun package from global node_modules'
+    When run bash -c "grep 'rm -rf.*gm.*bun' '$SCRIPT'"
+    The output should include 'bun'
+  End
+
+  It 'removes bun shims from .bin'
+    When run bash -c "grep 'rm -f.*\.bin/bun' '$SCRIPT'"
+    The output should include '.bin/bun'
+  End
+
+  It 'calls purge after each bun add --global'
+    When run bash -c "grep -A 1 'bun add --global.*dep.*2>/dev/null' '$SCRIPT' | grep 'purge_bun_npm_shim'"
+    The output should include 'purge_bun_npm_shim'
+  End
+End
+
 Describe 'native addon repair'
 It 'has a sqlite3 native binding repair step'
 When run bash -c "grep 'repair_sqlite3_native_binding' '$SCRIPT'"


### PR DESCRIPTION
## Summary
- The npm `bun` wrapper package gets pulled in as a transitive dependency during global installs
- Its postinstall is skipped by bun, leaving a broken stub at `.bin/bun` that shadows the real system bun
- This causes every subsequent postinstall that shells out to `bun` to fail (e.g. `@railway/cli`, and likely the other 12 failing packages)
- Added `purge_bun_npm_shim()` that removes the broken bun npm package and its `.bin` shims after every `bun add`/`bun install` operation

## Test plan
- [x] All 54 shellspec tests pass (4 new tests for the purge function)
- [ ] Run `install-npm-globals.sh` and verify `@railway/cli` installs successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes global installs failing due to a broken npm `bun` shim that shadowed the system `bun`, blocking `@railway/cli` installs. We now remove the npm `bun` wrapper and its `.bin` shims after each global install step.

- **Bug Fixes**
  - Added `purge_bun_npm_shim()` to delete the npm `bun` wrapper and `.bin/bun`/`bunx` shims from the global install.
  - Call purge after the initial global install, after each `bun add --global`, and after applying global overrides.
  - Added shellspec tests to verify the purge function, its removal targets, and that it’s invoked post-install.

<sup>Written for commit 86389fb365bd8fb93cf7ea75702c62a334220ea9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

