### PR TITLE
feat(codex): set agents.max_threads to 10

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -66,6 +66,9 @@ voice_transcription = true
 workspace_dependencies = true
 workspace_owner_usage_nudge = true
 
+[agents]
+max_threads = 10
+
 [model_providers.cliproxyapi]
 name = "CLIProxyAPI"
 base_url = "http://localhost:8317/v1"

--- a/config/codex/config.tpl.toml
+++ b/config/codex/config.tpl.toml
@@ -66,6 +66,9 @@ voice_transcription = true
 workspace_dependencies = true
 workspace_owner_usage_nudge = true
 
+[agents]
+max_threads = 10
+
 [model_providers.cliproxyapi]
 name = "CLIProxyAPI"
 base_url = "http://localhost:8317/v1"


### PR DESCRIPTION
## Changes
- Set \`agents.max_threads = 10\` in \`config/codex/config.toml\` and \`config.tpl.toml\`

## Technical Details
- Default is 6; this allows up to 9 concurrent subagents (max_threads - 1)

Generated with Claude Code by claude-sonnet-4-6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase Codex agent concurrency by setting `agents.max_threads` to 10 in `config/codex/config.toml` and `config/codex/config.tpl.toml`. Raises the default from 6, allowing up to 9 concurrent subagents.

<sup>Written for commit 1dc9e0233579a941b3fc8415a2cbf2e1638d4319. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

