### PR TITLE
feat: add Buildkite CLI

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -27,6 +27,7 @@ with pkgs;
   bat
   pkgs.llm-agents.bernstein
   broot
+  buildkite-cli
   bun
   choose
   clipse


### PR DESCRIPTION
## What changed

- add `buildkite-cli` to the shared Home Manager package list
- make the `bk` CLI available through the same declarative package path on macOS and Linux

## Why

Buildkite CLI should be installed through the dotfiles repo's existing Nix/Home Manager ownership seam instead of separate apt, dnf, or Homebrew setup.

## Impact

Applying the configuration installs `bk` in the user's Home Manager profile. Authentication remains local through `bk auth login`; no credentials are committed.

## Validation

- `make nix-format-check`
- `make build`
- evaluated `buildkite-cli` on `aarch64-darwin`, `aarch64-linux`, and `x86_64-linux`
- `make switch`
- `bk version` reports `3.42.0`

The live switch completed successfully. Existing optional global-tool hooks emitted unrelated warnings while compiling `worktrunk` and `yek`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `buildkite-cli` to the shared Home Manager packages so `bk` is installed declaratively on macOS and Linux.

- **Migration**
  - Run `make switch` to install `bk`.
  - Run `bk auth login` to authenticate (no credentials are stored in config).

<sup>Written for commit be9ad25302b38033934e79413ab668a7b2c7ba03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

