### PR TITLE
feat(fish): add grs function to reset worktree to origin default branch

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -143,6 +143,7 @@
       fpn = "_fzf_preview_name";
       fsh = "_fzf_shell_history --allow-execute";
       gco = "_gco_function";
+      grs = "_grs_function";
       grco = "_grco_function";
       grcr = "_grcr_function";
       grwxe = "_grwxe_function";
@@ -266,6 +267,7 @@
         "_fzf_preview_name"
         "_fzf_shell_history"
         "_gco_function"
+        "_grs_function"
         "_install_cargo_globals_function"
         "_install_npm_globals_function"
         "_install_uv_globals_function"

--- a/home-manager/programs/fish/functions/_grs_function.fish
+++ b/home-manager/programs/fish/functions/_grs_function.fish
@@ -1,0 +1,3 @@
+function _grs_function --description "Reset to origin default branch"
+    git fetch origin && git reset --hard origin/(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+end

--- a/spec/fish/_grs_function_test.fish
+++ b/spec/fish/_grs_function_test.fish
@@ -1,0 +1,22 @@
+set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_grs_function.fish
+
+set call_log (mktemp)
+
+function git
+    echo $argv >> $call_log
+    if test "$argv[1]" = symbolic-ref
+        echo "refs/remotes/origin/main"
+    end
+end
+
+function sed
+    echo "main"
+end
+
+_grs_function
+
+@test "fetches origin" (grep -c "fetch origin" $call_log) -ge 1
+@test "resets to origin default branch" (grep -c "reset --hard origin/main" $call_log) -ge 1
+
+rm -f $call_log


### PR DESCRIPTION
## Summary
- Add `grs` fish abbreviation that fetches origin and hard-resets to the default branch
- Works in both regular repos and git worktrees
- Add fishtape test for the new function

## Test plan
- [ ] `make format` passes
- [ ] `make shell-test` passes
- [ ] Run `grs` in a repo to verify fetch + reset behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du5ovCuAyNjB7mJq6T7bq4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `grs` fish function to fetch `origin` and hard-reset the current repo or worktree to the origin default branch. Registers the abbreviation and adds a test to ensure correct branch detection and reset.

- **New Features**
  - Map `grs` to `_grs_function` in fish config.
  - `_grs_function`: `git fetch origin` then `git reset --hard origin/<default>` (from `refs/remotes/origin/HEAD`).
  - Fishtape test covers fetch and reset to the default branch.

<sup>Written for commit 99cf816e3d7a7e8d7c859992c15ce71cc176cfd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

