### PR TITLE
chore(grok): disable codebase upload in harness config

### DIFF
--- a/config/grok/config.toml
+++ b/config/grok/config.toml
@@ -1,5 +1,8 @@
 hints = { worktree_tip_dismissed = true }
 
+[harness]
+disable_codebase_upload = true
+
 [ui]
 max_thoughts_width = 120
 fork_secondary_model = "grok-build"


### PR DESCRIPTION
Adds `[harness]` section with `disable_codebase_upload = true` to the grok config.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns off codebase upload in the Grok harness to avoid sending repository contents outside the runner. Adds a `[harness]` section with `disable_codebase_upload = true` in `config/grok/config.toml`.

<sup>Written for commit 859b53f3ccc931d7bb9e79db57556194d1c2e5c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

