### PR TITLE
fix: use kyber hostname for vpn exit node and fix toggle detection

### DIFF
--- a/home-manager/programs/fish/functions/_vpn_function.fish
+++ b/home-manager/programs/fish/functions/_vpn_function.fish
@@ -1,21 +1,21 @@
 function _vpn_function --description "Connect/disconnect Tailscale exit node through kyber"
-  set -l kyber_ip 100.74.174.97
+  set -l kyber_host kyber
 
   switch "$argv[1]"
     case on
-      sudo tailscale set --exit-node=$kyber_ip
+      sudo tailscale set --exit-node=$kyber_host
     case off
       sudo tailscale set --exit-node=
     case status
       tailscale status
     case ''
       # Toggle: if exit node is set, turn off; otherwise turn on
-      set -l current (tailscale status --json 2>/dev/null | string match -rg '"ExitNodeStatus"')
+      set -l current (tailscale status --json 2>/dev/null | jq -r '.ExitNodeStatus.ID // empty')
       if test -n "$current"
         sudo tailscale set --exit-node=
         echo "VPN disconnected"
       else
-        sudo tailscale set --exit-node=$kyber_ip
+        sudo tailscale set --exit-node=$kyber_host
         echo "VPN connected through kyber"
       end
     case '*'


### PR DESCRIPTION
## Problem

The `vpn` function was silently failing - traffic never routed through the exit node while it printed `VPN connected through kyber`.

## Root causes

1. **Stale hardcoded IP** (`100.74.174.97`): kyber's Tailscale IP rotated to `100.72.158.65`, so `tailscale set --exit-node=100.74.174.97` failed with `no node found in netmap`. The exit node never applied.
2. **Broken toggle detection**: `string match -rg '"ExitNodeStatus"'` has no capture group, so `$current` was always empty - the toggle always ran the 'turn on' branch and could never turn off or report real state.

## Fix

- Use hostname `kyber` instead of a hardcoded IP so it never goes stale on IP rotation.
- Detect active exit node via `jq -r '.ExitNodeStatus.ID // empty'`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `vpn` fish function so traffic actually routes through the Tailscale exit node. Switches from a stale hardcoded IP to the `kyber` hostname and fixes the toggle logic.

- **Bug Fixes**
  - Use `kyber` hostname for `tailscale set --exit-node` to avoid IP rotation issues.
  - Detect active exit node via `jq -r '.ExitNodeStatus.ID // empty'` so toggle on/off works correctly.

<sup>Written for commit c777d65b945b52371993a0c6f81d81eeed0d58e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

