### PR TITLE
ci: harden nix workflows against transient network and disk failures

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,6 +56,8 @@ jobs:
             max-jobs = auto
             cores = 0
             fallback = true
+            connect-timeout = 10
+            download-attempts = 5
       - name: Prepare System Files
         if: runner.os == 'macOS'
         run: |

--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -20,6 +20,10 @@ jobs:
         uses: cachix/install-nix-action@v31
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            fallback = true
+            connect-timeout = 10
+            download-attempts = 5
       - name: Validate Neovim Configuration (Dev Shell)
         run: make lua-check-neovim-dev
   lua-neovim-test:
@@ -32,6 +36,10 @@ jobs:
         uses: cachix/install-nix-action@v31
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            fallback = true
+            connect-timeout = 10
+            download-attempts = 5
       - name: Run Neovim Tests (Dev Shell)
         run: make neovim-test-dev
   lua-hammerspoon:
@@ -44,6 +52,10 @@ jobs:
         uses: cachix/install-nix-action@v31
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_nix_config: |
+            fallback = true
+            connect-timeout = 10
+            download-attempts = 5
       - name: Validate Hammerspoon Configuration (Dev Shell)
         run: make lua-check-hammerspoon-dev
   lua-check:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
-          tool-cache: false
+          tool-cache: true
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:
@@ -102,7 +102,7 @@ jobs:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
-          tool-cache: false
+          tool-cache: true
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:


### PR DESCRIPTION
## What this is (and isn't)

This is **flake hardening, not a bug fix**. Investigating the red runs on `main` turned up no broken code — the workflows mostly pass, and Docker and Lua had already recovered on their own before this PR.

## Diagnosis

Every recent failure was a *different* large package failing to build from source:

| Workflow | Failing derivation | Reported reason |
|---|---|---|
| Docker | `mise-2026.6.11`, `terraform-1.15.7` | exit 1, "may have been caused by lack of free disk space" |
| E2E | `lean4-4.30.0` (66 min build), `tree-sitter-bundled` | exit 2 |
| Nix | `intelephense-1.18.2-npm-deps` | `[56] Failure when receiving data from the peer` (npm registry) |
| Nix | `herdr-0.7.1`, `vector-0.56.0` | exit 101, "lack of free disk space" |
| Lua | `flake-parts` tarball | `HTTP error 503` from api.github.com |

The common thread is resource exhaustion and network flakes during mass source rebuilds. This flake tracks `nixpkgs-unstable`/`master`, so when Hydra hasn't prebuilt a revision yet, runners compile everything themselves — and a random large package tips over each time.

## Changes

Each change aligns a workflow with protection its siblings already had:

- **`lua.yml`** — add `fallback` / `connect-timeout` / `download-attempts` to all three jobs. The Lua failure was a 503 download with **no retry configured at all**; `nix.yml` has had these settings all along.
- **`e2e.yml`** — add `connect-timeout` / `download-attempts` alongside the existing `fallback`.
- **`nix.yml`** — reclaim the hosted tool cache on `nix-linux` and `nix-nixos` (the largest single disk win, ~8-10GB). Both jobs logged disk-space failures; `docker.yml` and `e2e.yml` already reclaim it.

Other `free-disk-space` settings are deliberately left untouched, so swap behaviour is unchanged and disk pressure isn't traded for OOM.

## Expected effect

This should **reduce** flake frequency, not eliminate it. The retry settings directly address the 503 and npm failures. The disk reclaim addresses the explicit out-of-space builds. What it cannot fix is the underlying cause: tracking unstable nixpkgs means occasionally compiling `lean4` from source on a 14GB runner. Durably fixing that needs a binary cache (e.g. pushing built artifacts to Cachix) — a larger change, out of scope here.

## Verification

YAML validated with `yq`; each edit confirmed present via query. CI on this PR is the real test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce CI flakes in Nix workflows by adding network retries/timeouts and freeing disk space. This makes source builds on `nixpkgs-unstable` more resilient to 503s and low-disk errors.

- **Reliability**
  - `lua.yml`: add `fallback`, `connect-timeout=10`, `download-attempts=5` to all jobs.
  - `e2e.yml`: add `connect-timeout=10`, `download-attempts=5` (keep `fallback`).
  - `nix.yml`: reclaim hosted tool cache via `jlumbroso/free-disk-space` (`tool-cache: true`) on `nix-linux` and `nix-nixos` to free ~8–10GB.

<sup>Written for commit a7641d429a22751b7f58df30e091ba34b855f12e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

