### PR TITLE
fix(spec): register night-shift script in shell coverage list

### DIFF
--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -113,6 +113,10 @@ It 'has spec file for home-manager/services/neverssl-keepalive/keepalive.sh'
 The path "spec/keepalive_spec.sh" should be exist
 End
 
+It 'has spec file for home-manager/services/night-shift/apply-night-shift.sh'
+The path "spec/night_shift_spec.sh" should be exist
+End
+
 It 'has spec file for install.sh'
 The path "spec/install_spec.sh" should be exist
 End
@@ -466,6 +470,7 @@ home-manager/services/gas-town/start.sh
 home-manager/services/k3s/activate.sh
 home-manager/services/make-updater/update.sh
 home-manager/services/neverssl-keepalive/keepalive.sh
+home-manager/services/night-shift/apply-night-shift.sh
 hosts/darwin/activate-remove-backups.sh
 hosts/linux/activate-backup-files.sh
 install.sh


### PR DESCRIPTION
## Summary

Fixes the `Shell` workflow failure on `main`.

`spec/coverage_spec.sh` asserts that every tracked `*.sh` file outside `spec/` appears in a hardcoded `covered_scripts` list. #2091 added `home-manager/services/night-shift/apply-night-shift.sh` (and `spec/night_shift_spec.sh`) but never registered the script in that list, so the coverage assertion has failed on every push since.

```
88d87
< home-manager/services/night-shift/apply-night-shift.sh
MISMATCH: Update coverage_spec.sh when adding new shell scripts
```

## Changes

- Add `apply-night-shift.sh` to `covered_scripts`.
- Add the matching `has spec file for ...` assertion, consistent with every other `home-manager/services` script.

## Verification

Full suite locally: `1629 examples, 0 failures` (was 1628 with 1 failure; +1 is the new existence assertion).

## Notes on the other red workflows

Checked but out of scope, no code fix needed:

- **Lua** (#2084): transient `HTTP 503` fetching the flake-parts tarball from api.github.com.
- **Nix** (#2086): a real `treefmt` failure on `home-manager/programs/gh/default.nix`, but already resolved on current `main` — `nixfmt --check` passes across all tracked `.nix` files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing Shell workflow by registering the night‑shift script in the coverage list and adding its spec check.

- **Bug Fixes**
  - Added `home-manager/services/night-shift/apply-night-shift.sh` to `covered_scripts` in `spec/coverage_spec.sh`.
  - Added assertion for `spec/night_shift_spec.sh` to match other service scripts.

<sup>Written for commit 17bf75a3395b2f141920bc0b01c0ee2b4b749246. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

