### PR TITLE
feat(fish): add matic abbreviation for SSH to matic

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -160,6 +160,7 @@
       kyber = "_kyber_function";
       kyberd = "_kyberd_function";
       kyberm = "_kyberm_function";
+      matic = "_matic_function";
       ocxe = "_ocxe_function";
       ocxel = "_ocxel_function";
       ocxeh = "_ocxeh_function";
@@ -287,6 +288,7 @@
         "_kyber_function"
         "_kyberd_function"
         "_kyberm_function"
+        "_matic_function"
         "_ocxe_function"
         "_ocxel_function"
         "_ocxeh_function"

--- a/home-manager/programs/fish/functions/_matic_function.fish
+++ b/home-manager/programs/fish/functions/_matic_function.fish
@@ -1,0 +1,3 @@
+function _matic_function --description "SSH to Matic server via Tailscale"
+  tailscale ssh shunkakinoki@matic
+end

--- a/spec/fish/_matic_function_test.fish
+++ b/spec/fish/_matic_function_test.fish
@@ -1,0 +1,11 @@
+set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_matic_function.fish
+
+set log (mktemp)
+function tailscale; echo $argv >> $log; end
+
+_matic_function
+
+@test "calls tailscale ssh to matic" (grep -c "ssh shunkakinoki@matic" $log) -ge 1
+
+rm -f $log


### PR DESCRIPTION
## Summary

Adds a `matic` fish abbreviation that SSHes into the matic machine over Tailscale, mirroring the existing `kyber` shortcut.

```fish
function _matic_function --description "SSH to Matic server via Tailscale"
  tailscale ssh shunkakinoki@matic
end
```

## Changes

- `home-manager/programs/fish/functions/_matic_function.fish` — new function
- `home-manager/programs/fish/default.nix` — registers the `matic` abbreviation and adds the function to the `xdg.configFile` source list
- `spec/fish/_matic_function_test.fish` — fishtape test mirroring `_kyber_function_test.fish`

## Notes

- Uses `shunkakinoki@` rather than kyber's `ubuntu@` — matic is declared with `username = "shunkakinoki"` in [flake.nix:148](https://github.com/shunkakinoki/dotfiles/blob/main/flake.nix#L148).
- Tailscale SSH is already enabled on matic via `--ssh` in `extraSetFlags` (#2112), so no host-side change is needed.
- Scoped to the plain `matic` command only. Kyber also has `kyberd` / `kyberm` zellij-session variants; say the word if you want those mirrored too.

## Verification

Function behavior confirmed with a stubbed `tailscale`:

```
captured: ssh shunkakinoki@matic
```

`nix-instantiate --parse` passes on the modified `default.nix`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `matic` fish abbreviation to SSH into the Matic server via `tailscale`. Uses the `shunkakinoki` user and mirrors the existing kyber shortcut.

- **New Features**
  - Added `_matic_function.fish` that runs `tailscale ssh shunkakinoki@matic`.
  - Registered `matic` in `home-manager/programs/fish/default.nix`.
  - Added fishtape test verifying the SSH call.

<sup>Written for commit 143d46960ae67f90c8e90672241122b40626d8a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

