### PR TITLE
fix(k3s): isolate containerd on dedicated SSD

### DIFF
--- a/config/k3s/containerd.mount
+++ b/config/k3s/containerd.mount
@@ -1,0 +1,13 @@
+[Unit]
+Description=Dedicated containerd filesystem for K3s
+Before=k3s.service
+
+[Mount]
+What=/dev/disk/by-label/k3s-containerd
+Where=/var/lib/rancher/k3s/agent/containerd
+Type=ext4
+Options=noatime
+TimeoutSec=90
+
+[Install]
+WantedBy=multi-user.target

--- a/config/k3s/default.nix
+++ b/config/k3s/default.nix
@@ -33,6 +33,11 @@ in
     force = true;
   };
 
+  home.file.".config/k3s/var-lib-rancher-k3s-agent-containerd.mount" = lib.mkIf isKyber {
+    source = ./containerd.mount;
+    force = true;
+  };
+
   home.sessionVariables = lib.mkIf (isKyber || isGalactica) {
     KUBECONFIG = kubeconfig;
   };
@@ -50,7 +55,7 @@ in
   '';
 
   home.activation.k3s-server = lib.mkIf isKyber (
-    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    lib.hm.dag.entryAfter [ "setupK3s" ] ''
       $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${serverActivateScript}"
     ''
   );

--- a/config/k3s/k3s.service
+++ b/config/k3s/k3s.service
@@ -2,7 +2,8 @@
 Description=Lightweight Kubernetes
 Documentation=https://k3s.io
 Wants=network-online.target
-After=network-online.target
+Requires=var-lib-rancher-k3s-agent-containerd.mount
+After=network-online.target var-lib-rancher-k3s-agent-containerd.mount
 
 [Service]
 Type=notify

--- a/home-manager/services/k3s/activate.sh
+++ b/home-manager/services/k3s/activate.sh
@@ -5,7 +5,10 @@ set -euo pipefail
 
 SERVICE_FILE="$1"
 KUBE_DIR="$2"
+MOUNT_FILE="$3"
 SYSTEM_SERVICE="/etc/systemd/system/k3s.service"
+SYSTEM_MOUNT="/etc/systemd/system/var-lib-rancher-k3s-agent-containerd.mount"
+MOUNT_POINT="/var/lib/rancher/k3s/agent/containerd"
 K3S_KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
 
 sudo_cmd=()
@@ -81,12 +84,43 @@ configure_root_ext4_reserve() {
 
 configure_root_ext4_reserve
 
+if [ -f "$MOUNT_FILE" ] && ! @findmnt@ --mountpoint "$MOUNT_POINT" >/dev/null 2>&1; then
+  if @systemctl@ is-active --quiet k3s; then
+    echo "Refusing to mount the containerd SSD while k3s is running" >&2
+    echo "Run named-hosts/kyber/prepare-containerd-disk.sh before activating this configuration" >&2
+    exit 1
+  fi
+  if [ -d "$MOUNT_POINT" ] && [ -n "$(@find@ "$MOUNT_POINT" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+    echo "Refusing to hide a non-empty containerd directory at $MOUNT_POINT" >&2
+    echo "Move or remove the old runtime only during an attended recovery" >&2
+    exit 1
+  fi
+fi
+
+systemd_changed=0
+if [ -f "$MOUNT_FILE" ] && ! @diff@ -q "$MOUNT_FILE" "$SYSTEM_MOUNT" >/dev/null 2>&1; then
+  require_sudo || exit 0
+  run_sudo cp -f "$MOUNT_FILE" "$SYSTEM_MOUNT"
+  systemd_changed=1
+fi
+
 if [ -f "$SERVICE_FILE" ] && ! @diff@ -q "$SERVICE_FILE" "$SYSTEM_SERVICE" >/dev/null 2>&1; then
   require_sudo || exit 0
-  run_sudo cp "$SERVICE_FILE" "$SYSTEM_SERVICE"
-  run_sudo @systemctl@ daemon-reload
-  run_sudo @systemctl@ enable --now k3s
+  run_sudo cp -f "$SERVICE_FILE" "$SYSTEM_SERVICE"
+  systemd_changed=1
 fi
+
+if [ "$systemd_changed" -eq 1 ]; then
+  run_sudo @systemctl@ daemon-reload
+fi
+
+if [ -f "$MOUNT_FILE" ]; then
+  require_sudo || exit 0
+  run_sudo mkdir -p "$MOUNT_POINT"
+  run_sudo @systemctl@ enable --now var-lib-rancher-k3s-agent-containerd.mount
+fi
+
+run_sudo @systemctl@ enable --now k3s
 
 if [ -f "$K3S_KUBECONFIG" ]; then
   run mkdir -p "$KUBE_DIR"

--- a/home-manager/services/k3s/activate.sh
+++ b/home-manager/services/k3s/activate.sh
@@ -90,10 +90,17 @@ if [ -f "$MOUNT_FILE" ] && ! @findmnt@ --mountpoint "$MOUNT_POINT" >/dev/null 2>
     echo "Run named-hosts/kyber/prepare-containerd-disk.sh before activating this configuration" >&2
     exit 1
   fi
-  if [ -d "$MOUNT_POINT" ] && [ -n "$(@find@ "$MOUNT_POINT" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
-    echo "Refusing to hide a non-empty containerd directory at $MOUNT_POINT" >&2
-    echo "Move or remove the old runtime only during an attended recovery" >&2
-    exit 1
+  if [ -d "$MOUNT_POINT" ]; then
+    require_sudo || exit 0
+    if ! first_entry="$(run_sudo @find@ "$MOUNT_POINT" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)"; then
+      echo "Refusing to mount because $MOUNT_POINT could not be inspected" >&2
+      exit 1
+    fi
+    if [ -n "$first_entry" ]; then
+      echo "Refusing to hide a non-empty containerd directory at $MOUNT_POINT" >&2
+      echo "Move or remove the old runtime only during an attended recovery" >&2
+      exit 1
+    fi
   fi
 fi
 

--- a/home-manager/services/k3s/default.nix
+++ b/home-manager/services/k3s/default.nix
@@ -11,16 +11,19 @@ let
   setupScript = pkgs.replaceVars ./activate.sh {
     awk = "${pkgs.gawk}/bin/awk";
     diff = "${pkgs.diffutils}/bin/diff";
+    find = "${pkgs.findutils}/bin/find";
     findmnt = "${pkgs.util-linux}/bin/findmnt";
     systemctl = "${pkgs.systemd}/bin/systemctl";
     tune2fs = "${pkgs.e2fsprogs}/bin/tune2fs";
   };
   serviceFile = "${homeDir}/.config/k3s/k3s.service";
+  mountFile = "${homeDir}/.config/k3s/var-lib-rancher-k3s-agent-containerd.mount";
 in
 lib.mkIf (pkgs.stdenv.isLinux && host.isKyber) {
   home.activation.setupK3s = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     ${pkgs.bash}/bin/bash "${setupScript}" \
       "${serviceFile}" \
-      "${homeDir}/.kube"
+      "${homeDir}/.kube" \
+      "${mountFile}"
   '';
 }

--- a/named-hosts/kyber/README.md
+++ b/named-hosts/kyber/README.md
@@ -49,31 +49,67 @@ Once Tailscale is set up:
 kyber  # Fish abbreviation that runs: ssh ubuntu@kyber
 ```
 
+## k3s Containerd SSD
+
+Kyber mounts a dedicated ext4 filesystem labeled `k3s-containerd` at
+`/var/lib/rancher/k3s/agent/containerd`. The generated `k3s.service` requires
+that mount, so a missing SSD fails closed instead of silently writing images to
+the root filesystem. Linux device letters are not stable across boots; the
+systemd mount intentionally resolves the filesystem label rather than
+hard-coding `/dev/sda`.
+
+On a new or intentionally wiped host, prepare the empty containerd SSD before
+the first `make switch`:
+
+```bash
+sudo systemctl stop k3s
+./named-hosts/kyber/prepare-containerd-disk.sh /dev/sda --confirm-wipe
+make switch
+```
+
+The preparation command destroys all data on the selected device. It refuses
+to run while k3s is active, while any filesystem on the device is mounted, or
+when the existing containerd directory is non-empty. Normal Home Manager
+activation never formats disks.
+
+Verify the persistent mount and service dependency after activation:
+
+```bash
+findmnt /var/lib/rancher/k3s/agent/containerd
+systemctl is-enabled var-lib-rancher-k3s-agent-containerd.mount
+systemctl show k3s -p Requires -p After
+sudo systemctl restart k3s
+findmnt /var/lib/rancher/k3s/agent/containerd
+```
+
+Persistent volumes remain outside the containerd SSD. In particular, an
+unrestricted local-path PVC must not be treated as a hard capacity quota.
+
 ## k3s Disk Headroom
 
-Kyber runs k3s and its embedded containerd on the root ext4 filesystem. The
-host activation keeps ext4 reserved blocks at 1% and limits kubelet to two
-parallel image pulls. On this 916 GiB volume, Ubuntu's default 5% reserve hid
-about 46 GiB from kubelet and left too little usable headroom during overlapping
-application rollouts.
+Host activation keeps the root ext4 reserved blocks at 1% and limits kubelet
+to two parallel image pulls. Before containerd received a dedicated SSD,
+Ubuntu's default 5% reserve on the 916 GiB root volume hid about 46 GiB from
+kubelet and left too little usable headroom during overlapping rollouts.
 
 Kubelet owns image, container, and pod-sandbox garbage collection. Do not add a
 separate `crictl` cleanup timer: deleting CRI objects behind kubelet can race
 active pod lifecycle operations and leave container names or cgroups stuck.
 
 The July 2026 incident was a disk-pressure feedback loop, not a slow Temporal
-queue. Root usage crossed kubelet's 85% image-GC threshold during concurrent
-image pulls. Kubelet attempted to reclaim tens of GiB from a much smaller
-logical image cache while containerd and Kine were already I/O-bound. CRI calls
-timed out, stale tasks accumulated, and Temporal workers could not start new
-chat turns. Reducing the ext4 reserve, limiting pull parallelism, and preserving
-free space prevent that loop.
+queue. The shared root image filesystem crossed kubelet's 85% image-GC
+threshold during concurrent pulls. Kubelet attempted to reclaim tens of GiB
+from a much smaller logical image cache while containerd and Kine were already
+I/O-bound. CRI calls timed out, stale tasks accumulated, and Temporal workers
+could not start new chat turns. The dedicated image filesystem removes that
+contention from the control-plane disk; pull limits and free-space thresholds
+remain defense in depth.
 
 For diagnosis, check filesystem headroom, I/O pressure, kubelet GC messages,
 and CRI health before restarting services:
 
 ```bash
-df -h /
+df -h / /var/lib/rancher/k3s/agent/containerd
 cat /proc/pressure/io
 sudo tune2fs -l "$(findmnt -n -o SOURCE /)" | grep -E 'Block count|Reserved block count'
 sudo journalctl -u k3s --since '30 minutes ago' | grep -E 'image garbage collection|DiskPressure|deadline exceeded'

--- a/named-hosts/kyber/prepare-containerd-disk.sh
+++ b/named-hosts/kyber/prepare-containerd-disk.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Prepare a dedicated, empty block device for Kyber's containerd filesystem.
+set -euo pipefail
+
+DEVICE="${1:-}"
+CONFIRMATION="${2:-}"
+MOUNT_LABEL="k3s-containerd"
+MOUNT_POINT="/var/lib/rancher/k3s/agent/containerd"
+
+if [ -z "$DEVICE" ] || [ "$CONFIRMATION" != "--confirm-wipe" ]; then
+  echo "Usage: $0 /dev/<device> --confirm-wipe" >&2
+  exit 2
+fi
+
+if [ ! -b "$DEVICE" ]; then
+  echo "Refusing to format a path that is not a block device: $DEVICE" >&2
+  exit 1
+fi
+
+if systemctl is-active --quiet k3s; then
+  echo "Refusing to prepare the containerd disk while k3s is running" >&2
+  echo "Stop k3s first: sudo systemctl stop k3s" >&2
+  exit 1
+fi
+
+if lsblk --noheadings --raw --output MOUNTPOINT "$DEVICE" | grep -q '[^[:space:]]'; then
+  echo "Refusing to format a device with mounted filesystems: $DEVICE" >&2
+  exit 1
+fi
+
+if findmnt --mountpoint "$MOUNT_POINT" >/dev/null 2>&1; then
+  echo "Refusing to replace the filesystem already mounted at $MOUNT_POINT" >&2
+  exit 1
+fi
+
+if [ -e "/dev/disk/by-label/$MOUNT_LABEL" ]; then
+  echo "Refusing to create a duplicate filesystem label: $MOUNT_LABEL" >&2
+  exit 1
+fi
+
+if [ -d "$MOUNT_POINT" ] && [ -n "$(find "$MOUNT_POINT" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+  echo "Refusing to hide a non-empty containerd directory at $MOUNT_POINT" >&2
+  exit 1
+fi
+
+sudo wipefs --all "$DEVICE"
+sudo mkfs.ext4 -F -L "$MOUNT_LABEL" "$DEVICE"
+sudo udevadm settle
+sudo mkdir -p "$MOUNT_POINT"
+sudo mount "/dev/disk/by-label/$MOUNT_LABEL" "$MOUNT_POINT"
+
+mounted_source="$(findmnt --noheadings --output SOURCE --target "$MOUNT_POINT")"
+resolved_device="$(readlink -f "$DEVICE")"
+resolved_source="$(readlink -f "$mounted_source")"
+if [ "$resolved_source" != "$resolved_device" ]; then
+  echo "Unexpected device mounted at $MOUNT_POINT: $mounted_source" >&2
+  exit 1
+fi
+
+echo "Prepared $DEVICE as $MOUNT_LABEL and mounted it at $MOUNT_POINT"
+echo "Run make switch to install the persistent systemd mount dependency"

--- a/named-hosts/kyber/prepare-containerd-disk.sh
+++ b/named-hosts/kyber/prepare-containerd-disk.sh
@@ -16,6 +16,7 @@ if [ ! -b "$DEVICE" ]; then
   echo "Refusing to format a path that is not a block device: $DEVICE" >&2
   exit 1
 fi
+resolved_device="$(readlink -f "$DEVICE")"
 
 if systemctl is-active --quiet k3s; then
   echo "Refusing to prepare the containerd disk while k3s is running" >&2
@@ -33,24 +34,41 @@ if findmnt --mountpoint "$MOUNT_POINT" >/dev/null 2>&1; then
   exit 1
 fi
 
+existing_label_device=""
 if [ -e "/dev/disk/by-label/$MOUNT_LABEL" ]; then
-  echo "Refusing to create a duplicate filesystem label: $MOUNT_LABEL" >&2
-  exit 1
+  existing_label_device="$(readlink -f "/dev/disk/by-label/$MOUNT_LABEL")"
+  if [ "$existing_label_device" != "$resolved_device" ]; then
+    echo "Refusing to create a duplicate filesystem label: $MOUNT_LABEL already exists on $existing_label_device" >&2
+    exit 1
+  fi
+  if [ "$(lsblk --noheadings --raw --nodeps --output FSTYPE "$DEVICE")" != "ext4" ]; then
+    echo "Refusing to reuse $DEVICE because its filesystem is not ext4" >&2
+    exit 1
+  fi
 fi
 
-if [ -d "$MOUNT_POINT" ] && [ -n "$(find "$MOUNT_POINT" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
-  echo "Refusing to hide a non-empty containerd directory at $MOUNT_POINT" >&2
-  exit 1
+if [ -d "$MOUNT_POINT" ]; then
+  if ! first_entry="$(sudo find "$MOUNT_POINT" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)"; then
+    echo "Refusing to prepare the disk because $MOUNT_POINT could not be inspected" >&2
+    exit 1
+  fi
+  if [ -n "$first_entry" ]; then
+    echo "Refusing to hide a non-empty containerd directory at $MOUNT_POINT" >&2
+    exit 1
+  fi
 fi
 
-sudo wipefs --all "$DEVICE"
-sudo mkfs.ext4 -F -L "$MOUNT_LABEL" "$DEVICE"
-sudo udevadm settle
+if [ -z "$existing_label_device" ]; then
+  sudo wipefs --all "$DEVICE"
+  sudo mkfs.ext4 -F -L "$MOUNT_LABEL" "$DEVICE"
+  sudo udevadm settle
+else
+  echo "Reusing $DEVICE with its existing $MOUNT_LABEL ext4 filesystem"
+fi
 sudo mkdir -p "$MOUNT_POINT"
 sudo mount "/dev/disk/by-label/$MOUNT_LABEL" "$MOUNT_POINT"
 
 mounted_source="$(findmnt --noheadings --output SOURCE --target "$MOUNT_POINT")"
-resolved_device="$(readlink -f "$DEVICE")"
 resolved_source="$(readlink -f "$mounted_source")"
 if [ "$resolved_source" != "$resolved_device" ]; then
   echo "Unexpected device mounted at $MOUNT_POINT: $mounted_source" >&2

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -481,6 +481,7 @@ hosts/linux/activate-backup-files.sh
 install.sh
 named-hosts/kyber/activate-backup-files.sh
 named-hosts/kyber/activate-ip-forwarding.sh
+named-hosts/kyber/prepare-containerd-disk.sh
 named-hosts/kyber/rekey-galactica.sh
 named-hosts/kyber/setup.sh
 named-hosts/matic/pam-gnome-keyring-tpm-unlock.sh

--- a/spec/k3s_service_activate_spec.sh
+++ b/spec/k3s_service_activate_spec.sh
@@ -18,11 +18,28 @@ End
 
 Describe 'config/k3s/k3s.service'
 SERVICE="$PWD/config/k3s/k3s.service"
+MOUNT_UNIT="$PWD/config/k3s/containerd.mount"
 
 It 'restarts k3s after an unexpected exit'
 When run grep '^Restart=always$' "$SERVICE"
 The output should include 'Restart=always'
 The status should be success
+End
+
+It 'requires the dedicated containerd mount'
+When run grep '^Requires=var-lib-rancher-k3s-agent-containerd.mount$' "$SERVICE"
+The output should include 'Requires=var-lib-rancher-k3s-agent-containerd.mount'
+The status should be success
+End
+
+It 'mounts the labeled SSD at the containerd path'
+When run bash -c "grep -qxF 'What=/dev/disk/by-label/k3s-containerd' '$MOUNT_UNIT' && grep -qxF 'Where=/var/lib/rancher/k3s/agent/containerd' '$MOUNT_UNIT'"
+The status should be success
+End
+
+It 'does not allow a missing SSD to fall back to root'
+When run grep -E '^Options=.*nofail' "$MOUNT_UNIT"
+The status should equal 1
 End
 
 Describe 'container garbage collection ownership'
@@ -62,9 +79,28 @@ End
 End
 
 Describe 'k3s setup'
+SERVER_MODULE="$PWD/config/k3s/default.nix"
+
 It 'installs the generated systemd service'
 When run bash -c "grep '/etc/systemd/system/k3s.service' '$SCRIPT'"
 The output should include '/etc/systemd/system/k3s.service'
+End
+
+It 'installs and starts the dedicated containerd mount first'
+When run bash -c "grep '/etc/systemd/system/var-lib-rancher-k3s-agent-containerd.mount' '$SCRIPT' && grep 'enable --now var-lib-rancher-k3s-agent-containerd.mount' '$SCRIPT'"
+The output should include 'var-lib-rancher-k3s-agent-containerd.mount'
+The status should be success
+End
+
+It 'orders the k3s config hook after the mount hook'
+When run grep 'entryAfter \[ "setupK3s" \]' "$SERVER_MODULE"
+The output should include 'entryAfter [ "setupK3s" ]'
+The status should be success
+End
+
+It 'refuses to hide a running or non-empty containerd directory'
+When run bash -c "grep -q 'Refusing to mount the containerd SSD while k3s is running' '$SCRIPT' && grep -q 'Refusing to hide a non-empty containerd directory' '$SCRIPT'"
+The status should be success
 End
 
 It 'reloads and enables k3s'
@@ -90,6 +126,28 @@ End
 It 'resolves the mounted root block device instead of hard-coding it'
 When run bash -c "grep '@findmnt@ --noheadings --output SOURCE --target /' '$SCRIPT'"
 The output should include '@findmnt@ --noheadings --output SOURCE --target /'
+End
+End
+
+Describe 'named-hosts/kyber/prepare-containerd-disk.sh'
+PREPARE_SCRIPT="$PWD/named-hosts/kyber/prepare-containerd-disk.sh"
+
+It 'requires explicit destructive confirmation'
+When run grep -- '--confirm-wipe' "$PREPARE_SCRIPT"
+The output should include '--confirm-wipe'
+The status should be success
+End
+
+It 'refuses to run while k3s is active'
+When run grep 'systemctl is-active --quiet k3s' "$PREPARE_SCRIPT"
+The output should include 'systemctl is-active --quiet k3s'
+The status should be success
+End
+
+It 'creates the stable containerd filesystem label'
+When run grep 'mkfs.ext4 -F -L "$MOUNT_LABEL"' "$PREPARE_SCRIPT"
+The output should include 'mkfs.ext4 -F -L "$MOUNT_LABEL"'
+The status should be success
 End
 End
 End

--- a/spec/k3s_service_activate_spec.sh
+++ b/spec/k3s_service_activate_spec.sh
@@ -103,6 +103,12 @@ When run bash -c "grep -q 'Refusing to mount the containerd SSD while k3s is run
 The status should be success
 End
 
+It 'inspects the root-owned containerd directory through sudo'
+When run grep 'run_sudo @find@ "$MOUNT_POINT"' "$SCRIPT"
+The output should include 'run_sudo @find@ "$MOUNT_POINT"'
+The status should be success
+End
+
 It 'reloads and enables k3s'
 When run bash -c "grep 'enable --now k3s' '$SCRIPT'"
 The output should include 'enable --now k3s'
@@ -147,6 +153,17 @@ End
 It 'creates the stable containerd filesystem label'
 When run grep 'mkfs.ext4 -F -L "$MOUNT_LABEL"' "$PREPARE_SCRIPT"
 The output should include 'mkfs.ext4 -F -L "$MOUNT_LABEL"'
+The status should be success
+End
+
+It 'inspects the root-owned target through sudo'
+When run grep 'sudo find "$MOUNT_POINT"' "$PREPARE_SCRIPT"
+The output should include 'sudo find "$MOUNT_POINT"'
+The status should be success
+End
+
+It 'reuses the label only when it resolves to the selected device'
+When run bash -c "grep -q 'existing_label_device=.*readlink -f' '$PREPARE_SCRIPT' && grep -q '\"\$existing_label_device\" != \"\$resolved_device\"' '$PREPARE_SCRIPT'"
 The status should be success
 End
 End


### PR DESCRIPTION
## Summary

- mount Kyber containerd from the ext4 filesystem labeled `k3s-containerd`
- make K3s require the mount so a missing SSD fails closed instead of consuming the root disk
- add an explicitly destructive, guarded disk-preparation command for clean installs
- order Home Manager activation so the mount is ready before K3s config can restart the service
- document bootstrap, verification, and PVC/storage boundaries

## Verification

- `make shell-test` (1,676 ShellSpec examples and 420 Fish tests)
- `shellspec spec/k3s_service_activate_spec.sh spec/activate_k3s_spec.sh spec/coverage_spec.sh` (131 examples)
- `shellcheck home-manager/services/k3s/activate.sh named-hosts/kyber/prepare-containerd-disk.sh`
- `make nix-format-check`
- `make build`
- Kyber activation DAG evaluation: `setupK3s` after `writeBoundary`, `k3s-server` after `setupK3s`

No disk was formatted, no Home Manager switch was run, and no live Kyber state was changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated `containerd` for `k3s` on a dedicated ext4 SSD labeled `k3s-containerd`, mounted at `/var/lib/rancher/k3s/agent/containerd`. `k3s` now hard-requires this mount to avoid using the root disk and to reduce I/O contention.

- **New Features**
  - Added a systemd mount unit resolving `/dev/disk/by-label/k3s-containerd` to the containerd path (no `nofail`), and updated `k3s.service` to `Require` and `After` the mount.
  - Activation installs/updates the mount unit, refuses risky states (k3s running or non-empty dir), enables the mount first, then `k3s`; `k3s-server` runs after `setupK3s`.
  - Hardened `named-hosts/kyber/prepare-containerd-disk.sh`: explicit `--confirm-wipe`, refuses non-block/mounted devices and active `k3s`, creates ext4 with the label, only reuses the label when it’s the same device and ext4, and verifies the mounted device matches. Docs and tests updated.

- **Migration**
  - New or wiped host: `sudo systemctl stop k3s`, run `./named-hosts/kyber/prepare-containerd-disk.sh /dev/<device> --confirm-wipe`, then `make switch`.
  - Verify: `findmnt /var/lib/rancher/k3s/agent/containerd`, `systemctl is-enabled var-lib-rancher-k3s-agent-containerd.mount`, `systemctl show k3s -p Requires -p After`, then restart `k3s`.

<sup>Written for commit 1b0e499b72ea99932845a3f7cc6dd640c3962098. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

