### PR TITLE
fix(codex): keep Desktop settings synchronized

### DIFF
--- a/config/codex/activate.sh
+++ b/config/codex/activate.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2016
-# Copy Codex config files and merge managed Desktop settings.
-# Usage: activate.sh <config_toml> <hooks_json> <desktop_settings_json> <jq_bin>
+# Copy Codex config files and synchronize managed Desktop settings.
+# Usage: activate.sh <config_toml> <hooks_json> <desktop_settings_json> <jq_bin> <sync_script>
 set -euo pipefail
 CONFIG_TOML="$1"
 HOOKS_JSON="$2"
 DESKTOP_SETTINGS_JSON="$3"
 JQ_BIN="$4"
-GLOBAL_STATE="$HOME/.codex/.codex-global-state.json"
+SYNC_SCRIPT="$5"
 
 mkdir -p ~/.codex/hooks
 cp -f "$CONFIG_TOML" ~/.codex/config.toml
@@ -15,22 +14,4 @@ chmod 600 ~/.codex/config.toml
 cp -f "$HOOKS_JSON" ~/.codex/hooks.json
 chmod 644 ~/.codex/hooks.json
 
-# Git and worktree preferences use Codex Desktop's global-state store rather
-# than config.toml. Merge only the managed keys so task and UI state survive.
-GLOBAL_STATE_TMP=$(mktemp "${GLOBAL_STATE}.tmp.XXXXXX")
-trap 'rm -f "$GLOBAL_STATE_TMP"' EXIT
-
-if [[ -s $GLOBAL_STATE ]]; then
-  "$JQ_BIN" --slurpfile settings "$DESKTOP_SETTINGS_JSON" '
-    .["electron-persisted-atom-state"] =
-      ((.["electron-persisted-atom-state"] // {}) + $settings[0])
-  ' "$GLOBAL_STATE" >"$GLOBAL_STATE_TMP"
-else
-  "$JQ_BIN" -n --slurpfile settings "$DESKTOP_SETTINGS_JSON" '
-    {"electron-persisted-atom-state": $settings[0]}
-  ' >"$GLOBAL_STATE_TMP"
-fi
-
-chmod 600 "$GLOBAL_STATE_TMP"
-mv -f "$GLOBAL_STATE_TMP" "$GLOBAL_STATE"
-trap - EXIT
+"$SYNC_SCRIPT" "$DESKTOP_SETTINGS_JSON" "$JQ_BIN"

--- a/config/codex/default.nix
+++ b/config/codex/default.nix
@@ -1,4 +1,13 @@
-{ lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  homeDir = config.home.homeDirectory;
+  syncDesktopSettings = ./sync-desktop-settings.sh;
+in
 {
   # Use activation script instead of home.file symlink
   # Codex CLI uses atomic writes that break symlinks, so we force-copy on each switch
@@ -7,8 +16,30 @@
       "${./config.toml}" \
       "${./hooks.json}" \
       "${./desktop-settings.json}" \
-      "${pkgs.jq}/bin/jq"
+      "${pkgs.jq}/bin/jq" \
+      "${syncDesktopSettings}"
   '';
+
+  # Codex caches Desktop preferences in memory and replaces its complete state
+  # file after activation. Restore managed keys after each app-owned rewrite;
+  # the synchronizer exits without writing once the values already match.
+  launchd.agents.codex-desktop-settings-sync = lib.mkIf pkgs.stdenv.isDarwin {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "${pkgs.bash}/bin/bash"
+        "${syncDesktopSettings}"
+        "${./desktop-settings.json}"
+        "${pkgs.jq}/bin/jq"
+      ];
+      WatchPaths = [ "${homeDir}/.codex/.codex-global-state.json" ];
+      ThrottleInterval = 2;
+      RunAtLoad = true;
+      KeepAlive = false;
+      StandardOutPath = "/tmp/codex-desktop-settings-sync.log";
+      StandardErrorPath = "/tmp/codex-desktop-settings-sync.error.log";
+    };
+  };
 
   home.file.".codex/hooks/notify.sh" = {
     source = ./hooks/notify.sh;

--- a/config/codex/sync-desktop-settings.sh
+++ b/config/codex/sync-desktop-settings.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+# Keep managed Codex Desktop preferences in the app-owned global-state store.
+set -euo pipefail
+
+DESKTOP_SETTINGS_JSON="$1"
+JQ_BIN="$2"
+GLOBAL_STATE="$HOME/.codex/.codex-global-state.json"
+
+mkdir -p "$HOME/.codex"
+
+# Codex keeps this state in memory and periodically replaces the entire file.
+# Avoid a write when the managed values already match so launchd's file watch
+# settles after the synchronizer restores an app-owned rewrite.
+if [[ -s $GLOBAL_STATE ]] && "$JQ_BIN" -e --slurpfile settings "$DESKTOP_SETTINGS_JSON" '
+  (.["electron-persisted-atom-state"] // {}) as $state
+  | ($settings[0] | to_entries | all(. as $entry |
+      $state[$entry.key] == $entry.value))
+' "$GLOBAL_STATE" >/dev/null; then
+  exit 0
+fi
+
+GLOBAL_STATE_TMP=$(mktemp "${GLOBAL_STATE}.tmp.XXXXXX")
+trap 'rm -f "$GLOBAL_STATE_TMP"' EXIT
+
+if [[ -s $GLOBAL_STATE ]]; then
+  "$JQ_BIN" --slurpfile settings "$DESKTOP_SETTINGS_JSON" '
+    .["electron-persisted-atom-state"] =
+      ((.["electron-persisted-atom-state"] // {}) + $settings[0])
+  ' "$GLOBAL_STATE" >"$GLOBAL_STATE_TMP"
+else
+  "$JQ_BIN" -n --slurpfile settings "$DESKTOP_SETTINGS_JSON" '
+    {"electron-persisted-atom-state": $settings[0]}
+  ' >"$GLOBAL_STATE_TMP"
+fi
+
+chmod 600 "$GLOBAL_STATE_TMP"
+mv -f "$GLOBAL_STATE_TMP" "$GLOBAL_STATE"
+trap - EXIT

--- a/spec/activate_config_spec.sh
+++ b/spec/activate_config_spec.sh
@@ -3,6 +3,7 @@
 
 Describe 'config/codex/activate.sh'
 SCRIPT="$PWD/config/codex/activate.sh"
+SYNC_SCRIPT="$PWD/config/codex/sync-desktop-settings.sh"
 HOOKS_JSON="$PWD/config/codex/hooks.json"
 CONFIG_TOML="$PWD/config/codex/config.toml"
 DESKTOP_SETTINGS_JSON="$PWD/config/codex/desktop-settings.json"
@@ -50,13 +51,43 @@ cat >"$TMP_HOME/.codex/.codex-global-state.json" <<'JSON'
 }
 JSON
 
-When run bash -c 'HOME="$1" bash "$2" "$3" "$4" "$5" "$6" && jq -r ".[\"unrelated-top-level\"], .[\"electron-persisted-atom-state\"][\"unrelated-setting\"], .[\"electron-persisted-atom-state\"][\"git-always-force-push\"], .[\"electron-persisted-atom-state\"][\"git-pull-request-merge-method\"], .[\"electron-persisted-atom-state\"][\"worktree-keep-count\"]" "$1/.codex/.codex-global-state.json"' _ "$TMP_HOME" "$SCRIPT" "$CONFIG_TOML" "$HOOKS_JSON" "$DESKTOP_SETTINGS_JSON" "$(command -v jq)"
+When run bash -c 'HOME="$1" bash "$2" "$3" "$4" "$5" "$6" "$7" && jq -r ".[\"unrelated-top-level\"], .[\"electron-persisted-atom-state\"][\"unrelated-setting\"], .[\"electron-persisted-atom-state\"][\"git-always-force-push\"], .[\"electron-persisted-atom-state\"][\"git-pull-request-merge-method\"], .[\"electron-persisted-atom-state\"][\"worktree-keep-count\"]" "$1/.codex/.codex-global-state.json"' _ "$TMP_HOME" "$SCRIPT" "$CONFIG_TOML" "$HOOKS_JSON" "$DESKTOP_SETTINGS_JSON" "$(command -v jq)" "$SYNC_SCRIPT"
 The status should be success
 The line 1 should eq 'preserved'
 The line 2 should eq '42'
 The line 3 should eq 'true'
 The line 4 should eq 'squash'
 The line 5 should eq '300'
+End
+
+It 'restores managed Desktop settings after the app replaces its state'
+TMP_HOME="$(mktemp -d)"
+mkdir -p "$TMP_HOME/.codex"
+cat >"$TMP_HOME/.codex/.codex-global-state.json" <<'JSON'
+{
+  "unrelated-top-level": "preserved",
+  "electron-persisted-atom-state": {
+    "unrelated-setting": 42
+  }
+}
+JSON
+
+When run bash -c 'HOME="$1" bash "$2" "$3" "$4" && jq -r ".[\"unrelated-top-level\"], .[\"electron-persisted-atom-state\"][\"unrelated-setting\"], .[\"electron-persisted-atom-state\"][\"git-branch-prefix\"], .[\"electron-persisted-atom-state\"][\"worktree-keep-count\"]" "$1/.codex/.codex-global-state.json"' _ "$TMP_HOME" "$SYNC_SCRIPT" "$DESKTOP_SETTINGS_JSON" "$(command -v jq)"
+The status should be success
+The line 1 should eq 'preserved'
+The line 2 should eq '42'
+The line 3 should eq 'codex/'
+The line 4 should eq '300'
+End
+
+It 'does not rewrite state when managed Desktop settings already match'
+TMP_HOME="$(mktemp -d)"
+mkdir -p "$TMP_HOME/.codex"
+printf '%s\n' '{"electron-persisted-atom-state": {}}' >"$TMP_HOME/.codex/.codex-global-state.json"
+
+When run bash -c 'HOME="$1" bash "$2" "$3" "$4" && before=$(ls -di "$1/.codex/.codex-global-state.json") && before=${before%% *} && HOME="$1" bash "$2" "$3" "$4" && after=$(ls -di "$1/.codex/.codex-global-state.json") && after=${after%% *} && test "$before" = "$after" && printf "%s\\n" unchanged' _ "$TMP_HOME" "$SYNC_SCRIPT" "$DESKTOP_SETTINGS_JSON" "$(command -v jq)"
+The status should be success
+The output should eq 'unchanged'
 End
 
 It 'registers the shared main/master push blocker'
@@ -72,6 +103,17 @@ End
 It 'registers dcg in the Bash pre-tool hook chain'
 When run jq -r '.hooks.PreToolUse[] | select(.matcher == "Bash") | .hooks[].command' "$HOOKS_JSON"
 The output should include 'command -v dcg >/dev/null 2>&1 && dcg'
+End
+End
+
+Describe 'config/codex/default.nix'
+DEFAULT_NIX="$PWD/config/codex/default.nix"
+
+It 'watches Codex Desktop global state for app-owned rewrites'
+When run cat "$DEFAULT_NIX"
+The output should include 'codex-desktop-settings-sync'
+The output should include 'WatchPaths'
+The output should include '.codex/.codex-global-state.json'
 End
 End
 

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -244,6 +244,10 @@ It 'has spec file for config/codex/activate.sh'
 The path "spec/activate_config_spec.sh" should be exist
 End
 
+It 'has spec file for config/codex/sync-desktop-settings.sh'
+The path "spec/activate_config_spec.sh" should be exist
+End
+
 It 'has spec file for config/dcg/activate.sh'
 The path "spec/activate_config_spec.sh" should be exist
 End
@@ -386,6 +390,7 @@ config/claude/hooks/security.sh
 config/claude/hooks/atuin-history.sh
 config/claude/hooks/statusline.sh
 config/codex/activate.sh
+config/codex/sync-desktop-settings.sh
 config/copilot/activate.sh
 config/codex/hooks/atuin-history.sh
 config/dcg/activate.sh


### PR DESCRIPTION
## What changed

- extract Codex Desktop preference merging into an idempotent synchronizer
- add a macOS launchd `WatchPaths` agent that restores managed keys after the app replaces `.codex-global-state.json`
- reuse the synchronizer during Home Manager activation
- add regression coverage for app-owned rewrites and no-op behavior when settings already match

## Root cause

Codex Desktop caches its Electron state in memory and atomically replaces the entire global-state file. A Home Manager activation performed while Codex was running injected the configured Git and worktree preferences only temporarily; the app's next state flush removed them.

## Impact

The managed settings remain present on disk after Codex rewrites its state. The synchronizer makes no file change when values already match, so the file watch settles without looping. After this configuration is activated, restart Codex once so the currently running app loads the restored values.

## Validation

- `shellspec spec/activate_config_spec.sh spec/coverage_spec.sh` — 141 examples, 0 failures
- `nix flake check --system aarch64-darwin --impure` — passed
- `nix build .#darwinConfigurations.aarch64-darwin.config.system.build.toplevel --no-link --print-build-logs` — passed
- `shellcheck config/codex/activate.sh config/codex/sync-desktop-settings.sh` — passed
- `nixfmt --check config/codex/default.nix` — passed
- `git diff --check` — passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps Codex Desktop’s managed settings in sync even when the app rewrites `.codex-global-state.json`. Adds an idempotent sync script used on activation and a macOS `launchd` watcher to restore managed keys without loops.

- **Bug Fixes**
  - Added `config/codex/sync-desktop-settings.sh` to merge managed keys and no-op when values already match.
  - Updated `config/codex/activate.sh` to call the synchronizer; reused during Home Manager activation.
  - Added a macOS `launchd` agent that watches the global state file and runs the synchronizer; regression tests included.

<sup>Written for commit a85eb782c0cb9b8dc9119c751f76727206a02551. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

