### PR TITLE
fix: keep macOS Tailscale DNS scoped

### DIFF
--- a/nix-darwin/config/networking.nix
+++ b/nix-darwin/config/networking.nix
@@ -1,3 +1,4 @@
+{ pkgs, ... }:
 {
   networking = {
     applicationFirewall = {
@@ -19,13 +20,19 @@
   };
 
   # Split DNS: route only Tailscale domains through Tailscale's DNS proxy.
-  # Regular DNS (internet, local router) is unaffected, so WiFi stays
-  # connectable even when the Tailscale tunnel is unreachable.
-  # Requires Tailscale's DNS proxy (100.100.100.100) to be active —
-  # ensure accept-dns=true in the Tailscale app (default).
+  # Keep Tailscale from installing its transient DNS proxy as the global
+  # resolver; regular internet DNS stays on the Wi-Fi service below.
   environment.etc = {
     "resolver/ts.net".text = ''
       nameserver 100.100.100.100
     '';
   };
+
+  # Tailscale is installed as a Homebrew app on macOS, so keep its mutable
+  # DNS preference aligned with this declarative split-DNS configuration.
+  system.activationScripts.tailscaleDns.text = ''
+    if ${pkgs.tailscale}/bin/tailscale status >/dev/null 2>&1; then
+      ${pkgs.tailscale}/bin/tailscale set --accept-dns=false || true
+    fi
+  '';
 }

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -10,7 +10,7 @@ let
   fonts = import ./config/fonts.nix { inherit pkgs; };
   homebrew = import ./config/homebrew.nix { inherit isRunner lib; };
   keyboard = import ./config/keyboard { inherit lib pkgs; };
-  networking = import ./config/networking.nix;
+  networking = import ./config/networking.nix { inherit pkgs; };
   nix = import ./config/nix.nix;
   security = import ./config/security.nix { inherit username; };
   serviceModules = import ./services { inherit lib isRunner pkgs; };


### PR DESCRIPTION
## Changes
- Keep Wi-Fi DNS on the configured public resolvers.
- Enforce `tailscale set --accept-dns=false` during Darwin activation.
- Preserve the `ts.net` split-DNS resolver for tailnet-only names.

## Root cause
Tailscale was advertising its transient `100.100.100.100` DNS proxy while the Mac's Wi-Fi resolver was otherwise healthy. Git's pull then intermittently failed with `Could not resolve host: github.com`.

## Testing
- `sudo tailscale set --accept-dns=false`
- Five repeated `git ls-remote --exit-code origin HEAD` attempts
- Exact `fish` `_gco_function` invocation
- `nix eval` for the activation script and DNS values
- `nix build --dry-run --impure --no-update-lock-file .#darwinConfigurations.galactica.system`
- `git diff --cached --check`

Generated with Codex by GPT-5.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope Tailscale DNS on macOS so only `ts.net` domains use its proxy and Wi‑Fi keeps public resolvers. Prevents Tailscale from setting `100.100.100.100` as the global resolver, fixing intermittent failures like `Could not resolve host: github.com`.

- **Bug Fixes**
  - Enforce `tailscale set --accept-dns=false` during activation via `system.activationScripts.tailscaleDns`.
  - Keep split-DNS by writing `/etc/resolver/ts.net` with `nameserver 100.100.100.100`.
  - Pass `pkgs` into `config/networking.nix` to access `tailscale`.

<sup>Written for commit d2f52e52aa757f2b55a4370df1791a02402b8ab7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

