### PR TITLE
fix: stabilize GitHub CLI and DNS connectivity

### DIFF
--- a/home-manager/programs/gh/default.nix
+++ b/home-manager/programs/gh/default.nix
@@ -5,7 +5,7 @@
     extensions = with pkgs; [ gh-markdown-preview ];
     settings = {
       editor = "nvim";
-      git_protocol = "ssh";
+      git_protocol = "https";
       prompt = "enabled";
     };
   };

--- a/nix-darwin/config/networking.nix
+++ b/nix-darwin/config/networking.nix
@@ -7,6 +7,10 @@
       enable = false;
       enableStealthMode = false;
     };
+    dns = [
+      "1.1.1.1"
+      "8.8.8.8"
+    ];
     knownNetworkServices = [
       "Wi-Fi"
       "Ethernet Adaptor"


### PR DESCRIPTION
## Changes
- Use HTTPS as the GitHub CLI Git protocol, matching the authenticated host and repository remote.
- Configure explicit Cloudflare and Google DNS fallbacks for macOS networking.

## Why
`gh auth login` reported a misleading GitHub connectivity error while direct HTTPS access worked. The machine had no usable GitHub SSH identity, and Wi-Fi DNS was relying on a Tailscale resolver without explicit public fallbacks.

## Testing
- `gh auth status --hostname github.com`
- `gh api rate_limit --hostname github.com`
- `git ls-remote origin`
- `nix eval --impure --json .#darwinConfigurations.galactica.config.networking.dns`
- `nix eval --impure --json .#darwinConfigurations.galactica.config.home-manager.users.shunkakinoki.programs.gh.settings.git_protocol`
- `git diff --cached --check`
- Darwin configuration build and activation invoked for `galactica`

Generated with Codex by GPT-5.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the `gh` Git protocol to HTTPS and add public DNS fallbacks to fix GitHub connectivity and stabilize macOS networking. Prevents misleading `gh auth` errors when no SSH key is configured.

- **Bug Fixes**
  - Set `gh.settings.git_protocol` to `"https"` to match authenticated `github.com` and remotes.
  - Added DNS fallbacks `1.1.1.1` and `8.8.8.8` in macOS `networking.dns` to avoid Tailscale-only resolver issues.

<sup>Written for commit f1172be259ba80d25b9009b600b3c4665ca6d07a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

