### PR TITLE
fix(k3s): honor containerd cleanup deadlines

### DIFF
--- a/config/k3s/containerd-cleanup.sh
+++ b/config/k3s/containerd-cleanup.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 crictl_bin=/var/lib/rancher/k3s/data/current/bin/crictl
 runtime_endpoint=unix:///run/k3s/containerd/containerd.sock
+crictl_timeout=10s
+command_timeout=12
 
 if [ ! -x "$crictl_bin" ]; then
   echo "k3s crictl binary is unavailable: $crictl_bin" >&2
@@ -10,23 +12,23 @@ if [ ! -x "$crictl_bin" ]; then
 fi
 
 echo "cleaning exited containerd containers"
-exited_containers=$(timeout 10 "$crictl_bin" --runtime-endpoint "$runtime_endpoint" ps -a --state Exited -q)
+exited_containers=$(timeout "$command_timeout" "$crictl_bin" --runtime-endpoint "$runtime_endpoint" --timeout "$crictl_timeout" ps -a --state Exited -q)
 while IFS= read -r container_id; do
   if [ -z "$container_id" ]; then
     continue
   fi
   echo "removing exited container: $container_id"
-  timeout 10 "$crictl_bin" --runtime-endpoint "$runtime_endpoint" rm -f "$container_id" || true
+  timeout "$command_timeout" "$crictl_bin" --runtime-endpoint "$runtime_endpoint" --timeout "$crictl_timeout" rm -f "$container_id" || true
 done <<<"$exited_containers"
 
 echo "cleaning not-ready containerd sandboxes"
-not_ready_sandboxes=$(timeout 10 "$crictl_bin" --runtime-endpoint "$runtime_endpoint" pods --state NotReady -q)
+not_ready_sandboxes=$(timeout "$command_timeout" "$crictl_bin" --runtime-endpoint "$runtime_endpoint" --timeout "$crictl_timeout" pods --state NotReady -q)
 while IFS= read -r sandbox_id; do
   if [ -z "$sandbox_id" ]; then
     continue
   fi
   echo "removing not-ready sandbox: $sandbox_id"
-  timeout 10 "$crictl_bin" --runtime-endpoint "$runtime_endpoint" rmp -f "$sandbox_id" || true
+  timeout "$command_timeout" "$crictl_bin" --runtime-endpoint "$runtime_endpoint" --timeout "$crictl_timeout" rmp -f "$sandbox_id" || true
 done <<<"$not_ready_sandboxes"
 
 echo "containerd cleanup complete"

--- a/spec/k3s_service_activate_spec.sh
+++ b/spec/k3s_service_activate_spec.sh
@@ -37,7 +37,7 @@ The status should be success
 End
 
 It 'bounds every runtime cleanup operation'
-When run bash -c "[ \"$(grep -c 'timeout 10' config/k3s/containerd-cleanup.sh)\" -eq 4 ]"
+When run bash -c "[ \"$(grep -c -- '--timeout.*crictl_timeout' config/k3s/containerd-cleanup.sh)\" -eq 4 ]"
 The status should be success
 End
 


### PR DESCRIPTION
## Summary

- give crictl RPCs an explicit 10-second deadline
- keep an outer 12-second process bound for every listing and removal
- cover all four runtime operations in the focused activation contract test

## Incident evidence

During Kyber recovery, the first merged cleanup pass failed removals at crictl default deadlines of about two seconds even though the process wrapper allowed ten seconds. This change makes the intended RPC deadline effective under containerd load.

## Validation

- bash -n
- ShellCheck
- focused ShellSpec: 15 examples, 0 failures
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure containerd cleanup honors RPC deadlines by adding explicit `crictl` timeouts and a slightly longer process timeout. Prevents failed removals under load during `k3s` recovery.

- **Bug Fixes**
  - Set `crictl` `--timeout` to 10s and outer `timeout` to 12s for ps/rm/pods/rmp.
  - Updated activation spec to assert all four operations use the explicit RPC timeout.

<sup>Written for commit 6c1eeed10b9e11dae40b24725ed494df34c02c3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

