### PR TITLE
feat(codex): update managed defaults

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -1,8 +1,8 @@
 suppress_unstable_features_warning = true
 web_search = "cached"
 model = "gpt-5.6-sol"
-enabled-reasoning-efforts = ["medium", "xhigh"]
-model_reasoning_effort = "xhigh"
+enabled-reasoning-efforts = ["medium", "high"]
+model_reasoning_effort = "high"
 approval_policy = "never"
 sandbox_mode = "danger-full-access"
 personality = "pragmatic"

--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -1,7 +1,14 @@
 suppress_unstable_features_warning = true
 web_search = "cached"
 model = "gpt-5.6-sol"
+enabled-reasoning-efforts = ["medium", "xhigh"]
 model_reasoning_effort = "xhigh"
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+personality = "pragmatic"
+model_verbosity = "low"
+model_reasoning_summary = "concise"
+notify = ["turn-ended"]
 oss_provider = "lmstudio"
 
 [features]
@@ -82,3 +89,15 @@ env_key = "OPENROUTER_API_KEY"
 model = "qwen3.5-0.8b-optiq"
 model_provider = "lmstudio"
 model_reasoning_effort = "minimal"
+
+[desktop]
+preventSleepWhileRunning = true
+show-context-window-usage = true
+notifications-turn-mode = "always"
+composerEnterBehavior = "cmdIfMultiline"
+
+[plugins."computer-use@openai-bundled"]
+enabled = true
+
+[plugins."browser@openai-bundled"]
+enabled = true

--- a/config/codex/config.tpl.toml
+++ b/config/codex/config.tpl.toml
@@ -1,8 +1,8 @@
 suppress_unstable_features_warning = true
 web_search = "cached"
 model = "__GPT__"
-enabled-reasoning-efforts = ["medium", "xhigh"]
-model_reasoning_effort = "xhigh"
+enabled-reasoning-efforts = ["medium", "high"]
+model_reasoning_effort = "high"
 approval_policy = "never"
 sandbox_mode = "danger-full-access"
 personality = "pragmatic"

--- a/config/codex/config.tpl.toml
+++ b/config/codex/config.tpl.toml
@@ -1,7 +1,14 @@
 suppress_unstable_features_warning = true
 web_search = "cached"
 model = "__GPT__"
+enabled-reasoning-efforts = ["medium", "xhigh"]
 model_reasoning_effort = "xhigh"
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+personality = "pragmatic"
+model_verbosity = "low"
+model_reasoning_summary = "concise"
+notify = ["turn-ended"]
 oss_provider = "lmstudio"
 
 [features]
@@ -82,3 +89,15 @@ env_key = "OPENROUTER_API_KEY"
 model = "__QWEN_LOCAL__"
 model_provider = "lmstudio"
 model_reasoning_effort = "minimal"
+
+[desktop]
+preventSleepWhileRunning = true
+show-context-window-usage = true
+notifications-turn-mode = "always"
+composerEnterBehavior = "cmdIfMultiline"
+
+[plugins."computer-use@openai-bundled"]
+enabled = true
+
+[plugins."browser@openai-bundled"]
+enabled = true


### PR DESCRIPTION
## Summary
- configure GPT-5.6 Sol with the requested reasoning, personality, verbosity, approval, and sandbox defaults
- enable the bundled Computer Use and Browser plugins
- persist the requested Desktop sleep, context-window, notification, and composer settings
- keep the generated Codex config synchronized with its template

## Validation
- `codex --strict-config doctor --summary` (config loaded; expected isolated-auth/terminal diagnostics only)
- `shellspec spec/activate_config_spec.sh spec/llm_update_spec.sh` (102 examples, 0 failures)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Codex managed defaults to use `gpt-5.6-sol`, limit reasoning to medium/high with a high default, set policy/sandbox behavior, enable core plugins, and sync `config.toml` with `config.tpl.toml`.

- **New Features**
  - Model defaults: `gpt-5.6-sol`; enabled reasoning efforts `["medium","high"]`; default effort `high`; personality `pragmatic`; verbosity `low`; reasoning summary `concise`.
  - Policies: `approval_policy: never`, `sandbox_mode: danger-full-access`, `notify: ["turn-ended"]`.
  - Desktop: prevent sleep while running; show context-window usage; notifications always; composer Enter = Cmd if multiline.
  - Plugins: enable `computer-use@openai-bundled` and `browser@openai-bundled`.
  - Keep `config.toml` and `config.tpl.toml` in sync.

<sup>Written for commit 17900060e535b26caf9076e0793f146edf7816f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

