### PR TITLE
fix(kyber): harden VPS firewall, sshd, and secret deploy

### DIFF
--- a/home-manager/activation/deploy-agenix-secret.sh
+++ b/home-manager/activation/deploy-agenix-secret.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Decrypt and deploy an agenix secret if destination doesn't exist
+# Decrypt and deploy an agenix secret, replacing the destination when content changes.
 # Usage: deploy-agenix-secret.sh <dest_path> <secret_file> <identity_key> <rage_bin>
 set -euo pipefail
 DEST="$1"
@@ -7,19 +7,36 @@ SECRET_FILE="$2"
 IDENTITY_KEY="$3"
 RAGE_BIN="$4"
 
-if [[ -f $DEST ]]; then
-  exit 0
-fi
-
-echo "Deploying secret from agenix..."
 if [[ ! -f $SECRET_FILE ]]; then
   echo "Warning: Secret file not found at $SECRET_FILE" >&2
   exit 0
 fi
 
-if "$RAGE_BIN" -d -i "$IDENTITY_KEY" "$SECRET_FILE" -o "$DEST" 2>/dev/null; then
-  chmod 0600 "$DEST"
-  echo "Secret deployed successfully"
-else
+TMP="$(mktemp)"
+cleanup() {
+  rm -f "$TMP"
+}
+trap cleanup EXIT
+
+echo "Deploying secret from agenix..."
+if ! "$RAGE_BIN" -d -i "$IDENTITY_KEY" "$SECRET_FILE" -o "$TMP" 2>/dev/null; then
   echo "Warning: SSH key not authorized to decrypt - skipping" >&2
+  exit 0
 fi
+
+chmod 0600 "$TMP"
+
+if [[ -f $DEST ]] && cmp -s "$TMP" "$DEST"; then
+  echo "Secret already up to date"
+  exit 0
+fi
+
+# Atomic replace into the destination directory
+DEST_DIR="$(dirname "$DEST")"
+mkdir -p "$DEST_DIR"
+STAGE="${DEST}.agenix.new"
+mv -f "$TMP" "$STAGE"
+trap - EXIT
+mv -f "$STAGE" "$DEST"
+chmod 0600 "$DEST"
+echo "Secret deployed successfully"

--- a/home-manager/services/firewall/activate.sh
+++ b/home-manager/services/firewall/activate.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
+# Converge Kyber WAN firewall on every activation (IPv4 + IPv6).
+# Public SSH is denied on the WAN NIC; access is via Tailscale (and Latitude SG).
 set -euo pipefail
 
 CHAIN="kyber-firewall"
-PUBLIC_IF="eno1"
 
 SUDO_CMD=""
 if command -v sudo >/dev/null 2>&1; then
@@ -30,26 +31,78 @@ ipt() {
   run_root @iptables@ "$@"
 }
 
-if ipt -L "$CHAIN" -n >/dev/null 2>&1; then
-  echo "Firewall chain $CHAIN already exists, skipping."
-  exit 0
-fi
+ip6t() {
+  run_root @ip6tables@ "$@"
+}
 
-echo "Configuring iptables firewall on $PUBLIC_IF..."
+detect_public_if() {
+  local ifc=""
+  if [ -n "${KYBER_PUBLIC_IF:-}" ]; then
+    printf '%s\n' "$KYBER_PUBLIC_IF"
+    return 0
+  fi
 
-ipt -N "$CHAIN"
+  ifc="$(@ip@ -4 route show default 2>/dev/null | awk '/default/ {
+    for (i = 1; i <= NF; i++) {
+      if ($i == "dev") {
+        print $(i + 1)
+        exit
+      }
+    }
+  }')"
 
-# Allow established/related connections
-ipt -A "$CHAIN" -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+  if [ -z "$ifc" ]; then
+    echo "Could not detect public interface (no default IPv4 route). Set KYBER_PUBLIC_IF." >&2
+    exit 1
+  fi
 
-# Allow SSH
-ipt -A "$CHAIN" -p tcp --dport 22 -j ACCEPT
+  if [ ! -d "/sys/class/net/$ifc" ]; then
+    echo "Detected public interface '$ifc' does not exist. Set KYBER_PUBLIC_IF." >&2
+    exit 1
+  fi
 
-# Drop everything else on public interface
-ipt -A "$CHAIN" -j DROP
+  printf '%s\n' "$ifc"
+}
 
-# Insert chain into INPUT for public interface only
-ipt -I INPUT 1 -i "$PUBLIC_IF" -j "$CHAIN"
+# Remove every INPUT jump into CHAIN, then attach for the current WAN NIC.
+resync_input_jump() {
+  local ipt_cmd="$1"
+  local public_if="$2"
+  local rule
 
-echo "Firewall enabled: only SSH (22) allowed on $PUBLIC_IF."
-echo "Tailscale, k3s, and Docker traffic unaffected (different interfaces)."
+  while IFS= read -r rule; do
+    # shellcheck disable=SC2086
+    $ipt_cmd -D ${rule#-A }
+  done < <($ipt_cmd -S INPUT 2>/dev/null | awk -v chain="$CHAIN" '
+    $1 == "-A" && $0 ~ ("-j " chain "$") { print }
+  ' || true)
+
+  $ipt_cmd -I INPUT 1 -i "$public_if" -j "$CHAIN"
+}
+
+ensure_chain() {
+  local ipt_cmd="$1"
+
+  if $ipt_cmd -L "$CHAIN" -n >/dev/null 2>&1; then
+    $ipt_cmd -F "$CHAIN"
+  else
+    $ipt_cmd -N "$CHAIN"
+  fi
+
+  # Established/related only. No public SSH: Tailscale + Latitude SG own remote access.
+  $ipt_cmd -A "$CHAIN" -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+  $ipt_cmd -A "$CHAIN" -j DROP
+}
+
+PUBLIC_IF="$(detect_public_if)"
+
+echo "Converging firewall on $PUBLIC_IF (IPv4 + IPv6)..."
+
+ensure_chain ipt
+resync_input_jump ipt "$PUBLIC_IF"
+
+ensure_chain ip6t
+resync_input_jump ip6t "$PUBLIC_IF"
+
+echo "Firewall enabled: WAN $PUBLIC_IF drops all new ingress (SSH via Tailscale only)."
+echo "Tailscale, k3s, and container traffic on other interfaces are unaffected."

--- a/home-manager/services/firewall/default.nix
+++ b/home-manager/services/firewall/default.nix
@@ -9,6 +9,8 @@ let
   inherit (inputs) host;
   activateScript = pkgs.replaceVars ./activate.sh {
     iptables = "${pkgs.iptables}/bin/iptables";
+    ip6tables = "${pkgs.iptables}/bin/ip6tables";
+    ip = "${pkgs.iproute2}/bin/ip";
   };
 in
 lib.mkIf host.isKyber {

--- a/home-manager/services/openclaw/default.nix
+++ b/home-manager/services/openclaw/default.nix
@@ -30,7 +30,7 @@ lib.mkIf host.isKyber {
     };
     Service = {
       Type = "simple";
-      ExecStart = "${homeDir}/.bun/bin/openclaw gateway --port 18789";
+      ExecStart = "${homeDir}/.bun/bin/openclaw gateway --port 18789 --bind loopback";
       Restart = "always";
       RestartSec = "5s";
       Environment = [

--- a/named-hosts/kyber/README.md
+++ b/named-hosts/kyber/README.md
@@ -49,6 +49,27 @@ Once Tailscale is set up:
 kyber  # Fish abbreviation that runs: ssh ubuntu@kyber
 ```
 
+Remote SSH should go through Tailscale. Latitude project firewall restricts
+TCP/22 to `100.64.0.0/10`, and host activation drops new WAN ingress on the
+public NIC (IPv4 + IPv6). Prefer keeping provider SG and host firewall aligned.
+
+## Security Posture
+
+Activation converges:
+
+- WAN `iptables` / `ip6tables` chain (default-route NIC, override with
+  `KYBER_PUBLIC_IF`) — established only, no public SSH
+- `/etc/ssh/sshd_config.d/99-kyber-hardening.conf` — pubkey-only, no root,
+  `AllowUsers ubuntu`
+- OpenClaw gateway forced `--bind loopback`
+- Tailscale `--advertise-exit-node` without `--ssh` (OpenSSH over Tailscale)
+
+Still intentional / follow-up:
+
+- Shared Galactica GitHub + GPG identity until per-host deploy keys exist
+- Bootstrap still uses vendor `curl | sh` installers (verify checksums)
+- Cluster-admin kubeconfig sync from Galactica remains break-glass style
+
 ## k3s Containerd SSD
 
 Kyber mounts the dedicated ext4 filesystem with UUID

--- a/named-hosts/kyber/activate-sshd.sh
+++ b/named-hosts/kyber/activate-sshd.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Install declarative OpenSSH hardening drop-in for Kyber.
+set -euo pipefail
+
+DROP_IN_DIR="/etc/ssh/sshd_config.d"
+DROP_IN_FILE="${DROP_IN_DIR}/99-kyber-hardening.conf"
+MARKER_BEGIN="# BEGIN kyber-hardening"
+MARKER_END="# END kyber-hardening"
+
+SUDO_CMD=""
+if command -v sudo >/dev/null 2>&1; then
+  SUDO_CMD="sudo"
+elif [ -x /run/wrappers/bin/sudo ]; then
+  SUDO_CMD="/run/wrappers/bin/sudo"
+elif [ -x /usr/bin/sudo ]; then
+  SUDO_CMD="/usr/bin/sudo"
+elif command -v doas >/dev/null 2>&1; then
+  SUDO_CMD="doas"
+elif [ "$(id -u)" -ne 0 ]; then
+  echo "sshd hardening requires root privileges." >&2
+  exit 1
+fi
+
+run_root() {
+  if [ -n "$SUDO_CMD" ]; then
+    "$SUDO_CMD" "$@"
+  else
+    "$@"
+  fi
+}
+
+CONTENT=$(
+  cat <<EOF
+${MARKER_BEGIN}
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PermitRootLogin no
+PubkeyAuthentication yes
+AllowUsers ubuntu
+MaxAuthTries 3
+AuthenticationMethods publickey
+${MARKER_END}
+EOF
+)
+
+if [ -f "$DROP_IN_FILE" ] && printf '%s\n' "$CONTENT" | cmp -s - "$DROP_IN_FILE"; then
+  echo "sshd hardening already up to date at $DROP_IN_FILE"
+  exit 0
+fi
+
+echo "Installing sshd hardening drop-in at $DROP_IN_FILE..."
+run_root mkdir -p "$DROP_IN_DIR"
+printf '%s\n' "$CONTENT" | run_root tee "$DROP_IN_FILE" >/dev/null
+run_root chmod 0644 "$DROP_IN_FILE"
+
+if run_root sshd -t; then
+  if command -v systemctl >/dev/null 2>&1; then
+    run_root systemctl reload ssh 2>/dev/null || run_root systemctl reload sshd 2>/dev/null || true
+  fi
+  echo "sshd hardening applied."
+else
+  echo "sshd -t failed after writing $DROP_IN_FILE; leaving file for inspection." >&2
+  exit 1
+fi

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -111,13 +111,13 @@ home-manager.lib.homeManagerConfiguration {
           };
         };
 
-        # GPG agent: short cache (matches Galactica). Shared signing key blast radius.
+        # GPG agent configuration
         services.gpg-agent = {
           enable = true;
           enableSshSupport = false;
           pinentry.package = pkgs.pinentry-tty;
-          defaultCacheTtl = 1800;
-          maxCacheTtl = 7200;
+          defaultCacheTtl = 94608000; # 3 years
+          maxCacheTtl = 94608000; # 3 years
         };
 
         # GPG_TTY is set in fish shell init instead of sessionVariables

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -75,12 +75,18 @@ home-manager.lib.homeManagerConfiguration {
 
         # Manually deploy agenix secrets during activation
         # This ensures secrets are deployed even if the agenix activation hook doesn't run properly
+        # Source ciphertext is galactica/keys/id_ed25519.age (secrets.nix keys/id_github.age)
         home.activation.deployAgenixSecrets = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
           $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/deploy-agenix-secret.sh}" \
             "${config.home.homeDirectory}/.ssh/id_ed25519_github" \
-            "${builtins.toString ../galactica/keys/id_github.age}" \
+            "${builtins.toString ../galactica/keys/id_ed25519.age}" \
             "${config.home.homeDirectory}/.ssh/id_ed25519" \
             "${pkgs.rage}/bin/rage"
+        '';
+
+        # Declarative OpenSSH hardening (password/root off; pubkey-only)
+        home.activation.hardenSshd = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+          $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-sshd.sh}"
         '';
 
         # Import GPG key from agenix (all systems with dotfiles)
@@ -105,13 +111,13 @@ home-manager.lib.homeManagerConfiguration {
           };
         };
 
-        # GPG agent configuration
+        # GPG agent: short cache (matches Galactica). Shared signing key blast radius.
         services.gpg-agent = {
           enable = true;
           enableSshSupport = false;
           pinentry.package = pkgs.pinentry-tty;
-          defaultCacheTtl = 94608000; # 3 years
-          maxCacheTtl = 94608000; # 3 years
+          defaultCacheTtl = 1800;
+          maxCacheTtl = 7200;
         };
 
         # GPG_TTY is set in fish shell init instead of sessionVariables
@@ -136,11 +142,11 @@ home-manager.lib.homeManagerConfiguration {
           installSystemService = true;
           # Auth key will be provided via agenix secret
           # authKeyFile = config.age.secrets."keys/tailscale-auth.age".path;
+          # Exit node kept; Tailscale SSH omitted — OpenSSH over Tailscale + Latitude SG.
           extraUpArgs = [
             "--reset"
             "--accept-dns=false"
             "--advertise-exit-node"
-            "--ssh"
           ];
         };
       }

--- a/named-hosts/kyber/secrets.nix
+++ b/named-hosts/kyber/secrets.nix
@@ -11,14 +11,14 @@ let
   ];
 in
 {
-  # Shared SSH key for GitHub authentication (synced from galactica)
-  # This is the id_github key from galactica, which is the GitHub-authorized key
+  # Shared GitHub deploy key (ciphertext: galactica/keys/id_ed25519.age).
+  # Prefer per-host least-privilege deploy keys when rotating credentials.
   "keys/id_github.age" = {
     file = ../galactica/keys/id_ed25519.age;
     publicKeys = allMachines;
   };
 
-  # GPG key for commit signing (synced from galactica)
+  # Shared GPG signing key (synced from galactica). Same blast-radius note as above.
   "keys/gpg.age" = {
     file = ../galactica/keys/gpg.age;
     publicKeys = allMachines;

--- a/named-hosts/kyber/setup.sh
+++ b/named-hosts/kyber/setup.sh
@@ -2,6 +2,10 @@
 
 # Kyber (Ubuntu) Initial Setup Script
 # Run this on the Kyber server to bootstrap the environment
+#
+# Supply-chain note: the Tailscale installer is fetched over HTTPS from the
+# vendor. Prefer verifying the published checksum/signature from
+# https://tailscale.com/download when bootstrapping a production host.
 
 set -e
 
@@ -10,6 +14,7 @@ echo "🚀 Setting up Kyber server..."
 # 1. Install Tailscale
 echo "📦 Installing Tailscale..."
 if ! command -v tailscale &>/dev/null; then
+  echo "Fetching Tailscale installer (verify vendor checksums for production)..."
   curl -fsSL https://tailscale.com/install.sh | sh
 fi
 

--- a/spec/activate_firewall_spec.sh
+++ b/spec/activate_firewall_spec.sh
@@ -34,9 +34,14 @@ When run bash -c "grep 'CHAIN=' '$SCRIPT'"
 The output should include 'kyber-firewall'
 End
 
-It 'targets the public interface'
-When run bash -c "grep 'PUBLIC_IF=' '$SCRIPT'"
-The output should include 'eno1'
+It 'detects the public interface from the default route'
+When run bash -c "grep 'route show default' '$SCRIPT'"
+The output should include 'route show default'
+End
+
+It 'allows KYBER_PUBLIC_IF override'
+When run bash -c "grep 'KYBER_PUBLIC_IF' '$SCRIPT'"
+The output should include 'KYBER_PUBLIC_IF'
 End
 
 It 'allows established connections'
@@ -44,9 +49,9 @@ When run bash -c "grep 'ESTABLISHED,RELATED' '$SCRIPT'"
 The output should include 'ESTABLISHED,RELATED'
 End
 
-It 'allows SSH on port 22'
-When run bash -c "grep 'dport 22' '$SCRIPT'"
-The output should include 'dport 22'
+It 'does not allow public SSH on the WAN chain'
+When run bash -c "grep -E 'dport[[:space:]]+22' '$SCRIPT' || true"
+The output should equal ''
 End
 
 It 'drops other traffic'
@@ -54,14 +59,21 @@ When run bash -c "grep -- '-j DROP' '$SCRIPT'"
 The output should include 'DROP'
 End
 
-It 'is idempotent by checking chain existence'
-When run bash -c "grep 'already exists' '$SCRIPT'"
-The output should include 'already exists'
+It 'reconverges by flushing the chain'
+When run bash -c "grep -- '-F \"\$CHAIN\"' '$SCRIPT'"
+The output should include '-F'
 End
 
-It 'uses a nix-substituted iptables path'
-When run bash -c "grep '@iptables@' '$SCRIPT'"
+It 'programs ip6tables as well as iptables'
+When run bash -c "grep '@ip6tables@' '$SCRIPT' && grep 'ensure_chain ip6t' '$SCRIPT'"
+The output should include '@ip6tables@'
+The output should include 'ensure_chain ip6t'
+End
+
+It 'uses nix-substituted iptables and ip paths'
+When run bash -c "grep '@iptables@' '$SCRIPT' && grep '@ip@' '$SCRIPT'"
 The output should include '@iptables@'
+The output should include '@ip@'
 End
 End
 End

--- a/spec/activate_kyber_spec.sh
+++ b/spec/activate_kyber_spec.sh
@@ -104,9 +104,9 @@ When run bash -c "grep 'activate-sshd.sh' '$PWD/named-hosts/kyber/default.nix'"
 The output should include 'activate-sshd.sh'
 End
 
-It 'uses a short gpg-agent cache ttl'
-When run bash -c "grep 'defaultCacheTtl = 1800' '$PWD/named-hosts/kyber/default.nix'"
-The output should include 'defaultCacheTtl = 1800'
+It 'keeps a long gpg-agent cache ttl'
+When run bash -c "grep 'defaultCacheTtl = 94608000' '$PWD/named-hosts/kyber/default.nix'"
+The output should include 'defaultCacheTtl = 94608000'
 End
 
 It 'does not enable Tailscale SSH'

--- a/spec/activate_kyber_spec.sh
+++ b/spec/activate_kyber_spec.sh
@@ -93,5 +93,68 @@ It 'quotes the agenix config directory argument'
 When run cat "$PWD/named-hosts/kyber/default.nix"
 The output should include '"${config.home.homeDirectory}/.config/agenix"'
 End
+
+It 'deploys the galactica id_ed25519.age ciphertext'
+When run bash -c "grep 'id_ed25519.age' '$PWD/named-hosts/kyber/default.nix'"
+The output should include 'id_ed25519.age'
+End
+
+It 'hardens sshd during activation'
+When run bash -c "grep 'activate-sshd.sh' '$PWD/named-hosts/kyber/default.nix'"
+The output should include 'activate-sshd.sh'
+End
+
+It 'uses a short gpg-agent cache ttl'
+When run bash -c "grep 'defaultCacheTtl = 1800' '$PWD/named-hosts/kyber/default.nix'"
+The output should include 'defaultCacheTtl = 1800'
+End
+
+It 'does not enable Tailscale SSH'
+When run bash -c "grep -F '\"--ssh\"' '$PWD/named-hosts/kyber/default.nix' || true"
+The output should equal ''
+End
+End
+End
+
+Describe 'named-hosts/kyber/activate-sshd.sh'
+SCRIPT="$PWD/named-hosts/kyber/activate-sshd.sh"
+
+Describe 'script properties'
+It 'uses bash shebang'
+When run bash -c "head -1 '$SCRIPT'"
+The output should include '#!/usr/bin/env bash'
+End
+
+It 'uses strict mode'
+When run bash -c "head -5 '$SCRIPT'"
+The output should include 'set -euo pipefail'
+End
+End
+
+Describe 'hardening content'
+It 'disables password authentication'
+When run bash -c "grep 'PasswordAuthentication no' '$SCRIPT'"
+The output should include 'PasswordAuthentication no'
+End
+
+It 'disables root login'
+When run bash -c "grep 'PermitRootLogin no' '$SCRIPT'"
+The output should include 'PermitRootLogin no'
+End
+
+It 'restricts AllowUsers to ubuntu'
+When run bash -c "grep 'AllowUsers ubuntu' '$SCRIPT'"
+The output should include 'AllowUsers ubuntu'
+End
+
+It 'writes an sshd_config.d drop-in'
+When run bash -c "grep '99-kyber-hardening.conf' '$SCRIPT'"
+The output should include '99-kyber-hardening.conf'
+End
+
+It 'validates config with sshd -t'
+When run bash -c "grep 'sshd -t' '$SCRIPT'"
+The output should include 'sshd -t'
+End
 End
 End

--- a/spec/activate_paperclip_openclaw_spec.sh
+++ b/spec/activate_paperclip_openclaw_spec.sh
@@ -30,6 +30,11 @@ It 'quotes the home directory argument when invoking the helper'
 When run cat "$PWD/home-manager/services/openclaw/default.nix"
 The output should include '"${./activate.sh}" "${homeDir}"'
 End
+
+It 'forces loopback bind on the gateway unit'
+When run bash -c "grep -- '--bind loopback' '$PWD/home-manager/services/openclaw/default.nix'"
+The output should include '--bind loopback'
+End
 End
 
 Describe 'home-manager/services/hermes/activate.sh'

--- a/spec/activation_shared_spec.sh
+++ b/spec/activation_shared_spec.sh
@@ -58,9 +58,9 @@ End
 End
 
 Describe 'secret deployment'
-It 'skips if destination already exists'
-When run bash -c "grep 'exit 0' '$SCRIPT'"
-The output should include 'exit 0'
+It 'redeploys when destination content differs'
+When run bash -c "grep 'cmp -s' '$SCRIPT'"
+The output should include 'cmp -s'
 End
 
 It 'uses rage for decryption'
@@ -76,6 +76,11 @@ End
 It 'warns when secret file not found'
 When run bash -c "grep 'Secret file not found' '$SCRIPT'"
 The output should include 'Secret file not found'
+End
+
+It 'replaces the destination atomically'
+When run bash -c "grep 'agenix.new' '$SCRIPT'"
+The output should include 'agenix.new'
 End
 End
 End

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -308,6 +308,10 @@ It 'has spec file for named-hosts/kyber/activate-ip-forwarding.sh'
 The path "spec/activate_kyber_spec.sh" should be exist
 End
 
+It 'has spec file for named-hosts/kyber/activate-sshd.sh'
+The path "spec/activate_kyber_spec.sh" should be exist
+End
+
 It 'has spec file for home-manager/modules/bin-shells/activate.sh'
 The path "spec/activate_bin_shells_spec.sh" should be exist
 End
@@ -484,6 +488,7 @@ hosts/linux/activate-backup-files.sh
 install.sh
 named-hosts/kyber/activate-backup-files.sh
 named-hosts/kyber/activate-ip-forwarding.sh
+named-hosts/kyber/activate-sshd.sh
 named-hosts/kyber/prepare-containerd-disk.sh
 named-hosts/kyber/rekey-galactica.sh
 named-hosts/kyber/setup.sh


### PR DESCRIPTION
## Summary
- Converge Kyber WAN firewall on every switch: detect default-route NIC, drop public SSH, add matching IPv6 `ip6tables` rules
- Install declarative sshd hardening drop-in (pubkey-only, no root, `AllowUsers ubuntu`)
- Fix agenix deploy path to `id_ed25519.age`, redeploy when ciphertext content changes, shorten GPG cache, drop Tailscale `--ssh`, force OpenClaw `--bind loopback`

## Test plan
- [ ] `shellspec spec/activate_firewall_spec.sh spec/activate_kyber_spec.sh spec/activation_shared_spec.sh spec/activate_paperclip_openclaw_spec.sh`
- [ ] On Kyber after merge: `make switch`, then verify `iptables -L kyber-firewall -n` and `ip6tables -L kyber-firewall -n` have no `:22` ACCEPT
- [ ] Confirm SSH still works via Tailscale / Latitude SG (`100.64.0.0/10`)
- [ ] Confirm `/etc/ssh/sshd_config.d/99-kyber-hardening.conf` exists and `sshd -t` passes
- [ ] Confirm OpenClaw unit includes `--bind loopback`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Kyber VPS by converging the WAN firewall for IPv4/IPv6, disabling public SSH, and adding an sshd hardening drop‑in. Also made agenix secret rotation atomic, tightened OpenClaw/Tailscale defaults, and kept a three‑year gpg‑agent cache TTL.

- New Features
  - Converge WAN firewall on each activation with `iptables` + `ip6tables`; auto-detect default-route NIC via `iproute2` (override with `KYBER_PUBLIC_IF`); drop all new ingress, no public SSH.
  - Install declarative sshd drop-in: pubkey-only, no root, AllowUsers ubuntu; validated with `sshd -t`.
  - Force OpenClaw gateway to `--bind loopback`; keep Tailscale exit-node and remove `--ssh` to use OpenSSH over Tailscale.
  - Keep three-year gpg‑agent cache TTL.

- Bug Fixes
  - agenix deploy: decrypt with `rage` to a temp file, compare and atomically replace, chmod 0600, and correct ciphertext path to `id_ed25519.age`.

<sup>Written for commit d5d2cbc9154da5fd39431adcc934759b08b7c4ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

