### PR TITLE
fix(matic): set username to shunkakinoki

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -147,7 +147,7 @@
               };
               matic = import ./named-hosts/matic {
                 inherit inputs;
-                username = "skakinoki";
+                username = "shunkakinoki";
               };
               viper = import ./named-hosts/viper {
                 inherit inputs;


### PR DESCRIPTION
## Summary
- Set the `matic` host username from `skakinoki` to `shunkakinoki` in `flake.nix`.

This aligns matic with the other hosts (galactica, viper) which already use `shunkakinoki`, and fixes the home directory / SSH identity paths (`/home/${username}/.ssh/...`) that derive from this value.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the `matic` host username to `shunkakinoki` in `flake.nix`. Aligns with other hosts and fixes derived home and SSH paths like `/home/${username}/.ssh/...`.

<sup>Written for commit 1751a54381c89c52313c36178ae29e96a2ad538b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

