### PR TITLE
fix(matic): enable Tailscale DNS acceptance

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -77,14 +77,13 @@ import ../../hosts/nixos {
           logRefusedConnections = true;
         };
 
-        # Tailscale - same settings as kyber (exit node, DNS left to NetworkManager).
         # extraSetFlags is used instead of extraUpFlags because the latter only
         # applies when authKeyFile is set; `tailscale set` is applied on every boot.
         services.tailscale = {
           enable = true;
           useRoutingFeatures = "both";
           extraSetFlags = [
-            "--accept-dns=false"
+            "--accept-dns=true"
             "--advertise-exit-node"
           ];
         };


### PR DESCRIPTION
## Summary
- Changed `--accept-dns=false` to `--accept-dns=true` in matic's Tailscale config

## Test plan
- [x] Verify Tailscale is running on matic with `tailscale status`
- [ ] Confirm DNS resolution works via Tailscale after `nixos-rebuild switch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141JniPQ6xwFnTivRm37TED

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable DNS acceptance in `tailscale` on matic by switching `--accept-dns=false` to `--accept-dns=true` in `services.tailscale.extraSetFlags`. Ensures tailnet DNS resolves correctly after `nixos-rebuild switch` and on boot.

<sup>Written for commit 80956c3ad6425024b39634072d78f1a1778591bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

