### PR TITLE
fix(k3s): cap parallel image pulls

### DIFF
--- a/config/k3s/activate.sh
+++ b/config/k3s/activate.sh
@@ -30,7 +30,11 @@ ensure_authorized_key() {
 
 ensure_authorized_key "$GALACTICA_AUTHORIZED_KEY"
 
-if [ ! -f "$HOME/.config/k3s/config.yaml" ]; then
+K3S_CONFIG_SOURCE="$HOME/.config/k3s/config.yaml"
+KUBELET_CONFIG_SOURCE="$HOME/.config/k3s/kubelet.conf.d/10-kyber.conf"
+KUBELET_CONFIG_TARGET="/var/lib/rancher/k3s/agent/etc/kubelet.conf.d/10-kyber.conf"
+
+if [ ! -f "$K3S_CONFIG_SOURCE" ] || [ ! -f "$KUBELET_CONFIG_SOURCE" ]; then
   exit 0
 fi
 
@@ -48,10 +52,20 @@ if [ -z "$SUDO_CMD" ]; then
   exit 0
 fi
 
-$SUDO_CMD mkdir -p /etc/rancher/k3s
+$SUDO_CMD mkdir -p /etc/rancher/k3s "$(dirname "$KUBELET_CONFIG_TARGET")"
 
-if ! diff -q "$HOME/.config/k3s/config.yaml" /etc/rancher/k3s/config.yaml >/dev/null 2>&1; then
-  $SUDO_CMD cp "$HOME/.config/k3s/config.yaml" /etc/rancher/k3s/config.yaml
+K3S_CONFIG_CHANGED=0
+if ! diff -q "$K3S_CONFIG_SOURCE" /etc/rancher/k3s/config.yaml >/dev/null 2>&1; then
+  $SUDO_CMD cp "$K3S_CONFIG_SOURCE" /etc/rancher/k3s/config.yaml
+  K3S_CONFIG_CHANGED=1
+fi
+
+if ! diff -q "$KUBELET_CONFIG_SOURCE" "$KUBELET_CONFIG_TARGET" >/dev/null 2>&1; then
+  $SUDO_CMD cp "$KUBELET_CONFIG_SOURCE" "$KUBELET_CONFIG_TARGET"
+  K3S_CONFIG_CHANGED=1
+fi
+
+if [ "$K3S_CONFIG_CHANGED" -eq 1 ]; then
   if systemctl is-active --quiet k3s; then
     $SUDO_CMD systemctl restart k3s
     echo "k3s restarted to apply config changes"

--- a/config/k3s/activate.sh
+++ b/config/k3s/activate.sh
@@ -55,12 +55,12 @@ fi
 $SUDO_CMD mkdir -p /etc/rancher/k3s "$(dirname "$KUBELET_CONFIG_TARGET")"
 
 K3S_CONFIG_CHANGED=0
-if ! diff -q "$K3S_CONFIG_SOURCE" /etc/rancher/k3s/config.yaml >/dev/null 2>&1; then
+if ! $SUDO_CMD diff -q "$K3S_CONFIG_SOURCE" /etc/rancher/k3s/config.yaml >/dev/null 2>&1; then
   $SUDO_CMD cp "$K3S_CONFIG_SOURCE" /etc/rancher/k3s/config.yaml
   K3S_CONFIG_CHANGED=1
 fi
 
-if ! diff -q "$KUBELET_CONFIG_SOURCE" "$KUBELET_CONFIG_TARGET" >/dev/null 2>&1; then
+if ! $SUDO_CMD diff -q "$KUBELET_CONFIG_SOURCE" "$KUBELET_CONFIG_TARGET" >/dev/null 2>&1; then
   $SUDO_CMD cp "$KUBELET_CONFIG_SOURCE" "$KUBELET_CONFIG_TARGET"
   K3S_CONFIG_CHANGED=1
 fi

--- a/config/k3s/default.nix
+++ b/config/k3s/default.nix
@@ -21,6 +21,11 @@ in
     force = true;
   };
 
+  home.file.".config/k3s/kubelet.conf.d/10-kyber.conf" = lib.mkIf isKyber {
+    source = ./kubelet.conf;
+    force = true;
+  };
+
   home.file.".config/k3s/k3s.service" = lib.mkIf isKyber {
     source = pkgs.replaceVars ./k3s.service {
       inherit (pkgs) coreutils k3s;

--- a/config/k3s/kubelet.conf
+++ b/config/k3s/kubelet.conf
@@ -1,0 +1,6 @@
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+# Keep limited parallelism for faster cold starts without allowing a full-node
+# restart to saturate containerd, disk I/O, and CRI request deadlines.
+serializeImagePulls: false
+maxParallelImagePulls: 4

--- a/spec/activate_k3s_spec.sh
+++ b/spec/activate_k3s_spec.sh
@@ -44,6 +44,11 @@ When run bash -c "grep 'config.yaml' '$SCRIPT'"
 The output should include 'config.yaml'
 End
 
+It 'copies the kubelet configuration drop-in'
+When run bash -c "grep 'KUBELET_CONFIG_TARGET' '$SCRIPT'"
+The output should include 'kubelet.conf.d/10-kyber.conf'
+End
+
 It 'skips if config file missing'
 When run bash -c "grep -A 1 '! -f' '$SCRIPT'"
 The output should include 'exit 0'


### PR DESCRIPTION
## Summary

- install a Kyber kubelet configuration drop-in through Home Manager
- retain parallel pulls but cap them at four concurrent images
- restart K3s once when either the server config or kubelet drop-in changes

## Root cause addressed

K3s 1.35 generated serializeImagePulls: false without maxParallelImagePulls. During cold runtime recovery, more than 40 image downloads ran concurrently, saturated the single disk, and caused CRI deadlines, name reservations, and pull-QPS failures. Kubernetes documents maxParallelImagePulls specifically to bound network and disk consumption while retaining parallel pulls.

## Validation

- shellspec spec/activate_k3s_spec.sh (16 examples)
- shellcheck config/k3s/activate.sh
- make nix-format-check
- Kyber Home Manager evaluation confirms the drop-in is present

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps `k3s` image pull concurrency at 4 using a kubelet config drop-in to prevent disk saturation and CRI timeouts during cold recovery. The activation script installs the drop-in and restarts `k3s` once when config changes.

- **Bug Fixes**
  - Add kubelet drop-in with serializeImagePulls: false and maxParallelImagePulls: 4.
  - Compare installed configs with sudo; copy server and kubelet configs only on change; restart `k3s` once.
  - Provision drop-in via Home Manager; add spec to assert presence; shellspec and shellcheck pass.

<sup>Written for commit 17524ccd6e160e92d8e0d594953556f9bc6682b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

