### PR TITLE
feat(packages): add Claude Desktop to Linux desktop packages

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -187,6 +187,7 @@ with pkgs;
   celluloid
   cheese
   chromium
+  pkgs.llm-agents.claude-desktop
   clickup
   cliphist
   code-cursor


### PR DESCRIPTION
## Summary
- Add `pkgs.llm-agents.claude-desktop` to the `isLinux && isDesktop` package list
- Available via the existing `llm-agents.nix` flake input (v1.22209.0)

## Test plan
- [ ] Rebuild NixOS on matic and verify Claude Desktop launches

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `pkgs.llm-agents.claude-desktop` to the Linux desktop package set so Claude Desktop is installed on Linux builds. Uses the existing `llm-agents.nix` flake input (v1.22209.0).

<sup>Written for commit 98d3b7a765a20bd1f51ddeaffd7e0d2ccb2ff534. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

