### PR TITLE
fix(makefile): refresh agent daemons after switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,28 @@ nvim-plugins-install: ## Download/build missing Neovim native plugin binaries (f
 	fi
 
 .PHONY: switch
-switch: nix-switch services nvim-plugins-install dotagents-sync ## Apply Nix configuration, restart services, and sync plugins.
+switch: nix-switch services nvim-plugins-install dotagents-sync ## Apply Nix config, refresh services/plugins, and update the Kyber Codex daemon.
+	@$(MAKE) codex-app-server-refresh
+
+.PHONY: codex-app-server-refresh
+codex-app-server-refresh: ## Update and restart the managed Codex app-server daemon on Kyber.
+	@set -euo pipefail; \
+	if [ "$(DETECTED_HOST)" != "kyber" ]; then \
+		echo "⏭️ Codex app-server refresh skipped (Kyber only)"; \
+		exit 0; \
+	fi; \
+	echo "🔄 Updating the Kyber Codex app-server daemon..."; \
+	curl -fsSL https://chatgpt.com/codex/install.sh \
+		| env PATH="$(HOME_DIR)/.local/bin:$$PATH" CODEX_NON_INTERACTIVE=1 sh; \
+	CODEX_BIN="$(HOME_DIR)/.local/bin/codex"; \
+	if ! "$$CODEX_BIN" app-server daemon restart; then \
+		echo "♻️ Replacing an unmanaged Codex app-server daemon..."; \
+		pkill -TERM -f '[c]odex app-server --listen unix://' || true; \
+		sleep 1; \
+		"$$CODEX_BIN" app-server daemon bootstrap; \
+	fi; \
+	"$$CODEX_BIN" app-server daemon version; \
+	echo "✅ Kyber Codex app-server daemon refreshed"
 
 .PHONY: clean
 clean: ## Clean up Nix generations older than 30 days and garbage collect.

--- a/Makefile
+++ b/Makefile
@@ -216,28 +216,45 @@ nvim-plugins-install: ## Download/build missing Neovim native plugin binaries (f
 	fi
 
 .PHONY: switch
-switch: nix-switch services nvim-plugins-install dotagents-sync ## Apply Nix config, refresh services/plugins, and update the Kyber Codex daemon.
-	@$(MAKE) codex-app-server-refresh
+switch: nix-switch services nvim-plugins-install dotagents-sync ## Apply Nix config, refresh services/plugins, and refresh agent daemons.
+	@$(MAKE) refresh
 
-.PHONY: codex-app-server-refresh
-codex-app-server-refresh: ## Update and restart the managed Codex app-server daemon on Kyber.
+.PHONY: refresh
+refresh: refresh-codex-daemon refresh-claude-daemon ## Refresh the Codex and Claude daemons.
+
+.PHONY: refresh-codex-daemon
+refresh-codex-daemon: ## Restart the managed Codex app-server daemon on Kyber.
 	@set -euo pipefail; \
 	if [ "$(DETECTED_HOST)" != "kyber" ]; then \
-		echo "⏭️ Codex app-server refresh skipped (Kyber only)"; \
+		echo "⏭️ Codex daemon refresh skipped (Kyber only)"; \
 		exit 0; \
 	fi; \
-	echo "🔄 Updating the Kyber Codex app-server daemon..."; \
-	curl -fsSL https://chatgpt.com/codex/install.sh \
-		| env PATH="$(HOME_DIR)/.local/bin:$$PATH" CODEX_NON_INTERACTIVE=1 sh; \
-	CODEX_BIN="$(HOME_DIR)/.local/bin/codex"; \
-	if ! "$$CODEX_BIN" app-server daemon restart; then \
-		echo "♻️ Replacing an unmanaged Codex app-server daemon..."; \
-		pkill -TERM -f '[c]odex app-server --listen unix://' || true; \
-		sleep 1; \
-		"$$CODEX_BIN" app-server daemon bootstrap; \
+	CODEX_BIN="$$(command -v codex || true)"; \
+	if [ -z "$$CODEX_BIN" ]; then \
+		echo "❌ Codex is not installed"; \
+		exit 1; \
 	fi; \
+	echo "🔄 Refreshing the Kyber Codex app-server daemon..."; \
+	"$$CODEX_BIN" app-server daemon restart; \
 	"$$CODEX_BIN" app-server daemon version; \
 	echo "✅ Kyber Codex app-server daemon refreshed"
+
+.PHONY: refresh-claude-daemon
+refresh-claude-daemon: ## Respawn Claude background sessions on the current binary on Kyber.
+	@set -euo pipefail; \
+	if [ "$(DETECTED_HOST)" != "kyber" ]; then \
+		echo "⏭️ Claude daemon refresh skipped (Kyber only)"; \
+		exit 0; \
+	fi; \
+	CLAUDE_BIN="$$(command -v claude || true)"; \
+	if [ -z "$$CLAUDE_BIN" ]; then \
+		echo "❌ Claude is not installed"; \
+		exit 1; \
+	fi; \
+	echo "🔄 Refreshing Kyber Claude background sessions..."; \
+	"$$CLAUDE_BIN" respawn --all; \
+	"$$CLAUDE_BIN" --version; \
+	echo "✅ Kyber Claude background sessions refreshed"
 
 .PHONY: clean
 clean: ## Clean up Nix generations older than 30 days and garbage collect.


### PR DESCRIPTION
## Summary

- add a `refresh` Makefile target that runs `refresh-codex-daemon` and `refresh-claude-daemon`
- invoke `refresh` after the existing `make switch` prerequisites complete
- restart the installed, managed Codex app-server daemon without reinstalling Codex
- use Claude's supported `respawn --all` flow so background jobs pick up the currently installed Claude binary
- keep both refresh targets scoped to Kyber

## Why

Kyber can update the installed Codex or Claude binary while long-running agent processes continue using the previous binary. The existing switch path already owns package installation, so daemon refresh belongs after activation and should not perform a second install.

## Validation

- live Kyber Codex restart moved the app server from 0.144.1 to the managed 0.144.2 binary
- live `claude respawn --all` initialized the background service and safely reported no live jobs to respawn
- confirmed the repo-managed Claude 2.1.193 binary supports `respawn --all`
- `make refresh DETECTED_HOST=galactica`
- `make --dry-run refresh DETECTED_HOST=kyber`
- `make shell-inline-check`
- `git diff --check`