### PR TITLE
fix(ci): update Noctalia PAM ShellSpec

### DIFF
--- a/spec/matic_pam_fingerprint_spec.sh
+++ b/spec/matic_pam_fingerprint_spec.sh
@@ -5,7 +5,7 @@ Describe 'named-hosts/matic/default.nix Noctalia fingerprint PAM'
 CONFIG="$PWD/named-hosts/matic/default.nix"
 
 It 'keeps lock-screen fingerprint auth from timing out'
-When run bash -c "awk '/security.pam.services.noctalia-shell = \\{/{in_service=1} in_service{print} in_service && /^        \\};/{exit}' '$CONFIG'"
+When run bash -c "awk '/security.pam.services.noctalia = \\{/{in_service=1} in_service{print} in_service && /^        \\};/{exit}' '$CONFIG'"
 The output should include 'fprintAuth = true;'
 The output should include 'max-tries = -1;'
 The output should include 'timeout = -1;'


### PR DESCRIPTION
## Summary
- update the Noctalia fingerprint PAM ShellSpec to match the v5 `noctalia` service name
- restore the Shell GitHub Actions workflow after PR #2161 renamed the production PAM service

## Validation
- `make shell-test-dev` (1714 ShellSpec examples, 420 fish tests; 0 failures)
- `shellcheck spec/matic_pam_fingerprint_spec.sh`
- `git diff --check`

Beads: `shunkakinokisoftware-vcd6`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Noctalia fingerprint PAM ShellSpec to look for the v5 `noctalia` service instead of `noctalia-shell`. This fixes the lock-screen fingerprint test and restores the Shell CI workflow.

<sup>Written for commit d63d4ce0a984a6448cdf37b5fc9ec75fb4f4e8e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

