### PR TITLE
chore(fish): sort gr* abbreviations alphabetically

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -143,10 +143,10 @@
       fpn = "_fzf_preview_name";
       fsh = "_fzf_shell_history --allow-execute";
       gco = "_gco_function";
-      grs = "_grs_function";
       grco = "_grco_function";
       grcr = "_grcr_function";
       grr = "_grr_function";
+      grs = "_grs_function";
       grwxe = "_grwxe_function";
       grwxeh = "_grwxeh_function";
       grxe = "_grxe_function";
@@ -268,13 +268,13 @@
         "_fzf_preview_name"
         "_fzf_shell_history"
         "_gco_function"
-        "_grs_function"
         "_install_cargo_globals_function"
         "_install_npm_globals_function"
         "_install_uv_globals_function"
         "_grco_function"
         "_grcr_function"
         "_grr_function"
+        "_grs_function"
         "_grwxe_function"
         "_grwxeh_function"
         "_grxe_function"


### PR DESCRIPTION
## Summary
- Sort `gr*` fish abbreviations alphabetically so `grr` sits between `grcr` and `grs`.
- Mirror the same order in the fish functions source list.

## Before
```
grs, grco, grcr, grr, grwxe, grwxeh, grxe, grxeh
```

## After
```
grco, grcr, grr, grs, grwxe, grwxeh, grxe, grxeh
```

## Test plan
- [ ] `nixfmt` / format check on `home-manager/programs/fish/default.nix`
- [ ] Confirm abbrevs still resolve: `grr`, `grs`, `grco`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sort `gr*` fish abbreviations alphabetically and mirror the same order in the functions source list. Puts `grr` between `grcr` and `grs` for consistent, easier-to-scan config.

<sup>Written for commit c6f223eab6965c57b7ab32fa73db52e41e50ac87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

