### PR TITLE
fix(spec): format npm_globals_spec.sh to satisfy treefmt check

### DIFF
--- a/spec/npm_globals_spec.sh
+++ b/spec/npm_globals_spec.sh
@@ -188,47 +188,47 @@ End
 End
 
 Describe 'bun npm shim purge'
-  It 'defines a purge_bun_npm_shim function'
-    When run bash -c "grep 'purge_bun_npm_shim()' '$SCRIPT'"
-    The output should include 'purge_bun_npm_shim'
-  End
+It 'defines a purge_bun_npm_shim function'
+When run bash -c "grep 'purge_bun_npm_shim()' '$SCRIPT'"
+The output should include 'purge_bun_npm_shim'
+End
 
-  It 'removes the bun package from global node_modules'
-    When run bash -c "grep 'rm -rf.*gm.*bun' '$SCRIPT'"
-    The output should include 'bun'
-  End
+It 'removes the bun package from global node_modules'
+When run bash -c "grep 'rm -rf.*gm.*bun' '$SCRIPT'"
+The output should include 'bun'
+End
 
-  It 'removes bun shims from .bin'
-    When run bash -c "grep 'rm -f.*\.bin/bun' '$SCRIPT'"
-    The output should include '.bin/bun'
-  End
+It 'removes bun shims from .bin'
+When run bash -c "grep 'rm -f.*\.bin/bun' '$SCRIPT'"
+The output should include '.bin/bun'
+End
 
-  It 'calls purge after each bun add --global'
-    When run bash -c "grep -A 1 'bun add --global.*dep.*2>/dev/null' '$SCRIPT' | grep 'purge_bun_npm_shim'"
-    The output should include 'purge_bun_npm_shim'
-  End
+It 'calls purge after each bun add --global'
+When run bash -c "grep -A 1 'bun add --global.*dep.*2>/dev/null' '$SCRIPT' | grep 'purge_bun_npm_shim'"
+The output should include 'purge_bun_npm_shim'
+End
 End
 
 Describe 'postinstall recovery'
-  It 'defines a run_postinstall_if_needed function'
-    When run bash -c "grep 'run_postinstall_if_needed()' '$SCRIPT'"
-    The output should include 'run_postinstall_if_needed'
-  End
+It 'defines a run_postinstall_if_needed function'
+When run bash -c "grep 'run_postinstall_if_needed()' '$SCRIPT'"
+The output should include 'run_postinstall_if_needed'
+End
 
-  It 'checks for postinstall script in package.json'
-    When run bash -c "grep 'scripts.postinstall' '$SCRIPT'"
-    The output should include 'scripts.postinstall'
-  End
+It 'checks for postinstall script in package.json'
+When run bash -c "grep 'scripts.postinstall' '$SCRIPT'"
+The output should include 'scripts.postinstall'
+End
 
-  It 'skips packages that already have a native binary'
-    When run bash -c "grep 'has_native=true' '$SCRIPT'"
-    The output should include 'has_native'
-  End
+It 'skips packages that already have a native binary'
+When run bash -c "grep 'has_native=true' '$SCRIPT'"
+The output should include 'has_native'
+End
 
-  It 'calls run_postinstall_if_needed after bun add'
-    When run bash -c "grep -A 2 'bun add --global.*dep.*2>/dev/null' '$SCRIPT' | grep 'run_postinstall_if_needed'"
-    The output should include 'run_postinstall_if_needed'
-  End
+It 'calls run_postinstall_if_needed after bun add'
+When run bash -c "grep -A 2 'bun add --global.*dep.*2>/dev/null' '$SCRIPT' | grep 'run_postinstall_if_needed'"
+The output should include 'run_postinstall_if_needed'
+End
 End
 
 Describe 'native addon repair'


### PR DESCRIPTION
## Changes
- Flatten ShellSpec DSL indentation in `spec/npm_globals_spec.sh` to match shfmt output

## Technical Details
- The `bun npm shim purge` and `postinstall recovery` blocks added in #2022/#2023/#2027 were committed with indented ShellSpec DSL, which shfmt (via treefmt) flattens
- This broke all four Nix workflow jobs on main (nix-format, nix-test, nix-flake, nix-check) since they all gate on the `checks.x86_64-linux.treefmt` flake check with `--fail-on-change`

## Testing
- `nix fmt -- --clear-cache --fail-on-change` passes (0 changed)
- `shellspec spec/npm_globals_spec.sh`: 61 examples, 0 failures

Generated with [Claude Code](https://claude.com/claude-code) by Fable 5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Formats `spec/npm_globals_spec.sh` to match `shfmt` output so `checks.x86_64-linux.treefmt` passes and Nix CI jobs run again.

- **Bug Fixes**
  - Flattened ShellSpec blocks in `bun npm shim purge` and `postinstall recovery` to match `shfmt`.
  - Unblocks Nix workflows gated by `--fail-on-change` (`nix-format`, `nix-test`, `nix-flake`, `nix-check`).
  - No logic changes; verified with `nix fmt -- --clear-cache --fail-on-change` and `shellspec` (61 examples, 0 failures).

<sup>Written for commit baf81051603090b44bc891899c6a6bafc8bf2fea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

