### PR TITLE
fix: verify PostHog api CLI instead of no-op bundle copy

### DIFF
--- a/home-manager/modules/npm-globals/install-npm-globals.sh
+++ b/home-manager/modules/npm-globals/install-npm-globals.sh
@@ -74,29 +74,32 @@ repair_sqlite3_native_binding() {
   echo "sqlite3 native binding rebuilt"
 }
 
-# Bun's global package layout moves the PostHog native launcher under
-# node_modules/.bin_real. The launcher loads its agent API bundle from the
-# versioned PostHog runtime directory, while the npm package ships that bundle
-# under its own lib directory. Seed the runtime location after every install.
-repair_posthog_api_cli_bundle() {
+# The @posthog/cli npm package is a cargo-dist launcher: `posthog-cli` is a
+# native binary that, for the `api` subcommand, self-extracts its bundled
+# posthog-api-cli.mjs into ${HOME}/.posthog/api-cli/<version>/ and runs it with
+# node. The binary re-seeds that bundle on demand, so the bundle is never the
+# missing piece -- the real runtime dependency is `node` on PATH (the bundle has
+# a `#!/usr/bin/env node` shebang). Verify the `api` surface actually runs after
+# install and report the true cause when it does not.
+verify_posthog_api_cli() {
   local posthog_cli_dir="${GLOBAL_MODULES}/@posthog/cli"
-  local source_bundle="${posthog_cli_dir}/lib/posthog-api-cli.mjs"
-  local version posthog_home target_bundle
+  local posthog_cli_bin="${HOME}/.bun/bin/posthog-cli"
 
-  [ -f "$source_bundle" ] || return 0
-  version=$(jq -r '.version // empty' "${posthog_cli_dir}/package.json" 2>/dev/null || true)
-  [ -n "$version" ] || return 0
+  [ -d "$posthog_cli_dir" ] || return 0
+  [ -x "$posthog_cli_bin" ] || return 0
 
-  posthog_home="${POSTHOG_HOME:-${HOME}/.posthog}"
-  target_bundle="${posthog_home}/api-cli/${version}/posthog-api-cli.mjs"
-  if [ -f "$target_bundle" ] && cmp -s "$source_bundle" "$target_bundle"; then
-    echo "PostHog API CLI bundle already installed"
+  if ! command -v node &>/dev/null; then
+    echo "PostHog api subcommand needs node on PATH; skipping verification" >&2
     return 0
   fi
 
-  mkdir -p "$(dirname "$target_bundle")"
-  cp -f "$source_bundle" "$target_bundle"
-  echo "Installed PostHog API CLI bundle for $version"
+  if "$posthog_cli_bin" api tools >/dev/null 2>&1; then
+    echo "PostHog API CLI bundle is loadable"
+    return 0
+  fi
+
+  echo "PostHog API CLI bundle is not loadable (is node on PATH?)" >&2
+  return 1
 }
 
 # Current-platform tokens used to recognise the native optionalDependency that
@@ -509,8 +512,8 @@ if ! repair_sqlite3_native_binding; then
   echo "Warning: sqlite3 native binding repair failed" >&2
 fi
 
-if ! repair_posthog_api_cli_bundle; then
-  echo "Warning: PostHog API CLI bundle repair failed" >&2
+if ! verify_posthog_api_cli; then
+  echo "Warning: PostHog API CLI bundle verification failed" >&2
 fi
 
 echo "npm globals installation complete"

--- a/spec/npm_globals_spec.sh
+++ b/spec/npm_globals_spec.sh
@@ -248,20 +248,25 @@ The output should include 'const sqlite3 = require'
 End
 End
 
-Describe 'PostHog API CLI bundle repair'
-It 'defines a PostHog API bundle repair step'
-When run bash -c "grep 'repair_posthog_api_cli_bundle()' '$SCRIPT'"
-The output should include 'repair_posthog_api_cli_bundle'
+Describe 'PostHog API CLI verification'
+It 'defines a PostHog API verification step'
+When run bash -c "grep 'verify_posthog_api_cli()' '$SCRIPT'"
+The output should include 'verify_posthog_api_cli'
 End
 
-It 'seeds the versioned PostHog runtime bundle path'
-When run bash -c "grep 'api-cli.*/posthog-api-cli.mjs' '$SCRIPT'"
-The output should include 'posthog-api-cli.mjs'
+It 'verifies the api subcommand actually runs'
+When run bash -c "grep 'api tools' '$SCRIPT'"
+The output should include 'api tools'
 End
 
-It 'runs the PostHog repair after global installs'
-When run bash -c "grep 'repair_posthog_api_cli_bundle' '$SCRIPT' | tail -1"
-The output should include 'repair_posthog_api_cli_bundle'
+It 'reports node on PATH as the real dependency'
+When run bash -c "grep 'needs node on PATH' '$SCRIPT'"
+The output should include 'node on PATH'
+End
+
+It 'runs the PostHog verification after global installs'
+When run bash -c "grep 'verify_posthog_api_cli' '$SCRIPT' | tail -1"
+The output should include 'verify_posthog_api_cli'
 End
 End
 


### PR DESCRIPTION
## Problem

"PostHog's API bundle is still unavailable, so no PostHog issues" - but the bundle is **not** actually unavailable. `posthog-cli api call query-error-tracking-issues-list '{}'` returns live issues.

The `repair_posthog_api_cli_bundle` function added in #2137 is a **no-op**, built on a wrong premise:

| Claim in #2137 | Reality |
|---|---|
| The bundle must be seeded into `~/.posthog/api-cli/<version>/` | The native `posthog-cli` binary self-seeds it there on every `api` call - deleting the dir, it is recreated automatically with an identical file (same SHA) |
| Copying `lib/posthog-api-cli.mjs` "repairs" availability | It just races the binary to write the same bytes. Fixes nothing. |

The only dependency the binary cannot self-provide is `node` - the bundle is a `.mjs` with a `#!/usr/bin/env node` shebang. Strip node from PATH and you get `env: node: No such file or directory`, which is the real "bundle unavailable" symptom. Copying the `.mjs` does nothing for that.

## Fix

Replace the ineffective copy-repair with `verify_posthog_api_cli`, which:
- runs `posthog-cli api tools` to actually verify the `api` surface loads (mirrors the existing sqlite3 `node -e` verification pattern), and
- reports node on PATH as the true dependency when node is missing, instead of silently copying a file that changes nothing.

## Verification

- `shellcheck` clean
- `shellspec spec/npm_globals_spec.sh` -> 65 examples, 0 failures
- Executed `verify_posthog_api_cli` in both node-present (`bundle is loadable`) and node-absent (`needs node on PATH; skipping`) cases