### PR TITLE
fix(nixos): mount labeled root filesystem

### DIFF
--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -127,14 +127,26 @@ let
 
         services.getty.autologinUser = lib.mkIf isRunner "root";
         boot.loader.timeout = lib.mkIf isRunner 0;
+        boot.initrd.availableKernelModules = lib.optionals (!isRunner) [ "nvme" ];
 
         boot.consoleLogLevel = 7;
         services.journald.extraConfig = "Storage=volatile";
 
         fileSystems."/" = {
-          device = "/dev/sda1";
+          device = if isRunner then "/dev/sda1" else "/dev/disk/by-label/root";
           fsType = "ext4";
         };
+        fileSystems."/boot" = lib.mkIf (!isRunner) {
+          device = "/dev/disk/by-partlabel/EFI";
+          fsType = "vfat";
+          options = [
+            "fmask=0077"
+            "dmask=0077"
+          ];
+        };
+        swapDevices = lib.optionals (!isRunner) [
+          { device = "/dev/disk/by-label/swap"; }
+        ];
 
         fonts.packages = with pkgs; [
           nerd-fonts.jetbrains-mono

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -53,19 +53,29 @@ let
   # --- NixOS configurations (x86_64-linux only) ---
   nixosChecks = lib.optionalAttrs (system == "x86_64-linux") {
     eval-nixos-default =
-      mkEvalCheck "nixos-default"
-        (import ../hosts/nixos {
+      let
+        nixosDefault = import ../hosts/nixos {
           inherit inputs;
           username = "shunkakinoki";
-        }).config.system.build.toplevel;
+        };
+      in
+      assert nixosDefault.config.fileSystems."/".device == "/dev/disk/by-label/root";
+      assert nixosDefault.config.fileSystems."/boot".device == "/dev/disk/by-partlabel/EFI";
+      assert lib.elem "nvme" nixosDefault.config.boot.initrd.availableKernelModules;
+      assert builtins.length nixosDefault.config.swapDevices == 1;
+      assert (builtins.head nixosDefault.config.swapDevices).device == "/dev/disk/by-label/swap";
+      mkEvalCheck "nixos-default" nixosDefault.config.system.build.toplevel;
 
     eval-nixos-runner =
-      mkEvalCheck "nixos-runner"
-        (import ../hosts/nixos {
+      let
+        nixosRunner = import ../hosts/nixos {
           inherit inputs;
           isRunner = true;
           username = "runner";
-        }).config.system.build.toplevel;
+        };
+      in
+      assert nixosRunner.config.fileSystems."/".device == "/dev/sda1";
+      mkEvalCheck "nixos-runner" nixosRunner.config.system.build.toplevel;
 
     eval-nixos-matic =
       mkEvalCheck "nixos-matic"


### PR DESCRIPTION
## Summary

- mount the physical generic NixOS root filesystem by its `root` label instead of `/dev/sda1`
- mount the EFI System Partition at `/boot` by its `EFI` partition label
- configure the labeled swap partition and include the NVMe initrd module
- preserve `/dev/sda1` for the CI runner
- add evaluation assertions for the physical-host and runner storage layouts

## Root cause

The generic NixOS profile used `/dev/sda1` for every host. On the affected laptop, `/dev/sda` is the NixOS installer media and the installed root filesystem is the NVMe partition labeled `root`. The generated initrd therefore attempted `fsck` on `/dev/sda1`, failed to find the root filesystem, and entered emergency mode with the root account locked.

This follows up #2097, which corrected the bootloader mode but left the independent root filesystem device hard-coded.

## Validation

- reproduced the source-level failure with an assertion that rejected the literal `/dev/sda1` physical-root configuration
- reran the assertion after the fix: `PASS: generic physical root no longer hard-codes /dev/sda1`
- added Nix evaluation assertions for root, EFI, swap, NVMe initrd support, and the runner fallback
- `nixfmt --check hosts/nixos/default.nix tests/eval.nix`
- `git diff --check`

Full local flake evaluation could not be rerun because this sandbox denied access to the local Nix daemon socket; the new evaluation assertions will run in Nix CI.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mount root and EFI partitions by labels to fix boot on NVMe hosts while preserving `/dev/sda1` for the CI runner. Adds NVMe initrd support, labeled swap, and evaluation assertions to prevent regressions.

- **Bug Fixes**
  - Use `/dev/disk/by-label/root` for `/` on physical hosts; keep `/dev/sda1` for the runner.
  - Mount `/boot` via `/dev/disk/by-partlabel/EFI` with restrictive `fmask`/`dmask`.
  - Configure swap at `/dev/disk/by-label/swap` and include `nvme` in `initrd` for non-runner hosts.
  - Add Nix eval assertions covering root, EFI, swap, NVMe module, and runner fallback.

<sup>Written for commit 55b72e69ec65ca127647c0c5088727ece1a1295f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

