### PR TITLE
fix(makefile): honor detected NixOS host in CI builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -544,7 +544,15 @@ nix-build: nix-connect nix-trust ## Build Nix configuration.
 				HOST=runner HOSTNAME=runner $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#$(NIX_CONFIG_TYPE).runner.system $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
 			fi; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "nixosConfigurations" ]; then \
-			HOST=runner HOSTNAME=runner $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#nixosConfigurations.runner.config.system.build.toplevel $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
+			if [ -n "$(HOST)" ]; then \
+				echo "Building named NixOS host: $(HOST)"; \
+				$(SUDO) env HOST=$(HOST) HOSTNAME=$(HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- build --flake .#$(HOST) --impure; \
+			elif [ -n "$(DETECTED_HOST)" ]; then \
+				echo "Auto-detected host: $(DETECTED_HOST)"; \
+				$(SUDO) env HOST=$(DETECTED_HOST) HOSTNAME=$(DETECTED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- build --flake .#$(DETECTED_HOST) --impure; \
+			else \
+				HOST=runner HOSTNAME=runner $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#nixosConfigurations.runner.config.system.build.toplevel $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
+			fi; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "homeConfigurations" ]; then \
 			if [ -n "$(HOST)" ]; then \
 				echo "Building named home config: $(HOST)"; \
@@ -689,8 +697,16 @@ nix-switch: ## Activate Nix configuration.
 		if [ "$(OS)" = "Darwin" ]; then \
 			$(SUDO) env CI="$$CI" IN_DOCKER="$$IN_DOCKER" HOST=runner HOSTNAME=runner $(NIX_ALLOW_UNFREE) $(DARWIN_REBUILD) switch --flake .#runner --impure --no-update-lock-file; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "nixosConfigurations" ]; then \
-			echo "⏭️ NixOS switch skipped in CI as the runner is not a NixOS system"; \
-			$(SUDO) env HOST=runner HOSTNAME=runner $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure nixpkgs#nixos-rebuild -- switch --flake .#runner --no-update-lock-file || exit 0; \
+			if [ -n "$(HOST)" ]; then \
+				echo "Switching named host: $(HOST)"; \
+				$(SUDO) env HOST=$(HOST) HOSTNAME=$(HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure nixpkgs#nixos-rebuild -- switch --flake .#$(HOST) --no-update-lock-file || exit 0; \
+			elif [ -n "$(DETECTED_HOST)" ]; then \
+				echo "Auto-detected host: $(DETECTED_HOST)"; \
+				$(SUDO) env HOST=$(DETECTED_HOST) HOSTNAME=$(DETECTED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure nixpkgs#nixos-rebuild -- switch --flake .#$(DETECTED_HOST) --no-update-lock-file || exit 0; \
+			else \
+				echo "⏭️ NixOS switch skipped in CI as the runner is not a NixOS system"; \
+				$(SUDO) env HOST=runner HOSTNAME=runner $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure nixpkgs#nixos-rebuild -- switch --flake .#runner --no-update-lock-file || exit 0; \
+			fi; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "homeConfigurations" ]; then \
 			if [ "$$SKIP_HOME_MANAGER_SWITCH" = "true" ]; then \
 				echo "⏭️ Home-manager switch skipped (SKIP_HOME_MANAGER_SWITCH=true)"; \


### PR DESCRIPTION
## Problem

The `Shell` workflow is failing on `main`. Two shellspec cases in `spec/make_build_host_resolution_spec.sh` fail:

- `detects matic from Framework 13 AMD AI 300 DMI data when the hostname is generic`
- `switches the detected matic host through the generic NixOS path`

The CI branches of `nix-build` and `nix-switch` hardcoded the `runner` host for `nixosConfigurations`, ignoring both `HOST` and `DETECTED_HOST`. The Framework 13 DMI detection added in #2100 only wired into the non-CI branches, so it never took effect when `CI=true`. The specs run in CI, hit the hardcoded path, and got `--flake .#runner` instead of `--flake .#matic`.

The Darwin CI branch already resolved `HOST` / `DETECTED_HOST` correctly, which is why the other two cases in the same spec passed.

## Change

Both CI branches now resolve `HOST` first, then `DETECTED_HOST`, and fall back to the existing hardcoded `runner` path when neither is set. Real CI runs set neither, so the `runner` behavior is unchanged there.

## Verification

Reproduced the failure and confirmed the fix locally:

- `CI=true shellspec spec/make_build_host_resolution_spec.sh` before the change: 4 examples, 2 failures
- Same command after: 4 examples, 0 failures
- Full suite `CI=true shellspec`: 1635 examples, 0 failures

## Not addressed

The `Docker` workflow failure on main (run 29617921853) was a transient `No space left on device` while Nix built `mise` from source. Five subsequent `Docker` runs on `main` succeeded, so it is not a persistent breakage and is left alone here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI builds to honor the detected NixOS host so the correct flake target is used. Removes the hardcoded `runner` path in `nix-build` and `nix-switch` CI branches, fixing the failing shellspec cases on `main`.

- **Bug Fixes**
  - For `nixosConfigurations`, resolve `HOST`, then `DETECTED_HOST`; otherwise fall back to `runner`.
  - Use `nixpkgs#nixos-rebuild` with `--flake .#<host>` and set `HOST`/`HOSTNAME` accordingly.
  - Keeps default CI behavior when no host is set; Darwin path unchanged.

<sup>Written for commit 1dd9258d1b69581529e6291f05a69c51f7ecf577. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

