### PR TITLE
fix(npm-globals): re-run postinstall after native binary repair

### DIFF
--- a/home-manager/modules/npm-globals/install-npm-globals.sh
+++ b/home-manager/modules/npm-globals/install-npm-globals.sh
@@ -277,6 +277,7 @@ if [ -n "$DEPS" ]; then
           # re-triggers the same bun transitive-optional drop.
           if repair_native_optional_dep "$dep"; then
             echo "$dep native binary repaired in place"
+            run_postinstall_if_needed "$dep"
             continue
           fi
           echo "$dep native binary repair failed, reinstalling wrapper"
@@ -307,7 +308,11 @@ if [ "${#MISSING[@]}" -gt 0 ]; then
     # Heal in the same run: bun drops transitive platform binaries on fresh
     # global installs, so repair immediately instead of waiting for next activation.
     if missing_native_optional_dep "$dep"; then
-      repair_native_optional_dep "$dep" || echo "Native binary repair failed: $dep" >&2
+      if repair_native_optional_dep "$dep"; then
+        run_postinstall_if_needed "$dep"
+      else
+        echo "Native binary repair failed: $dep" >&2
+      fi
     fi
   done
 else


### PR DESCRIPTION
## Summary

- After `repair_native_optional_dep` installs a missing native binary (e.g. `@ampcode/cli-darwin-arm64`), the wrapper's postinstall wasn't re-run, leaving the error-stub shim (`~/.bun/bin/amp`) in place
- Packages like `@ampcode/cli` use a `postinstall` script (`install.cjs`) to hard-link the native binary into `bin/amp.exe` - this must run after the native package is present
- Added `run_postinstall_if_needed` call after successful `repair_native_optional_dep` in both code paths: the "already installed but native missing" path and the "fresh install with native repair" path

## Root cause

`~/.bun/bin/amp` is a symlink to `@ampcode/cli/bin/amp.exe`. When bun installs `@ampcode/cli` without its `@ampcode/cli-darwin-arm64` optional dep, the postinstall writes a fallback error stub to `bin/amp.exe`. The script then installs the native binary via `repair_native_optional_dep` but never re-ran postinstall, so the stub persisted and `amp` kept printing "Amp native binary not installed."

## Test plan

- [ ] Run `make switch` - `amp` should work after activation without manual intervention
- [ ] Verify `amp --version` outputs a version string rather than the error message

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-runs postinstall for npm global wrappers after a native optional dependency is repaired, replacing the error-stub shim with the real binary. Fixes `@ampcode/cli` so `~/.bun/bin/amp` works right after activation.

- **Bug Fixes**
  - Call `run_postinstall_if_needed "$dep"` after successful `repair_native_optional_dep` in both paths (existing wrapper with missing native, and fresh install with immediate repair).
  - Ensures `@ampcode/cli` links its native package (e.g., `@ampcode/cli-darwin-arm64`) into `bin/amp.exe`, removing the "Amp native binary not installed" stub.

<sup>Written for commit f0526dec1353066c0ae515a384f9578b2978ce3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

