### PR TITLE
fix(fish): grs aborts on unmerged branches instead of force-resetting

### DIFF
--- a/home-manager/programs/fish/functions/_grs_function.fish
+++ b/home-manager/programs/fish/functions/_grs_function.fish
@@ -1,3 +1,11 @@
-function _grs_function --description "Reset to origin default branch"
-    git fetch origin && git reset --hard origin/(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+function _grs_function --description "Reset to origin default branch (safe: aborts if unmerged)"
+    set -l default_branch (git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+    git fetch origin
+
+    if not git merge-base --is-ancestor HEAD origin/$default_branch
+        echo "grs: current branch is not merged into origin/$default_branch, aborting." >&2
+        return 1
+    end
+
+    git reset --hard origin/$default_branch
 end

--- a/home-manager/programs/fish/functions/_grs_function.fish
+++ b/home-manager/programs/fish/functions/_grs_function.fish
@@ -1,5 +1,11 @@
-function _grs_function --description "Reset to origin default branch (safe: aborts if unmerged)"
+function _grs_function --description "Reset to origin default branch (safe: aborts if dirty or unmerged)"
     set -l default_branch (git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+
+    if not git diff --quiet; or not git diff --cached --quiet
+        echo "grs: working tree is dirty, aborting." >&2
+        return 1
+    end
+
     git fetch origin
 
     if not git merge-base --is-ancestor HEAD origin/$default_branch

--- a/spec/fish/_grs_function_test.fish
+++ b/spec/fish/_grs_function_test.fish
@@ -1,7 +1,7 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
 source $fn/_grs_function.fish
 
-# --- Test: merged branch resets to origin ---
+# --- Test: merged clean branch resets to origin ---
 
 set call_log (mktemp)
 
@@ -9,6 +9,8 @@ function git
     echo $argv >> $call_log
     if test "$argv[1]" = symbolic-ref
         echo "refs/remotes/origin/main"
+    else if test "$argv[1]" = diff
+        return 0
     else if test "$argv[1]" = merge-base
         return 0
     end
@@ -26,6 +28,34 @@ _grs_function
 
 rm -f $call_log
 
+# --- Test: dirty working tree aborts ---
+
+set call_log (mktemp)
+set err_log (mktemp)
+
+function git
+    echo $argv >> $call_log
+    if test "$argv[1]" = symbolic-ref
+        echo "refs/remotes/origin/main"
+    else if test "$argv[1]" = diff
+        return 1
+    end
+end
+
+function sed
+    echo "main"
+end
+
+_grs_function 2>$err_log
+set exit_code $status
+
+@test "dirty: aborts with error" $exit_code -eq 1
+@test "dirty: no fetch" (grep -c "fetch" $call_log) -eq 0
+@test "dirty: no reset" (grep -c "reset" $call_log) -eq 0
+@test "dirty: prints warning" (grep -c "dirty" $err_log) -ge 1
+
+rm -f $call_log $err_log
+
 # --- Test: unmerged branch aborts ---
 
 set call_log (mktemp)
@@ -35,6 +65,8 @@ function git
     echo $argv >> $call_log
     if test "$argv[1]" = symbolic-ref
         echo "refs/remotes/origin/main"
+    else if test "$argv[1]" = diff
+        return 0
     else if test "$argv[1]" = merge-base
         return 1
     end

--- a/spec/fish/_grs_function_test.fish
+++ b/spec/fish/_grs_function_test.fish
@@ -1,12 +1,16 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
 source $fn/_grs_function.fish
 
+# --- Test: merged branch resets to origin ---
+
 set call_log (mktemp)
 
 function git
     echo $argv >> $call_log
     if test "$argv[1]" = symbolic-ref
         echo "refs/remotes/origin/main"
+    else if test "$argv[1]" = merge-base
+        return 0
     end
 end
 
@@ -17,6 +21,34 @@ end
 _grs_function
 
 @test "fetches origin" (grep -c "fetch origin" $call_log) -ge 1
+@test "checks merge status" (grep -c "merge-base" $call_log) -ge 1
 @test "resets to origin default branch" (grep -c "reset --hard origin/main" $call_log) -ge 1
 
 rm -f $call_log
+
+# --- Test: unmerged branch aborts ---
+
+set call_log (mktemp)
+set err_log (mktemp)
+
+function git
+    echo $argv >> $call_log
+    if test "$argv[1]" = symbolic-ref
+        echo "refs/remotes/origin/main"
+    else if test "$argv[1]" = merge-base
+        return 1
+    end
+end
+
+function sed
+    echo "main"
+end
+
+_grs_function 2>$err_log
+set exit_code $status
+
+@test "unmerged: aborts with error" $exit_code -eq 1
+@test "unmerged: no reset" (grep -c "reset" $call_log) -eq 0
+@test "unmerged: prints warning" (grep -c "not merged" $err_log) -ge 1
+
+rm -f $call_log $err_log


### PR DESCRIPTION
## Summary
- `grs` now checks if the current branch is merged into origin's default branch before resetting
- If the branch is unmerged, it aborts with an error instead of force-resetting and causing conflicts
- Fixes the issue where `grs` in a worktree would destroy unmerged work

## Test plan
- [ ] `make format` passes
- [ ] `make shell-test` passes
- [ ] Run `grs` on a merged branch - resets to origin/main
- [ ] Run `grs` on an unmerged branch - aborts with error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du5ovCuAyNjB7mJq6T7bq4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `grs` a safe reset command. It now aborts on dirty trees or unmerged branches and only hard-resets to `origin/<default>` when safe.

- **Bug Fixes**
  - Detects `origin` default branch, fetches, and validates ancestry before resetting.
  - Adds tests for clean reset, dirty abort, and unmerged abort.

<sup>Written for commit 2c45e097bb123ff05602b03c6702c0743ff4417a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

