### PR TITLE
feat(gh): add gh-stack extension

### DIFF
--- a/home-manager/programs/gh/default.nix
+++ b/home-manager/programs/gh/default.nix
@@ -2,7 +2,7 @@
 {
   programs.gh = {
     enable = true;
-    extensions = with pkgs; [ gh-markdown-preview ];
+    extensions = with pkgs; [ gh-markdown-preview gh-stack ];
     settings = {
       editor = "nvim";
       git_protocol = "https";


### PR DESCRIPTION
## Summary
- Add `gh-stack` (stacked PRs) to declarative gh extensions in home-manager

## Test plan
- [ ] `make switch` activates successfully
- [ ] `gh extension list` shows `gh-stack`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `gh-stack` to the declarative `gh` extensions in `home-manager`. This enables creating and managing stacked PRs from the GitHub CLI.

<sup>Written for commit 402330c64c44991fa81e6ebd6a987795e59b3bbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

