### PR TITLE
chore(grok): disable trace upload in harness config

### DIFF
--- a/config/grok/config.toml
+++ b/config/grok/config.toml
@@ -2,6 +2,7 @@ hints = { worktree_tip_dismissed = true }
 
 [harness]
 disable_codebase_upload = true
+trace_upload_enabled = false
 
 [ui]
 max_thoughts_width = 120


### PR DESCRIPTION
Adds `trace_upload_enabled = false` to the `[harness]` section in grok config.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable trace uploads in the Grok harness by setting `trace_upload_enabled = false` in `config/grok/config.toml`. Prevents traces from being uploaded during runs.

<sup>Written for commit 5e769a993958e742e69fc391d774636bac7666d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

