### PR TITLE
fix: remove renamed codex-app cask and unused anomalyco tap

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -19,10 +19,6 @@
       # to load formulae/casks from non-official taps unless explicitly trusted.
       # Mark our non-official taps as trusted so activation can install them.
       {
-        name = "anomalyco/tap";
-        trusted = true;
-      }
-      {
         name = "entireio/tap";
         trusted = true;
       }
@@ -127,7 +123,6 @@
       "claude-code"
       "cmux"
       "codex"
-      "codex-app"
       "codexbar"
       "conductor"
       "copilot-money"


### PR DESCRIPTION
## Summary
- Remove `codex-app` cask (renamed to `chatgpt`, already listed)
- Remove `anomalyco/tap` (untapped, no installed formulae depend on it)

## Test plan
- [ ] `darwin-rebuild switch` completes without brew warnings about codex-app rename

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the deprecated `codex-app` cask (renamed to `chatgpt`, already listed) and drop the unused `anomalyco/tap` to simplify the Homebrew config and avoid rename warnings during `darwin-rebuild`.

<sup>Written for commit 4acb976556ec8cf137776a8fd35e38ee9165bf36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

