### PR TITLE
fix(npm-globals): bypass minimum-release-age on global install

### DIFF
--- a/home-manager/modules/npm-globals/install-npm-globals.sh
+++ b/home-manager/modules/npm-globals/install-npm-globals.sh
@@ -301,7 +301,7 @@ fi
 if [ "${#MISSING[@]}" -gt 0 ]; then
   echo "Installing ${#MISSING[@]} missing packages..."
   for dep in "${MISSING[@]}"; do
-    timeout 600 bun add --global "$dep" 2>/dev/null || echo "Install failed: $dep"
+    timeout 600 bun add --global "$dep" --minimum-release-age 0 2>/dev/null || echo "Install failed: $dep"
     purge_bun_npm_shim
     run_postinstall_if_needed "$dep"
     # Heal in the same run: bun drops transitive platform binaries on fresh


### PR DESCRIPTION
Line 304 in `install-npm-globals.sh` runs `bun add --global` without `--minimum-release-age 0`, so `bunfig.toml`'s 7-day cooldown silently blocks newly published versions (errors swallowed by `2>/dev/null`). Lines 163 and 433 already bypass this; this aligns line 304.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bypass `bun`’s 7-day release cooldown for global installs by adding `--minimum-release-age 0` to `bun add --global` in the npm-globals installer. This matches other install paths and prevents new versions from being silently skipped due to `bunfig.toml` and suppressed errors.

<sup>Written for commit a7c7dca7f38f56f2ec77e9a6ccc2ed2d2bac6e99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

