### PR TITLE
fix(ssh): add matic host alias so herdr --remote matic resolves

### DIFF
--- a/home-manager/programs/ssh/default.nix
+++ b/home-manager/programs/ssh/default.nix
@@ -32,6 +32,10 @@
         IdentityFile = [ "~/.ssh/id_rsa" ];
         IdentitiesOnly = "yes";
       };
+      "matic" = {
+        HostName = "matic.tail950b36.ts.net";
+        User = "shunkakinoki";
+      };
       "github.com" = {
         ServerAliveInterval = 0;
         IdentityFile = [ "~/.ssh/id_ed25519_github" ];

--- a/spec/ssh_config_spec.sh
+++ b/spec/ssh_config_spec.sh
@@ -17,4 +17,16 @@ The output should include 'IdentityFile = [ "~/.ssh/id_rsa" ]'
 The output should include 'IdentitiesOnly = "yes"'
 End
 End
+
+Describe 'matic host'
+It 'resolves the bare matic alias so herdr --remote matic works'
+When run bash -c "grep 'HostName =' '$SSH_CONFIG_NIX' | grep matic"
+The output should include 'matic.tail950b36.ts.net'
+End
+
+It 'uses the shunkakinoki login'
+When run bash -c "grep -A2 '\"matic\" = {' '$SSH_CONFIG_NIX'"
+The output should include 'User = "shunkakinoki"'
+End
+End
 End


### PR DESCRIPTION
## Problem

`_herdrm_function` (`herdr --remote matic`) failed with:

```
error: remote platform detection failed: ssh: Could not resolve hostname matic: nodename nor servname provided, or not known
```

`herdr --remote` shells out to plain `ssh`, and there was no `Host matic` block in the generated SSH config. The bare name is not resolvable via system DNS — only `matic.tail950b36.ts.net` is (100.76.48.66).

The `matic` abbreviation added in #2119 works because `tailscale ssh` resolves MagicDNS names itself, bypassing the SSH config entirely.

## Change

Adds a `matic` host block mirroring `kyber`:

```nix
"matic" = {
  HostName = "matic.tail950b36.ts.net";
  User = "shunkakinoki";
};
```

No `IdentityFile` override — matic uses the default `~/.ssh/id_ed25519` from the `*` block (kyber pins `id_rsa` for Codex compatibility).

## Test

Spec coverage added in `spec/ssh_config_spec.sh`.

```
$ shellspec spec/ssh_config_spec.sh
4 examples, 0 failures
```

Note: first connect will prompt for host key acceptance since matic is not in `known_hosts` yet.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `herdr --remote matic` by adding an SSH `Host matic` alias so plain `ssh` can resolve and connect. It points to `matic.tail950b36.ts.net` and uses user `shunkakinoki`.

- **Bug Fixes**
  - Added `Host matic` in SSH config (mirrors `kyber`), no `IdentityFile` override (uses default from `*`).
  - Added spec coverage to verify hostname and user for `matic`.

<sup>Written for commit 599a0a21b01e17213638b0159d67ce7421a0d75d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

