### PR TITLE
fix(k3s): keep reserve setup best effort

### DIFF
--- a/config/k3s/kubelet.conf
+++ b/config/k3s/kubelet.conf
@@ -7,5 +7,6 @@ maxParallelImagePulls: 2
 # Make the single-node disk contract explicit. The ext4 root reserve is managed
 # by the Kyber activation script, keeping ordinary usage below the low watermark
 # while kubelet remains the sole owner of image and container garbage collection.
+# These are kubelet's defaults, pinned here so the host headroom contract is visible.
 imageGCHighThresholdPercent: 85
 imageGCLowThresholdPercent: 80

--- a/home-manager/services/k3s/activate.sh
+++ b/home-manager/services/k3s/activate.sh
@@ -35,10 +35,11 @@ require_sudo() {
     echo "Warning: sudo not found, skipping k3s system setup" >&2
     return 1
   fi
+  return 0
 }
 
 configure_root_ext4_reserve() {
-  local root_source root_fs_type block_count reserved_blocks target_reserved_blocks
+  local root_source root_fs_type filesystem_info block_count reserved_blocks target_reserved_blocks
   local target_reserved_percent=1
 
   root_source="$(@findmnt@ --noheadings --output SOURCE --target /)"
@@ -53,10 +54,14 @@ configure_root_ext4_reserve() {
   fi
 
   require_sudo || return 0
+  if ! filesystem_info="$(run_sudo @tune2fs@ -l "$root_source")"; then
+    echo "Warning: unable to inspect ext4 reserve on $root_source" >&2
+    return 0
+  fi
   # shellcheck disable=SC2016
-  block_count="$(run_sudo @tune2fs@ -l "$root_source" 2>/dev/null | @awk@ -F: '/^Block count:/ { gsub(/[[:space:]]/, "", $2); print $2 }')"
+  block_count="$(@awk@ -F: '/^Block count:/ { gsub(/[[:space:]]/, "", $2); print $2 }' <<<"$filesystem_info")"
   # shellcheck disable=SC2016
-  reserved_blocks="$(run_sudo @tune2fs@ -l "$root_source" 2>/dev/null | @awk@ -F: '/^Reserved block count:/ { gsub(/[[:space:]]/, "", $2); print $2 }')"
+  reserved_blocks="$(@awk@ -F: '/^Reserved block count:/ { gsub(/[[:space:]]/, "", $2); print $2 }' <<<"$filesystem_info")"
   if [ -z "$block_count" ] || [ -z "$reserved_blocks" ]; then
     echo "Warning: unable to inspect ext4 reserve on $root_source" >&2
     return 0
@@ -67,7 +72,10 @@ configure_root_ext4_reserve() {
     return 0
   fi
 
-  run_sudo @tune2fs@ -m "$target_reserved_percent" "$root_source"
+  if ! run_sudo @tune2fs@ -m "$target_reserved_percent" "$root_source"; then
+    echo "Warning: unable to configure ext4 reserve on $root_source" >&2
+    return 0
+  fi
   echo "Configured $root_source ext4 reserved blocks to ${target_reserved_percent}%"
 }
 

--- a/named-hosts/kyber/README.md
+++ b/named-hosts/kyber/README.md
@@ -74,6 +74,7 @@ and CRI health before restarting services:
 
 ```bash
 df -h /
+cat /proc/pressure/io
 sudo tune2fs -l "$(findmnt -n -o SOURCE /)" | grep -E 'Block count|Reserved block count'
 sudo journalctl -u k3s --since '30 minutes ago' | grep -E 'image garbage collection|DiskPressure|deadline exceeded'
 sudo k3s crictl info

--- a/spec/k3s_service_activate_spec.sh
+++ b/spec/k3s_service_activate_spec.sh
@@ -53,6 +53,12 @@ It 'warns when sudo is unavailable'
 When run bash -c "grep 'sudo not found' '$SCRIPT'"
 The output should include 'sudo not found'
 End
+
+It 'returns success when sudo is available'
+When run bash -c "sed -n '/^require_sudo()/,/^}/p' '$SCRIPT' | grep -xF '  return 0'"
+The output should include 'return 0'
+The status should be success
+End
 End
 
 Describe 'k3s setup'
@@ -77,7 +83,7 @@ The output should include 'DRY_RUN_CMD'
 End
 
 It 'keeps one percent of the ext4 root volume reserved'
-When run bash -c "grep 'target_reserved_percent=1' '$SCRIPT'"
+When run bash -c "grep -xF '  local target_reserved_percent=1' '$SCRIPT'"
 The output should include 'target_reserved_percent=1'
 End
 


### PR DESCRIPTION
## Summary

- keep Kyber ext4 reserve inspection and mutation best-effort during activation
- inspect filesystem metadata once so block counts stay internally consistent
- make the kubelet default-threshold policy and I/O-pressure diagnosis explicit
- tighten the reserve-policy regression assertion

## Validation

- `shellcheck home-manager/services/k3s/activate.sh config/k3s/activate.sh`
- `shellspec spec/k3s_service_activate_spec.sh spec/activate_k3s_spec.sh` (31 examples, 0 failures)
- `git diff --check`
- `make nix-format-check`

Follow-up to #2126 for review findings that arrived as it auto-merged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Kyber k3s activation keep the ext4 root reserve setup best-effort and consistent, and pin kubelet image GC thresholds. Improves reliability during activation and clarifies disk/IO pressure behavior.

- **Bug Fixes**
  - Activation: read `tune2fs -l` once, parse a single snapshot, warn and skip on failures, set a 1% ext4 reserve when possible, and return success when `sudo` is available.
  - Kubelet: pin `imageGCHighThresholdPercent: 85` and `imageGCLowThresholdPercent: 80`, documented in `kubelet.conf` to make the host headroom contract explicit.
  - Docs: add `/proc/pressure/io` to troubleshooting steps.
  - Tests: add a success-path check for `require_sudo` and tighten the reserve-policy assertion to match the exact `target_reserved_percent=1` line.

<sup>Written for commit 83bfbfb5b96727acf78a56645ad082d8ecf1d468. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

