### PR TITLE
fix(nixos): install GRUB in UEFI mode

### DIFF
--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -90,9 +90,13 @@ let
     (
       { lib, ... }:
       {
-        boot.loader.grub.enable = true;
-        boot.loader.grub.device = "/dev/sda";
-        boot.loader.grub.useOSProber = true;
+        boot.loader.grub = {
+          enable = true;
+          device = if isRunner then "/dev/sda" else "nodev";
+          efiSupport = !isRunner;
+          useOSProber = true;
+        };
+        boot.loader.efi.canTouchEfiVariables = !isRunner;
         boot.loader.systemd-boot.configurationLimit = 10;
 
         users.users.${username} = {


### PR DESCRIPTION
## Summary

- configure the generic physical NixOS host to use EFI-capable GRUB
- register the boot entry through UEFI variables
- preserve the existing BIOS GRUB configuration for the CI runner

## Root cause

The shared generic NixOS module always installed BIOS GRUB to `/dev/sda`. On the affected UEFI/GPT laptop, `/dev/sda` is the NixOS installer media while the target system and EFI System Partition live on the NVMe disk. This selected the wrong GRUB installation mode and device.

## Impact

The `x86_64-linux` configuration now generates UEFI GRUB with `device = "nodev"`, while the runner continues to install BIOS GRUB to `/dev/sda`.

## Validation

- evaluated the physical host as `device = "nodev"`, `efiSupport = true`, and `canTouchEfiVariables = true`
- evaluated the runner as `device = "/dev/sda"`, `efiSupport = false`, and `canTouchEfiVariables = false`
- `nix flake check --no-build`
- `make nix-format-check`
- `make nix-lint`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch NixOS physical hosts to install GRUB in UEFI mode and register the boot entry via UEFI variables, while keeping the CI runner on BIOS GRUB to avoid writing to the wrong disk.

- **Bug Fixes**
  - Physical hosts: set `boot.loader.grub.device = "nodev"`, enable `efiSupport`, and allow `boot.loader.efi.canTouchEfiVariables`.
  - CI runner: keep BIOS GRUB with `boot.loader.grub.device = "/dev/sda"` and disable EFI settings.

<sup>Written for commit 0191273d0eb4026790116cfca7a44cd6affc2485. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

