### PR TITLE
fix(obsidian): expose gitleaks to wiki sync hook

### DIFF
--- a/home-manager/services/obsidian/default.nix
+++ b/home-manager/services/obsidian/default.nix
@@ -30,7 +30,7 @@ let
   wikiGitSync = pkgs.writeShellScriptBin "wiki-git-sync" (
     builtins.readFile (
       pkgs.replaceVars ./obsidian-git-trigger.sh {
-        inherit (pkgs) coreutils git;
+        inherit (pkgs) coreutils git gitleaks;
         utilLinux = pkgs.util-linux;
         vaultDir = "${homeDir}/ghq/github.com/shunkakinoki/wiki";
       }

--- a/home-manager/services/obsidian/default.nix
+++ b/home-manager/services/obsidian/default.nix
@@ -30,7 +30,12 @@ let
   wikiGitSync = pkgs.writeShellScriptBin "wiki-git-sync" (
     builtins.readFile (
       pkgs.replaceVars ./obsidian-git-trigger.sh {
-        inherit (pkgs) coreutils git gitleaks;
+        inherit (pkgs)
+          coreutils
+          gh
+          git
+          gitleaks
+          ;
         utilLinux = pkgs.util-linux;
         vaultDir = "${homeDir}/ghq/github.com/shunkakinoki/wiki";
       }

--- a/home-manager/services/obsidian/obsidian-git-trigger.sh
+++ b/home-manager/services/obsidian/obsidian-git-trigger.sh
@@ -4,6 +4,8 @@
 
 set -euo pipefail
 
+export PATH="@gitleaks@/bin:$PATH"
+
 VAULT="@vaultDir@"
 GIT="@git@/bin/git"
 

--- a/home-manager/services/obsidian/obsidian-git-trigger.sh
+++ b/home-manager/services/obsidian/obsidian-git-trigger.sh
@@ -32,7 +32,7 @@ if ! "$GIT" -C "$VAULT" diff --cached --quiet; then
 fi
 
 "$GIT" -C "$VAULT" fetch origin main
-"$GIT" -C "$VAULT" rebase origin/main
+"$GIT" -C "$VAULT" rebase --autostash origin/main
 
 if [ "$("$GIT" -C "$VAULT" rev-parse HEAD)" != "$("$GIT" -C "$VAULT" rev-parse origin/main)" ]; then
   "$GIT" -C "$VAULT" push origin HEAD:main

--- a/home-manager/services/obsidian/obsidian-git-trigger.sh
+++ b/home-manager/services/obsidian/obsidian-git-trigger.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-export PATH="@gitleaks@/bin:$PATH"
+export PATH="@gh@/bin:@gitleaks@/bin:$HOME/.local/bin:$PATH"
 
 VAULT="@vaultDir@"
 GIT="@git@/bin/git"

--- a/spec/obsidian_git_trigger_spec.sh
+++ b/spec/obsidian_git_trigger_spec.sh
@@ -11,7 +11,7 @@ The output should include '#!/usr/bin/env bash'
 End
 
 It 'passes bash syntax check after replacing placeholders'
-When run bash -c "sed -e 's|@coreutils@|/usr|g' -e 's|@git@|/usr|g' -e 's|@gitleaks@|/usr|g' -e 's|@utilLinux@|/usr|g' -e 's|@vaultDir@|/tmp/wiki|g' '$SCRIPT' | bash -n"
+When run bash -c "sed -e 's|@coreutils@|/usr|g' -e 's|@gh@|/usr|g' -e 's|@git@|/usr|g' -e 's|@gitleaks@|/usr|g' -e 's|@utilLinux@|/usr|g' -e 's|@vaultDir@|/tmp/wiki|g' '$SCRIPT' | bash -n"
 The status should be success
 End
 End
@@ -20,6 +20,11 @@ Describe 'placeholder references'
 It 'references git via placeholder'
 When run bash -c "grep '@git@' '$SCRIPT'"
 The output should include '@git@'
+End
+
+It 'references the GitHub CLI via placeholder'
+When run bash -c "grep '@gh@' '$SCRIPT'"
+The output should include '@gh@'
 End
 
 It 'references gitleaks via placeholder'

--- a/spec/obsidian_git_trigger_spec.sh
+++ b/spec/obsidian_git_trigger_spec.sh
@@ -11,7 +11,7 @@ The output should include '#!/usr/bin/env bash'
 End
 
 It 'passes bash syntax check after replacing placeholders'
-When run bash -c "sed -e 's|@coreutils@|/usr|g' -e 's|@git@|/usr|g' -e 's|@utilLinux@|/usr|g' -e 's|@vaultDir@|/tmp/wiki|g' '$SCRIPT' | bash -n"
+When run bash -c "sed -e 's|@coreutils@|/usr|g' -e 's|@git@|/usr|g' -e 's|@gitleaks@|/usr|g' -e 's|@utilLinux@|/usr|g' -e 's|@vaultDir@|/tmp/wiki|g' '$SCRIPT' | bash -n"
 The status should be success
 End
 End
@@ -20,6 +20,11 @@ Describe 'placeholder references'
 It 'references git via placeholder'
 When run bash -c "grep '@git@' '$SCRIPT'"
 The output should include '@git@'
+End
+
+It 'references gitleaks via placeholder'
+When run bash -c "grep '@gitleaks@' '$SCRIPT'"
+The output should include '@gitleaks@'
 End
 
 It 'references flock via placeholder'

--- a/spec/obsidian_git_trigger_spec.sh
+++ b/spec/obsidian_git_trigger_spec.sh
@@ -1,6 +1,54 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2329
 
+sync_with_failing_scanner() {
+  script=$1
+  fixture=$(mktemp -d)
+  git_bin=$(command -v git)
+  git_prefix=${git_bin%/bin/git}
+
+  mkdir -p \
+    "$fixture/coreutils/bin" \
+    "$fixture/gitleaks/bin" \
+    "$fixture/gh/bin" \
+    "$fixture/util-linux/bin" \
+    "$fixture/vault/.hooks"
+
+  ln -s "$(command -v date)" "$fixture/coreutils/bin/date"
+  printf '#!/bin/sh\nprintf "generated context rejected\\n" >&2\nexit 23\n' >"$fixture/gitleaks/bin/gitleaks"
+  printf '#!/bin/sh\nexit 0\n' >"$fixture/util-linux/bin/flock"
+  printf '#!/bin/sh\ngitleaks detect\n' >"$fixture/vault/.hooks/pre-commit"
+  chmod +x \
+    "$fixture/gitleaks/bin/gitleaks" \
+    "$fixture/util-linux/bin/flock" \
+    "$fixture/vault/.hooks/pre-commit"
+
+  "$git_bin" -C "$fixture/vault" init -q
+  "$git_bin" -C "$fixture/vault" config user.email test@example.com
+  "$git_bin" -C "$fixture/vault" config user.name 'Wiki Sync Test'
+  printf 'initial\n' >"$fixture/vault/context.md"
+  "$git_bin" -C "$fixture/vault" add context.md
+  "$git_bin" -C "$fixture/vault" -c commit.gpgsign=false commit -q -m initial
+  "$git_bin" -C "$fixture/vault" branch -M main
+  "$git_bin" -C "$fixture/vault" config core.hooksPath .hooks
+  printf 'updated\n' >>"$fixture/vault/context.md"
+
+  sed \
+    -e "s|@coreutils@|$fixture/coreutils|g" \
+    -e "s|@gh@|$fixture/gh|g" \
+    -e "s|@git@|$git_prefix|g" \
+    -e "s|@gitleaks@|$fixture/gitleaks|g" \
+    -e "s|@utilLinux@|$fixture/util-linux|g" \
+    -e "s|@vaultDir@|$fixture/vault|g" \
+    "$script" >"$fixture/sync"
+  chmod +x "$fixture/sync"
+
+  PATH=/usr/bin:/bin "$fixture/sync"
+  status=$?
+  rm -rf "$fixture"
+  return "$status"
+}
+
 Describe 'home-manager/services/obsidian/obsidian-git-trigger.sh'
 SCRIPT="$PWD/home-manager/services/obsidian/obsidian-git-trigger.sh"
 
@@ -52,6 +100,12 @@ End
 It 'disables interactive signing for unattended commits'
 When run bash -c "grep 'commit.gpgsign=false' '$SCRIPT'"
 The output should include 'commit.gpgsign=false'
+End
+
+It 'fails closed when the pre-commit scanner rejects generated context'
+When call sync_with_failing_scanner "$SCRIPT"
+The status should be failure
+The stderr should include 'generated context rejected'
 End
 
 It 'fails when the vault is not a Git checkout'

--- a/spec/obsidian_git_trigger_spec.sh
+++ b/spec/obsidian_git_trigger_spec.sh
@@ -39,9 +39,9 @@ When run bash -c "grep 'flock -n' '$SCRIPT'"
 The output should include 'flock -n'
 End
 
-It 'rebases before pushing main'
-When run bash -c "grep 'rebase origin/main' '$SCRIPT'"
-The output should include 'rebase origin/main'
+It 'preserves concurrent vault writes while rebasing'
+When run bash -c "grep 'rebase --autostash origin/main' '$SCRIPT'"
+The output should include 'rebase --autostash origin/main'
 End
 
 It 'disables interactive signing for unattended commits'


### PR DESCRIPTION
## Summary
- inject the Nix-provided Gitleaks binary into the wiki sync script PATH
- keep the secret-redaction pre-commit hook fail-closed under systemd

## Live evidence
The deployed direct sync correctly failed before commit because systemd could not resolve `gitleaks`. Importing the Home Manager profile PATH allowed the same service run to proceed; this patch makes that durable without relying on manager state.

## Verification
- `shellspec spec/obsidian_git_trigger_spec.sh` (9 examples, 0 failures)
- `nixfmt --check home-manager/services/obsidian/default.nix`
- `nix-instantiate --parse home-manager/services/obsidian/default.nix`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `gitleaks` and `gh` to the Obsidian wiki sync hook and set a deterministic PATH so secret scans run under systemd. Preserve concurrent vault writes during rebases to avoid losing local edits.

- **Bug Fixes**
  - Inject `@gitleaks@` and `@gh@` via Nix `replaceVars`, export them in PATH; update shellspec to stub placeholders and verify the sync fails closed when the scanner rejects generated context.
  - Rebase with `--autostash` to preserve concurrent vault writes; update test to assert the new flag.

<sup>Written for commit 4af673e65dd8999412a9568e75c0f7803bed30e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

