### PR TITLE
fix(k3s): preserve automatic crash restart

### DIFF
--- a/config/k3s/k3s.service
+++ b/config/k3s/k3s.service
@@ -19,7 +19,6 @@ Restart=always
 RestartSec=5s
 ExecStartPre=-@coreutils@/bin/rm -f /run/k3s/containerd/containerd.sock
 ExecStart=@k3s@/bin/k3s server
-ExecStopPost=-@k3s@/bin/k3s-killall.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/spec/k3s_service_activate_spec.sh
+++ b/spec/k3s_service_activate_spec.sh
@@ -16,6 +16,21 @@ The output should include 'set -euo pipefail'
 End
 End
 
+Describe 'config/k3s/k3s.service'
+SERVICE="$PWD/config/k3s/k3s.service"
+
+It 'restarts k3s after an unexpected exit'
+When run grep '^Restart=always$' "$SERVICE"
+The output should include 'Restart=always'
+The status should be success
+End
+
+It 'does not run the destructive killall helper after service exit'
+When run grep 'ExecStopPost=.*k3s-killall' "$SERVICE"
+The status should equal 1
+End
+End
+
 Describe 'sudo detection'
 It 'checks for sudo command'
 When run bash -c "grep 'command -v sudo' '$SCRIPT'"


### PR DESCRIPTION
## Summary

- remove the destructive `k3s-killall.sh` post-stop hook from the Kyber k3s unit
- preserve systemd automatic restart after an unexpected k3s exit
- add a regression check for the service lifecycle contract

## Why

`k3s-killall.sh` stops k3s services and resets container/runtime networking state. Running it automatically after every service exit defeats `Restart=always`, which left Kyber k3s failed after the scheduler safety exit.

After this change, a normal `systemctl stop k3s` matches upstream behavior and does not perform a full container/network teardown. Operators can still run `k3s-killall.sh` explicitly when that full reset is intended.

## Verification

- `shellspec spec/k3s_service_activate_spec.sh`
- `shellcheck spec/k3s_service_activate_spec.sh`
- `make nix-format-check`
- `git diff --check`