### PR TITLE
fix(makefile): use named host for homeConfigurations build and switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -483,7 +483,15 @@ nix-build: nix-connect nix-trust ## Build Nix configuration.
 		elif [ "$(NIX_CONFIG_TYPE)" = "nixosConfigurations" ]; then \
 			HOST=runner HOSTNAME=runner $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#nixosConfigurations.runner.config.system.build.toplevel $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "homeConfigurations" ]; then \
-			HOST=$(DETECTED_HOST) HOSTNAME=$(DETECTED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#$(NIX_CONFIG_TYPE)."$(NIX_USERNAME)@$(NIX_SYSTEM)".activationPackage $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
+			if [ -n "$(HOST)" ]; then \
+				echo "Building named home config: $(HOST)"; \
+				HOST=$(HOST) HOSTNAME=$(HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#homeConfigurations.$(HOST).activationPackage $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
+			elif [ -n "$(DETECTED_HOST)" ]; then \
+				echo "Auto-detected host: $(DETECTED_HOST)"; \
+				HOST=$(DETECTED_HOST) HOSTNAME=$(DETECTED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#homeConfigurations.$(DETECTED_HOST).activationPackage $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
+			else \
+				HOST=$(NIX_SYSTEM) HOSTNAME=$(NIX_SYSTEM) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#$(NIX_CONFIG_TYPE)."$(NIX_USERNAME)@$(NIX_SYSTEM)".activationPackage $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
+			fi; \
 		else \
 			echo "Unsupported OS $(OS) for non-CI build"; \
 			exit 1; \
@@ -521,7 +529,15 @@ nix-build: nix-connect nix-trust ## Build Nix configuration.
 				$(SUDO) env HOST=$(NIX_SYSTEM) HOSTNAME=$(NIX_SYSTEM) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- build --flake .#$(NIX_SYSTEM) --impure; \
 			fi; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "homeConfigurations" ]; then \
-			HOST=$(DETECTED_HOST) HOSTNAME=$(DETECTED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#$(NIX_CONFIG_TYPE)."$(NIX_USERNAME)@$(NIX_SYSTEM)".activationPackage $(NIX_FLAGS) --impure --show-trace; \
+			if [ -n "$(HOST)" ]; then \
+				echo "Building named home config: $(HOST)"; \
+				HOST=$(HOST) HOSTNAME=$(HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#homeConfigurations.$(HOST).activationPackage $(NIX_FLAGS) --impure --show-trace; \
+			elif [ -n "$(DETECTED_HOST)" ]; then \
+				echo "Auto-detected host: $(DETECTED_HOST)"; \
+				HOST=$(DETECTED_HOST) HOSTNAME=$(DETECTED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#homeConfigurations.$(DETECTED_HOST).activationPackage $(NIX_FLAGS) --impure --show-trace; \
+			else \
+				HOST=$(NIX_SYSTEM) HOSTNAME=$(NIX_SYSTEM) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#$(NIX_CONFIG_TYPE)."$(NIX_USERNAME)@$(NIX_SYSTEM)".activationPackage $(NIX_FLAGS) --impure --show-trace; \
+			fi; \
 		else \
 			echo "Unsupported OS $(OS) for non-CI build"; \
 			exit 1; \
@@ -615,8 +631,14 @@ nix-switch: ## Activate Nix configuration.
 		elif [ "$(NIX_CONFIG_TYPE)" = "homeConfigurations" ]; then \
 			if [ "$$SKIP_HOME_MANAGER_SWITCH" = "true" ]; then \
 				echo "⏭️ Home-manager switch skipped (SKIP_HOME_MANAGER_SWITCH=true)"; \
+			elif [ -n "$(HOST)" ]; then \
+				echo "Switching named home config: $(HOST)"; \
+				HOST=$(HOST) HOSTNAME=$(HOST) USER=$(NIX_USERNAME) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure .#homeConfigurations.$(HOST).activationPackage; \
+			elif [ -n "$(DETECTED_HOST)" ]; then \
+				echo "Auto-detected host: $(DETECTED_HOST)"; \
+				HOST=$(DETECTED_HOST) HOSTNAME=$(DETECTED_HOST) USER=$(NIX_USERNAME) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure .#homeConfigurations.$(DETECTED_HOST).activationPackage; \
 			else \
-				HOST=$(DETECTED_HOST) HOSTNAME=$(DETECTED_HOST) USER=$(NIX_USERNAME) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure .#$(NIX_CONFIG_TYPE)."$(NIX_USERNAME)@$(NIX_SYSTEM)".activationPackage; \
+				HOST=$(NIX_SYSTEM) HOSTNAME=$(NIX_SYSTEM) USER=$(NIX_USERNAME) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure .#$(NIX_CONFIG_TYPE)."$(NIX_USERNAME)@$(NIX_SYSTEM)".activationPackage; \
 			fi; \
 		else \
 			echo "Unsupported OS $(OS) for non-CI switch"; \


### PR DESCRIPTION
## Summary
- The `nix-build` target's `homeConfigurations` branches (both CI and non-CI) always used `"user@system"` format, ignoring `HOST`/`DETECTED_HOST`
- On named hosts like `kyber`, this built `homeConfigurations."ubuntu@x86_64-linux"` instead of `homeConfigurations.kyber`, producing the wrong config
- Added `HOST`/`DETECTED_HOST` checks to all four `homeConfigurations` branches (`nix-build` CI, `nix-build` non-CI, `nix-switch` CI), matching the pattern already used by `nix-switch` non-CI

## Test plan
- [x] `make -n build` on kyber resolves to `homeConfigurations.kyber.activationPackage`
- [ ] `make build && make switch` on kyber

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `homeConfigurations` builds and switches to use a named host when `HOST` or `DETECTED_HOST` is set, instead of always using `"user@system"`. This ensures named hosts (e.g., kyber) get the correct config in CI and local runs.

- **Bug Fixes**
  - In `homeConfigurations` for `nix-build` (CI and local) and `nix-switch` (CI), prefer `HOST`, then `DETECTED_HOST`; fall back to `"${NIX_USERNAME}@${NIX_SYSTEM}"` only if none are set.
  - Aligns all paths with the existing local `nix-switch` behavior for consistent host selection.

<sup>Written for commit eab6c65aa425573c456330313aadbd19586eedce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

