### PR TITLE
fix(fish): make vpn on/off reliable without sudo

### DIFF
--- a/home-manager/programs/fish/functions/_vpn_function.fish
+++ b/home-manager/programs/fish/functions/_vpn_function.fish
@@ -3,20 +3,22 @@ function _vpn_function --description "Connect/disconnect Tailscale exit node thr
 
   switch "$argv[1]"
     case on
-      sudo tailscale set --exit-node=$kyber_host
+      tailscale set --exit-node=$kyber_host
+      and echo "VPN connected through kyber"
     case off
-      sudo tailscale set --exit-node=
+      tailscale set --exit-node=
+      and echo "VPN disconnected"
     case status
       tailscale status
     case ''
       # Toggle: if exit node is set, turn off; otherwise turn on
       set -l current (tailscale status --json 2>/dev/null | jq -r '.ExitNodeStatus.ID // empty')
       if test -n "$current"
-        sudo tailscale set --exit-node=
-        echo "VPN disconnected"
+        tailscale set --exit-node=
+        and echo "VPN disconnected"
       else
-        sudo tailscale set --exit-node=$kyber_host
-        echo "VPN connected through kyber"
+        tailscale set --exit-node=$kyber_host
+        and echo "VPN connected through kyber"
       end
     case '*'
       echo "Usage: vpn [on|off|status]"


### PR DESCRIPTION
## Problem
`vpn off` (a fish abbr → `_vpn_function`) appeared to do nothing.

## Root cause
Every `tailscale set` call was prefixed with `sudo`. On macOS `tailscale set` needs no sudo, so interactively `sudo tailscale set` blocked on a password prompt and the command never ran. The `on`/`off` cases also printed no confirmation, reinforcing the "not working" impression.

## Fix
- Drop `sudo` from all `tailscale set` calls (verified: clears the exit node with exit 0 without it).
- Gate `on`/`off` confirmations on command success (`and echo ...`).

## Test
`spec/fish/_vpn_function_test.fish` passes (2/2).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `vpn on/off` reliable on macOS by removing `sudo` from `tailscale set` in `_vpn_function`, avoiding password prompts that made `vpn off` appear to do nothing. Show a confirmation only when the command succeeds.

<sup>Written for commit 489a8757be5ad9a64b0fe3c2e4fdb9b29e0cb04d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

