### PR TITLE
fix(k3s): clean stale containerd runtime state

### DIFF
--- a/config/k3s/containerd-cleanup.service
+++ b/config/k3s/containerd-cleanup.service
@@ -2,7 +2,7 @@
 Description=Clean stale k3s containerd state
 Documentation=https://k3s.io
 After=k3s.service
-Requires=k3s.service
+Requisite=k3s.service
 
 [Service]
 Type=oneshot

--- a/config/k3s/containerd-cleanup.service
+++ b/config/k3s/containerd-cleanup.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Clean stale k3s containerd state
+Documentation=https://k3s.io
+After=k3s.service
+Requires=k3s.service
+
+[Service]
+Type=oneshot
+ExecStart=@cleanupScript@
+TimeoutStartSec=10min
+Nice=10
+IOSchedulingClass=idle

--- a/config/k3s/containerd-cleanup.sh
+++ b/config/k3s/containerd-cleanup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+crictl_bin=/var/lib/rancher/k3s/data/current/bin/crictl
+runtime_endpoint=unix:///run/k3s/containerd/containerd.sock
+
+if [ ! -x "$crictl_bin" ]; then
+  echo "k3s crictl binary is unavailable: $crictl_bin" >&2
+  exit 1
+fi
+
+echo "cleaning exited containerd containers"
+while IFS= read -r container_id; do
+  if [ -z "$container_id" ]; then
+    continue
+  fi
+  echo "removing exited container: $container_id"
+  timeout 10 "$crictl_bin" --runtime-endpoint "$runtime_endpoint" rm -f "$container_id" || true
+done < <(
+  "$crictl_bin" --runtime-endpoint "$runtime_endpoint" ps -a --state Exited -q
+)
+
+echo "cleaning not-ready containerd sandboxes"
+while IFS= read -r sandbox_id; do
+  if [ -z "$sandbox_id" ]; then
+    continue
+  fi
+  echo "removing not-ready sandbox: $sandbox_id"
+  timeout 10 "$crictl_bin" --runtime-endpoint "$runtime_endpoint" rmp -f "$sandbox_id" || true
+done < <(
+  "$crictl_bin" --runtime-endpoint "$runtime_endpoint" pods --state NotReady -q
+)
+
+echo "containerd cleanup complete"

--- a/config/k3s/containerd-cleanup.sh
+++ b/config/k3s/containerd-cleanup.sh
@@ -10,25 +10,23 @@ if [ ! -x "$crictl_bin" ]; then
 fi
 
 echo "cleaning exited containerd containers"
+exited_containers=$(timeout 10 "$crictl_bin" --runtime-endpoint "$runtime_endpoint" ps -a --state Exited -q)
 while IFS= read -r container_id; do
   if [ -z "$container_id" ]; then
     continue
   fi
   echo "removing exited container: $container_id"
   timeout 10 "$crictl_bin" --runtime-endpoint "$runtime_endpoint" rm -f "$container_id" || true
-done < <(
-  "$crictl_bin" --runtime-endpoint "$runtime_endpoint" ps -a --state Exited -q
-)
+done <<<"$exited_containers"
 
 echo "cleaning not-ready containerd sandboxes"
+not_ready_sandboxes=$(timeout 10 "$crictl_bin" --runtime-endpoint "$runtime_endpoint" pods --state NotReady -q)
 while IFS= read -r sandbox_id; do
   if [ -z "$sandbox_id" ]; then
     continue
   fi
   echo "removing not-ready sandbox: $sandbox_id"
   timeout 10 "$crictl_bin" --runtime-endpoint "$runtime_endpoint" rmp -f "$sandbox_id" || true
-done < <(
-  "$crictl_bin" --runtime-endpoint "$runtime_endpoint" pods --state NotReady -q
-)
+done <<<"$not_ready_sandboxes"
 
 echo "containerd cleanup complete"

--- a/config/k3s/containerd-cleanup.timer
+++ b/config/k3s/containerd-cleanup.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Periodically clean stale k3s containerd state
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=10min
+RandomizedDelaySec=30s
+Persistent=true
+Unit=k3s-containerd-cleanup.service
+
+[Install]
+WantedBy=timers.target

--- a/config/k3s/default.nix
+++ b/config/k3s/default.nix
@@ -8,6 +8,11 @@
 let
   inherit (inputs.host) isKyber isGalactica;
   kubeconfig = "${config.home.homeDirectory}/.kube/config-kyber";
+  containerdCleanup = pkgs.writeShellApplication {
+    name = "k3s-containerd-cleanup";
+    runtimeInputs = [ pkgs.coreutils ];
+    text = builtins.readFile ./containerd-cleanup.sh;
+  };
   # Authorize galactica on kyber so the client activation can scp the
   # kubeconfig over Tailscale.
   galacticaAuthorizedKey = (import ../../named-hosts/pubkeys.nix).galactica;
@@ -25,6 +30,18 @@ in
     source = pkgs.replaceVars ./k3s.service {
       inherit (pkgs) coreutils k3s;
     };
+    force = true;
+  };
+
+  home.file.".config/k3s/k3s-containerd-cleanup.service" = lib.mkIf isKyber {
+    source = pkgs.replaceVars ./containerd-cleanup.service {
+      cleanupScript = "${containerdCleanup}/bin/k3s-containerd-cleanup";
+    };
+    force = true;
+  };
+
+  home.file.".config/k3s/k3s-containerd-cleanup.timer" = lib.mkIf isKyber {
+    source = ./containerd-cleanup.timer;
     force = true;
   };
 

--- a/home-manager/services/k3s/activate.sh
+++ b/home-manager/services/k3s/activate.sh
@@ -45,7 +45,12 @@ install_system_unit() {
   local source_file="$1"
   local destination_file="$2"
 
-  if [ ! -f "$source_file" ] || @diff@ -q "$source_file" "$destination_file" >/dev/null 2>&1; then
+  if [ ! -f "$source_file" ]; then
+    echo "Warning: generated systemd unit is unavailable: $source_file" >&2
+    return 1
+  fi
+
+  if @diff@ -q "$source_file" "$destination_file" >/dev/null 2>&1; then
     return 1
   fi
   require_sudo || return 1
@@ -70,8 +75,9 @@ if [ "$units_changed" = true ]; then
   run_sudo @systemctl@ daemon-reload
 fi
 if [ -f "$CLEANUP_SYSTEM_TIMER" ] || [ -f "$CLEANUP_TIMER_FILE" ]; then
-  require_sudo || exit 0
-  run_sudo @systemctl@ enable --now k3s-containerd-cleanup.timer
+  if require_sudo; then
+    run_sudo @systemctl@ enable --now k3s-containerd-cleanup.timer
+  fi
 fi
 
 if [ -f "$K3S_KUBECONFIG" ]; then

--- a/home-manager/services/k3s/activate.sh
+++ b/home-manager/services/k3s/activate.sh
@@ -5,7 +5,11 @@ set -euo pipefail
 
 SERVICE_FILE="$1"
 KUBE_DIR="$2"
+CLEANUP_SERVICE_FILE="$3"
+CLEANUP_TIMER_FILE="$4"
 SYSTEM_SERVICE="/etc/systemd/system/k3s.service"
+CLEANUP_SYSTEM_SERVICE="/etc/systemd/system/k3s-containerd-cleanup.service"
+CLEANUP_SYSTEM_TIMER="/etc/systemd/system/k3s-containerd-cleanup.timer"
 K3S_KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
 
 sudo_cmd=()
@@ -37,11 +41,37 @@ require_sudo() {
   fi
 }
 
+install_system_unit() {
+  local source_file="$1"
+  local destination_file="$2"
+
+  if [ ! -f "$source_file" ] || @diff@ -q "$source_file" "$destination_file" >/dev/null 2>&1; then
+    return 1
+  fi
+  require_sudo || return 1
+  run_sudo cp "$source_file" "$destination_file"
+}
+
 if [ -f "$SERVICE_FILE" ] && ! @diff@ -q "$SERVICE_FILE" "$SYSTEM_SERVICE" >/dev/null 2>&1; then
   require_sudo || exit 0
   run_sudo cp "$SERVICE_FILE" "$SYSTEM_SERVICE"
   run_sudo @systemctl@ daemon-reload
   run_sudo @systemctl@ enable --now k3s
+fi
+
+units_changed=false
+if install_system_unit "$CLEANUP_SERVICE_FILE" "$CLEANUP_SYSTEM_SERVICE"; then
+  units_changed=true
+fi
+if install_system_unit "$CLEANUP_TIMER_FILE" "$CLEANUP_SYSTEM_TIMER"; then
+  units_changed=true
+fi
+if [ "$units_changed" = true ]; then
+  run_sudo @systemctl@ daemon-reload
+fi
+if [ -f "$CLEANUP_SYSTEM_TIMER" ] || [ -f "$CLEANUP_TIMER_FILE" ]; then
+  require_sudo || exit 0
+  run_sudo @systemctl@ enable --now k3s-containerd-cleanup.timer
 fi
 
 if [ -f "$K3S_KUBECONFIG" ]; then

--- a/home-manager/services/k3s/default.nix
+++ b/home-manager/services/k3s/default.nix
@@ -13,11 +13,15 @@ let
     systemctl = "${pkgs.systemd}/bin/systemctl";
   };
   serviceFile = "${homeDir}/.config/k3s/k3s.service";
+  cleanupServiceFile = "${homeDir}/.config/k3s/k3s-containerd-cleanup.service";
+  cleanupTimerFile = "${homeDir}/.config/k3s/k3s-containerd-cleanup.timer";
 in
 lib.mkIf (pkgs.stdenv.isLinux && host.isKyber) {
   home.activation.setupK3s = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     ${pkgs.bash}/bin/bash "${setupScript}" \
       "${serviceFile}" \
-      "${homeDir}/.kube"
+      "${homeDir}/.kube" \
+      "${cleanupServiceFile}" \
+      "${cleanupTimerFile}"
   '';
 }

--- a/spec/k3s_service_activate_spec.sh
+++ b/spec/k3s_service_activate_spec.sh
@@ -25,6 +25,23 @@ The output should include 'Restart=always'
 The status should be success
 End
 
+Describe 'containerd cleanup timer'
+It 'installs cleanup as a host-level systemd timer'
+When run bash -c "grep -q 'k3s-containerd-cleanup.service' home-manager/services/k3s/activate.sh && grep -q 'enable --now k3s-containerd-cleanup.timer' home-manager/services/k3s/activate.sh"
+The status should be success
+End
+
+It 'only removes exited containers and not-ready sandboxes'
+When run bash -c "grep -q 'ps -a --state Exited' config/k3s/containerd-cleanup.sh && grep -q 'pods --state NotReady' config/k3s/containerd-cleanup.sh"
+The status should be success
+End
+
+It 'bounds every runtime cleanup operation'
+When run grep -q 'timeout 10' config/k3s/containerd-cleanup.sh
+The status should be success
+End
+End
+
 It 'does not run the destructive killall helper after service exit'
 When run grep 'ExecStopPost=.*k3s-killall' "$SERVICE"
 The status should equal 1

--- a/spec/k3s_service_activate_spec.sh
+++ b/spec/k3s_service_activate_spec.sh
@@ -37,7 +37,12 @@ The status should be success
 End
 
 It 'bounds every runtime cleanup operation'
-When run grep -q 'timeout 10' config/k3s/containerd-cleanup.sh
+When run bash -c "[ \"$(grep -c 'timeout 10' config/k3s/containerd-cleanup.sh)\" -eq 4 ]"
+The status should be success
+End
+
+It 'does not start k3s when the cleanup timer fires during maintenance'
+When run grep -q '^Requisite=k3s.service$' config/k3s/containerd-cleanup.service
 The status should be success
 End
 End


### PR DESCRIPTION
## Summary

- install a Kyber host-level systemd timer that cleans exited containers and NotReady sandboxes every ten minutes
- bound each CRI removal and the overall oneshot service runtime
- keep cleanup limited to stale runtime state and leave running containers untouched

## Why

A containerd backlog left 48 exited containers and stale sandbox/name reservations, causing widespread CreateContainerError states and taking all Temporal Cassandra replicas out of service. The existing cleanup runs inside Kubernetes, so it is not a reliable recovery layer when container creation itself is degraded.

## Validation

- focused ShellSpec: 14 examples, 0 failures
- ShellCheck on the cleanup and activation scripts
- make shell-inline-check
- make nix-format-check (passed before merging latest main; post-merge rerun is sandbox-blocked by Nix daemon access)
- nix eval homeConfigurations includes kyber
- full Kyber activation derivation evaluation reaches an unrelated x86_64-linux-only Obsidian package on aarch64-darwin

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a host-level systemd cleanup on `kyber` to remove stale `containerd` state every 10 minutes. Prevents CreateContainerError by clearing exited containers and NotReady sandboxes when `k3s` is degraded.

- **New Features**
  - `k3s-containerd-cleanup` script using `crictl`; only removes Exited containers and NotReady sandboxes; 10s per operation; leaves running containers.
  - `k3s-containerd-cleanup.service` (oneshot, 10min timeout, low IO/CPU, Requisite=k3s.service) and `.timer` (boot after 5min, every 10min, +30s jitter, persistent).
  - Hardened activation: only install when units change, reload `systemd` only if needed, enable the timer idempotently; requires sudo; no-ops if units are missing.
  - Nix packaging via `pkgs.writeShellApplication`; tests cover install, timeouts, and not starting k3s during maintenance.

<sup>Written for commit 2439370286d69bae4b67a1365f5c08d93a75fbc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

