### PR TITLE
feat(matic): enable tailscale with kyber settings

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -77,6 +77,18 @@ import ../../hosts/nixos {
           logRefusedConnections = true;
         };
 
+        # Tailscale - same settings as kyber (exit node, DNS left to NetworkManager).
+        # extraSetFlags is used instead of extraUpFlags because the latter only
+        # applies when authKeyFile is set; `tailscale set` is applied on every boot.
+        services.tailscale = {
+          enable = true;
+          useRoutingFeatures = "both";
+          extraSetFlags = [
+            "--accept-dns=false"
+            "--advertise-exit-node"
+          ];
+        };
+
         # Audit logging
         security.auditd.enable = true;
         security.audit = {

--- a/spec/matic_tailscale_spec.sh
+++ b/spec/matic_tailscale_spec.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'named-hosts/matic/default.nix tailscale'
+CONFIG="$PWD/named-hosts/matic/default.nix"
+
+It 'enables the tailscale service'
+When run bash -c "grep -A1 -F 'services.tailscale = {' '$CONFIG'"
+The output should include 'enable = true'
+End
+
+It 'enables routing features for exit node use'
+When run bash -c "grep -F 'useRoutingFeatures = \"both\";' '$CONFIG'"
+The output should include 'useRoutingFeatures = "both"'
+End
+
+It 'advertises the host as an exit node'
+When run bash -c "grep -F '\"--advertise-exit-node\"' '$CONFIG'"
+The output should include '--advertise-exit-node'
+End
+
+It 'leaves DNS to NetworkManager'
+When run bash -c "grep -F '\"--accept-dns=false\"' '$CONFIG'"
+The output should include '--accept-dns=false'
+End
+
+It 'trusts the tailscale interface in the firewall'
+When run bash -c "grep -F 'trustedInterfaces = [ \"tailscale0\" ];' '$CONFIG'"
+The output should include 'tailscale0'
+End
+
+End


### PR DESCRIPTION
## Summary

Enables Tailscale on `matic` with the same effective settings as `kyber`: advertised as an exit node, with DNS left to NetworkManager.

Uses the NixOS-native `services.tailscale` rather than the `modules.tailscale` home-manager module — the latter exists only because kyber is an Ubuntu host where home-manager has to hand-install a `tailscaled.service` via sudo. On NixOS that indirection is unnecessary and would conflict with the system module.

Mapping of kyber's `extraUpArgs` to matic:

| kyber | matic |
| --- | --- |
| `--advertise-exit-node` | `extraSetFlags` + `useRoutingFeatures = "both"` (enables IP forwarding, replacing kyber's `activate-ip-forwarding.sh`) |
| `--accept-dns=false` | `extraSetFlags` |
| `--reset` | dropped - not a valid `tailscale set` flag, and it only exists on kyber to clear stale `tailscale up` state |

`extraSetFlags` is used instead of `extraUpFlags` because the NixOS module only applies `extraUpFlags` when `authKeyFile` is set. `extraSetFlags` runs via a `tailscaled-set` unit on every boot, so the flags apply without an auth key.

`networking.firewall.trustedInterfaces` already listed `tailscale0`, so no firewall change was needed.

## Test plan

- `shellspec spec/matic_tailscale_spec.sh` - 5 examples, 0 failures
- Evaluated the matic NixOS config; `systemd.services.tailscaled-set.script` resolves to `tailscale set '--accept-dns=false' --advertise-exit-node`
- Not yet applied on the machine - `tailscale up` still needs a one-time interactive login, and the exit node must be approved in the admin console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Tailscale on `matic` using NixOS `services.tailscale`, matching `kyber` settings. The host advertises as an exit node and leaves DNS to NetworkManager.

- **New Features**
  - Enable `services.tailscale` with `useRoutingFeatures = "both"` to support exit-node routing.
  - Apply `extraSetFlags` (`--accept-dns=false`, `--advertise-exit-node`) via `tailscale set` on boot.
  - Add shellspec tests for service enablement, routing flags, and firewall trust (`tailscale0` already trusted).

- **Migration**
  - Run `tailscale up` once to log in.
  - Approve the exit node in the admin console.

<sup>Written for commit d81a4a2b700a8495cd1d361263068a92d9b789a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

