### PR TITLE
feat: add unzip to home-manager packages

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -122,6 +122,7 @@ with pkgs;
   tree-sitter
   trippy
   turso-cli
+  unzip
   uv
   watchexec
   websocat


### PR DESCRIPTION
Adds `unzip` to the cross-platform package list in `home-manager/packages/default.nix`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `unzip` to the cross-platform package list in `home-manager/packages/default.nix` so ZIP files can be extracted by default on all platforms.

<sup>Written for commit 9aff486184dd272467f17cd32082571b3b2adf1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

