### PR TITLE
feat(fish): add maticd and maticm zellij session shortcuts

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -161,6 +161,8 @@
       kyberd = "_kyberd_function";
       kyberm = "_kyberm_function";
       matic = "_matic_function";
+      maticd = "_maticd_function";
+      maticm = "_maticm_function";
       ocxe = "_ocxe_function";
       ocxel = "_ocxel_function";
       ocxeh = "_ocxeh_function";
@@ -289,6 +291,8 @@
         "_kyberd_function"
         "_kyberm_function"
         "_matic_function"
+        "_maticd_function"
+        "_maticm_function"
         "_ocxe_function"
         "_ocxel_function"
         "_ocxeh_function"

--- a/home-manager/programs/fish/functions/_maticd_function.fish
+++ b/home-manager/programs/fish/functions/_maticd_function.fish
@@ -1,0 +1,3 @@
+function _maticd_function --description "SSH to Matic with zellij desktop session"
+  ssh -t shunkakinoki@(tailscale ip -4 matic) "zellij attach desktop -c"
+end

--- a/home-manager/programs/fish/functions/_maticm_function.fish
+++ b/home-manager/programs/fish/functions/_maticm_function.fish
@@ -1,0 +1,3 @@
+function _maticm_function --description "SSH to Matic with zellij mobile session"
+  ssh -t shunkakinoki@(tailscale ip -4 matic) "zellij attach mobile -c"
+end

--- a/spec/fish/_maticd_function_test.fish
+++ b/spec/fish/_maticd_function_test.fish
@@ -1,0 +1,13 @@
+set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_maticd_function.fish
+
+set log (mktemp)
+function tailscale; echo 100.1.2.3; end
+function ssh; echo $argv >> $log; end
+
+_maticd_function
+
+@test "calls ssh to matic IP" (grep -c "shunkakinoki@100.1.2.3" $log) -ge 1
+@test "attaches to desktop session" (grep -c "desktop" $log) -ge 1
+
+rm -f $log

--- a/spec/fish/_maticm_function_test.fish
+++ b/spec/fish/_maticm_function_test.fish
@@ -1,0 +1,13 @@
+set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_maticm_function.fish
+
+set log (mktemp)
+function tailscale; echo 100.1.2.3; end
+function ssh; echo $argv >> $log; end
+
+_maticm_function
+
+@test "calls ssh to matic IP" (grep -c "shunkakinoki@100.1.2.3" $log) -ge 1
+@test "attaches to mobile session" (grep -c "mobile" $log) -ge 1
+
+rm -f $log


### PR DESCRIPTION
Mirrors the `kyberd` / `kyberm` shortcuts for matic.

## Changes

- `_maticd_function` - SSH to matic, attach zellij `desktop` session
- `_maticm_function` - SSH to matic, attach zellij `mobile` session
- fishtape tests for both
- abbr entries + function registration in `home-manager/programs/fish/default.nix`

## Deviations from the kyber originals

- User is `shunkakinoki@` (matching existing `_matic_function`), not `ubuntu@`
- Dropped `-i ~/.ssh/id_ed25519` that `_kyberd_function` carries - `_kyberm_function` does not have it either, and matic's key path is not pinned anywhere in the repo

`_vpn_function` is not ported: it is kyber-specific (Tailscale exit node).

## Testing

```
fishtape spec/fish/_maticd_function_test.fish spec/fish/_maticm_function_test.fish
# pass 4
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Fish shortcuts `maticd` and `maticm` to SSH into Matic and attach `zellij` desktop or mobile sessions. Mirrors the `kyberd`/`kyberm` workflow for faster Tailscale-based access.

- New Features
  - `_maticd_function` and `_maticm_function`: SSH to `tailscale ip -4 matic` as `shunkakinoki@` and attach `zellij` `desktop`/`mobile` with `-c`.
  - Registered abbreviations and functions in `home-manager/programs/fish/default.nix`.
  - Tests: `fishtape` specs for both functions.
  - Differences vs kyber: user is `shunkakinoki@` (not `ubuntu@`), no `-i ~/.ssh/id_ed25519`, `_vpn_function` not ported (kyber-specific).

<sup>Written for commit 4fe7b77fd474dbf5c0e1474be73ada2d0408399a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

