### PR TITLE
fix(obsidian): make wiki sync direct and observable

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -1052,7 +1052,7 @@
       "memory-wiki": {
         "enabled": true,
         "config": {
-          "vaultMode": "unsafe-local",
+          "vaultMode": "bridge",
           "vault": {
             "path": "__HOME__/ghq/github.com/shunkakinoki/wiki",
             "renderMode": "obsidian"
@@ -1063,11 +1063,13 @@
             "vaultName": "Shun Kakinoki",
             "openAfterWrites": false
           },
-          "unsafeLocal": {
-            "allowPrivateMemoryCoreAccess": true,
-            "paths": [
-              "__HOME__/.openclaw/workspace"
-            ]
+          "bridge": {
+            "enabled": true,
+            "readMemoryArtifacts": true,
+            "indexDreamReports": true,
+            "indexDailyNotes": true,
+            "indexMemoryRoot": true,
+            "followMemoryEvents": true
           },
           "ingest": {
             "autoCompile": true,

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -1052,7 +1052,7 @@
       "memory-wiki": {
         "enabled": true,
         "config": {
-          "vaultMode": "unsafe-local",
+          "vaultMode": "bridge",
           "vault": {
             "path": "__HOME__/ghq/github.com/shunkakinoki/wiki",
             "renderMode": "obsidian"
@@ -1063,11 +1063,13 @@
             "vaultName": "Shun Kakinoki",
             "openAfterWrites": false
           },
-          "unsafeLocal": {
-            "allowPrivateMemoryCoreAccess": true,
-            "paths": [
-              "__HOME__/.openclaw/workspace"
-            ]
+          "bridge": {
+            "enabled": true,
+            "readMemoryArtifacts": true,
+            "indexDreamReports": true,
+            "indexDailyNotes": true,
+            "indexMemoryRoot": true,
+            "followMemoryEvents": true
           },
           "ingest": {
             "autoCompile": true,

--- a/home-manager/services/obsidian/default.nix
+++ b/home-manager/services/obsidian/default.nix
@@ -25,14 +25,14 @@ let
     )
   );
 
-  # Trigger obsidian-git's auto-backup via CDP. The Electron renderer's
-  # setTimeout doesn't fire under headless xvfb (futex blocks the event
-  # loop), but CDP uses IPC and bypasses it. All git operations still
-  # run through the obsidian-git plugin.
-  obsidianGitTrigger = pkgs.writeShellScriptBin "obsidian-git-trigger" (
+  # Sync the vault directly with Git. Headless Obsidian does not reliably
+  # load community plugins, so Git durability must not depend on its renderer.
+  wikiGitSync = pkgs.writeShellScriptBin "wiki-git-sync" (
     builtins.readFile (
       pkgs.replaceVars ./obsidian-git-trigger.sh {
-        inherit (pkgs) curl jq websocat;
+        inherit (pkgs) coreutils git;
+        utilLinux = pkgs.util-linux;
+        vaultDir = "${homeDir}/ghq/github.com/shunkakinoki/wiki";
       }
     )
   );
@@ -64,19 +64,19 @@ lib.mkIf host.isKyber {
 
   systemd.user.services.obsidian-git-trigger = {
     Unit = {
-      Description = "Trigger obsidian-git auto-backup via CDP";
-      After = [ "obsidian.service" ];
+      Description = "Commit and push the memory wiki vault";
+      After = [ "network-online.target" ];
       X-SwitchMethod = "keep-old";
     };
     Service = {
       Type = "oneshot";
-      ExecStart = "${obsidianGitTrigger}/bin/obsidian-git-trigger";
+      ExecStart = "${wikiGitSync}/bin/wiki-git-sync";
     };
   };
 
   systemd.user.timers.obsidian-git-trigger = {
     Unit = {
-      Description = "Trigger obsidian-git auto-backup every 3 minutes";
+      Description = "Commit and push the memory wiki every 3 minutes";
     };
     Timer = {
       OnBootSec = "2min";

--- a/home-manager/services/obsidian/obsidian-git-trigger.sh
+++ b/home-manager/services/obsidian/obsidian-git-trigger.sh
@@ -1,21 +1,37 @@
 #!/usr/bin/env bash
-# Trigger obsidian-git's commitAndSync via CDP.
-#
-# The Electron renderer's setTimeout doesn't fire under headless xvfb
-# (futex_wait_queue blocks the event loop pump), but CDP messages use
-# IPC and bypass the stuck loop. We trigger the backup and keep the
-# websocket open with ping-interval for 15s to pump the event loop
-# while git operations complete through the obsidian-git plugin.
+# Commit, rebase, and push the memory wiki without depending on Obsidian's
+# headless renderer or the obsidian-git community plugin.
 
-CDP="http://localhost:9222"
+set -euo pipefail
 
-WS_URL=$(@curl@/bin/curl -sf "$CDP/json" | @jq@/bin/jq -r '.[0].webSocketDebuggerUrl // empty')
-[ -z "$WS_URL" ] && exit 0
+VAULT="@vaultDir@"
+GIT="@git@/bin/git"
 
-# Send trigger, then keep stdin open for 15s so websocat stays alive.
-# The --ping-interval sends websocket pings that pump the Electron
-# event loop, allowing the obsidian-git promise queue to execute.
-{
-  echo '{"id":1,"method":"Runtime.evaluate","params":{"expression":"app.plugins.plugins['"'"'obsidian-git'"'"']?.automaticsManager?.doAutoCommitAndSync()"}}'
-  sleep 15
-} | @websocat@/bin/websocat --ping-interval 1 "$WS_URL" >/dev/null 2>&1 || true
+if ! "$GIT" -C "$VAULT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "wiki-git-sync: vault is not a Git checkout: $VAULT" >&2
+  exit 1
+fi
+
+BRANCH=$("$GIT" -C "$VAULT" symbolic-ref --short HEAD)
+if [ "$BRANCH" != "main" ]; then
+  echo "wiki-git-sync: expected main branch, found $BRANCH" >&2
+  exit 1
+fi
+
+exec 9>"$VAULT/.git/wiki-sync.lock"
+if ! @utilLinux@/bin/flock -n 9; then
+  exit 0
+fi
+
+"$GIT" -C "$VAULT" add -A
+
+if ! "$GIT" -C "$VAULT" diff --cached --quiet; then
+  "$GIT" -C "$VAULT" -c commit.gpgsign=false commit -m "vault backup: $(@coreutils@/bin/date -u '+%Y-%m-%d %H:%M:%S UTC')"
+fi
+
+"$GIT" -C "$VAULT" fetch origin main
+"$GIT" -C "$VAULT" rebase origin/main
+
+if [ "$("$GIT" -C "$VAULT" rev-parse HEAD)" != "$("$GIT" -C "$VAULT" rev-parse origin/main)" ]; then
+  "$GIT" -C "$VAULT" push origin HEAD:main
+fi

--- a/spec/obsidian_git_trigger_spec.sh
+++ b/spec/obsidian_git_trigger_spec.sh
@@ -11,37 +11,42 @@ The output should include '#!/usr/bin/env bash'
 End
 
 It 'passes bash syntax check after replacing placeholders'
-When run bash -c "sed -e 's|@curl@|/usr|g' -e 's|@jq@|/usr|g' -e 's|@websocat@|/usr|g' '$SCRIPT' | bash -n"
+When run bash -c "sed -e 's|@coreutils@|/usr|g' -e 's|@git@|/usr|g' -e 's|@utilLinux@|/usr|g' -e 's|@vaultDir@|/tmp/wiki|g' '$SCRIPT' | bash -n"
 The status should be success
 End
 End
 
 Describe 'placeholder references'
-It 'references curl via placeholder'
-When run bash -c "grep '@curl@' '$SCRIPT'"
-The output should include '@curl@'
+It 'references git via placeholder'
+When run bash -c "grep '@git@' '$SCRIPT'"
+The output should include '@git@'
 End
 
-It 'references jq via placeholder'
-When run bash -c "grep '@jq@' '$SCRIPT'"
-The output should include '@jq@'
-End
-
-It 'references websocat via placeholder'
-When run bash -c "grep '@websocat@' '$SCRIPT'"
-The output should include '@websocat@'
+It 'references flock via placeholder'
+When run bash -c "grep '@utilLinux@' '$SCRIPT'"
+The output should include '@utilLinux@'
 End
 End
 
-Describe 'CDP integration'
-It 'connects to CDP on port 9222'
-When run bash -c "grep '9222' '$SCRIPT'"
-The output should include '9222'
+Describe 'Git synchronization'
+It 'serializes overlapping timer runs'
+When run bash -c "grep 'flock -n' '$SCRIPT'"
+The output should include 'flock -n'
 End
 
-It 'triggers doAutoCommitAndSync'
-When run bash -c "grep 'doAutoCommitAndSync' '$SCRIPT'"
-The output should include 'doAutoCommitAndSync'
+It 'rebases before pushing main'
+When run bash -c "grep 'rebase origin/main' '$SCRIPT'"
+The output should include 'rebase origin/main'
+End
+
+It 'disables interactive signing for unattended commits'
+When run bash -c "grep 'commit.gpgsign=false' '$SCRIPT'"
+The output should include 'commit.gpgsign=false'
+End
+
+It 'fails when the vault is not a Git checkout'
+When run bash -c "grep 'vault is not a Git checkout' '$SCRIPT'"
+The output should include 'vault is not a Git checkout'
 End
 End
 


### PR DESCRIPTION
## Summary
- switch Memory Wiki from unsafe-local workspace scraping to bridge mode with memory artifacts, daily notes, dreams, root memory, and event logs
- replace the silent headless Obsidian Git plugin trigger with a locked direct Git commit/rebase/push service
- fail visibly on missing checkout or wrong branch and disable interactive GPG signing for unattended commits

## Live evidence
- Kyber wiki directory had lost its `.git` metadata and the Obsidian Git plugin was enabled but never loaded under headless Obsidian 1.12.7
- checkout metadata was rebuilt non-destructively with timestamped recovery copies retained
- bridge import completed with a fresh July 10 ingest
- recovered wiki commit `922c7190ef6296de483d2ef18bf1fc544f1a43a0` is clean locally on Kyber and awaits explicit remote-push authorization

## Verification
- `shellspec spec/obsidian_git_trigger_spec.sh spec/openclaw_hydrate_spec.sh` (28 examples, 0 failures)
- `nixfmt --check home-manager/services/obsidian/default.nix`
- `nix-instantiate --parse home-manager/services/obsidian/default.nix`
- both OpenClaw JSON templates parse and match
- full Kyber wiki Gitleaks scan: 61.56 MB, no leaks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the memory wiki to bridge mode and replaces the fragile headless plugin trigger with a direct, locked Git sync for the Kyber vault. Sync is now observable, fails loudly on misconfig, and runs reliably every 3 minutes.

- **Bug Fixes**
  - Set `vaultMode` to `bridge` and enable reading memory artifacts, daily notes, dreams, memory root, and event events.
  - Replaced CDP-based `obsidian-git` trigger with `wiki-git-sync` (add/commit with `commit.gpgsign=false`, fetch/rebase `origin/main`, push), guarded by `flock` and branch checks.
  - Updated `systemd` user service/timer to run after `network-online.target` on a 3-minute cadence.
  - Adjusted tests for new placeholders, locking, rebase-before-push, signing flag, and error paths.

<sup>Written for commit 91d8533b819e4d1dd7510956555ee4b85e3de6e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

