### PR TITLE
fix(nix): restore Claude Desktop CI evaluation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -96,11 +96,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778446047,
-        "narHash": "sha256-oQvcadh2BCkrog+SGrG6YffKJrveYpjj3TdQJWaKhaM=",
+        "lastModified": 1782772816,
+        "narHash": "sha256-s9BuFv0mRuZx9C1MF8qPHRdcAK14ONi0A5m6E2wqOoM=",
         "owner": "nix-community",
         "repo": "bun2nix",
-        "rev": "f2bc12af1a6369648aac41041ceeaa0b866599c6",
+        "rev": "5a39d717029e94163ac223aee8d5c9946cafed1c",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -514,11 +514,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1782712305,
-        "narHash": "sha256-/YpID6fna+dWWSqP058xGqDdOihCAIifJmIfso0ECaI=",
+        "lastModified": 1783416216,
+        "narHash": "sha256-vRBG4ldP7GisR3OAlvFk0GTjX2lrzrL+ZxSwUO69W6o=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "8d041d85b7f0a93b11c04983c069d96eb59467a1",
+        "rev": "23c2c2049b21ff57bc4c159ccb1e0eddb1d4238b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- advance `llm-agents.nix` to a revision that exports Claude Desktop
- retain the existing `stdenv.isLinux && isDesktop` package gate
- keep the upstream `overlays.default` contract used by this repository

## Root cause

PR #2114 referenced `pkgs.llm-agents.claude-desktop`, but `flake.lock` still pointed to a revision from the period when upstream had removed that package. Newer revisions after July 12 also remove `overlays.default`, so this selects the July 7 compatibility revision containing the repaired Claude Desktop package.

## Validation

- `nix eval --impure --raw .#nixosConfigurations.matic.pkgs.llm-agents.claude-desktop.drvPath` -> `claude-desktop-1.18286.0.drv`
- `make nix-format-check`
- `nix flake check --system x86_64-linux --no-build` advances past the original missing attribute; Linux-only Docker IFD cannot execute on the local aarch64-darwin host and is left to GitHub Actions


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Claude Desktop evaluation in Nix CI by pinning `llm-agents.nix` to a revision that exports `llm-agents.claude-desktop`. Keeps the `stdenv.isLinux && isDesktop` gate and the upstream `overlays.default` contract.

<sup>Written for commit c9e711f69848b3b7ab03aee58efd20180f235472. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

