### PR TITLE
fix(matic): update SSH public key for new machine

### DIFF
--- a/named-hosts/pubkeys.nix
+++ b/named-hosts/pubkeys.nix
@@ -4,5 +4,5 @@
 {
   galactica = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEKze2jlpV7SyTKA2ezqbumpCiDn+5Sj4z5SxrqfzesX shunkakinoki@gmail.com";
   kyber = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO0IZtP3KSzY6GVSZ+R+VQYYfu3sEOVaQGDblQxAtwNM ubuntu@kyber";
-  matic = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEeknNbHasmT+43PgO9oy0mutoe+V2R2ZNRa5SPOLmLN skakinoki@matic";
+  matic = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOsMGpqklcznrSAH/TiGvcJoHEF4hyf5yiRz9MDjVVUj skakinoki@matic";
 }


### PR DESCRIPTION
## Summary
- Updated matic's SSH public key in `pubkeys.nix` after generating a new key on the new machine
- Next step: re-encrypt `.age` secrets from galactica with `agenix -r`

## Test plan
- [ ] Re-encrypt secrets from galactica
- [ ] Run `make switch` on matic to verify GPG key import

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141JniPQ6xwFnTivRm37TED

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the SSH public key for `matic` in `named-hosts/pubkeys.nix` to match the new machine. This ensures provisioning and `agenix` secrets target the correct host.

- **Migration**
  - Re-encrypt `.age` secrets from `galactica` with `agenix -r` to include the new `matic` key.
  - Run `make switch` on `matic` to apply the config and verify key import.

<sup>Written for commit 8cab96e7b39b8dc709f263b8098a3a676b1cfebc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

