### PR TITLE
test(k3s): allow literal shellcheck assertions

### DIFF
--- a/spec/k3s_service_activate_spec.sh
+++ b/spec/k3s_service_activate_spec.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2329
+# shellcheck disable=SC2016,SC2329
 
 Describe 'home-manager/services/k3s/activate.sh'
 SCRIPT="$PWD/home-manager/services/k3s/activate.sh"
@@ -104,8 +104,8 @@ The status should be success
 End
 
 It 'inspects the root-owned containerd directory through sudo'
-When run grep "run_sudo @find@ \"\$MOUNT_POINT\"" "$SCRIPT"
-The output should include "run_sudo @find@ \"\$MOUNT_POINT\""
+When run grep 'run_sudo @find@ "$MOUNT_POINT"' "$SCRIPT"
+The output should include 'run_sudo @find@ "$MOUNT_POINT"'
 The status should be success
 End
 
@@ -151,14 +151,14 @@ The status should be success
 End
 
 It 'creates the stable containerd filesystem label'
-When run grep "mkfs.ext4 -F -L \"\$MOUNT_LABEL\"" "$PREPARE_SCRIPT"
-The output should include "mkfs.ext4 -F -L \"\$MOUNT_LABEL\""
+When run grep 'mkfs.ext4 -F -L "$MOUNT_LABEL"' "$PREPARE_SCRIPT"
+The output should include 'mkfs.ext4 -F -L "$MOUNT_LABEL"'
 The status should be success
 End
 
 It 'inspects the root-owned target through sudo'
-When run grep "sudo find \"\$MOUNT_POINT\"" "$PREPARE_SCRIPT"
-The output should include "sudo find \"\$MOUNT_POINT\""
+When run grep 'sudo find "$MOUNT_POINT"' "$PREPARE_SCRIPT"
+The output should include 'sudo find "$MOUNT_POINT"'
 The status should be success
 End
 

--- a/spec/k3s_service_activate_spec.sh
+++ b/spec/k3s_service_activate_spec.sh
@@ -104,8 +104,8 @@ The status should be success
 End
 
 It 'inspects the root-owned containerd directory through sudo'
-When run grep 'run_sudo @find@ "$MOUNT_POINT"' "$SCRIPT"
-The output should include 'run_sudo @find@ "$MOUNT_POINT"'
+When run grep "run_sudo @find@ \"\$MOUNT_POINT\"" "$SCRIPT"
+The output should include "run_sudo @find@ \"\$MOUNT_POINT\""
 The status should be success
 End
 
@@ -151,14 +151,14 @@ The status should be success
 End
 
 It 'creates the stable containerd filesystem label'
-When run grep 'mkfs.ext4 -F -L "$MOUNT_LABEL"' "$PREPARE_SCRIPT"
-The output should include 'mkfs.ext4 -F -L "$MOUNT_LABEL"'
+When run grep "mkfs.ext4 -F -L \"\$MOUNT_LABEL\"" "$PREPARE_SCRIPT"
+The output should include "mkfs.ext4 -F -L \"\$MOUNT_LABEL\""
 The status should be success
 End
 
 It 'inspects the root-owned target through sudo'
-When run grep 'sudo find "$MOUNT_POINT"' "$PREPARE_SCRIPT"
-The output should include 'sudo find "$MOUNT_POINT"'
+When run grep "sudo find \"\$MOUNT_POINT\"" "$PREPARE_SCRIPT"
+The output should include "sudo find \"\$MOUNT_POINT\""
 The status should be success
 End
 


### PR DESCRIPTION
## Summary

- mark SC2016 as intentional in the K3s ShellSpec file, where assertions match literal shell-variable text
- preserve the repository formatter canonical single-quote style
- fix the shell-lint failure from merged PR #2132 without changing runtime or host configuration

## Verification

- `make shell-check-dev`
- `make nix-format-check`
- `shellspec spec/k3s_service_activate_spec.sh spec/activate_k3s_spec.sh spec/coverage_spec.sh` (134 examples, 0 failures)