### PR TITLE
fix(npm-globals): run postinstall for packages missing native binaries

### DIFF
--- a/home-manager/modules/npm-globals/install-npm-globals.sh
+++ b/home-manager/modules/npm-globals/install-npm-globals.sh
@@ -129,6 +129,36 @@ purge_bun_npm_shim() {
   fi
 }
 
+run_postinstall_if_needed() {
+  local dep="$1"
+  local dep_dir="${GLOBAL_MODULES}/${dep}"
+  local pj="${dep_dir}/package.json"
+  [ -f "$pj" ] || return 0
+  local postinstall
+  postinstall=$(jq -r '.scripts.postinstall // empty' "$pj" 2>/dev/null || true)
+  [ -n "$postinstall" ] || return 0
+  local bin_dir="${dep_dir}/bin"
+  if [ -d "$bin_dir" ]; then
+    local has_native=false
+    for f in "$bin_dir"/*; do
+      [ -f "$f" ] || continue
+      case "$f" in *.js | *.cjs | *.mjs) continue ;; esac
+      has_native=true
+      break
+    done
+    if $has_native; then
+      return 0
+    fi
+  fi
+  echo "Running postinstall for $dep (native binary missing)..."
+  if command -v node &>/dev/null; then
+    (cd "$dep_dir" && node -e "
+      const {execSync} = require('child_process');
+      execSync($(printf '%s' "$postinstall" | jq -Rs .), {stdio: 'inherit', cwd: '.'});
+    ") 2>&1 || echo "Postinstall failed for $dep" >&2
+  fi
+}
+
 echo "Installing npm global packages from package.json using bun..."
 cd "${HOME}/dotfiles"
 
@@ -215,6 +245,7 @@ if [ "${#MISSING[@]}" -gt 0 ]; then
   for dep in "${MISSING[@]}"; do
     timeout 600 bun add --global "$dep" 2>/dev/null || echo "Install failed: $dep"
     purge_bun_npm_shim
+    run_postinstall_if_needed "$dep"
   done
 else
   echo "All npm global packages already installed"

--- a/spec/npm_globals_spec.sh
+++ b/spec/npm_globals_spec.sh
@@ -209,6 +209,28 @@ Describe 'bun npm shim purge'
   End
 End
 
+Describe 'postinstall recovery'
+  It 'defines a run_postinstall_if_needed function'
+    When run bash -c "grep 'run_postinstall_if_needed()' '$SCRIPT'"
+    The output should include 'run_postinstall_if_needed'
+  End
+
+  It 'checks for postinstall script in package.json'
+    When run bash -c "grep 'scripts.postinstall' '$SCRIPT'"
+    The output should include 'scripts.postinstall'
+  End
+
+  It 'skips packages that already have a native binary'
+    When run bash -c "grep 'has_native=true' '$SCRIPT'"
+    The output should include 'has_native'
+  End
+
+  It 'calls run_postinstall_if_needed after bun add'
+    When run bash -c "grep -A 2 'bun add --global.*dep.*2>/dev/null' '$SCRIPT' | grep 'run_postinstall_if_needed'"
+    The output should include 'run_postinstall_if_needed'
+  End
+End
+
 Describe 'native addon repair'
 It 'has a sqlite3 native binding repair step'
 When run bash -c "grep 'repair_sqlite3_native_binding' '$SCRIPT'"


### PR DESCRIPTION
## Summary
- Bun's `bun add --global` silently skips postinstall scripts that download native binaries
- Added `run_postinstall_if_needed()` that detects packages with a postinstall script whose bin directory lacks a native binary, and runs the postinstall manually via node
- Generalized fix - works for any package using this pattern (e.g. `@railway/cli`, `@getgrit/cli`, `@sourcegraph/amp`)
- Combined with the bun npm shim purge from #2022, this should fix most of the 13 failing package installs

## Test plan
- [x] All 58 shellspec tests pass (4 new tests for postinstall recovery)
- [x] Manually verified `@railway/cli` installs and `railway --version` works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run postinstall scripts for global npm packages when Bun skips them, restoring missing native binaries. Fixes broken installs for CLIs like `@railway/cli`.

- **Bug Fixes**
  - Added `run_postinstall_if_needed`: if a package has a `postinstall` and its `bin/` lacks a native binary, run the script via `node`.
  - Called after each `bun add --global`, alongside the existing Bun npm shim purge.
  - Generalized for packages that download binaries (e.g., `@railway/cli`, `@getgrit/cli`, `@sourcegraph/amp`).
  - Added shellspec tests for postinstall recovery.

<sup>Written for commit 0c8eecf764834393c0cb9eb580cf5a678d892136. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

