### PR TITLE
refactor(makefile): extract host detection into a script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,34 +90,14 @@ else ifdef CI
 NIX_FLAGS += --option substituters "$(NIX_SUBSTITUTERS)" --option trusted-public-keys "$(NIX_TRUSTED_KEYS)"
 endif
 
-# Machine detection for automatic host mapping
-DETECTED_HOST := $(shell \
-	if [ "$(OS)" = "Darwin" ] && [ "$(shell whoami)" = "shunkakinoki" ] && [ "$(ARCH)" = "arm64" ]; then \
-		computer_name=$$(scutil --get ComputerName 2>/dev/null || echo ""); \
-		if echo "$$computer_name" | grep -q "Shun's MacBook M4"; then \
-			echo "galactica"; \
-		else \
-			echo ""; \
-		fi; \
-	elif [ "$(OS)" = "Linux" ]; then \
-		if [ -n "$$RUNPOD_POD_ID" ]; then \
-			echo "pod"; \
-		else \
-			hostname=$$(hostname 2>/dev/null || echo ""); \
-			if [ "$$hostname" = "kyber" ]; then \
-				echo "kyber"; \
-			elif [ "$$hostname" = "matic" ]; then \
-				echo "matic"; \
-			elif [ "$(DMI_SYS_VENDOR)" = "Framework" ] \
-				&& echo "$(DMI_PRODUCT_NAME)" | grep -q "Laptop 13.*AMD Ryzen AI 300"; then \
-				echo "matic"; \
-			else \
-				echo ""; \
-			fi; \
-		fi; \
-	else \
-		echo ""; \
-	fi)
+# Machine detection for automatic host mapping. The logic lives in a script so
+# it can be exercised directly by spec/detect_host_spec.sh.
+DETECTED_HOST := $(shell OS='$(OS)' ARCH='$(ARCH)' \
+	DMI_SYS_VENDOR='$(DMI_SYS_VENDOR)' DMI_PRODUCT_NAME='$(DMI_PRODUCT_NAME)' \
+	bash ./scripts/detect-host.sh)
+
+# Effective host: an explicit HOST always wins over machine detection.
+RESOLVED_HOST := $(or $(HOST),$(DETECTED_HOST))
 
 # User's home directory
 HOME_DIR := $(shell echo $$HOME)
@@ -160,6 +140,11 @@ install: setup git-submodule-sync nix-build nix-switch shell-install ## Set up f
 
 .PHONY: build
 build: nix-build ## Build Nix configuration.
+
+.PHONY: detect-host
+detect-host: ## Show the host this machine maps to (and the host builds will use).
+	@echo "Detected host: $(if $(DETECTED_HOST),$(DETECTED_HOST),<none>)"
+	@echo "Resolved host: $(if $(RESOLVED_HOST),$(RESOLVED_HOST),<none>)$(if $(HOST), (from HOST=$(HOST)),)"
 
 .PHONY: check
 check: ## Run all validation checks (nix, format, lua).
@@ -526,40 +511,31 @@ nix-build: nix-connect nix-trust ## Build Nix configuration.
 	@if [ "$$CI" = "true" ] || [ "$$IN_DOCKER" = "true" ]; then \
 		echo "🤖 Running in CI/Docker environment"; \
 		if [ "$(OS)" = "Darwin" ]; then \
-			if [ -n "$(HOST)" ]; then \
+			if [ -n "$(RESOLVED_HOST)" ]; then \
 				case " $(NIXOS_NAMED_HOSTS) " in \
-					*" $(HOST) "*) \
-						echo "Building named NixOS host: $(HOST)"; \
-						HOST=$(HOST) HOSTNAME=$(HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#nixosConfigurations.$(HOST).config.system.build.toplevel $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
+					*" $(RESOLVED_HOST) "*) \
+						echo "Building named NixOS host: $(RESOLVED_HOST)"; \
+						HOST=$(RESOLVED_HOST) HOSTNAME=$(RESOLVED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#nixosConfigurations.$(RESOLVED_HOST).config.system.build.toplevel $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
 						;; \
 					*) \
-						echo "Building named Darwin host: $(HOST)"; \
-						HOST=$(HOST) HOSTNAME=$(HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#darwinConfigurations.$(HOST).system $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
+						echo "Building named Darwin host: $(RESOLVED_HOST)"; \
+						HOST=$(RESOLVED_HOST) HOSTNAME=$(RESOLVED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#darwinConfigurations.$(RESOLVED_HOST).system $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
 						;; \
 				esac; \
-			elif [ -n "$(DETECTED_HOST)" ]; then \
-				echo "Auto-detected host: $(DETECTED_HOST)"; \
-				HOST=$(DETECTED_HOST) HOSTNAME=$(DETECTED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#darwinConfigurations.$(DETECTED_HOST).system $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
 			else \
 				HOST=runner HOSTNAME=runner $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#$(NIX_CONFIG_TYPE).runner.system $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
 			fi; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "nixosConfigurations" ]; then \
-			if [ -n "$(HOST)" ]; then \
-				echo "Building named NixOS host: $(HOST)"; \
-				$(SUDO) env HOST=$(HOST) HOSTNAME=$(HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- build --flake .#$(HOST) --impure; \
-			elif [ -n "$(DETECTED_HOST)" ]; then \
-				echo "Auto-detected host: $(DETECTED_HOST)"; \
-				$(SUDO) env HOST=$(DETECTED_HOST) HOSTNAME=$(DETECTED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- build --flake .#$(DETECTED_HOST) --impure; \
+			if [ -n "$(RESOLVED_HOST)" ]; then \
+				echo "Building named NixOS host: $(RESOLVED_HOST)"; \
+				$(SUDO) env HOST=$(RESOLVED_HOST) HOSTNAME=$(RESOLVED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- build --flake .#$(RESOLVED_HOST) --impure; \
 			else \
 				HOST=runner HOSTNAME=runner $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#nixosConfigurations.runner.config.system.build.toplevel $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
 			fi; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "homeConfigurations" ]; then \
-			if [ -n "$(HOST)" ]; then \
-				echo "Building named home config: $(HOST)"; \
-				HOST=$(HOST) HOSTNAME=$(HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#homeConfigurations.$(HOST).activationPackage $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
-			elif [ -n "$(DETECTED_HOST)" ]; then \
-				echo "Auto-detected host: $(DETECTED_HOST)"; \
-				HOST=$(DETECTED_HOST) HOSTNAME=$(DETECTED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#homeConfigurations.$(DETECTED_HOST).activationPackage $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
+			if [ -n "$(RESOLVED_HOST)" ]; then \
+				echo "Building named home config: $(RESOLVED_HOST)"; \
+				HOST=$(RESOLVED_HOST) HOSTNAME=$(RESOLVED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#homeConfigurations.$(RESOLVED_HOST).activationPackage $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
 			else \
 				HOST=$(NIX_SYSTEM) HOSTNAME=$(NIX_SYSTEM) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#$(NIX_CONFIG_TYPE)."$(NIX_USERNAME)@$(NIX_SYSTEM)".activationPackage $(NIX_FLAGS) --impure --no-update-lock-file --show-trace; \
 			fi; \
@@ -572,40 +548,31 @@ nix-build: nix-connect nix-trust ## Build Nix configuration.
 			echo "❌ Unsupported system architecture: $(OS) $(ARCH)"; \
 			exit 1; \
 		elif [ "$(OS)" = "Darwin" ]; then \
-			if [ -n "$(HOST)" ]; then \
+			if [ -n "$(RESOLVED_HOST)" ]; then \
 				case " $(NIXOS_NAMED_HOSTS) " in \
-					*" $(HOST) "*) \
-						echo "Building named NixOS host: $(HOST)"; \
-						HOST=$(HOST) HOSTNAME=$(HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#nixosConfigurations.$(HOST).config.system.build.toplevel $(NIX_FLAGS) --impure --show-trace; \
+					*" $(RESOLVED_HOST) "*) \
+						echo "Building named NixOS host: $(RESOLVED_HOST)"; \
+						HOST=$(RESOLVED_HOST) HOSTNAME=$(RESOLVED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#nixosConfigurations.$(RESOLVED_HOST).config.system.build.toplevel $(NIX_FLAGS) --impure --show-trace; \
 						;; \
 					*) \
-						echo "Building named Darwin host: $(HOST)"; \
-						HOST=$(HOST) HOSTNAME=$(HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#darwinConfigurations.$(HOST).system $(NIX_FLAGS) --impure --show-trace; \
+						echo "Building named Darwin host: $(RESOLVED_HOST)"; \
+						HOST=$(RESOLVED_HOST) HOSTNAME=$(RESOLVED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#darwinConfigurations.$(RESOLVED_HOST).system $(NIX_FLAGS) --impure --show-trace; \
 						;; \
 				esac; \
-			elif [ -n "$(DETECTED_HOST)" ]; then \
-				echo "Auto-detected host: $(DETECTED_HOST)"; \
-				HOST=$(DETECTED_HOST) HOSTNAME=$(DETECTED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#darwinConfigurations.$(DETECTED_HOST).system $(NIX_FLAGS) --impure --show-trace; \
 			else \
 				HOST=$(NIX_SYSTEM) HOSTNAME=$(NIX_SYSTEM) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#$(NIX_CONFIG_TYPE).$(NIX_SYSTEM).system $(NIX_FLAGS) --impure --show-trace; \
 			fi; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "nixosConfigurations" ]; then \
-			if [ -n "$(HOST)" ]; then \
-				echo "Building named host: $(HOST)"; \
-				$(SUDO) env HOST=$(HOST) HOSTNAME=$(HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- build --flake .#$(HOST) --impure; \
-			elif [ -n "$(DETECTED_HOST)" ]; then \
-				echo "Auto-detected host: $(DETECTED_HOST)"; \
-				$(SUDO) env HOST=$(DETECTED_HOST) HOSTNAME=$(DETECTED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- build --flake .#$(DETECTED_HOST) --impure; \
+			if [ -n "$(RESOLVED_HOST)" ]; then \
+				echo "Building named host: $(RESOLVED_HOST)"; \
+				$(SUDO) env HOST=$(RESOLVED_HOST) HOSTNAME=$(RESOLVED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- build --flake .#$(RESOLVED_HOST) --impure; \
 			else \
 				$(SUDO) env HOST=$(NIX_SYSTEM) HOSTNAME=$(NIX_SYSTEM) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- build --flake .#$(NIX_SYSTEM) --impure; \
 			fi; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "homeConfigurations" ]; then \
-			if [ -n "$(HOST)" ]; then \
-				echo "Building named home config: $(HOST)"; \
-				HOST=$(HOST) HOSTNAME=$(HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#homeConfigurations.$(HOST).activationPackage $(NIX_FLAGS) --impure --show-trace; \
-			elif [ -n "$(DETECTED_HOST)" ]; then \
-				echo "Auto-detected host: $(DETECTED_HOST)"; \
-				HOST=$(DETECTED_HOST) HOSTNAME=$(DETECTED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#homeConfigurations.$(DETECTED_HOST).activationPackage $(NIX_FLAGS) --impure --show-trace; \
+			if [ -n "$(RESOLVED_HOST)" ]; then \
+				echo "Building named home config: $(RESOLVED_HOST)"; \
+				HOST=$(RESOLVED_HOST) HOSTNAME=$(RESOLVED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#homeConfigurations.$(RESOLVED_HOST).activationPackage $(NIX_FLAGS) --impure --show-trace; \
 			else \
 				HOST=$(NIX_SYSTEM) HOSTNAME=$(NIX_SYSTEM) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) build .#$(NIX_CONFIG_TYPE)."$(NIX_USERNAME)@$(NIX_SYSTEM)".activationPackage $(NIX_FLAGS) --impure --show-trace; \
 			fi; \
@@ -697,12 +664,9 @@ nix-switch: ## Activate Nix configuration.
 		if [ "$(OS)" = "Darwin" ]; then \
 			$(SUDO) env CI="$$CI" IN_DOCKER="$$IN_DOCKER" HOST=runner HOSTNAME=runner $(NIX_ALLOW_UNFREE) $(DARWIN_REBUILD) switch --flake .#runner --impure --no-update-lock-file; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "nixosConfigurations" ]; then \
-			if [ -n "$(HOST)" ]; then \
-				echo "Switching named host: $(HOST)"; \
-				$(SUDO) env HOST=$(HOST) HOSTNAME=$(HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure nixpkgs#nixos-rebuild -- switch --flake .#$(HOST) --no-update-lock-file || exit 0; \
-			elif [ -n "$(DETECTED_HOST)" ]; then \
-				echo "Auto-detected host: $(DETECTED_HOST)"; \
-				$(SUDO) env HOST=$(DETECTED_HOST) HOSTNAME=$(DETECTED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure nixpkgs#nixos-rebuild -- switch --flake .#$(DETECTED_HOST) --no-update-lock-file || exit 0; \
+			if [ -n "$(RESOLVED_HOST)" ]; then \
+				echo "Switching named host: $(RESOLVED_HOST)"; \
+				$(SUDO) env HOST=$(RESOLVED_HOST) HOSTNAME=$(RESOLVED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure nixpkgs#nixos-rebuild -- switch --flake .#$(RESOLVED_HOST) --no-update-lock-file || exit 0; \
 			else \
 				echo "⏭️ NixOS switch skipped in CI as the runner is not a NixOS system"; \
 				$(SUDO) env HOST=runner HOSTNAME=runner $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure nixpkgs#nixos-rebuild -- switch --flake .#runner --no-update-lock-file || exit 0; \
@@ -710,12 +674,9 @@ nix-switch: ## Activate Nix configuration.
 		elif [ "$(NIX_CONFIG_TYPE)" = "homeConfigurations" ]; then \
 			if [ "$$SKIP_HOME_MANAGER_SWITCH" = "true" ]; then \
 				echo "⏭️ Home-manager switch skipped (SKIP_HOME_MANAGER_SWITCH=true)"; \
-			elif [ -n "$(HOST)" ]; then \
-				echo "Switching named home config: $(HOST)"; \
-				HOST=$(HOST) HOSTNAME=$(HOST) USER=$(NIX_USERNAME) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure .#homeConfigurations.$(HOST).activationPackage; \
-			elif [ -n "$(DETECTED_HOST)" ]; then \
-				echo "Auto-detected host: $(DETECTED_HOST)"; \
-				HOST=$(DETECTED_HOST) HOSTNAME=$(DETECTED_HOST) USER=$(NIX_USERNAME) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure .#homeConfigurations.$(DETECTED_HOST).activationPackage; \
+			elif [ -n "$(RESOLVED_HOST)" ]; then \
+				echo "Switching named home config: $(RESOLVED_HOST)"; \
+				HOST=$(RESOLVED_HOST) HOSTNAME=$(RESOLVED_HOST) USER=$(NIX_USERNAME) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure .#homeConfigurations.$(RESOLVED_HOST).activationPackage; \
 			else \
 				HOST=$(NIX_SYSTEM) HOSTNAME=$(NIX_SYSTEM) USER=$(NIX_USERNAME) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure .#$(NIX_CONFIG_TYPE)."$(NIX_USERNAME)@$(NIX_SYSTEM)".activationPackage; \
 			fi; \
@@ -728,32 +689,23 @@ nix-switch: ## Activate Nix configuration.
 			echo "❌ Unsupported system architecture: $(OS) $(ARCH)"; \
 			exit 1; \
 		elif [ "$(OS)" = "Darwin" ]; then \
-			if [ -n "$(HOST)" ]; then \
-				echo "Switching named host: $(HOST)"; \
-				$(SUDO) env HOST=$(HOST) HOSTNAME=$(HOST) $(NIX_ALLOW_UNFREE) $(DARWIN_REBUILD) switch --flake .#$(HOST) --impure; \
-			elif [ -n "$(DETECTED_HOST)" ]; then \
-				echo "Auto-detected host: $(DETECTED_HOST)"; \
-				$(SUDO) env HOST=$(DETECTED_HOST) HOSTNAME=$(DETECTED_HOST) $(NIX_ALLOW_UNFREE) $(DARWIN_REBUILD) switch --flake .#$(DETECTED_HOST) --impure; \
+			if [ -n "$(RESOLVED_HOST)" ]; then \
+				echo "Switching named host: $(RESOLVED_HOST)"; \
+				$(SUDO) env HOST=$(RESOLVED_HOST) HOSTNAME=$(RESOLVED_HOST) $(NIX_ALLOW_UNFREE) $(DARWIN_REBUILD) switch --flake .#$(RESOLVED_HOST) --impure; \
 			else \
 				$(SUDO) env HOST=$(NIX_SYSTEM) HOSTNAME=$(NIX_SYSTEM) $(NIX_ALLOW_UNFREE) $(DARWIN_REBUILD) switch --flake .#$(NIX_SYSTEM) --impure; \
 			fi; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "nixosConfigurations" ]; then \
-			if [ -n "$(HOST)" ]; then \
-				echo "Switching named host: $(HOST)"; \
-				$(SUDO) env HOST=$(HOST) HOSTNAME=$(HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- switch --flake .#$(HOST) --impure; \
-			elif [ -n "$(DETECTED_HOST)" ]; then \
-				echo "Auto-detected host: $(DETECTED_HOST)"; \
-				$(SUDO) env HOST=$(DETECTED_HOST) HOSTNAME=$(DETECTED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- switch --flake .#$(DETECTED_HOST) --impure; \
+			if [ -n "$(RESOLVED_HOST)" ]; then \
+				echo "Switching named host: $(RESOLVED_HOST)"; \
+				$(SUDO) env HOST=$(RESOLVED_HOST) HOSTNAME=$(RESOLVED_HOST) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- switch --flake .#$(RESOLVED_HOST) --impure; \
 			else \
 				$(SUDO) env HOST=$(NIX_SYSTEM) HOSTNAME=$(NIX_SYSTEM) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) nixpkgs#nixos-rebuild -- switch --flake .#$(NIX_SYSTEM) --impure; \
 			fi; \
 		elif [ "$(NIX_CONFIG_TYPE)" = "homeConfigurations" ]; then \
-			if [ -n "$(HOST)" ]; then \
-				echo "Switching named home config: $(HOST)"; \
-				HOST=$(HOST) HOSTNAME=$(HOST) USER=$(NIX_USERNAME) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure .#homeConfigurations.$(HOST).activationPackage; \
-			elif [ -n "$(DETECTED_HOST)" ]; then \
-				echo "Auto-detected host: $(DETECTED_HOST)"; \
-				HOST=$(DETECTED_HOST) HOSTNAME=$(DETECTED_HOST) USER=$(NIX_USERNAME) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure .#homeConfigurations.$(DETECTED_HOST).activationPackage; \
+			if [ -n "$(RESOLVED_HOST)" ]; then \
+				echo "Switching named home config: $(RESOLVED_HOST)"; \
+				HOST=$(RESOLVED_HOST) HOSTNAME=$(RESOLVED_HOST) USER=$(NIX_USERNAME) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure .#homeConfigurations.$(RESOLVED_HOST).activationPackage; \
 			else \
 				HOST=$(NIX_SYSTEM) HOSTNAME=$(NIX_SYSTEM) USER=$(NIX_USERNAME) $(NIX_ALLOW_UNFREE) $(NIX_EXEC) run $(NIX_FLAGS) --impure .#$(NIX_CONFIG_TYPE)."$(NIX_USERNAME)@$(NIX_SYSTEM)".activationPackage; \
 			fi; \

--- a/scripts/detect-host.sh
+++ b/scripts/detect-host.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Resolve the named host configuration for the current machine.
+#
+# Prints the host name on stdout, or nothing when the machine does not map to
+# a named host. Reads its inputs from the environment so callers (and specs)
+# can drive detection without touching the real machine:
+#
+#   OS, ARCH                          uname-derived platform
+#   DMI_SYS_VENDOR, DMI_PRODUCT_NAME  /sys/class/dmi/id values on Linux
+#   RUNPOD_POD_ID                     set inside RunPod containers
+
+set -euo pipefail
+
+OS="${OS:-}"
+ARCH="${ARCH:-}"
+DMI_SYS_VENDOR="${DMI_SYS_VENDOR:-}"
+DMI_PRODUCT_NAME="${DMI_PRODUCT_NAME:-}"
+RUNPOD_POD_ID="${RUNPOD_POD_ID:-}"
+
+detect_darwin_host() {
+  if [ "$(whoami 2>/dev/null || true)" != "shunkakinoki" ] || [ "$ARCH" != "arm64" ]; then
+    return 0
+  fi
+
+  local computer_name
+  computer_name="$(scutil --get ComputerName 2>/dev/null || true)"
+  if echo "$computer_name" | grep -q "Shun's MacBook M4"; then
+    echo "galactica"
+  fi
+  return 0
+}
+
+detect_linux_host() {
+  if [ -n "$RUNPOD_POD_ID" ]; then
+    echo "pod"
+    return 0
+  fi
+
+  local hostname
+  hostname="$(hostname 2>/dev/null || true)"
+  case "$hostname" in
+  kyber | matic)
+    echo "$hostname"
+    return 0
+    ;;
+  esac
+
+  # Framework 13 (AMD Ryzen AI 300) ships with a generic hostname, so fall back
+  # to the DMI identity burned into the board.
+  if [ "$DMI_SYS_VENDOR" = "Framework" ] &&
+    echo "$DMI_PRODUCT_NAME" | grep -q "Laptop 13.*AMD Ryzen AI 300"; then
+    echo "matic"
+  fi
+  return 0
+}
+
+case "$OS" in
+Darwin) detect_darwin_host ;;
+Linux) detect_linux_host ;;
+esac

--- a/spec/detect_host_spec.sh
+++ b/spec/detect_host_spec.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'scripts/detect-host.sh'
+SCRIPT="$PWD/scripts/detect-host.sh"
+
+Describe 'script properties'
+It 'uses bash shebang'
+When run bash -c "head -1 '$SCRIPT'"
+The output should include '#!/usr/bin/env bash'
+End
+
+It 'uses strict mode'
+When run bash -c "grep 'set -euo pipefail' '$SCRIPT'"
+The output should include 'set -euo pipefail'
+End
+End
+
+Describe 'Linux detection'
+It 'maps a Framework 13 AMD Ryzen AI 300 board to matic'
+When run env OS=Linux ARCH=x86_64 DMI_SYS_VENDOR=Framework \
+  DMI_PRODUCT_NAME='Laptop 13 (AMD Ryzen AI 300 Series)' \
+  RUNPOD_POD_ID= bash "$SCRIPT"
+The status should be success
+The output should equal 'matic'
+End
+
+It 'prefers a RunPod pod over DMI data'
+When run env OS=Linux ARCH=x86_64 DMI_SYS_VENDOR=Framework \
+  DMI_PRODUCT_NAME='Laptop 13 (AMD Ryzen AI 300 Series)' \
+  RUNPOD_POD_ID=abc123 bash "$SCRIPT"
+The status should be success
+The output should equal 'pod'
+End
+
+It 'ignores a Framework board that is not the AMD Ryzen AI 300 model'
+When run env OS=Linux ARCH=x86_64 DMI_SYS_VENDOR=Framework \
+  DMI_PRODUCT_NAME='Laptop 13 (12th Gen Intel Core)' \
+  RUNPOD_POD_ID= bash "$SCRIPT"
+The status should be success
+The output should equal ''
+End
+
+It 'ignores matching product data from another vendor'
+When run env OS=Linux ARCH=x86_64 DMI_SYS_VENDOR=Acme \
+  DMI_PRODUCT_NAME='Laptop 13 (AMD Ryzen AI 300 Series)' \
+  RUNPOD_POD_ID= bash "$SCRIPT"
+The status should be success
+The output should equal ''
+End
+
+It 'reports no host when there is no DMI data'
+When run env OS=Linux ARCH=x86_64 DMI_SYS_VENDOR= DMI_PRODUCT_NAME= \
+  RUNPOD_POD_ID= bash "$SCRIPT"
+The status should be success
+The output should equal ''
+End
+End
+
+Describe 'Darwin detection'
+It 'reports no host on a non-arm64 Mac'
+When run env OS=Darwin ARCH=x86_64 bash "$SCRIPT"
+The status should be success
+The output should equal ''
+End
+End
+
+Describe 'unknown platforms'
+It 'reports no host'
+When run env OS=Plan9 ARCH=x86_64 bash "$SCRIPT"
+The status should be success
+The output should equal ''
+End
+
+It 'reports no host when OS is unset'
+When run env -u OS ARCH=x86_64 bash "$SCRIPT"
+The status should be success
+The output should equal ''
+End
+End
+End


### PR DESCRIPTION
Follow-up to #2105.

## Detection moves to a script

Machine detection was a 27-line `$(shell ...)` blob inline in the Makefile. It was testable only indirectly, by driving `make build` with a mocked `nix` and grepping the resulting command log.

It now lives in `scripts/detect-host.sh`, matching the existing `scripts/*.sh` + `spec/*_spec.sh` convention. It reads `OS`, `ARCH`, `DMI_SYS_VENDOR`, `DMI_PRODUCT_NAME` and `RUNPOD_POD_ID` from the environment, so `spec/detect_host_spec.sh` can exercise detection directly instead of through a build. That spec covers the Framework 13 DMI match, the RunPod override, a non-matching Framework model, matching product data from another vendor, and the various no-host cases.

`make detect-host` prints what the current machine maps to:

```
$ make detect-host
Detected host: galactica
Resolved host: galactica

$ make detect-host HOST=viper
Detected host: galactica
Resolved host: viper (from HOST=viper)
```

Note on shape: detection can't be a make *target* that the Makefile itself invokes — `DETECTED_HOST := $(shell $(MAKE) ...)` would re-enter the Makefile during parsing and recurse. So the script is what does the work, and `detect-host` is a thin target over it.

## Resolution collapses onto one variable

The `HOST` -> `DETECTED_HOST` -> fallback chain was repeated 11 times across `nix-build` and `nix-switch`, once per (CI x non-CI) x (Darwin, nixos, home). That duplication is exactly what caused #2105: #2100 updated the non-CI copies and missed the CI ones.

All 11 now read a single `RESOLVED_HOST := $(or $(HOST),$(DETECTED_HOST))`, which halves the branch count and makes it structurally impossible to update one arm without the other. This is in the same commit because it rewrites the same block.

One behavior note: the Darwin branches previously ran the `NIXOS_NAMED_HOSTS` check only for an explicit `HOST`, and always built `darwinConfigurations` for a detected host. Now both go through the case. This is equivalent, because the Darwin detection path only ever yields `galactica`, which is not in `NIXOS_NAMED_HOSTS` and so falls to the same default branch.

## Deliberately not changed

The guard-style checks (`[ "$(DETECTED_HOST)" = x ] || [ "$(HOST)" = x ]`) and the `build-vm` / `run-vm` / `build-iso` targets still use `DETECTED_HOST` directly. Switching those to `RESOLVED_HOST` would change their semantics — e.g. `make ... HOST=viper` on the galactica machine currently satisfies a `galactica` guard, and would stop doing so. That is arguably more correct, but it is a real behavior change and doesn't belong in a refactor.

## Verification

- `shellspec` full suite: 1645 examples, 0 failures
- `CI=true shellspec` full suite: 1645 examples, 0 failures
- `make shell-check` (repo shellcheck): clean
- `make detect-host` on this machine still resolves `galactica`, matching pre-refactor behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted host detection from the Makefile into `scripts/detect-host.sh` and unified host selection via `RESOLVED_HOST`. This removes duplicated logic in `nix-build`/`nix-switch`, makes detection testable, and keeps behavior the same.

- **Refactors**
  - Replaced the Makefile `$(shell ...)` blob with `scripts/detect-host.sh` reading `OS`, `ARCH`, `DMI_SYS_VENDOR`, `DMI_PRODUCT_NAME`, `RUNPOD_POD_ID`.
  - Collapsed `HOST`/`DETECTED_HOST` into `RESOLVED_HOST := $(or $(HOST),$(DETECTED_HOST))` used across CI and non-CI paths.
  - Darwin paths now use `RESOLVED_HOST`; behavior unchanged since detection only yields `galactica` (not in `NIXOS_NAMED_HOSTS`).
  - Kept guard checks and `build-vm`/`run-vm`/`build-iso` on `DETECTED_HOST` to avoid behavior changes.

- **New Features**
  - Added `make detect-host` to print detected and resolved host.
  - Added `spec/detect_host_spec.sh` covering Framework 13, RunPod override, `kyber`/`matic`, and no-host cases.

<sup>Written for commit 65043cc3158317265564d77729b609c49a354e00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

