### PR TITLE
fix(matic): hibernate on battery lid close

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -246,8 +246,8 @@ import ../../hosts/nixos {
 
         # Power button behavior - lock screen instead of shutdown
         services.logind.settings.Login.HandlePowerKey = "lock";
-        # Suspend on battery lid close; on AC, Hyprland locks on the lid switch event.
-        services.logind.settings.Login.HandleLidSwitch = "suspend";
+        # Hibernate on battery lid close; on AC, Hyprland locks on the lid switch event.
+        services.logind.settings.Login.HandleLidSwitch = "hibernate";
         services.logind.settings.Login.HandleLidSwitchExternalPower = "ignore";
 
         # Auto timezone (via geolocation)

--- a/spec/matic_lid_policy_spec.sh
+++ b/spec/matic_lid_policy_spec.sh
@@ -4,9 +4,9 @@
 Describe 'named-hosts/matic/default.nix lid policy'
 CONFIG="$PWD/named-hosts/matic/default.nix"
 
-It 'keeps battery lid close as suspend'
-When run bash -c "grep -F 'services.logind.settings.Login.HandleLidSwitch = \"suspend\";' '$CONFIG'"
-The output should include 'HandleLidSwitch = "suspend"'
+It 'hibernates on battery lid close'
+When run bash -c "grep -F 'services.logind.settings.Login.HandleLidSwitch = \"hibernate\";' '$CONFIG'"
+The output should include 'HandleLidSwitch = "hibernate"'
 End
 
 It 'lets Hyprland handle lid close while on AC power'


### PR DESCRIPTION
## Summary

- change Matic's battery lid-close action from suspend to hibernate
- keep the existing AC-powered lid-close behavior unchanged
- update the focused lid-policy regression spec

## Why

Matic should preserve the session to disk when its lid closes on battery instead of using suspend.

## Validation

- `shellspec spec/matic_lid_policy_spec.sh`
- `make nix-format-check`
- evaluated `nixosConfigurations.matic.config.services.logind.settings.Login.HandleLidSwitch` as `hibernate`

The full Matic build was attempted but cannot realize an x86_64-linux Docker derivation from this aarch64-darwin host.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Matic’s battery lid-close action from suspend to hibernate to save the session to disk. AC-powered behavior remains unchanged, and the lid-policy regression test now expects `HandleLidSwitch = "hibernate"`.

<sup>Written for commit e35994ff7c3c93c952caa44516df8321540618d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

