### PR TITLE
chore(git): ignore graphify-out directory globally

### DIFF
--- a/home-manager/programs/git/.gitignore.global
+++ b/home-manager/programs/git/.gitignore.global
@@ -20,6 +20,7 @@
 .cache/
 .devenv/
 .jj/
+graphify-out/
 
 # Tmp files
 tmp


### PR DESCRIPTION
Adds `graphify-out/` to the global gitignore.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore `graphify-out/` globally to prevent committing generated Graphify output.
Reduces noise in diffs and avoids accidental commits across repos.

<sup>Written for commit b836ac81194a35bc74d9153d356f1d21728d353c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

