### PR TITLE
feat(codex): persist Desktop Git settings

### DIFF
--- a/config/codex/activate.sh
+++ b/config/codex/activate.sh
@@ -1,12 +1,36 @@
 #!/usr/bin/env bash
-# Copy Codex config files (atomic writes break symlinks)
-# Usage: activate.sh <config_toml> <hooks_json>
+# shellcheck disable=SC2016
+# Copy Codex config files and merge managed Desktop settings.
+# Usage: activate.sh <config_toml> <hooks_json> <desktop_settings_json> <jq_bin>
 set -euo pipefail
 CONFIG_TOML="$1"
 HOOKS_JSON="$2"
+DESKTOP_SETTINGS_JSON="$3"
+JQ_BIN="$4"
+GLOBAL_STATE="$HOME/.codex/.codex-global-state.json"
 
 mkdir -p ~/.codex/hooks
 cp -f "$CONFIG_TOML" ~/.codex/config.toml
 chmod 600 ~/.codex/config.toml
 cp -f "$HOOKS_JSON" ~/.codex/hooks.json
 chmod 644 ~/.codex/hooks.json
+
+# Git and worktree preferences use Codex Desktop's global-state store rather
+# than config.toml. Merge only the managed keys so task and UI state survive.
+GLOBAL_STATE_TMP=$(mktemp "${GLOBAL_STATE}.tmp.XXXXXX")
+trap 'rm -f "$GLOBAL_STATE_TMP"' EXIT
+
+if [[ -s $GLOBAL_STATE ]]; then
+  "$JQ_BIN" --slurpfile settings "$DESKTOP_SETTINGS_JSON" '
+    .["electron-persisted-atom-state"] =
+      ((.["electron-persisted-atom-state"] // {}) + $settings[0])
+  ' "$GLOBAL_STATE" >"$GLOBAL_STATE_TMP"
+else
+  "$JQ_BIN" -n --slurpfile settings "$DESKTOP_SETTINGS_JSON" '
+    {"electron-persisted-atom-state": $settings[0]}
+  ' >"$GLOBAL_STATE_TMP"
+fi
+
+chmod 600 "$GLOBAL_STATE_TMP"
+mv -f "$GLOBAL_STATE_TMP" "$GLOBAL_STATE"
+trap - EXIT

--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -95,6 +95,7 @@ preventSleepWhileRunning = true
 show-context-window-usage = true
 notifications-turn-mode = "always"
 composerEnterBehavior = "cmdIfMultiline"
+reviewDelivery = "inline"
 
 [plugins."computer-use@openai-bundled"]
 enabled = true

--- a/config/codex/config.tpl.toml
+++ b/config/codex/config.tpl.toml
@@ -95,6 +95,7 @@ preventSleepWhileRunning = true
 show-context-window-usage = true
 notifications-turn-mode = "always"
 composerEnterBehavior = "cmdIfMultiline"
+reviewDelivery = "inline"
 
 [plugins."computer-use@openai-bundled"]
 enabled = true

--- a/config/codex/default.nix
+++ b/config/codex/default.nix
@@ -3,7 +3,11 @@
   # Use activation script instead of home.file symlink
   # Codex CLI uses atomic writes that break symlinks, so we force-copy on each switch
   home.activation.codexConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-    $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${./config.toml}" "${./hooks.json}"
+    $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" \
+      "${./config.toml}" \
+      "${./hooks.json}" \
+      "${./desktop-settings.json}" \
+      "${pkgs.jq}/bin/jq"
   '';
 
   home.file.".codex/hooks/notify.sh" = {

--- a/config/codex/desktop-settings.json
+++ b/config/codex/desktop-settings.json
@@ -1,0 +1,8 @@
+{
+  "git-branch-prefix": "codex/",
+  "git-always-force-push": true,
+  "git-create-pull-request-as-draft": true,
+  "git-pull-request-merge-method": "squash",
+  "worktree-auto-cleanup-enabled": true,
+  "worktree-keep-count": 300
+}

--- a/spec/activate_config_spec.sh
+++ b/spec/activate_config_spec.sh
@@ -4,6 +4,8 @@
 Describe 'config/codex/activate.sh'
 SCRIPT="$PWD/config/codex/activate.sh"
 HOOKS_JSON="$PWD/config/codex/hooks.json"
+CONFIG_TOML="$PWD/config/codex/config.toml"
+DESKTOP_SETTINGS_JSON="$PWD/config/codex/desktop-settings.json"
 
 It 'uses bash shebang'
 When run bash -c "head -1 '$SCRIPT'"
@@ -23,6 +25,38 @@ End
 It 'copies hooks.json'
 When run bash -c "grep 'HOOKS_JSON' '$SCRIPT'"
 The output should include 'HOOKS_JSON'
+End
+
+It 'declares the Codex Desktop Git and worktree preferences'
+When run jq -r '[.["git-branch-prefix"], .["git-pull-request-merge-method"], .["git-always-force-push"], .["git-create-pull-request-as-draft"], .["worktree-auto-cleanup-enabled"], .["worktree-keep-count"]] | @tsv' "$DESKTOP_SETTINGS_JSON"
+The output should eq 'codex/	squash	true	true	true	300'
+End
+
+It 'persists inline review delivery through config.toml'
+When run grep -qF 'reviewDelivery = "inline"' "$CONFIG_TOML"
+The status should be success
+End
+
+It 'merges managed Desktop settings without replacing unrelated state'
+TMP_HOME="$(mktemp -d)"
+mkdir -p "$TMP_HOME/.codex"
+cat >"$TMP_HOME/.codex/.codex-global-state.json" <<'JSON'
+{
+  "unrelated-top-level": "preserved",
+  "electron-persisted-atom-state": {
+    "unrelated-setting": 42,
+    "git-always-force-push": false
+  }
+}
+JSON
+
+When run bash -c 'HOME="$1" bash "$2" "$3" "$4" "$5" "$6" && jq -r ".[\"unrelated-top-level\"], .[\"electron-persisted-atom-state\"][\"unrelated-setting\"], .[\"electron-persisted-atom-state\"][\"git-always-force-push\"], .[\"electron-persisted-atom-state\"][\"git-pull-request-merge-method\"], .[\"electron-persisted-atom-state\"][\"worktree-keep-count\"]" "$1/.codex/.codex-global-state.json"' _ "$TMP_HOME" "$SCRIPT" "$CONFIG_TOML" "$HOOKS_JSON" "$DESKTOP_SETTINGS_JSON" "$(command -v jq)"
+The status should be success
+The line 1 should eq 'preserved'
+The line 2 should eq '42'
+The line 3 should eq 'true'
+The line 4 should eq 'squash'
+The line 5 should eq '300'
 End
 
 It 'registers the shared main/master push blocker'


### PR DESCRIPTION
## Summary

- persist Codex Desktop Git preferences through the dotfiles activation
- enforce squash merges and keep 300 worktrees with automatic cleanup enabled
- keep inline review delivery in managed `config.toml` and preserve unrelated Desktop state

## Validation

- `shellcheck config/codex/activate.sh`
- `shellspec spec/activate_config_spec.sh` (48 examples)
- `make shell-test` (1,630 ShellSpec examples and 393 Fish tests)
- `make nix-format-check`
- `make nix-test`
- `make build`
- live Desktop state verified as `squash` and `300`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist Codex Desktop Git and worktree settings across Home Manager activations by merging managed keys into the Desktop global state. Enforces squash merges and keeps 300 worktrees, while preserving unrelated Desktop state.

- **New Features**
  - Merge managed Git/worktree prefs into `.codex-global-state.json` using `jq` (no overwrite of unrelated state).
  - Enforce `git-pull-request-merge-method: "squash"`, `worktree-auto-cleanup-enabled: true`, and `worktree-keep-count: 300`.
  - Set `reviewDelivery = "inline"` in both `config.toml` and template.
  - Updated activation to accept `desktop-settings.json` and `jq`; added tests to verify merge and persistence.

<sup>Written for commit d0c0f39fd9c75d1ee46e2df27525015819c21ebf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

