### PR TITLE
fix(spec): align shell specs with matic DNS and k3s cleanup changes

### DIFF
--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -288,6 +288,10 @@ It 'has spec file for config/k3s/activate-client.sh'
 The path "spec/activate_k3s_client_spec.sh" should be exist
 End
 
+It 'has spec file for config/k3s/containerd-cleanup.sh'
+The path "spec/k3s_containerd_cleanup_spec.sh" should be exist
+End
+
 It 'has spec file for hosts/darwin/activate-remove-backups.sh'
 The path "spec/activate_hosts_spec.sh" should be exist
 End
@@ -408,6 +412,7 @@ config/hyprland/scripts/record-screen.sh
 config/hyprland/scripts/toggle-terminal.sh
 config/k3s/activate-client.sh
 config/k3s/activate.sh
+config/k3s/containerd-cleanup.sh
 config/noctalia/ac-idle-inhibit.sh
 config/noctalia/lock-before-sleep.sh
 config/noctalia/quit-active-app.sh

--- a/spec/k3s_containerd_cleanup_spec.sh
+++ b/spec/k3s_containerd_cleanup_spec.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'config/k3s/containerd-cleanup.sh'
+SCRIPT="$PWD/config/k3s/containerd-cleanup.sh"
+
+Describe 'script properties'
+It 'uses bash shebang'
+When run bash -c "head -1 '$SCRIPT'"
+The output should include '#!/usr/bin/env bash'
+End
+
+It 'uses strict mode'
+When run bash -c "grep 'set -euo pipefail' '$SCRIPT'"
+The output should include 'set -euo pipefail'
+End
+End
+
+Describe 'crictl configuration'
+It 'uses the k3s bundled crictl binary'
+When run bash -c "grep -F 'crictl_bin=/var/lib/rancher/k3s/data/current/bin/crictl' '$SCRIPT'"
+The output should include '/var/lib/rancher/k3s/data/current/bin/crictl'
+End
+
+It 'targets the k3s containerd socket'
+When run bash -c "grep -F 'runtime_endpoint=unix:///run/k3s/containerd/containerd.sock' '$SCRIPT'"
+The output should include '/run/k3s/containerd/containerd.sock'
+End
+
+It 'fails fast when crictl is unavailable'
+When run bash -c "grep -F 'if [ ! -x \"\$crictl_bin\" ]; then' '$SCRIPT'"
+The output should include 'crictl_bin'
+End
+End
+
+Describe 'cleanup deadlines'
+It 'sets a crictl request timeout'
+When run bash -c "grep -F 'crictl_timeout=10s' '$SCRIPT'"
+The output should include 'crictl_timeout=10s'
+End
+
+It 'sets an outer command timeout'
+When run bash -c "grep -F 'command_timeout=12' '$SCRIPT'"
+The output should include 'command_timeout=12'
+End
+
+It 'wraps crictl calls in timeout'
+When run bash -c "grep -c -F 'timeout \"\$command_timeout\"' '$SCRIPT'"
+The output should not eq '0'
+End
+End
+
+Describe 'cleanup behaviour'
+It 'lists exited containers'
+When run bash -c "grep -F 'ps -a --state Exited -q' '$SCRIPT'"
+The output should include '--state Exited'
+End
+
+It 'force removes exited containers'
+When run bash -c "grep -F 'rm -f \"\$container_id\"' '$SCRIPT'"
+The output should include 'rm -f'
+End
+
+It 'lists not-ready sandboxes'
+When run bash -c "grep -F 'pods --state NotReady -q' '$SCRIPT'"
+The output should include '--state NotReady'
+End
+
+It 'force removes not-ready sandboxes'
+When run bash -c "grep -F 'rmp -f \"\$sandbox_id\"' '$SCRIPT'"
+The output should include 'rmp -f'
+End
+
+It 'tolerates individual removal failures'
+When run bash -c "grep -c -F '|| true' '$SCRIPT'"
+The output should not eq '0'
+End
+
+It 'reports completion'
+When run bash -c "grep -F 'containerd cleanup complete' '$SCRIPT'"
+The output should include 'containerd cleanup complete'
+End
+End
+
+End

--- a/spec/matic_tailscale_spec.sh
+++ b/spec/matic_tailscale_spec.sh
@@ -19,9 +19,9 @@ When run bash -c "grep -F '\"--advertise-exit-node\"' '$CONFIG'"
 The output should include '--advertise-exit-node'
 End
 
-It 'leaves DNS to NetworkManager'
-When run bash -c "grep -F '\"--accept-dns=false\"' '$CONFIG'"
-The output should include '--accept-dns=false'
+It 'accepts DNS from tailscale'
+When run bash -c "grep -F '\"--accept-dns=true\"' '$CONFIG'"
+The output should include '--accept-dns=true'
 End
 
 It 'trusts the tailscale interface in the firewall'


### PR DESCRIPTION
## Summary

Fixes the two `shell-test` failures that have been red on `main` since #2109 / #2115.

## Failures

```
spec/coverage_spec.sh:377      # covers all non-spec shell scripts in the repository FAILED
spec/matic_tailscale_spec.sh:22 # tailscale leaves DNS to NetworkManager FAILED
```

## Fixes

1. **matic tailscale spec** — #2109 flipped `--accept-dns` to `true` in `named-hosts/matic/default.nix`, but the spec still asserted `false`. Updated the assertion and renamed the example to match the actual behavior.
2. **coverage spec** — `config/k3s/containerd-cleanup.sh` (added in #2115) was missing from the covered-scripts list. Added it, plus the spec-file existence check, and wrote `spec/k3s_containerd_cleanup_spec.sh` covering the crictl paths, the cleanup deadlines from #2117, and the exited-container / not-ready-sandbox removal logic.

## Verification

```
shellspec spec/k3s_containerd_cleanup_spec.sh spec/matic_tailscale_spec.sh spec/coverage_spec.sh
109 examples, 0 failures
```

`shellcheck` passes on the new spec.

Note: the `Nix`, `Lua`, and `E2E` runs on main are *queued*, not failing — runner capacity, not a code issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two failing shell specs on main by aligning Tailscale DNS behavior and adding coverage for the k3s containerd cleanup script. Restores the shell test suite to green.

- **Bug Fixes**
  - Update `spec/matic_tailscale_spec.sh` to expect `--accept-dns=true` and rename the example to match current behavior.
  - Add `spec/k3s_containerd_cleanup_spec.sh` and include `config/k3s/containerd-cleanup.sh` in `spec/coverage_spec.sh`; the new spec checks the bundled `crictl` path/socket, timeouts, exited-container and NotReady sandbox removal, and the completion message.

<sup>Written for commit 18797ab4cffbe5df91505a1fe8d1808baa864568. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

