### PR TITLE
fix(install): bootstrap git and nix daemon on fresh Linux servers

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -65,8 +65,16 @@ if ! command -v nix >/dev/null 2>&1; then
       NIX_EFFECTIVE_BIN_PATH="$HOME/.nix-profile/bin"
     else # Linux multi-user
       echo "Performing Determinate Nix multi-user installation..."
-      curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux
-      # For Linux multi-user installations, add the default Nix path for the current shell.
+      curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux --no-confirm
+      # Start the Nix daemon so nix commands work in this session
+      if command -v systemctl >/dev/null 2>&1; then
+        sudo systemctl start nix-daemon.service 2>/dev/null || true
+      fi
+      # Source the Nix profile to add nix to PATH
+      if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+        # shellcheck source=/dev/null
+        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+      fi
       export PATH="/nix/var/nix/profiles/default/bin:$PATH"
       NIX_EFFECTIVE_BIN_PATH="/nix/var/nix/profiles/default/bin"
     fi
@@ -89,6 +97,23 @@ else
       NIX_EFFECTIVE_BIN_PATH="/nix/var/nix/profiles/default/bin"
     fi
     echo "Using fallback NIX_EFFECTIVE_BIN_PATH: $NIX_EFFECTIVE_BIN_PATH"
+  fi
+fi
+
+# Ensure git is available (fresh Ubuntu minimal installs may not have it)
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is not installed. Installing git..."
+  if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update -qq && sudo apt-get install -y -qq git
+  elif command -v dnf >/dev/null 2>&1; then
+    sudo dnf install -y git
+  elif command -v yum >/dev/null 2>&1; then
+    sudo yum install -y git
+  elif command -v pacman >/dev/null 2>&1; then
+    sudo pacman -Sy --noconfirm git
+  else
+    echo "Error: Could not install git. No supported package manager found."
+    exit 1
   fi
 fi
 


### PR DESCRIPTION
## Summary
- Install `git` via system package manager (apt/dnf/yum/pacman) if not available on fresh servers
- Start the nix daemon after multi-user Linux install so nix commands work immediately
- Source the nix profile on multi-user Linux installs (matching the macOS behavior)
- Add `--no-confirm` to Linux multi-user install to match other install paths

Fixes `curl ... | HOST=kyber sh` failing on fresh Ubuntu bare metal with `git: not found`.

## Test plan
- [ ] Run `curl -fsSL https://raw.githubusercontent.com/shunkakinoki/dotfiles/main/install.sh | HOST=kyber sh` on fresh Ubuntu 24.04

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bootstraps `git` and the Nix daemon on fresh Linux installs so `install.sh` runs end-to-end without manual setup. Fixes failures on minimal Ubuntu where `git` is missing and Nix isn’t available immediately after install.

- **Bug Fixes**
  - Auto-installs `git` via `apt-get`/`dnf`/`yum`/`pacman` if missing.
  - For Linux multi-user Nix: add `--no-confirm`, start `nix-daemon` with `systemctl` when available, and source `/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh` to update PATH.
  - Matches macOS behavior by sourcing the Nix profile; `nix` and `git` work right after installation.

<sup>Written for commit f324c54b6fd101cab4627df66375076d413bfc15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

