### PR TITLE
feat(moshi-hook): add systemd service and install mosh

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -91,6 +91,7 @@ with pkgs;
   mariadb
   mise
   mkcert
+  mosh
   mtr
   navi
   ncdu

--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -20,6 +20,7 @@ let
   k3s = ./k3s;
   keydApplicationMapper = ./keyd-application-mapper;
   makeUpdater = import ./make-updater { inherit pkgs; };
+  moshiHook = ./moshi-hook;
   neversslKeepalive = import ./neverssl-keepalive { inherit pkgs; };
   nightShift = import ./night-shift { inherit pkgs; };
   obsidian = import ./obsidian { inherit config pkgs inputs; };
@@ -46,6 +47,7 @@ in
   k3s
   keydApplicationMapper
   makeUpdater
+  moshiHook
   neversslKeepalive
   nightShift
   obsidian

--- a/home-manager/services/moshi-hook/default.nix
+++ b/home-manager/services/moshi-hook/default.nix
@@ -1,0 +1,21 @@
+{ pkgs, ... }:
+let
+  inherit (pkgs) lib;
+in
+{
+  systemd.user.services.moshi-hook = lib.mkIf pkgs.stdenv.isLinux {
+    Unit = {
+      Description = "Moshi Hook daemon";
+      After = [ "network.target" ];
+    };
+    Service = {
+      Type = "simple";
+      ExecStart = "%h/.local/bin/moshi-hook serve";
+      Restart = "always";
+      RestartSec = 5;
+    };
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- Add `moshi-hook serve` as a systemd user service that starts on login with auto-restart
- Add `mosh` package to fix `moshi-hook host setup` failing due to missing `mosh-server`
- Register the new service module in `home-manager/services/default.nix`

## Test plan
- [ ] Rebuild NixOS/home-manager and verify `moshi-hook.service` is active
- [ ] Verify `which mosh-server` resolves after rebuild
- [ ] Verify `moshi-hook host setup` no longer reports missing mosh-server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `moshi-hook` as a systemd user service that starts on login and auto-restarts. Installs `mosh` so `moshi-hook host setup` works by providing `mosh-server`.

- **New Features**
  - Added systemd user service for `moshi-hook` that starts on login and auto-restarts; registered in `home-manager/services`.

- **Bug Fixes**
  - Installed `mosh` to resolve `moshi-hook host setup` failing due to missing `mosh-server`.

<sup>Written for commit 0ebb52444f1ed8d25a5d40969e87327a8ad1ac82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

