### PR TITLE
ci: move nix store and docker data root to /mnt on linux runners

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,21 +44,7 @@ jobs:
           swap-storage: true
       - name: Relocate Docker Data Root to /mnt
         if: runner.os == 'Linux'
-        run: |
-          set -euo pipefail
-          if ! mountpoint -q /mnt; then
-            echo "/mnt is not a separate mount; leaving the Docker data root on /"
-            exit 0
-          fi
-          sudo mkdir -p /mnt/docker /etc/docker
-          if [ -s /etc/docker/daemon.json ]; then
-            jq '. + {"data-root": "/mnt/docker"}' /etc/docker/daemon.json > /tmp/daemon.json
-          else
-            echo '{"data-root": "/mnt/docker"}' > /tmp/daemon.json
-          fi
-          sudo mv /tmp/daemon.json /etc/docker/daemon.json
-          sudo systemctl restart docker
-          docker info -f 'Docker root dir: {{ .DockerRootDir }}'
+        run: make docker-relocate-root
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Login to GHCR

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,6 +42,23 @@ jobs:
           haskell: true
           large-packages: true
           swap-storage: true
+      - name: Relocate Docker Data Root to /mnt
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          if ! mountpoint -q /mnt; then
+            echo "/mnt is not a separate mount; leaving the Docker data root on /"
+            exit 0
+          fi
+          sudo mkdir -p /mnt/docker /etc/docker
+          if [ -s /etc/docker/daemon.json ]; then
+            jq '. + {"data-root": "/mnt/docker"}' /etc/docker/daemon.json > /tmp/daemon.json
+          else
+            echo '{"data-root": "/mnt/docker"}' > /tmp/daemon.json
+          fi
+          sudo mv /tmp/daemon.json /etc/docker/daemon.json
+          sudo systemctl restart docker
+          docker info -f 'Docker root dir: {{ .DockerRootDir }}'
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Login to GHCR

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,15 +38,7 @@ jobs:
           swap-storage: true
       - name: Relocate Nix Store to /mnt
         if: runner.os == 'Linux'
-        run: |
-          set -euo pipefail
-          if ! mountpoint -q /mnt; then
-            echo "/mnt is not a separate mount; leaving the Nix store on /"
-            exit 0
-          fi
-          sudo mkdir -p /mnt/nix /nix
-          sudo mount --bind /mnt/nix /nix
-          df -h /nix
+        run: make nix-relocate-store
       - name: KVM Linux Virtualization
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,6 +36,17 @@ jobs:
           haskell: true
           large-packages: true
           swap-storage: true
+      - name: Relocate Nix Store to /mnt
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          if ! mountpoint -q /mnt; then
+            echo "/mnt is not a separate mount; leaving the Nix store on /"
+            exit 0
+          fi
+          sudo mkdir -p /mnt/nix /nix
+          sudo mount --bind /mnt/nix /nix
+          df -h /nix
       - name: KVM Linux Virtualization
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -76,6 +76,16 @@ jobs:
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: true
+      - name: Relocate Nix Store to /mnt
+        run: |
+          set -euo pipefail
+          if ! mountpoint -q /mnt; then
+            echo "/mnt is not a separate mount; leaving the Nix store on /"
+            exit 0
+          fi
+          sudo mkdir -p /mnt/nix /nix
+          sudo mount --bind /mnt/nix /nix
+          df -h /nix
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:
@@ -103,6 +113,16 @@ jobs:
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: true
+      - name: Relocate Nix Store to /mnt
+        run: |
+          set -euo pipefail
+          if ! mountpoint -q /mnt; then
+            echo "/mnt is not a separate mount; leaving the Nix store on /"
+            exit 0
+          fi
+          sudo mkdir -p /mnt/nix /nix
+          sudo mount --bind /mnt/nix /nix
+          df -h /nix
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -77,15 +77,7 @@ jobs:
         with:
           tool-cache: true
       - name: Relocate Nix Store to /mnt
-        run: |
-          set -euo pipefail
-          if ! mountpoint -q /mnt; then
-            echo "/mnt is not a separate mount; leaving the Nix store on /"
-            exit 0
-          fi
-          sudo mkdir -p /mnt/nix /nix
-          sudo mount --bind /mnt/nix /nix
-          df -h /nix
+        run: make nix-relocate-store
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:
@@ -114,15 +106,7 @@ jobs:
         with:
           tool-cache: true
       - name: Relocate Nix Store to /mnt
-        run: |
-          set -euo pipefail
-          if ! mountpoint -q /mnt; then
-            echo "/mnt is not a separate mount; leaving the Nix store on /"
-            exit 0
-          fi
-          sudo mkdir -p /mnt/nix /nix
-          sudo mount --bind /mnt/nix /nix
-          df -h /nix
+        run: make nix-relocate-store
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:

--- a/Makefile
+++ b/Makefile
@@ -480,6 +480,26 @@ nix-install: ## Install Nix if not already installed.
 	fi
 	@echo "✅ Nix environment installed!"
 
+.PHONY: nix-relocate-store
+nix-relocate-store: ## Relocate the Nix store to /mnt (CI-only, Linux runners).
+	@if [ "$(OS)" != "Linux" ]; then \
+		echo "🏃‍♂️ Nix store relocation is Linux-only. Skipping on $(OS)."; \
+	elif [ "$$CI" != "true" ]; then \
+		echo "🏃‍♂️ Nix store relocation only runs in CI. Skipping."; \
+	elif ! mountpoint -q /mnt; then \
+		echo "ℹ️ /mnt is not a separate mount. Leaving the Nix store on /."; \
+	elif mountpoint -q /nix; then \
+		echo "✅ /nix is already a separate mount. Skipping."; \
+	elif [ -d /nix ] && [ -n "$$(ls -A /nix 2>/dev/null)" ]; then \
+		echo "ℹ️ /nix already exists and is not empty. Leaving it alone."; \
+	else \
+		echo "💾 Relocating the Nix store to /mnt/nix..."; \
+		$(SUDO) mkdir -p /mnt/nix /nix; \
+		$(SUDO) mount --bind /mnt/nix /nix; \
+		df -h /nix; \
+		echo "✅ Nix store relocated to /mnt/nix"; \
+	fi
+
 ##@ Nix
 
 .PHONY: nix-update
@@ -927,6 +947,28 @@ docker-build: ## Build Docker image.
 	@echo "🐳 Building Docker image: $(DOCKER_IMAGE_LATEST) and $(DOCKER_IMAGE_TAGGED)..."
 	@docker build -t $(DOCKER_IMAGE_LATEST) -t $(DOCKER_IMAGE_TAGGED) -f Dockerfile .
 	@echo "✅ Docker image built: $(DOCKER_IMAGE_LATEST) and $(DOCKER_IMAGE_TAGGED)"
+
+.PHONY: docker-relocate-root
+docker-relocate-root: ## Relocate the Docker data root to /mnt (CI-only, Linux runners).
+	@if [ "$(OS)" != "Linux" ]; then \
+		echo "🏃‍♂️ Docker data root relocation is Linux-only. Skipping on $(OS)."; \
+	elif [ "$$CI" != "true" ]; then \
+		echo "🏃‍♂️ Docker data root relocation only runs in CI. Skipping."; \
+	elif ! mountpoint -q /mnt; then \
+		echo "ℹ️ /mnt is not a separate mount. Leaving the Docker data root on /."; \
+	else \
+		echo "🐳 Relocating the Docker data root to /mnt/docker..."; \
+		$(SUDO) mkdir -p /mnt/docker /etc/docker; \
+		if [ -s /etc/docker/daemon.json ]; then \
+			jq '. + {"data-root": "/mnt/docker"}' /etc/docker/daemon.json > /tmp/daemon.json; \
+		else \
+			echo '{"data-root": "/mnt/docker"}' > /tmp/daemon.json; \
+		fi; \
+		$(SUDO) mv /tmp/daemon.json /etc/docker/daemon.json; \
+		$(SUDO) systemctl restart docker; \
+		docker info -f 'Docker root dir: {{ .DockerRootDir }}'; \
+		echo "✅ Docker data root relocated to /mnt/docker"; \
+	fi
 
 ##@ Neovim
 


### PR DESCRIPTION
## Problem

The `Docker` and `E2E` failures on `main` are **disk exhaustion during nix source builds**, not code defects:

```
cp: error copying '.../release/mise.d' to '.../release-tmp/mise.d': No space left on device
note: build failure may have been caused by lack of free disk space
```

They are intermittent. Across the last 100 runs on `main`, the nix-heavy workflows flake while every non-nix workflow is perfectly green:

| Workflow | Result |
| --- | --- |
| Docker | failure=2 success=9 |
| E2E | failure=3 success=8 |
| Lua | failure=1 success=10 |
| Nix | failure=1 success=9 |
| Python / Shell / Upgrade / Auto Approve | 100% success |

## Why the existing cleanup isn't enough

`docker.yml` and `e2e.yml` already enable **every** `jlumbroso/free-disk-space` option, so there is nothing left for that action to reclaim. The runner's own disk report shows the real problem:

```
AFTER CLEAN-UP:
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   23G   50G  32% /      <- build dies here
/dev/sdb1        76G   28K   70G   1% /mnt   <- 70G completely unused
```

Cleanup frees 31GiB, the build still exhausts the 50G on `/`, and a separate **70G disk at `/mnt` sits idle**.

## Fix

Two new Makefile targets point the write-heavy stores at `/mnt`, invoked from the workflows the same way CI already drives everything else (`make nix-build`, `make flake-check`, `make shell-inline-check`):

- **`make nix-relocate-store`** - bind-mounts `/nix` onto `/mnt/nix`. Called by `e2e.yml` and `nix.yml` (`nix-linux`, `nix-nixos`) before installing Nix.
- **`make docker-relocate-root`** - points the Docker data root at `/mnt/docker` before buildx starts, so the BuildKit container builds against the 70G disk. `daemon.json` is merged with `jq` so unrelated daemon settings are preserved.

`/nix` is bind-mounted at the **parent** rather than `/nix/store`. That keeps the installer's rename of `/nix/temp-install-dir` into `/nix/store` on a single filesystem and avoids the cross-device link error reported for a `/nix/store` bind mount ([nix-installer#850](https://github.com/DeterminateSystems/nix-installer/issues/850)).

## Safety

These are `make` targets, so they are reachable outside CI on a machine with a **real** Nix store. They guard accordingly and no-op unless every condition holds:

| Guard | Behaviour |
| --- | --- |
| `OS != Linux` | skip (protects macOS workstations) |
| `CI != true` | skip (protects real Linux boxes: kyber, matic) |
| `/mnt` not a separate mount | skip (arm64 runner / any image without a temp disk) |
| `/nix` already a mount, or exists and non-empty | skip - never bind-mounts over a populated store |

Swap is left alone: `free-disk-space` already deletes `/mnt/swapfile`, which frees `/mnt` rather than `/`, so removing it never helped the disk that actually fills. macOS jobs and `docker-merge-manifests` are untouched.

## Verification

- All 10 workflow files parse; Makefile parses and both targets appear in `make help`.
- Every guard branch was exercised locally with stubbed `mountpoint`/`sudo`/`mount`:
  - on this macOS box with a real populated `/nix`, both targets print `Linux-only. Skipping.` and **`/nix` is confirmed untouched**;
  - forced to `OS=Linux` with a populated `/nix` -> `already exists and is not empty. Leaving it alone.` (the destructive branch is not taken);
  - `CI` unset -> `only runs in CI. Skipping.`;
  - no `/mnt` mount -> falls back cleanly;
  - happy path -> issues `mount --bind /mnt/nix /nix`.
- The `jq` merge was exercised directly: preserves existing keys, overrides an existing `data-root` without duplicating it, and the `-s` guard handles an empty `daemon.json` (which would otherwise leave Docker with a config it can't start from).
- Confirmed the Makefile still parses **before** Nix exists (`NIX_EXEC`/`NIX_ENV` degrade to empty/`not_found`), which is required since the relocate step runs before `Install Nix`.
- Step ordering confirmed per job: `Free Disk Space` -> `Relocate` -> `Install Nix` / `Set up Docker Buildx`.
- The real test is this PR's own `Docker`, `E2E`, and `Nix` runs, which exercise the Linux path on actual runners.

Follows up on #2087, which covered the network-retry side and `nix.yml` tool-cache reclamation but left `/mnt` unused.