### PR TITLE
fix(install): Prefer NixOS sudo wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,10 +123,10 @@ DARWIN_REBUILD := $(shell command -v darwin-rebuild 2>/dev/null || echo "./resul
 
 # Sudo path (NixOS uses /run/wrappers/bin/sudo)
 SUDO := $(shell \
-	if command -v sudo >/dev/null 2>&1; then \
-		echo "sudo"; \
-	elif [ -x /run/wrappers/bin/sudo ]; then \
+	if [ -x /run/wrappers/bin/sudo ]; then \
 		echo "/run/wrappers/bin/sudo"; \
+	elif command -v sudo >/dev/null 2>&1; then \
+		echo "sudo"; \
 	elif [ -x /usr/bin/sudo ]; then \
 		echo "/usr/bin/sudo"; \
 	else \

--- a/install.sh
+++ b/install.sh
@@ -128,15 +128,20 @@ else
   fi
 fi
 
-# Handle `make` installation
+# Use make from nixpkgs when the base system does not provide it. This avoids
+# invoking the non-setuid sudo package binary on fresh NixOS machines.
 if ! command -v make >/dev/null 2>&1; then
-  echo "Installing make..."
-  if [ "$OS" = "macos" ]; then
-    brew install make
-  else
-    sudo apt-get install make
-  fi
+  echo "make is not installed; it will be provided temporarily by nixpkgs."
 fi
+
+run_make_install() {
+  if command -v make >/dev/null 2>&1; then
+    HOST="$HOST" make install
+  else
+    HOST="$HOST" nix --extra-experimental-features "nix-command flakes" \
+      shell nixpkgs#gnumake --command make install
+  fi
+}
 
 # Install Nix packages
 echo "Running installation commands..."
@@ -146,11 +151,13 @@ fi
 if [ -n "$NIX_EFFECTIVE_BIN_PATH" ] && [ -d "$NIX_EFFECTIVE_BIN_PATH" ]; then
   echo "Prepending $NIX_EFFECTIVE_BIN_PATH to PATH for 'make install' command."
   echo "Ensuring USER=$USER and CI=$CI are passed to make install."
-  env PATH="$NIX_EFFECTIVE_BIN_PATH:$PATH" USER="$USER" CI="$CI" HOST="$HOST" make install
+  PATH="$NIX_EFFECTIVE_BIN_PATH:$PATH"
+  export PATH USER CI HOST
+  run_make_install
 else
   echo "Warning: NIX_EFFECTIVE_BIN_PATH ('$NIX_EFFECTIVE_BIN_PATH') is not set or not a directory."
   echo "Running 'make install' with potentially incomplete PATH. Current PATH: $PATH"
   echo "Attempting to find nix via 'command -v nix': $(command -v nix || echo 'nix not found in current PATH')"
   echo "USER=$USER will be available to make install (exported)."
-  HOST="$HOST" make install
+  run_make_install
 fi

--- a/spec/install_spec.sh
+++ b/spec/install_spec.sh
@@ -95,6 +95,16 @@ When run bash -c "grep 'command -v make' '$SCRIPT'"
 The output should include 'command -v make'
 End
 
+It 'uses gnumake from nixpkgs when make is absent'
+When run bash -c "grep 'shell nixpkgs#gnumake --command make install' '$SCRIPT'"
+The output should include 'shell nixpkgs#gnumake --command make install'
+End
+
+It 'does not use apt-get to bootstrap make'
+When run bash -c "grep 'apt-get install make' '$SCRIPT'"
+The status should be failure
+End
+
 It 'runs make install'
 When run bash -c "grep 'make install' '$SCRIPT'"
 The output should include 'make install'

--- a/spec/make_sudo_resolution_spec.sh
+++ b/spec/make_sudo_resolution_spec.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016,SC2329
+
+Describe 'Makefile sudo resolution'
+
+It 'prefers the NixOS setuid wrapper over a sudo found on PATH'
+When run bash -c '
+  wrapper_line=$(grep -n "if \[ -x /run/wrappers/bin/sudo \]" Makefile | cut -d: -f1)
+  path_line=$(grep -n "elif command -v sudo" Makefile | cut -d: -f1)
+  test -n "$wrapper_line" && test -n "$path_line" && test "$wrapper_line" -lt "$path_line"
+'
+The status should be success
+End
+
+End


### PR DESCRIPTION
## Summary

- prefer the NixOS setuid sudo wrapper before PATH-based sudo resolution
- bootstrap missing make through nixpkgs instead of apt-get
- add regression coverage for fresh-machine installation

## Root cause

NixOS keeps the privileged sudo entry point at /run/wrappers/bin/sudo. A fresh machine could resolve /run/current-system/sw/bin/sudo first; that package binary is intentionally not setuid and refuses to run. The installer also assumed apt-get when make was missing, which is not valid on NixOS.

## Validation

- full ShellSpec suite
- focused install and sudo-resolution ShellSpec suite (23 examples)
- ShellCheck
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes NixOS installs by preferring the setuid `sudo` wrapper and bootstrapping `make` from `nixpkgs` when missing. Adds regression tests for sudo resolution and the install path.

- **Bug Fixes**
  - Prefer `/run/wrappers/bin/sudo` over PATH `sudo` to avoid the non-setuid `/run/current-system/sw/bin/sudo`.
  - When `make` is absent, use `nix shell nixpkgs#gnumake --command make install` (with `nix-command flakes`) instead of `apt-get`.
  - Add ShellSpec tests for sudo resolution and `make` bootstrap; ensure no `apt-get install make` path is used.

<sup>Written for commit 20d1abfea2659fbb9e52cd26c7c2c4fb83d0f7f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

