### PR TITLE
feat(herdr): add herdrm function for remote matic connection

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -152,6 +152,7 @@
       grxe = "_grxe_function";
       grxeh = "_grxeh_function";
       herdrd = "_herdrd_function";
+      herdrm = "_herdrm_function";
       hme = "_hm_load_env_file";
       icg = "_install_cargo_globals_function";
       ing = "_install_npm_globals_function";
@@ -280,6 +281,7 @@
         "_grxe_function"
         "_grxeh_function"
         "_herdrd_function"
+        "_herdrm_function"
         "_hm_load_env_file"
         "_llm_update_function"
         "_kyber_function"

--- a/home-manager/programs/fish/functions/_herdrm_function.fish
+++ b/home-manager/programs/fish/functions/_herdrm_function.fish
@@ -1,0 +1,3 @@
+function _herdrm_function --description "Attach to herdr running on remote Matic over SSH"
+  herdr --remote matic $argv
+end

--- a/spec/fish/_herdrm_function_test.fish
+++ b/spec/fish/_herdrm_function_test.fish
@@ -1,0 +1,12 @@
+set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_herdrm_function.fish
+
+set call_log (mktemp)
+
+function herdr; echo $argv >> $call_log; end
+
+_herdrm_function
+
+@test "passes --remote matic" (grep -c -- "--remote matic" $call_log) -ge 1
+
+rm -f $call_log


### PR DESCRIPTION
## Summary
- Add `herdrm` fish alias that runs `herdr --remote matic` (mirrors existing `herdrd` for kyber)
- Register the function in fish shell config
- Add test for the new function

## Test plan
- [ ] Verify `herdrm` connects to herdr on matic via SSH

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Fish function `herdrm` that runs `herdr --remote matic` to connect to the remote Matic host. Registered in Home Manager and covered by a simple test.

<sup>Written for commit ec8cb6dd6aa62908aee40fe44123834140648329. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

