### PR TITLE
fix(nixos): auto-detect matic host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ NIX_USER_TRUSTED := $(shell grep -qE "trusted-users.*=.*(\\*|$(shell whoami))" /
 NAMED_HOSTS := galactica kyber matic pod viper
 NIXOS_NAMED_HOSTS := $(filter matic viper,$(NAMED_HOSTS))
 ISO_NAMED_HOSTS := $(filter matic viper,$(NAMED_HOSTS))
+DMI_SYS_VENDOR ?= $(shell cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)
+DMI_PRODUCT_NAME ?= $(shell cat /sys/class/dmi/id/product_name 2>/dev/null || true)
 
 # Nix configuration system
 NIX_SYSTEM := $(shell if [ "$(OS)" = "Darwin" ] && [ "$(ARCH)" = "arm64" ]; then \
@@ -105,6 +107,9 @@ DETECTED_HOST := $(shell \
 			if [ "$$hostname" = "kyber" ]; then \
 				echo "kyber"; \
 			elif [ "$$hostname" = "matic" ]; then \
+				echo "matic"; \
+			elif [ "$(DMI_SYS_VENDOR)" = "Framework" ] \
+				&& echo "$(DMI_PRODUCT_NAME)" | grep -q "Laptop 13.*AMD Ryzen AI 300"; then \
 				echo "matic"; \
 			else \
 				echo ""; \

--- a/named-hosts/matic/README.md
+++ b/named-hosts/matic/README.md
@@ -19,8 +19,13 @@ If the boot chain changes (firmware/kernel update), TPM2 will refuse and fall ba
 ## Building and Switching
 
 ```bash
-make build HOST=matic && make switch HOST=matic
+make build
+make switch
 ```
+
+The Makefile detects matic from its Framework 13 AMD AI 300 DMI identity, even
+when a recovery generation still uses a generic hostname. `HOST=matic` remains
+available as an explicit override.
 
 Or use `boot` instead of `switch` for major config changes (avoids dbus reload issues):
 

--- a/spec/make_build_host_resolution_spec.sh
+++ b/spec/make_build_host_resolution_spec.sh
@@ -28,4 +28,18 @@ The output should include '.#darwinConfigurations.galactica.system'
 The output should not include '.#nixosConfigurations.matic.config.system.build.toplevel'
 End
 
+It 'detects matic from Framework 13 AMD AI 300 DMI data when the hostname is generic'
+When run bash -c 'make build OS=Linux ARCH=x86_64 NIX_SYSTEM=x86_64-linux NIX_CONFIG_TYPE=nixosConfigurations DMI_SYS_VENDOR=Framework DMI_PRODUCT_NAME="Laptop 13 (AMD Ryzen AI 300 Series)" NIX_EXEC=nix NIX_ENV=ok NIX_FLAGS= NIX_USER_TRUSTED=yes SUDO=env 2>/dev/null; cat "$MOCK_LOG"'
+The status should be success
+The output should include '--flake .#matic'
+The output should not include '--flake .#x86_64-linux'
+End
+
+It 'switches the detected matic host through the generic NixOS path'
+When run bash -c 'make nix-switch OS=Linux ARCH=x86_64 NIX_SYSTEM=x86_64-linux NIX_CONFIG_TYPE=nixosConfigurations DMI_SYS_VENDOR=Framework DMI_PRODUCT_NAME="Laptop 13 (AMD Ryzen AI 300 Series)" NIX_EXEC=nix NIX_ENV=ok NIX_FLAGS= NIX_USER_TRUSTED=yes SUDO=env 2>/dev/null; cat "$MOCK_LOG"'
+The status should be success
+The output should include '-- switch --flake .#matic'
+The output should not include '-- switch --flake .#x86_64-linux'
+End
+
 End


### PR DESCRIPTION
## Summary

- detect the Framework 13 AMD Ryzen AI 300 laptop as `matic` from DMI data when its current hostname is still generic
- keep `nix-switch` fully generic and feed the detected host through the existing host-resolution path
- document plain `make build` and `make switch` for matic while preserving `HOST=matic` as an override

## Validation

- `shellspec spec/make_build_host_resolution_spec.sh` (4 examples, 0 failures)
- `make shell-test` (1,635 ShellSpec examples and 414 fish tests, 0 failures)
- `git diff --check`

## Note

`make nix-format-check` could not reach the host Nix daemon from the Codex sandbox. No Nix files are changed by this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-detect the `matic` host on Framework Laptop 13 (AMD Ryzen AI 300 Series) using DMI so machines with a generic hostname pick the right config. `make build` and `make switch` now work without `HOST=matic`; the generic host-resolution and `nix-switch` flow is unchanged, and the override still works.

<sup>Written for commit afe22d809880f1328d737101b651cb96cb8804c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

