### PR TITLE
fix(k3s): raise pod capacity

### DIFF
--- a/config/k3s/config.yaml
+++ b/config/k3s/config.yaml
@@ -6,6 +6,12 @@ disable:
   # FailedGetResourceMetric/Unhealthy events; disable it so k3s stops managing
   # it. Delete the leftover kube-system deploy/svc once after this applies.
   - metrics-server
+# The single kyber node routinely runs more than 100 platform pods before
+# chat sandboxes and rolling-update surge pods are added. Raise the scheduler
+# ceiling so the 32-pod sandbox warm pool and normal deployment overlap do not
+# starve replacement workloads.
+kubelet-arg:
+  - "max-pods=300"
 tls-san:
   - "100.72.158.65"
   - "kyber.tail950b36.ts.net"


### PR DESCRIPTION
## Summary

- raise kyber's kubelet `max-pods` ceiling from the default 110 to 300
- leave headroom for the production platform baseline, the Agent Sandbox warm pool, and rolling-update surge pods
- keep the change in the Nix-managed k3s source config so the host reconciles it through the existing dotfiles updater

## Incident evidence

Production was pinned at 110/110 non-terminated pods. Replacement worker/router pods and Agent Sandbox warm-pool pods were unschedulable with `0/1 nodes are available: 1 Too many pods`, causing chat turns to terminate with `SandboxAdmissionSaturatedError` and the user-visible sandbox-capacity message. The remote fallbacks also failed because Rivet was not configured and Vercel OIDC was unavailable inside Kubernetes.

The node currently has a `/24` PodCIDR. This setting removes the kubelet scheduler blockade for the current workload range; reaching 300 ordinary pod IPs would still require expanding the per-node PodCIDR or adding nodes.

## Verification

- parsed `config/k3s/config.yaml` and asserted `kubelet-arg == ["max-pods=300"]`
- `git diff --check`
- kyber Home Manager evaluation reached `homeConfigurations.kyber` successfully during `make check`
- full local `make check` was interrupted after the value changed and a second run encountered unrelated concurrent Nix/Home Manager database contention; PR CI will run the complete matrix

## AI assistance

Implemented with OpenAI Codex assistance after live kyber log and scheduler inspection.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise kyber’s kubelet pod limit from 110 to 300 to avoid unschedulable pods during surges and keep headroom for the Agent Sandbox warm pool and rolling updates. Applied in the Nix-managed `k3s` config so the host reconciles it automatically.

<sup>Written for commit 8e8acab4abe3481b959edff11083eeb7aa8ed8f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

