### PR TITLE
fix: repair PostHog API bundle through ing

### DIFF
--- a/home-manager/modules/npm-globals/install-npm-globals.sh
+++ b/home-manager/modules/npm-globals/install-npm-globals.sh
@@ -74,6 +74,31 @@ repair_sqlite3_native_binding() {
   echo "sqlite3 native binding rebuilt"
 }
 
+# Bun's global package layout moves the PostHog native launcher under
+# node_modules/.bin_real. The launcher loads its agent API bundle from the
+# versioned PostHog runtime directory, while the npm package ships that bundle
+# under its own lib directory. Seed the runtime location after every install.
+repair_posthog_api_cli_bundle() {
+  local posthog_cli_dir="${GLOBAL_MODULES}/@posthog/cli"
+  local source_bundle="${posthog_cli_dir}/lib/posthog-api-cli.mjs"
+  local version posthog_home target_bundle
+
+  [ -f "$source_bundle" ] || return 0
+  version=$(jq -r '.version // empty' "${posthog_cli_dir}/package.json" 2>/dev/null || true)
+  [ -n "$version" ] || return 0
+
+  posthog_home="${POSTHOG_HOME:-${HOME}/.posthog}"
+  target_bundle="${posthog_home}/api-cli/${version}/posthog-api-cli.mjs"
+  if [ -f "$target_bundle" ] && cmp -s "$source_bundle" "$target_bundle"; then
+    echo "PostHog API CLI bundle already installed"
+    return 0
+  fi
+
+  mkdir -p "$(dirname "$target_bundle")"
+  cp -f "$source_bundle" "$target_bundle"
+  echo "Installed PostHog API CLI bundle for $version"
+}
+
 # Current-platform tokens used to recognise the native optionalDependency that
 # actually carries a package's binary (e.g. *-darwin-arm64, @esbuild/linux-x64).
 case "$(uname -s)" in
@@ -482,6 +507,10 @@ done
 
 if ! repair_sqlite3_native_binding; then
   echo "Warning: sqlite3 native binding repair failed" >&2
+fi
+
+if ! repair_posthog_api_cli_bundle; then
+  echo "Warning: PostHog API CLI bundle repair failed" >&2
 fi
 
 echo "npm globals installation complete"

--- a/spec/npm_globals_spec.sh
+++ b/spec/npm_globals_spec.sh
@@ -248,6 +248,23 @@ The output should include 'const sqlite3 = require'
 End
 End
 
+Describe 'PostHog API CLI bundle repair'
+It 'defines a PostHog API bundle repair step'
+When run bash -c "grep 'repair_posthog_api_cli_bundle()' '$SCRIPT'"
+The output should include 'repair_posthog_api_cli_bundle'
+End
+
+It 'seeds the versioned PostHog runtime bundle path'
+When run bash -c "grep 'api-cli.*/posthog-api-cli.mjs' '$SCRIPT'"
+The output should include 'posthog-api-cli.mjs'
+End
+
+It 'runs the PostHog repair after global installs'
+When run bash -c "grep 'repair_posthog_api_cli_bundle' '$SCRIPT' | tail -1"
+The output should include 'repair_posthog_api_cli_bundle'
+End
+End
+
 Describe 'native binary completeness'
 It 'detects a missing platform-native optionalDependency'
 When run bash -c "grep 'missing_native_optional_dep' '$SCRIPT'"


### PR DESCRIPTION
## Summary
- seed PostHog's versioned API bundle runtime location after global installs
- keep plain `posthog-cli api` usable without environment overrides
- cover the installer repair with focused shell specs

## Validation
- `bash -n home-manager/modules/npm-globals/install-npm-globals.sh`
- `make shell-test`
- `posthog-cli api search 'error|exception'`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs the PostHog API CLI bundle after global installs so `posthog-cli api` works without environment overrides. Seeds the versioned runtime path expected by the launcher on Bun’s global package layout.

- **Bug Fixes**
  - Copy `posthog-api-cli.mjs` from `@posthog/cli` into the PostHog runtime directory (`~/.posthog/api-cli/<version>/`).
  - Run the repair step at the end of `install-npm-globals.sh`, with a warning if it fails.
  - Add shell specs to verify the repair logic and execution.

<sup>Written for commit 8b8cdb4fedd5453ee089499f81abb9684c2cff36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

