### PR TITLE
feat: add gemma-4-31b-it preset and wire to cliproxy

### DIFF
--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -92,8 +92,8 @@ openai-compatibility:
         alias: "gpt-image-2"
       - name: "@preset/glm-4-7"
         alias: "glm-4.7"
-      - name: "google/gemma-4-27b-it"
-        alias: "gemma-4-27b-it"
+      - name: "@preset/gemma-4-31b-it"
+        alias: "gemma-4-31b-it"
   - name: "z-ai"
     base-url: "https://api.z.ai/api/coding/paas/v4"
     api-key-entries:

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -92,7 +92,7 @@ openai-compatibility:
         alias: "__GPT_IMAGE__"
       - name: "@preset/__GLM_NONDOT__"
         alias: "__GLM__"
-      - name: "google/__GEMMA__"
+      - name: "@preset/__GEMMA_NONDOT__"
         alias: "__GEMMA__"
   - name: "z-ai"
     base-url: "https://api.z.ai/api/coding/paas/v4"

--- a/models.json
+++ b/models.json
@@ -13,7 +13,7 @@
   "grok": "grok-4.5",
   "glm": "glm-4.7",
   "minimax": "minimax-m2.7",
-  "gemma": "gemma-4-27b-it",
+  "gemma": "gemma-4-31b-it",
   "kimi": "kimi-2.6",
   "qwen": "qwen3.6-plus",
   "qwen-local": "qwen3.5-0.8b-optiq"


### PR DESCRIPTION
## Summary
- Upgrade gemma model from `gemma-4-27b-it` to `gemma-4-31b-it` in `models.json`
- Switch cliproxy gemma routing from direct `google/gemma-4-27b-it` to `@preset/gemma-4-31b-it`
- Update template config to use `@preset/__GEMMA_NONDOT__` pattern consistent with other presets

## Test plan
- [ ] Verify cliproxy resolves `gemma-4-31b-it` alias through OpenRouter preset
- [ ] Confirm template rendering produces correct config

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Gemma to `gemma-4-31b-it` and route `cliproxy` through the OpenRouter preset for consistent config and simpler maintenance.

- **Dependencies**
  - Update `models.json` to set `gemma` → `gemma-4-31b-it`.
  - Switch `cliproxy` routing from `google/gemma-4-27b-it` to `@preset/gemma-4-31b-it` with alias `gemma-4-31b-it`.
  - Align template to `@preset/__GEMMA_NONDOT__` for consistency with other presets.

<sup>Written for commit bd115636b03d46310949076ee5a11b5b2a47e9e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

