### PR TITLE
feat(noctalia): add Restart keyword alias to Reboot launcher entry

### DIFF
--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -111,6 +111,7 @@ in
     terminal = false;
     categories = [ "System" ];
     icon = "system-reboot";
+    settings.Keywords = "Restart;";
   };
 
   xdg.desktopEntries.shut-down = {


### PR DESCRIPTION
## Summary
- Add `Keywords = Restart;` to the Reboot desktop entry so it can be found by typing "Restart" in any XDG launcher

## Test plan
- [ ] Rebuild and verify `~/.local/share/applications/reboot.desktop` contains `Keywords=Restart;`
- [ ] Open launcher and search "Restart" - should show the Reboot entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a "Restart" keyword to the Reboot launcher entry so it shows up when users type "Restart" in XDG app launchers. Implemented by setting `settings.Keywords = "Restart;"` on the `reboot.desktop` entry; no behavior change.

<sup>Written for commit 1f10031978bb2f336a912ca7529cf6e34e0a1f1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

