### PR TITLE
chore(dock): remove Codex.app from persistent apps

### DIFF
--- a/nix-darwin/config/dock.nix
+++ b/nix-darwin/config/dock.nix
@@ -22,7 +22,6 @@
       "/System/Applications/Notes.app"
       "/System/Applications/Mail.app"
       "/Applications/ChatGPT.app"
-      "/Applications/Codex.app"
       "/Applications/Claude.app"
       "/Applications/Cursor.app"
       "/Applications/OpenCode.app"


### PR DESCRIPTION
## Summary
- Remove `/Applications/Codex.app` from the dock persistent-apps list in `nix-darwin/config/dock.nix`

## Test plan
- [ ] `darwin-rebuild switch` applies without errors
- [ ] Codex.app no longer appears in the Dock

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed Codex.app from the persistent Dock apps in `nix-darwin/config/dock.nix`, so it no longer appears after rebuilds.

- **Migration**
  - Run `darwin-rebuild switch`.
  - Confirm Codex.app is not in the Dock.

<sup>Written for commit 3b618b802034c99adf2199a72da549002e30fe00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

