### PR TITLE
fix(codex): self-heal desktop settings agent

### DIFF
--- a/config/codex/default.nix
+++ b/config/codex/default.nix
@@ -9,36 +9,6 @@ let
   desktopSettingsAgentLabel = "org.nix-community.home.codex-desktop-settings-sync";
   syncDesktopSettings = ./sync-desktop-settings.sh;
   ensureDesktopSettingsAgent = ./ensure-desktop-settings-agent.sh;
-  desktopSettingsAgentFallback = pkgs.writeText "${desktopSettingsAgentLabel}.plist" ''
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-      <key>Label</key>
-      <string>${desktopSettingsAgentLabel}</string>
-      <key>ProgramArguments</key>
-      <array>
-        <string>/bin/sh</string>
-        <string>-c</string>
-        <string>/bin/wait4path /nix/store &amp;&amp; exec ${pkgs.bash}/bin/bash ${syncDesktopSettings} ${./desktop-settings.json} ${pkgs.jq}/bin/jq</string>
-      </array>
-      <key>WatchPaths</key>
-      <array>
-        <string>${homeDir}/.codex/.codex-global-state.json</string>
-      </array>
-      <key>ThrottleInterval</key>
-      <integer>2</integer>
-      <key>RunAtLoad</key>
-      <true/>
-      <key>KeepAlive</key>
-      <false/>
-      <key>StandardOutPath</key>
-      <string>/tmp/codex-desktop-settings-sync.log</string>
-      <key>StandardErrorPath</key>
-      <string>/tmp/codex-desktop-settings-sync.error.log</string>
-    </dict>
-    </plist>
-  '';
 in
 {
   # Use activation script instead of home.file symlink
@@ -80,7 +50,7 @@ in
     lib.hm.dag.entryAfter [ "setupLaunchAgents" ] ''
       $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${ensureDesktopSettingsAgent}" \
         "${desktopSettingsAgentLabel}" \
-        "${desktopSettingsAgentFallback}" \
+        "$newGenPath/LaunchAgents/${desktopSettingsAgentLabel}.plist" \
         "/bin/launchctl" \
         "${pkgs.coreutils}/bin/install" \
         "${pkgs.coreutils}/bin/id"

--- a/config/codex/default.nix
+++ b/config/codex/default.nix
@@ -6,7 +6,39 @@
 }:
 let
   homeDir = config.home.homeDirectory;
+  desktopSettingsAgentLabel = "org.nix-community.home.codex-desktop-settings-sync";
   syncDesktopSettings = ./sync-desktop-settings.sh;
+  ensureDesktopSettingsAgent = ./ensure-desktop-settings-agent.sh;
+  desktopSettingsAgentFallback = pkgs.writeText "${desktopSettingsAgentLabel}.plist" ''
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>Label</key>
+      <string>${desktopSettingsAgentLabel}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>/bin/sh</string>
+        <string>-c</string>
+        <string>/bin/wait4path /nix/store &amp;&amp; exec ${pkgs.bash}/bin/bash ${syncDesktopSettings} ${./desktop-settings.json} ${pkgs.jq}/bin/jq</string>
+      </array>
+      <key>WatchPaths</key>
+      <array>
+        <string>${homeDir}/.codex/.codex-global-state.json</string>
+      </array>
+      <key>ThrottleInterval</key>
+      <integer>2</integer>
+      <key>RunAtLoad</key>
+      <true/>
+      <key>KeepAlive</key>
+      <false/>
+      <key>StandardOutPath</key>
+      <string>/tmp/codex-desktop-settings-sync.log</string>
+      <key>StandardErrorPath</key>
+      <string>/tmp/codex-desktop-settings-sync.error.log</string>
+    </dict>
+    </plist>
+  '';
 in
 {
   # Use activation script instead of home.file symlink
@@ -40,6 +72,20 @@ in
       StandardErrorPath = "/tmp/codex-desktop-settings-sync.error.log";
     };
   };
+
+  # Home Manager normally installs and bootstraps launchd.agents during
+  # setupLaunchAgents. Self-heal after that phase so a missed registration
+  # cannot leave the app free to replace the managed settings permanently.
+  home.activation.codexDesktopSettingsAgent = lib.mkIf pkgs.stdenv.isDarwin (
+    lib.hm.dag.entryAfter [ "setupLaunchAgents" ] ''
+      $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${ensureDesktopSettingsAgent}" \
+        "${desktopSettingsAgentLabel}" \
+        "${desktopSettingsAgentFallback}" \
+        "/bin/launchctl" \
+        "${pkgs.coreutils}/bin/install" \
+        "${pkgs.coreutils}/bin/id"
+    ''
+  );
 
   home.file.".codex/hooks/notify.sh" = {
     source = ./hooks/notify.sh;

--- a/config/codex/ensure-desktop-settings-agent.sh
+++ b/config/codex/ensure-desktop-settings-agent.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 AGENT_LABEL="$1"
-FALLBACK_PLIST="$2"
+SOURCE_PLIST="$2"
 LAUNCHCTL_BIN="$3"
 INSTALL_BIN="$4"
 ID_BIN="$5"
@@ -22,7 +22,7 @@ fi
 
 # A loaded service without its plist would disappear on the next login.
 if [[ ! -s $AGENT_PLIST ]]; then
-  "$INSTALL_BIN" -m 444 "$FALLBACK_PLIST" "$AGENT_PLIST"
+  "$INSTALL_BIN" -m 444 "$SOURCE_PLIST" "$AGENT_PLIST"
 fi
 
 if [[ $agent_loaded == true ]]; then
@@ -35,5 +35,5 @@ fi
 
 # Recover from a stale or malformed destination plist before retrying.
 "$LAUNCHCTL_BIN" bootout "$AGENT_DOMAIN/$AGENT_LABEL" >/dev/null 2>&1 || true
-"$INSTALL_BIN" -m 444 "$FALLBACK_PLIST" "$AGENT_PLIST"
+"$INSTALL_BIN" -m 444 "$SOURCE_PLIST" "$AGENT_PLIST"
 "$LAUNCHCTL_BIN" bootstrap "$AGENT_DOMAIN" "$AGENT_PLIST"

--- a/config/codex/ensure-desktop-settings-agent.sh
+++ b/config/codex/ensure-desktop-settings-agent.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Ensure the Home Manager-managed Codex Desktop settings watcher is persistent
+# and loaded, even when launchd setup did not register the new agent.
+set -euo pipefail
+
+AGENT_LABEL="$1"
+FALLBACK_PLIST="$2"
+LAUNCHCTL_BIN="$3"
+INSTALL_BIN="$4"
+ID_BIN="$5"
+
+AGENT_DIR="$HOME/Library/LaunchAgents"
+AGENT_PLIST="$AGENT_DIR/$AGENT_LABEL.plist"
+AGENT_DOMAIN="gui/$("$ID_BIN" -u)"
+
+mkdir -p "$AGENT_DIR"
+
+agent_loaded=false
+if "$LAUNCHCTL_BIN" print "$AGENT_DOMAIN/$AGENT_LABEL" >/dev/null 2>&1; then
+  agent_loaded=true
+fi
+
+# A loaded service without its plist would disappear on the next login.
+if [[ ! -s $AGENT_PLIST ]]; then
+  "$INSTALL_BIN" -m 444 "$FALLBACK_PLIST" "$AGENT_PLIST"
+fi
+
+if [[ $agent_loaded == true ]]; then
+  exit 0
+fi
+
+if "$LAUNCHCTL_BIN" bootstrap "$AGENT_DOMAIN" "$AGENT_PLIST"; then
+  exit 0
+fi
+
+# Recover from a stale or malformed destination plist before retrying.
+"$LAUNCHCTL_BIN" bootout "$AGENT_DOMAIN/$AGENT_LABEL" >/dev/null 2>&1 || true
+"$INSTALL_BIN" -m 444 "$FALLBACK_PLIST" "$AGENT_PLIST"
+"$LAUNCHCTL_BIN" bootstrap "$AGENT_DOMAIN" "$AGENT_PLIST"

--- a/config/codex/ensure-desktop-settings-agent.sh
+++ b/config/codex/ensure-desktop-settings-agent.sh
@@ -20,8 +20,8 @@ if "$LAUNCHCTL_BIN" print "$AGENT_DOMAIN/$AGENT_LABEL" >/dev/null 2>&1; then
   agent_loaded=true
 fi
 
-# A loaded service without its plist would disappear on the next login.
-if [[ ! -s $AGENT_PLIST ]]; then
+# Keep the persisted plist byte-identical to Home Manager's generated source.
+if ! cmp -s "$SOURCE_PLIST" "$AGENT_PLIST"; then
   "$INSTALL_BIN" -m 444 "$SOURCE_PLIST" "$AGENT_PLIST"
 fi
 

--- a/spec/activate_config_spec.sh
+++ b/spec/activate_config_spec.sh
@@ -4,6 +4,7 @@
 Describe 'config/codex/activate.sh'
 SCRIPT="$PWD/config/codex/activate.sh"
 SYNC_SCRIPT="$PWD/config/codex/sync-desktop-settings.sh"
+ENSURE_AGENT_SCRIPT="$PWD/config/codex/ensure-desktop-settings-agent.sh"
 HOOKS_JSON="$PWD/config/codex/hooks.json"
 CONFIG_TOML="$PWD/config/codex/config.toml"
 DESKTOP_SETTINGS_JSON="$PWD/config/codex/desktop-settings.json"
@@ -90,6 +91,47 @@ The status should be success
 The output should eq 'unchanged'
 End
 
+It 'installs and bootstraps a missing Desktop settings LaunchAgent'
+TMP_HOME="$(mktemp -d)"
+MOCK_BIN="$TMP_HOME/bin"
+LAUNCHCTL_LOG="$TMP_HOME/launchctl.log"
+FALLBACK_PLIST="$TMP_HOME/fallback.plist"
+mkdir -p "$MOCK_BIN"
+printf '%s\n' '<plist><dict><key>Label</key><string>test-agent</string></dict></plist>' >"$FALLBACK_PLIST"
+cat >"$MOCK_BIN/launchctl" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$LAUNCHCTL_LOG"
+if [[ $1 == print ]]; then
+  exit 1
+fi
+SH
+chmod +x "$MOCK_BIN/launchctl"
+
+When run bash -c 'HOME="$1" LAUNCHCTL_LOG="$2" bash "$3" "test-agent" "$4" "$5" "$(command -v install)" "$(command -v id)" && cmp -s "$4" "$1/Library/LaunchAgents/test-agent.plist" && cat "$2"' _ "$TMP_HOME" "$LAUNCHCTL_LOG" "$ENSURE_AGENT_SCRIPT" "$FALLBACK_PLIST" "$MOCK_BIN/launchctl"
+The status should be success
+The line 1 should eq "print gui/$(id -u)/test-agent"
+The line 2 should eq "bootstrap gui/$(id -u) $TMP_HOME/Library/LaunchAgents/test-agent.plist"
+End
+
+It 'persists the fallback plist without restarting an already loaded agent'
+TMP_HOME="$(mktemp -d)"
+MOCK_BIN="$TMP_HOME/bin"
+LAUNCHCTL_LOG="$TMP_HOME/launchctl.log"
+FALLBACK_PLIST="$TMP_HOME/fallback.plist"
+mkdir -p "$MOCK_BIN"
+printf '%s\n' '<plist><dict><key>Label</key><string>test-agent</string></dict></plist>' >"$FALLBACK_PLIST"
+cat >"$MOCK_BIN/launchctl" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$LAUNCHCTL_LOG"
+exit 0
+SH
+chmod +x "$MOCK_BIN/launchctl"
+
+When run bash -c 'HOME="$1" LAUNCHCTL_LOG="$2" bash "$3" "test-agent" "$4" "$5" "$(command -v install)" "$(command -v id)" && cmp -s "$4" "$1/Library/LaunchAgents/test-agent.plist" && cat "$2"' _ "$TMP_HOME" "$LAUNCHCTL_LOG" "$ENSURE_AGENT_SCRIPT" "$FALLBACK_PLIST" "$MOCK_BIN/launchctl"
+The status should be success
+The output should eq "print gui/$(id -u)/test-agent"
+End
+
 It 'registers the shared main/master push blocker'
 When run jq -r '.hooks.PreToolUse[] | select(.matcher == "Bash") | .hooks[].command' "$HOOKS_JSON"
 The output should include 'config/shared/hooks/block-git-push.sh'
@@ -114,6 +156,12 @@ When run cat "$DEFAULT_NIX"
 The output should include 'codex-desktop-settings-sync'
 The output should include 'WatchPaths'
 The output should include '.codex/.codex-global-state.json'
+End
+
+It 'self-heals a missed Desktop settings LaunchAgent registration'
+When run cat "$DEFAULT_NIX"
+The output should include 'ensureDesktopSettingsAgent'
+The output should include 'entryAfter [ "setupLaunchAgents" ]'
 End
 End
 

--- a/spec/activate_config_spec.sh
+++ b/spec/activate_config_spec.sh
@@ -113,13 +113,14 @@ The line 1 should eq "print gui/$(id -u)/test-agent"
 The line 2 should eq "bootstrap gui/$(id -u) $TMP_HOME/Library/LaunchAgents/test-agent.plist"
 End
 
-It 'persists the generated plist without restarting an already loaded agent'
+It 'replaces a stale plist without restarting an already loaded agent'
 TMP_HOME="$(mktemp -d)"
 MOCK_BIN="$TMP_HOME/bin"
 LAUNCHCTL_LOG="$TMP_HOME/launchctl.log"
 SOURCE_PLIST="$TMP_HOME/source.plist"
-mkdir -p "$MOCK_BIN"
+mkdir -p "$MOCK_BIN" "$TMP_HOME/Library/LaunchAgents"
 printf '%s\n' '<plist><dict><key>Label</key><string>test-agent</string></dict></plist>' >"$SOURCE_PLIST"
+printf '%s\n' '<plist><dict><key>Label</key><string>stale-agent</string></dict></plist>' >"$TMP_HOME/Library/LaunchAgents/test-agent.plist"
 cat >"$MOCK_BIN/launchctl" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$LAUNCHCTL_LOG"

--- a/spec/activate_config_spec.sh
+++ b/spec/activate_config_spec.sh
@@ -95,9 +95,9 @@ It 'installs and bootstraps a missing Desktop settings LaunchAgent'
 TMP_HOME="$(mktemp -d)"
 MOCK_BIN="$TMP_HOME/bin"
 LAUNCHCTL_LOG="$TMP_HOME/launchctl.log"
-FALLBACK_PLIST="$TMP_HOME/fallback.plist"
+SOURCE_PLIST="$TMP_HOME/source.plist"
 mkdir -p "$MOCK_BIN"
-printf '%s\n' '<plist><dict><key>Label</key><string>test-agent</string></dict></plist>' >"$FALLBACK_PLIST"
+printf '%s\n' '<plist><dict><key>Label</key><string>test-agent</string></dict></plist>' >"$SOURCE_PLIST"
 cat >"$MOCK_BIN/launchctl" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$LAUNCHCTL_LOG"
@@ -107,19 +107,19 @@ fi
 SH
 chmod +x "$MOCK_BIN/launchctl"
 
-When run bash -c 'HOME="$1" LAUNCHCTL_LOG="$2" bash "$3" "test-agent" "$4" "$5" "$(command -v install)" "$(command -v id)" && cmp -s "$4" "$1/Library/LaunchAgents/test-agent.plist" && cat "$2"' _ "$TMP_HOME" "$LAUNCHCTL_LOG" "$ENSURE_AGENT_SCRIPT" "$FALLBACK_PLIST" "$MOCK_BIN/launchctl"
+When run bash -c 'HOME="$1" LAUNCHCTL_LOG="$2" bash "$3" "test-agent" "$4" "$5" "$(command -v install)" "$(command -v id)" && cmp -s "$4" "$1/Library/LaunchAgents/test-agent.plist" && cat "$2"' _ "$TMP_HOME" "$LAUNCHCTL_LOG" "$ENSURE_AGENT_SCRIPT" "$SOURCE_PLIST" "$MOCK_BIN/launchctl"
 The status should be success
 The line 1 should eq "print gui/$(id -u)/test-agent"
 The line 2 should eq "bootstrap gui/$(id -u) $TMP_HOME/Library/LaunchAgents/test-agent.plist"
 End
 
-It 'persists the fallback plist without restarting an already loaded agent'
+It 'persists the generated plist without restarting an already loaded agent'
 TMP_HOME="$(mktemp -d)"
 MOCK_BIN="$TMP_HOME/bin"
 LAUNCHCTL_LOG="$TMP_HOME/launchctl.log"
-FALLBACK_PLIST="$TMP_HOME/fallback.plist"
+SOURCE_PLIST="$TMP_HOME/source.plist"
 mkdir -p "$MOCK_BIN"
-printf '%s\n' '<plist><dict><key>Label</key><string>test-agent</string></dict></plist>' >"$FALLBACK_PLIST"
+printf '%s\n' '<plist><dict><key>Label</key><string>test-agent</string></dict></plist>' >"$SOURCE_PLIST"
 cat >"$MOCK_BIN/launchctl" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$LAUNCHCTL_LOG"
@@ -127,7 +127,7 @@ exit 0
 SH
 chmod +x "$MOCK_BIN/launchctl"
 
-When run bash -c 'HOME="$1" LAUNCHCTL_LOG="$2" bash "$3" "test-agent" "$4" "$5" "$(command -v install)" "$(command -v id)" && cmp -s "$4" "$1/Library/LaunchAgents/test-agent.plist" && cat "$2"' _ "$TMP_HOME" "$LAUNCHCTL_LOG" "$ENSURE_AGENT_SCRIPT" "$FALLBACK_PLIST" "$MOCK_BIN/launchctl"
+When run bash -c 'HOME="$1" LAUNCHCTL_LOG="$2" bash "$3" "test-agent" "$4" "$5" "$(command -v install)" "$(command -v id)" && cmp -s "$4" "$1/Library/LaunchAgents/test-agent.plist" && cat "$2"' _ "$TMP_HOME" "$LAUNCHCTL_LOG" "$ENSURE_AGENT_SCRIPT" "$SOURCE_PLIST" "$MOCK_BIN/launchctl"
 The status should be success
 The output should eq "print gui/$(id -u)/test-agent"
 End

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -248,6 +248,10 @@ It 'has spec file for config/codex/sync-desktop-settings.sh'
 The path "spec/activate_config_spec.sh" should be exist
 End
 
+It 'has spec file for config/codex/ensure-desktop-settings-agent.sh'
+The path "spec/activate_config_spec.sh" should be exist
+End
+
 It 'has spec file for config/dcg/activate.sh'
 The path "spec/activate_config_spec.sh" should be exist
 End
@@ -394,6 +398,7 @@ config/claude/hooks/security.sh
 config/claude/hooks/atuin-history.sh
 config/claude/hooks/statusline.sh
 config/codex/activate.sh
+config/codex/ensure-desktop-settings-agent.sh
 config/codex/sync-desktop-settings.sh
 config/copilot/activate.sh
 config/codex/hooks/atuin-history.sh


### PR DESCRIPTION
## Summary

- add a post-Home Manager activation self-heal for the Codex Desktop settings watcher
- reuse the exact LaunchAgent plist generated by Home Manager; no plist XML is duplicated or hardcoded
- bootstrap missing agents while leaving already-loaded agents stable
- add focused behavioral and coverage specs

## Root cause

Codex Desktop keeps preferences in memory and can replace `.codex-global-state.json` after activation. The existing watcher was declared through `launchd.agents`, but a completed Galactica switch left the plist absent and the service unloaded, so the app restored its default worktree limit of 15 instead of the managed value of 300.

## Impact

The managed Codex Desktop Git and worktree preferences remain enforced after app-owned state rewrites, even when Home Manager launchd registration is missed.

## Validation

- `shellspec spec/activate_config_spec.sh spec/coverage_spec.sh` — 146 examples, 0 failures
- `shellcheck config/codex/ensure-desktop-settings-agent.sh config/codex/sync-desktop-settings.sh config/codex/activate.sh`
- `make nix-format-check`
- `make build`
- generated activation order verified: `setupLaunchAgents` precedes `codexDesktopSettingsAgent`
- generated source plist verified with `plutil -lint`
- live recovery test: unloaded the agent and moved aside its plist; the self-heal restored the plist, bootstrapped the service with exit code 0, and preserved `worktree-keep-count=300`

Beads: `shunkakinokisoftware-6sz2`