### PR TITLE
fix(install): use /proc/1/comm for systemd detection instead of pidof

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -49,7 +49,9 @@ if ! command -v nix >/dev/null 2>&1; then
     NIX_EFFECTIVE_BIN_PATH="/nix/var/nix/profiles/default/bin"
   else # Linux
     # Auto-detect container environment (Docker, Podman, RunPod, etc.)
-    if [ "$IN_DOCKER" = "true" ] || [ -f /.dockerenv ] || [ -f /run/.containerenv ] || ! pidof systemd >/dev/null 2>&1; then
+    # Use /proc/1/comm instead of pidof - pidof can fail on minimal installs even when systemd is PID 1
+    _init_name=$(cat /proc/1/comm 2>/dev/null || echo "unknown")
+    if [ "$IN_DOCKER" = "true" ] || [ -f /.dockerenv ] || [ -f /run/.containerenv ] || [ "$_init_name" != "systemd" ]; then
       echo "Performing Determinate Nix installation (Docker environment)..."
       curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux --init none --no-confirm
       # Source the Nix profile script to add Nix to PATH for the current shell


### PR DESCRIPTION
## Summary
- Replace `pidof systemd` with `/proc/1/comm` check for container vs bare metal detection
- `pidof systemd` returns exit 1 on minimal Ubuntu even when systemd IS PID 1, causing bare metal servers to take the Docker/container install path (`--init none`)
- This results in no systemd service for nix-daemon, breaking `make install`

Root cause of `nix-daemon.service not found` on fresh Latitude.sh bare metal.

## Test plan
- [ ] Uninstall nix on server, re-run `curl ... | HOST=kyber sh`
- [ ] Verify it takes the multi-user path (not Docker path)
- [ ] Verify `nix-daemon.service` exists after install

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `/proc/1/comm` instead of `pidof` to detect `systemd` during install. Fixes false container detection on minimal Ubuntu so bare-metal installs take the multi-user path and install the `nix-daemon` systemd service.

<sup>Written for commit f066f883d491468f94f7b8da19a544ed04e5182e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

