### PR TITLE
fix(k3s): query service status with sudo

### DIFF
--- a/config/k3s/activate.sh
+++ b/config/k3s/activate.sh
@@ -66,7 +66,7 @@ if ! $SUDO_CMD diff -q "$KUBELET_CONFIG_SOURCE" "$KUBELET_CONFIG_TARGET" >/dev/n
 fi
 
 if [ "$K3S_CONFIG_CHANGED" -eq 1 ]; then
-  if systemctl is-active --quiet k3s; then
+  if $SUDO_CMD systemctl is-active --quiet k3s; then
     $SUDO_CMD systemctl restart k3s
     echo "k3s restarted to apply config changes"
   fi

--- a/spec/activate_k3s_spec.sh
+++ b/spec/activate_k3s_spec.sh
@@ -49,6 +49,11 @@ When run bash -c "grep 'KUBELET_CONFIG_TARGET' '$SCRIPT'"
 The output should include 'kubelet.conf.d/10-kyber.conf'
 End
 
+It 'checks the system k3s service through sudo'
+When run bash -c "grep '\$SUDO_CMD systemctl is-active' '$SCRIPT'"
+The output should include '$SUDO_CMD systemctl is-active'
+End
+
 It 'skips if config file missing'
 When run bash -c "grep -A 1 '! -f' '$SCRIPT'"
 The output should include 'exit 0'


### PR DESCRIPTION
## Summary

- query the system K3s unit through the detected sudo command during Home Manager activation
- ensure a changed K3s or kubelet configuration actually triggers the intended restart
- add focused regression coverage

## Live evidence

PR #2123 built and switched successfully and installed the kubelet drop-in, but its activation log copied the file without restarting the active K3s service. The user-level updater environment did not observe the system service as active through the unprivileged query. A direct restart applied the configuration; this follow-up makes future activations self-contained.

## Validation

- shellcheck config/k3s/activate.sh
- shellspec spec/activate_k3s_spec.sh (17 examples)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Query `k3s` service status using the detected `$SUDO_CMD` during Home Manager activation so config changes reliably trigger a restart. Adds a regression test to verify the sudo-based `systemctl is-active` check.

<sup>Written for commit 4c2f2542f0a31d28acf49606d209770a43fe4e2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

