### PR TITLE
fix(fish): route DNS through exit node so vpn works

### DIFF
--- a/home-manager/programs/fish/functions/_vpn_function.fish
+++ b/home-manager/programs/fish/functions/_vpn_function.fish
@@ -3,10 +3,12 @@ function _vpn_function --description "Connect/disconnect Tailscale exit node thr
 
   switch "$argv[1]"
     case on
-      tailscale set --exit-node=$kyber_host
+      # --accept-dns=true routes DNS through the exit node; without it
+      # DNS queries break while tunnelled and name resolution fails.
+      tailscale set --exit-node=$kyber_host --accept-dns=true
       and echo "VPN connected through kyber"
     case off
-      tailscale set --exit-node=
+      tailscale set --exit-node= --accept-dns=false
       and echo "VPN disconnected"
     case status
       tailscale status
@@ -14,10 +16,10 @@ function _vpn_function --description "Connect/disconnect Tailscale exit node thr
       # Toggle: if exit node is set, turn off; otherwise turn on
       set -l current (tailscale status --json 2>/dev/null | jq -r '.ExitNodeStatus.ID // empty')
       if test -n "$current"
-        tailscale set --exit-node=
+        tailscale set --exit-node= --accept-dns=false
         and echo "VPN disconnected"
       else
-        tailscale set --exit-node=$kyber_host
+        tailscale set --exit-node=$kyber_host --accept-dns=true
         and echo "VPN connected through kyber"
       end
     case '*'


### PR DESCRIPTION
## Summary

`_vpn_function.fish` set the Tailscale exit node but not `--accept-dns`. With `CorpDNS: false` in prefs, DNS stayed pointed at 1.1.1.1/8.8.8.8 and those UDP:53 queries failed through the tunnel - traffic routed but name resolution broke (`http:000`), which read as "VPN not working".

## Changes

- on / toggle-on: `tailscale set --exit-node=kyber --accept-dns=true`
- off / toggle-off: `tailscale set --exit-node= --accept-dns=false`

## Testing

- `make fish-test` -> 414 passing
- `vpn on` -> exit-node IP (91.242.214.231), DNS resolves
- `vpn off` -> direct IP (203.106.130.122)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes VPN name resolution by routing DNS through the `tailscale` exit node in `_vpn_function.fish`. Turning VPN off now restores local DNS.

- **Bug Fixes**
  - On: `tailscale set --exit-node=$kyber_host --accept-dns=true`
  - Off/Toggle off: `tailscale set --exit-node= --accept-dns=false`

<sup>Written for commit 354fb4e853752becf6965fd4c733a688711bb591. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

