### PR TITLE
fix(matic): rename PAM service to match noctalia v5 binary

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -216,7 +216,7 @@ import ../../hosts/nixos {
               };
           };
         };
-        security.pam.services.noctalia-shell = {
+        security.pam.services.noctalia = {
           fprintAuth = true;
           rules.auth.fprintd.settings = {
             max-tries = -1;


### PR DESCRIPTION
## Summary
- Renamed PAM service from `noctalia-shell` to `noctalia` to match the v5 binary name
- v5 renamed the binary from `noctalia-shell` to `noctalia`, so the lock screen fingerprint PAM auth was never matched

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rename the PAM service from `noctalia-shell` to `noctalia` to match the v5 binary, restoring lock screen fingerprint auth via `fprintd`.

<sup>Written for commit 5861d44073066d49655afff3b23adb46242a7b2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

