### PR TITLE
feat(opencode): add grok 4.5 and default to it via x.ai subscription

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,7 @@ OPENCLAW_ANTHROPIC_API_KEY=sk-ant-api03-your-key-here
 OPENCLAW_GATEWAY_TOKEN=your-gateway-token-here
 # OpenCode API key for OpenCode Go access via cliproxyapi
 OPENCODE_API_KEY=your-opencode-api-key-here
+# xAI API key for Grok access via x.ai subscription (used by opencode xai provider)
+XAI_API_KEY=xai-your-key-here
 # Paperclip database URL
 DATABASE_URL=postgres://user:password@host:5432/paperclip

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "cliproxyapi/glm-4.7",
+  "model": "xai/grok-4.5",
   "small_model": "cliproxyapi/glm-4.7",
   "autoupdate": true,
   "agent": {
@@ -190,6 +190,17 @@
         "glm-4.7": {
           "id": "@preset/glm-4-7",
           "name": "Preset GLM-4.7 (via OpenRouter)"
+        }
+      }
+    },
+    "xai": {
+      "name": "xAI",
+      "options": {
+        "apiKey": "{env:XAI_API_KEY}"
+      },
+      "models": {
+        "grok-4.5": {
+          "name": "Grok 4.5 (via xAI subscription)"
         }
       }
     },

--- a/config/opencode/opencode.tpl.jsonc
+++ b/config/opencode/opencode.tpl.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "cliproxyapi/__GLM__",
+  "model": "xai/__GROK__",
   "small_model": "cliproxyapi/__GLM__",
   "autoupdate": true,
   "agent": {
@@ -190,6 +190,17 @@
         "glm-4.7": {
           "id": "@preset/__GLM_NONDOT__",
           "name": "Preset GLM-4.7 (via OpenRouter)"
+        }
+      }
+    },
+    "xai": {
+      "name": "xAI",
+      "options": {
+        "apiKey": "{env:XAI_API_KEY}"
+      },
+      "models": {
+        "__GROK__": {
+          "name": "__GROK_PRETTY__ (via xAI subscription)"
         }
       }
     },

--- a/models.json
+++ b/models.json
@@ -10,6 +10,7 @@
   "gpt-nano": "gpt-5.4-nano",
   "gemini-pro": "gemini-3.1-pro-preview",
   "gemini-flash": "gemini-3.1-flash-preview",
+  "grok": "grok-4.5",
   "glm": "glm-4.7",
   "minimax": "minimax-m2.7",
   "gemma": "gemma-4-27b-it",


### PR DESCRIPTION
## Summary
- Add `grok` → `grok-4.5` to `models.json`
- Set opencode default `model` to `xai/grok-4.5` (small_model stays on GLM-4.7)
- Add `xai` provider block to opencode config, authed via `XAI_API_KEY` (x.ai subscription)
- Document `XAI_API_KEY` in `.env.example`

Generated `config/opencode/opencode.jsonc` was regenerated from the template via `scripts/llm-update.sh`.

## Test plan
- [x] `jq empty models.json` passes
- [x] `scripts/llm-update.sh` regenerates `opencode.jsonc` with `xai/grok-4.5` as default and the `xai` provider block
- [ ] Set `XAI_API_KEY` in `.env` and confirm opencode connects to Grok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaulted OpenCode to `xai/grok-4.5` via the x.ai subscription and added an `xai` provider. `small_model` stays on `cliproxyapi/glm-4.7`.

- **New Features**
  - Added `grok` → `grok-4.5` in `models.json`.
  - Set default model to `xai/grok-4.5` in `config/opencode/opencode.jsonc` and `config/opencode/opencode.tpl.jsonc`.
  - Added `xai` provider with `XAI_API_KEY` auth; documented in `.env.example`.

- **Migration**
  - Set `XAI_API_KEY` in your `.env` to enable Grok via x.ai.
  - If using the template, run `scripts/llm-update.sh` to regenerate config.

<sup>Written for commit aa1384552290f9aea590259b0583269e3835733e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

