### PR TITLE
feat(tailscale): enable Tailscale SSH on matic and kyber

### DIFF
--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -140,6 +140,7 @@ home-manager.lib.homeManagerConfiguration {
             "--reset"
             "--accept-dns=false"
             "--advertise-exit-node"
+            "--ssh"
           ];
         };
       }

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -85,6 +85,7 @@ import ../../hosts/nixos {
           extraSetFlags = [
             "--accept-dns=true"
             "--advertise-exit-node"
+            "--ssh"
           ];
         };
 


### PR DESCRIPTION
## Summary
- Added `--ssh` flag to Tailscale config on both matic and kyber
- Enables SSH access over Tailscale network

## Test plan
- [ ] Run `sudo tailscale set --ssh` on matic
- [ ] Run `tailscale ssh` to verify from another Tailscale node

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141JniPQ6xwFnTivRm37TED

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Tailscale SSH on matic and kyber by adding the `--ssh` flag to the `tailscale` service config. This allows SSH access over the Tailscale network to both hosts.

- **Migration**
  - Deploy the NixOS changes on matic and kyber.
  - From another Tailscale node, verify: `tailscale ssh <user>@matic` and `tailscale ssh <user>@kyber`.

<sup>Written for commit 68da0abe23f83c6bb92e945b7d1c9f345420cc30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

