### PR TITLE
fix(screenshot-clipboard): filter fswatch to CloseWrite on Linux

### DIFF
--- a/home-manager/services/screenshot-clipboard/watch.sh
+++ b/home-manager/services/screenshot-clipboard/watch.sh
@@ -43,8 +43,19 @@ wait_until_stable() {
 
 # fswatch event filters are backend-specific; on macOS FSEvents can report
 # screenshot writes with combined flags that do not pass --event filters. Watch
-# all events and keep the stable filename filtering here instead.
+# all events there and keep the stable filename filtering here instead.
 #
+# On Linux (inotify) watching all events is a feedback loop: clipboard-copy-image
+# reads the screenshot to pipe it into wl-copy, the read itself emits new events
+# on the same path, and the copy repeats forever, clobbering every clipboard
+# write system-wide. CloseWrite fires once per completed write and never on
+# reads. Renames are reported at directory level by inotify here either way, so
+# the filter loses nothing: hyprshot/grim write the file in place.
+fswatch_args=()
+if [ "$(uname -s)" = "Linux" ]; then
+  fswatch_args=(--event CloseWrite)
+fi
+
 # fswatch on macOS uses FSEvents which is always recursive, so the patterns are
 # anchored to "$DESKTOP_DIR/" to ignore screenshots inside subfolders (e.g.
 # project directories) and only react to fresh top-level captures.
@@ -52,7 +63,7 @@ wait_until_stable() {
 #   - "Screenshot ..." / "Screen Shot ..." : macOS defaults (current / legacy)
 #   - "*_hyprshot.png"                     : hyprshot default name on Linux
 #     (HYPRSHOT_DIR is set to $HOME/Desktop in config/hyprland/hyprland.conf)
-fswatch -0 "$DESKTOP_DIR" |
+fswatch -0 "${fswatch_args[@]}" "$DESKTOP_DIR" |
   while IFS= read -r -d '' path; do
     case "$path" in
     "$DESKTOP_DIR/Screenshot "*.png | \

--- a/spec/screenshot_clipboard_spec.sh
+++ b/spec/screenshot_clipboard_spec.sh
@@ -25,6 +25,15 @@ The status should be success
 The output should include '"$DESKTOP_DIR/'
 End
 
+# On Linux inotify, unfiltered fswatch reports reads too; clipboard-copy-image
+# reads the screenshot it copies, so without the CloseWrite filter the watcher
+# retriggers itself forever and clobbers the clipboard system-wide.
+It 'filters fswatch to CloseWrite on Linux to prevent a copy feedback loop'
+When run awk '/^if \[ "\$\(uname -s\)" = "Linux" \]/,/^fi/' "$SCRIPT"
+The status should be success
+The output should include '--event CloseWrite'
+End
+
 Describe 'when fswatch is missing'
 setup() {
   TEMP_HOME=$(mktemp -d)


### PR DESCRIPTION
## Problem

Copy stopped working system-wide (terminal, Slack, everywhere). Diagnosis traced it to `screenshot-clipboard.service` spawning `wl-copy --type image/png` ~8 times per second, clobbering every clipboard write with stale screenshots from `~/Desktop`.

## Root cause

A feedback loop in `watch.sh`:

1. fswatch watches `~/Desktop` with no event filters (a deliberate macOS FSEvents workaround)
2. On Linux the inotify backend reports **reads** as events
3. `clipboard-copy-image` reads the screenshot to pipe it into `wl-copy`
4. That read emits a new event on the same path, and the copy repeats forever

Any single read of a matching screenshot (thumbnailer, file manager) kicks off the loop, and it sustains itself indefinitely.

## Fix

Filter fswatch to `--event CloseWrite` on Linux only: fires exactly once per completed write and never on reads. hyprshot/grim write the file in place, so nothing is missed (inotify renames are reported at directory level by this fswatch build regardless). macOS keeps unfiltered watching per the existing FSEvents comment.

## Verification

- Reproduced: unfiltered fswatch emits 3 events for a pure read of a watched file
- With filter: 0 events on read, 1 on write
- End-to-end: patched watcher + a copy script that reads the file → exactly 1 copy in 8 s (previously ~8/s indefinitely)
- `shellspec spec/screenshot_clipboard_spec.sh`: 6 examples, 0 failures (includes new regression test)
- `nix fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Linux-only clipboard feedback loop in the screenshot clipboard watcher by filtering `fswatch` to `--event CloseWrite`. Prevents `wl-copy` from re-triggering the watcher and clobbering the clipboard across apps.

- **Bug Fixes**
  - Linux: pass `--event CloseWrite` to `fswatch` so `inotify` read events don't retrigger copies.
  - macOS: keep unfiltered watching due to `FSEvents` flag combinations.
  - Add a shellspec test to assert the `CloseWrite` filter is applied on Linux.

<sup>Written for commit b8153708e92106a96497e1d946183b74907b98ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

