### PR TITLE
fix(nix): stop neovim checks and heavy runner packages from failing CI

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -19,7 +19,6 @@ with pkgs;
   age
   aichat
   angle-grinder
-  pkgs.llm-agents.antigravity-cli
   argocd
   ast-grep
   awscli
@@ -122,7 +121,6 @@ with pkgs;
   trippy
   turso-cli
   uv
-  vector
   watchexec
   websocat
   wget
@@ -131,6 +129,11 @@ with pkgs;
   yq
   zellij
   zoxide
+]
+# Heavy packages: skip on CI runners (disk pressure / LTO OOM on macos-latest).
+++ lib.optionals (!isRunner) [
+  pkgs.llm-agents.antigravity-cli
+  vector
 ]
 ++ lib.optionals stdenv.isDarwin [
   darwin.trash

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -5,19 +5,24 @@
   inputs.foundry.overlay
   (_: prev: {
     # Ensure neovim-unwrapped exposes a lua attribute for wrapper consumers (e.g., home-manager)
+    # Also disable checks on both neovim and neovim-unwrapped: neovim-nightly-overlay
+    # sets them to distinct derivations, and programs.neovim / devenv use pkgs.neovim.
+    # The nightly functionaltest suite (e.g. treesitter) is flaky on cache miss.
     neovim-unwrapped =
       (prev.neovim-unwrapped.overrideAttrs (oldAttrs: {
         passthru = (oldAttrs.passthru or { }) // {
           lua = prev.lua5_4;
         };
-        # The nightly neovim functionaltest suite (e.g. treesitter) is flaky and
-        # fails on some revs when built from source (cache miss). Skip checks so
-        # a neovim test regression does not break nix-nixos / e2e NixOS builds.
         doCheck = false;
+        doInstallCheck = false;
       }))
       // {
         lua = prev.lua5_4;
       };
+    neovim = prev.neovim.overrideAttrs (_: {
+      doCheck = false;
+      doInstallCheck = false;
+    });
   })
   (_: prev: {
     # Provide non-deprecated alias so upstream modules using pkgs.system don't emit warnings.

--- a/tests/overlays.nix
+++ b/tests/overlays.nix
@@ -14,6 +14,18 @@
     touch $out
   '';
 
+  # programs.neovim / devenv use pkgs.neovim, which neovim-nightly keeps distinct
+  # from neovim-unwrapped. Both must skip flaky functional tests on cache miss.
+  overlay-neovim-nocheck = pkgs.runCommand "overlay-neovim-nocheck" { } ''
+    ${
+      if !(pkgs.neovim.doCheck or true) && !(pkgs.neovim-unwrapped.doCheck or true) then
+        ''echo "neovim and neovim-unwrapped have doCheck=false"''
+      else
+        ''echo "FAIL: expected doCheck=false on neovim and neovim-unwrapped" && exit 1''
+    }
+    touch $out
+  '';
+
   overlay-system-alias = pkgs.runCommand "overlay-system-alias" { } ''
     ${
       if pkgs ? system && builtins.isString pkgs.system then


### PR DESCRIPTION
## Summary
- Pending renovate/feature PRs were failing mainly on e2e/lua because `pkgs.neovim` still had `doCheck=true` (only `neovim-unwrapped` was patched). Cache misses rebuilt nightly neovim and ran flaky treesitter functional tests.
- Also skip `vector` and `antigravity-cli` on CI runners: vector LTO OOMs on macos-latest, and antigravity was the last package when NixOS e2e hit "No space left on device".

## Test plan
- [ ] Confirm overlay eval: `pkgs.neovim.doCheck == false` and same drv as `neovim-unwrapped`
- [ ] CI: nix / lua / e2e green on this PR
- [ ] After merge, rebase or retrigger failing renovate PRs


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable flaky Neovim tests and skip heavy packages on CI runners to stop e2e/lua failures and OOM/disk errors. Keeps builds green by avoiding nightly functional tests on cache misses.

- **Bug Fixes**
  - Turned off `doCheck` and `doInstallCheck` for `pkgs.neovim` and `neovim-unwrapped`; kept `lua` passthru on `neovim-unwrapped`.
  - Skipped `vector` and `pkgs.llm-agents.antigravity-cli` on CI runners only.
  - Added an overlay test that asserts both Neovim derivations have checks disabled.

<sup>Written for commit de09d7fd20c2e6fd39ab5a27ea01445418d5bbc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

