### PR TITLE
feat(models): default gpt to gpt-5.6-sol

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -1,6 +1,6 @@
 suppress_unstable_features_warning = true
 web_search = "cached"
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "xhigh"
 oss_provider = "lmstudio"
 

--- a/config/omp/config.yml
+++ b/config/omp/config.yml
@@ -64,15 +64,15 @@ disabledExtensions: []
 #   slow:    openai-codex/gpt-5.3-codex:high
 modelRoles:
   # Default model role used as the fallback when no other role is selected.
-  default: "openai-codex/gpt-5.5"
+  default: "openai-codex/gpt-5.6-sol"
   # Smaller / dumber model for cheap lightweight work.
   smol: "openai-codex/gpt-5.4-mini"
   # Strongest model in the suite for hard tasks.
-  slow: "openai-codex/gpt-5.5"
+  slow: "openai-codex/gpt-5.6-sol"
   # Keep vision on the main default model.
-  vision: "openai-codex/gpt-5.5"
+  vision: "openai-codex/gpt-5.6-sol"
   # Planning / architecture model.
-  plan: "openai-codex/gpt-5.5"
+  plan: "openai-codex/gpt-5.6-sol"
   # Commit message model.
   commit: "openai/gpt-5.4-nano"
   # Fast subagent path.
@@ -472,14 +472,14 @@ task:
   maxRecursionDepth: 2
   disabledAgents: []
   agentModelOverrides:
-    code-architect: "gpt-5.5"
+    code-architect: "gpt-5.6-sol"
     code-explorer: "gpt-5.3-codex-spark"
-    code-reviewer: "gpt-5.5"
-    code-simplifier: "gpt-5.5"
+    code-reviewer: "gpt-5.6-sol"
+    code-simplifier: "gpt-5.6-sol"
     comment-analyzer: "gpt-5.4-nano"
     pr-test-analyzer: "gpt-5.4-mini"
-    silent-failure-hunter: "gpt-5.5"
-    type-design-analyzer: "gpt-5.5"
+    silent-failure-hunter: "gpt-5.6-sol"
+    type-design-analyzer: "gpt-5.6-sol"
 # --- Agent Definitions -------------------------------------------------------
 # Inline agent definitions (alternative to skill/agent files).
 # agents: {}

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -65,8 +65,8 @@
             "maxTokens": 32000
           },
           {
-            "id": "gpt-5.5",
-            "name": "GPT 5.5",
+            "id": "gpt-5.6-sol",
+            "name": "GPT 5.6 Sol",
             "reasoning": false,
             "input": [
               "text",
@@ -276,7 +276,7 @@
         "name": "Code Reviewer (GPT)",
         "workspace": "__HOME__/.openclaw/workspace/agents/code-review",
         "model": {
-          "primary": "cliproxy/gpt-5.5",
+          "primary": "cliproxy/gpt-5.6-sol",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"
@@ -440,7 +440,7 @@
         "name": "Sales Agent",
         "workspace": "__HOME__/.openclaw/workspace/agents/sales",
         "model": {
-          "primary": "cliproxy/gpt-5.5",
+          "primary": "cliproxy/gpt-5.6-sol",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"
@@ -477,7 +477,7 @@
         "name": "Twitter (GPT)",
         "workspace": "__HOME__/.openclaw/workspace/agents/twitter",
         "model": {
-          "primary": "cliproxy/gpt-5.5",
+          "primary": "cliproxy/gpt-5.6-sol",
           "fallbacks": [
             "cliproxy/minimax-m2.7",
             "cliproxy/glm-4.7",
@@ -575,7 +575,7 @@
         "name": "Dev (GPT)",
         "workspace": "__HOME__/.openclaw/workspace/agents/dev",
         "model": {
-          "primary": "cliproxy/gpt-5.5",
+          "primary": "cliproxy/gpt-5.6-sol",
           "fallbacks": [
             "cliproxy/gpt-5.3-codex",
             "cliproxy/glm-4.7",
@@ -598,7 +598,7 @@
         "model": {
           "primary": "cliproxy/gpt-5.3-codex",
           "fallbacks": [
-            "cliproxy/gpt-5.5",
+            "cliproxy/gpt-5.6-sol",
             "cliproxy/glm-4.7",
             "cliproxy/free"
           ]
@@ -654,7 +654,7 @@
         "name": "Strategy (GPT)",
         "workspace": "__HOME__/.openclaw/workspace/agents/strategy",
         "model": {
-          "primary": "cliproxy/gpt-5.5",
+          "primary": "cliproxy/gpt-5.6-sol",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -33,8 +33,8 @@
         "claude-haiku-4-5-20251001": {
           "name": "Claude Haiku 4.5 (via shunkakinoki's CLIProxy)"
         },
-        "gpt-5.5": {
-          "name": "GPT 5.5 (via shunkakinoki's CLIProxy)"
+        "gpt-5.6-sol": {
+          "name": "GPT 5.6 Sol (via shunkakinoki's CLIProxy)"
         },
         "gpt-5.3-codex": {
           "name": "GPT 5.3 Codex (via shunkakinoki's CLIProxy)"
@@ -70,8 +70,8 @@
         "claude-haiku-4-5-20251001": {
           "name": "Claude Haiku 4.5 (via local CLIProxyAPI)"
         },
-        "gpt-5.5": {
-          "name": "GPT 5.5 (via local CLIProxyAPI)"
+        "gpt-5.6-sol": {
+          "name": "GPT 5.6 Sol (via local CLIProxyAPI)"
         },
         "gpt-5.3-codex": {
           "name": "GPT 5.3 Codex (via local CLIProxyAPI)"

--- a/config/pi/models.json
+++ b/config/pi/models.json
@@ -23,8 +23,8 @@
           "maxTokens": 128000
         },
         {
-          "id": "gpt-5.5",
-          "name": "GPT 5.5 [ChatGPT Pro]",
+          "id": "gpt-5.6-sol",
+          "name": "GPT 5.6 Sol [ChatGPT Pro]",
           "reasoning": true,
           "input": [
             "text",

--- a/home-manager/programs/fish/functions/_coxe_function.fish
+++ b/home-manager/programs/fish/functions/_coxe_function.fish
@@ -5,9 +5,9 @@ function _coxe_function --description "Run Codex with a free-form prompt"
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
     codex --dangerously-bypass-approvals-and-sandbox resume $argv[2]
   else if test (count $argv) -eq 0
-    codex --dangerously-bypass-approvals-and-sandbox --model 'gpt-5.5' -c model_reasoning_summary_format=experimental
+    codex --dangerously-bypass-approvals-and-sandbox --model 'gpt-5.6-sol' -c model_reasoning_summary_format=experimental
   else
     set -l prompt (string join " " -- $argv)
-    codex --dangerously-bypass-approvals-and-sandbox exec --model 'gpt-5.5' -c model_reasoning_summary_format=experimental -- "$prompt"
+    codex --dangerously-bypass-approvals-and-sandbox exec --model 'gpt-5.6-sol' -c model_reasoning_summary_format=experimental -- "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_coxeh_function.fish
+++ b/home-manager/programs/fish/functions/_coxeh_function.fish
@@ -14,5 +14,5 @@ function _coxeh_function --description "Run Codex headlessly with a prompted inp
     return 1
   end
 
-  codex --dangerously-bypass-approvals-and-sandbox exec --model 'gpt-5.5' -c model_reasoning_summary_format=experimental -- "$prompt"
+  codex --dangerously-bypass-approvals-and-sandbox exec --model 'gpt-5.6-sol' -c model_reasoning_summary_format=experimental -- "$prompt"
 end

--- a/models.json
+++ b/models.json
@@ -2,7 +2,7 @@
   "claude-opus": "claude-opus-4-7",
   "claude-sonnet": "claude-sonnet-4-6",
   "claude-haiku": "claude-haiku-4-5-20251001",
-  "gpt": "gpt-5.5",
+  "gpt": "gpt-5.6-sol",
   "gpt-codex": "gpt-5.3-codex",
   "gpt-codex-spark": "gpt-5.3-codex-spark",
   "gpt-image": "gpt-image-2",


### PR DESCRIPTION
Update the `gpt` alias in `models.json` from `gpt-5.5` to `gpt-5.6-sol`, the latest frontier agentic coding model.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the `gpt` alias in `models.json` to `gpt-5.6-sol` as the new default. Regenerated configs and shell helpers (`codex`, `omp`, `openclaw`, `opencode`, `pi`, fish) so tools and agents use `gpt-5.6-sol`.

<sup>Written for commit 52fce75065367e14faec1df57426ca7820afa92b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

