### PR TITLE
fix(dolt): configure shared Beads CLI credentials

### DIFF
--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -37,6 +37,8 @@ lib.mkIf enabled {
   home.sessionVariables = {
     BEADS_DOLT_SHARED_SERVER = "1";
     BEADS_DOLT_SERVER_PORT = "3307";
+    DOLT_CLI_USER = "root";
+    DOLT_CLI_PASSWORD = "";
   };
 
   launchd.agents.dolt = lib.mkIf pkgs.stdenv.isDarwin {


### PR DESCRIPTION
## Changes
- Export `DOLT_CLI_USER=root` for the Dolt CLI subprocess used by Beads remote sync.
- Export an explicit empty `DOLT_CLI_PASSWORD` for the loopback-only shared Dolt server.
- Keep pull/push on the same account as the healthy Beads SQL connection instead of falling back to `__dolt_local_user__`.

## Testing
- `git diff --check origin/main...codex/fix-dolt-cli-auth`
- Parsed `home-manager/services/dolt/default.nix` with `nix-instantiate --parse`.
- The same explicit environment pair has been verified with successful `bd dolt pull` and `bd dolt push` against `127.0.0.1:3307`.

Generated with Codex by GPT-5.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configure Dolt CLI auth for the shared Beads server by exporting DOLT_CLI_USER=root and an empty DOLT_CLI_PASSWORD. This keeps remote pull/push on the root account against 127.0.0.1:3307 instead of falling back to __dolt_local_user__.

<sup>Written for commit c88efa70d42c9c2a558f69117dc2d16f848a64ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

