### PR TITLE
fix(matic): update encrypted disk UUIDs

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -42,7 +42,7 @@ import ../../hosts/nixos {
 
         # TPM2 auto-unlock for LUKS disk encryption
         boot.initrd.systemd.enable = true;
-        boot.initrd.luks.devices."luks-4a2ddfc4-1a40-4e18-99f5-250baf72b4ac".crypttabExtraOpts = [
+        boot.initrd.luks.devices."luks-eb20879c-a48d-4334-99a4-bf77a3ad289a".crypttabExtraOpts = [
           "tpm2-device=auto"
         ];
 

--- a/named-hosts/matic/hardware-configuration.nix
+++ b/named-hosts/matic/hardware-configuration.nix
@@ -25,15 +25,15 @@
   boot.extraModulePackages = [ ];
 
   fileSystems."/" = {
-    device = "/dev/mapper/luks-4a2ddfc4-1a40-4e18-99f5-250baf72b4ac";
+    device = "/dev/mapper/luks-eb20879c-a48d-4334-99a4-bf77a3ad289a";
     fsType = "ext4";
   };
 
-  boot.initrd.luks.devices."luks-4a2ddfc4-1a40-4e18-99f5-250baf72b4ac".device =
-    "/dev/disk/by-uuid/4a2ddfc4-1a40-4e18-99f5-250baf72b4ac";
+  boot.initrd.luks.devices."luks-eb20879c-a48d-4334-99a4-bf77a3ad289a".device =
+    "/dev/disk/by-uuid/eb20879c-a48d-4334-99a4-bf77a3ad289a";
 
   fileSystems."/boot" = {
-    device = "/dev/disk/by-uuid/D849-552A";
+    device = "/dev/disk/by-uuid/CCCC-F42C";
     fsType = "vfat";
     options = [
       "fmask=0077"


### PR DESCRIPTION
## Summary

- update the matic root mapper and LUKS device UUID after the clean encrypted reinstall
- update the EFI filesystem UUID
- attach TPM2 auto-unlock options to the new LUKS mapper name

## Root cause

The declarative matic hardware configuration still referenced the partitions from the previous installation. Switching to it would generate an initrd that waited for a nonexistent LUKS UUID and failed before mounting the root filesystem.

## Impact

The matic configuration now matches the verified on-disk layout, so it can be built and activated without recreating the initrd boot failure.

## Validation

- `make nix-format-check`
- evaluated `nixosConfigurations.matic.config.fileSystems`
- evaluated `nixosConfigurations.matic.config.boot.initrd.luks.devices`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update matic host to the new LUKS and EFI UUIDs after a clean encrypted reinstall. Fixes the initrd boot hang on the old UUID and keeps TPM2 auto-unlock working.

- **Bug Fixes**
  - Point `/` to `/dev/mapper/luks-eb20879c-a48d-4334-99a4-bf77a3ad289a`.
  - Update `boot.initrd.luks.devices` key and device UUID to `eb20879c-a48d-4334-99a4-bf77a3ad289a`.
  - Switch `/boot` to EFI UUID `CCCC-F42C`.
  - Preserve `tpm2-device=auto` on the new LUKS mapper.

<sup>Written for commit af211e7a21d6073faa2f6efcd0795da7a0667c78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

