### PR TITLE
feat(night-shift): default Night Shift to always on

### DIFF
--- a/home-manager/programs/gh/default.nix
+++ b/home-manager/programs/gh/default.nix
@@ -2,7 +2,10 @@
 {
   programs.gh = {
     enable = true;
-    extensions = with pkgs; [ gh-markdown-preview gh-stack ];
+    extensions = with pkgs; [
+      gh-markdown-preview
+      gh-stack
+    ];
     settings = {
       editor = "nvim";
       git_protocol = "https";

--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -21,6 +21,7 @@ let
   keydApplicationMapper = ./keyd-application-mapper;
   makeUpdater = import ./make-updater { inherit pkgs; };
   neversslKeepalive = import ./neverssl-keepalive { inherit pkgs; };
+  nightShift = import ./night-shift { inherit pkgs; };
   obsidian = import ./obsidian { inherit config pkgs inputs; };
   ollama = ./ollama;
   qmd = ./qmd;
@@ -46,6 +47,7 @@ in
   keydApplicationMapper
   makeUpdater
   neversslKeepalive
+  nightShift
   obsidian
   ollama
   qmd

--- a/home-manager/services/night-shift/apply-night-shift.sh
+++ b/home-manager/services/night-shift/apply-night-shift.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+nightlight_bin="@nightlightBin@"
+temperature=@temperature@
+
+# A sunset-to-sunrise schedule turns Night Shift back off at sunrise, so the
+# schedule has to be cleared before `on` can mean "stays on".
+"$nightlight_bin" schedule stop
+"$nightlight_bin" temp "$temperature"
+"$nightlight_bin" on

--- a/home-manager/services/night-shift/default.nix
+++ b/home-manager/services/night-shift/default.nix
@@ -1,0 +1,30 @@
+{ pkgs }:
+let
+  # 0 = least warm, 100 = warmest.
+  temperature = 100;
+
+  applyNightShiftScript = pkgs.replaceVars ./apply-night-shift.sh {
+    nightlightBin = "${pkgs.nightlight}/bin/nightlight";
+    inherit temperature;
+  };
+in
+{
+  # Night Shift state lives in the per-user CoreBrightness session and is not
+  # exposed through any plist `system.defaults` can write, so the only way to
+  # express "on by default" is to talk to that session on login.
+  #
+  # RunAtLoad without a StartInterval deliberately makes this a default rather
+  # than an enforcement: a manual toggle sticks until the next login.
+  launchd.agents.night-shift = pkgs.lib.mkIf pkgs.stdenv.isDarwin {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "${pkgs.bash}/bin/bash"
+        "${applyNightShiftScript}"
+      ];
+      RunAtLoad = true;
+      StandardOutPath = "/tmp/night-shift.log";
+      StandardErrorPath = "/tmp/night-shift.error.log";
+    };
+  };
+}

--- a/spec/night_shift_spec.sh
+++ b/spec/night_shift_spec.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'home-manager/services/night-shift/apply-night-shift.sh'
+SCRIPT="$PWD/home-manager/services/night-shift/apply-night-shift.sh"
+
+Describe 'script properties'
+It 'uses bash shebang'
+When run bash -c "head -1 '$SCRIPT'"
+The output should include '#!/usr/bin/env bash'
+End
+
+It 'uses strict mode'
+When run bash -c "head -5 '$SCRIPT'"
+The output should include 'set -euo pipefail'
+End
+
+It 'passes bash syntax check after replacing placeholders'
+When run bash -c "sed -e 's|@nightlightBin@|/usr/bin/true|g' -e 's|@temperature@|100|g' '$SCRIPT' | bash -n"
+The status should be success
+End
+End
+
+setup_night_shift_script() {
+  TEST_DIR=$(mktemp -d)
+  NIGHTLIGHT_LOG="$TEST_DIR/nightlight.log"
+  NIGHTLIGHT_BIN="$TEST_DIR/nightlight"
+  PREPROCESSED_SCRIPT="$TEST_DIR/apply-night-shift.sh"
+  : >"$NIGHTLIGHT_LOG"
+
+  cat >"$NIGHTLIGHT_BIN" <<'EOF'
+#!/usr/bin/env bash
+set -eu
+printf '%s\n' "$*" >>"$NIGHTLIGHT_LOG"
+EOF
+  chmod +x "$NIGHTLIGHT_BIN"
+
+  sed \
+    -e "s|@nightlightBin@|$NIGHTLIGHT_BIN|g" \
+    -e 's|@temperature@|100|g' \
+    "$SCRIPT" >"$PREPROCESSED_SCRIPT"
+  chmod +x "$PREPROCESSED_SCRIPT"
+}
+
+cleanup_night_shift_script() {
+  rm -rf "$TEST_DIR"
+}
+
+Describe 'applying the Night Shift default'
+Before 'setup_night_shift_script'
+After 'cleanup_night_shift_script'
+
+It 'clears the schedule before turning Night Shift on'
+When run bash -c ': >"'"$NIGHTLIGHT_LOG"'"; NIGHTLIGHT_LOG="'"$NIGHTLIGHT_LOG"'" "'"$PREPROCESSED_SCRIPT"'" >/dev/null && cat "'"$NIGHTLIGHT_LOG"'"'
+The status should be success
+The line 1 of output should eq 'schedule stop'
+The line 2 of output should eq 'temp 100'
+The line 3 of output should eq 'on'
+End
+End
+
+End


### PR DESCRIPTION
## What

Makes Night Shift the default color mode on macOS: always on, rather than the previous sunset-to-sunrise schedule.

Adds a home-manager service at `home-manager/services/night-shift/`, wired into `home-manager/services/default.nix`, with a shellspec covering the apply script.

## Why this shape

Night Shift state lives in the per-user CoreBrightness session and is **not** exposed through any plist `system.defaults` can write, so there is no declarative nix-darwin option for it. The only way to express "on by default" is to talk to that session, which is why this shells out to `nightlight` (in nixpkgs, darwin-only) from a launchd agent. Same reasoning as the keyboard module shelling out to `hidutil`.

It lives in home-manager rather than nix-darwin because the state is per-user, not system-wide.

## Notes for reviewers

Two deliberate choices worth a look:

- **`schedule stop` before `on`.** A sunset-to-sunrise schedule turns Night Shift back off at sunrise, so the schedule has to be cleared before `on` can mean "stays on".
- **`RunAtLoad` with no `StartInterval`.** This makes the setting a *default* rather than an enforcement — a manual toggle off sticks until the next login. A periodic re-assert would fight the user every few minutes.

Temperature is pinned at 100 (warmest), matching what the machine was already set to, so the mode is fully declarative rather than half-pinned.

## Commits

1. `feat(night-shift): default Night Shift to always on` — the change itself.
2. `style(gh): format extensions list` — drive-by treefmt fix on `home-manager/programs/gh/default.nix`, unformatted on main since the gh-stack commit (797139fc). Whitespace only, unrelated to Night Shift; separated out so it stays easy to skip.

## Verification

- `spec/night_shift_spec.sh` passes (4 examples, 0 failures); picked up by normal shellspec discovery.
- `nix build .#checks.aarch64-darwin.eval-darwin-default` passes.
- `nix build .#checks.aarch64-darwin.treefmt` passes (failed on main before commit 2).
- Ran the built store script directly: status `on until sunrise` -> `on`, schedule `sunset to sunrise` -> `off`, temp `100`.
- Confirmed the darwin-only `nightlight` package does not break Linux evaluation — the Linux home config errors at the identical pre-existing `docker.service` platform mismatch (same drv hash) with and without this change.