### PR TITLE
fix(codex): persist desktop worktree settings

### DIFF
--- a/config/codex/default.nix
+++ b/config/codex/default.nix
@@ -23,8 +23,9 @@ in
   '';
 
   # Codex caches Desktop preferences in memory and replaces its complete state
-  # file after activation. Restore managed keys after each app-owned rewrite;
-  # the synchronizer exits without writing once the values already match.
+  # file after activation. Restore managed top-level global-state keys after
+  # each app-owned rewrite; the synchronizer exits without writing once the
+  # values already match.
   launchd.agents.codex-desktop-settings-sync = lib.mkIf pkgs.stdenv.isDarwin {
     enable = true;
     config = {

--- a/config/codex/sync-desktop-settings.sh
+++ b/config/codex/sync-desktop-settings.sh
@@ -9,13 +9,21 @@ GLOBAL_STATE="$HOME/.codex/.codex-global-state.json"
 
 mkdir -p "$HOME/.codex"
 
+# Codex stores these preferences as top-level global-state keys. Older Desktop
+# builds kept them inside electron-persisted-atom-state, so also require those
+# legacy copies to be absent before treating the file as synchronized.
+#
 # Codex keeps this state in memory and periodically replaces the entire file.
 # Avoid a write when the managed values already match so launchd's file watch
 # settles after the synchronizer restores an app-owned rewrite.
 if [[ -s $GLOBAL_STATE ]] && "$JQ_BIN" -e --slurpfile settings "$DESKTOP_SETTINGS_JSON" '
-  (.["electron-persisted-atom-state"] // {}) as $state
-  | ($settings[0] | to_entries | all(. as $entry |
+  $settings[0] as $managed
+  | . as $state
+  | ($managed | to_entries | all(. as $entry |
       $state[$entry.key] == $entry.value))
+    and
+    ((.["electron-persisted-atom-state"] // {}) as $legacy
+      | ($managed | keys | all(. as $key | $legacy | has($key) | not)))
 ' "$GLOBAL_STATE" >/dev/null; then
   exit 0
 fi
@@ -25,12 +33,18 @@ trap 'rm -f "$GLOBAL_STATE_TMP"' EXIT
 
 if [[ -s $GLOBAL_STATE ]]; then
   "$JQ_BIN" --slurpfile settings "$DESKTOP_SETTINGS_JSON" '
-    .["electron-persisted-atom-state"] =
-      ((.["electron-persisted-atom-state"] // {}) + $settings[0])
+    $settings[0] as $managed
+    | . + $managed
+    | if (.["electron-persisted-atom-state"] | type) == "object" then
+        .["electron-persisted-atom-state"] |=
+          with_entries(select(.key as $key | $managed | has($key) | not))
+      else
+        .
+      end
   ' "$GLOBAL_STATE" >"$GLOBAL_STATE_TMP"
 else
   "$JQ_BIN" -n --slurpfile settings "$DESKTOP_SETTINGS_JSON" '
-    {"electron-persisted-atom-state": $settings[0]}
+    $settings[0]
   ' >"$GLOBAL_STATE_TMP"
 fi
 

--- a/spec/activate_config_spec.sh
+++ b/spec/activate_config_spec.sh
@@ -39,20 +39,20 @@ When run grep -qF 'reviewDelivery = "inline"' "$CONFIG_TOML"
 The status should be success
 End
 
-It 'merges managed Desktop settings without replacing unrelated state'
+It 'merges managed top-level Desktop settings without replacing unrelated state'
 TMP_HOME="$(mktemp -d)"
 mkdir -p "$TMP_HOME/.codex"
 cat >"$TMP_HOME/.codex/.codex-global-state.json" <<'JSON'
 {
   "unrelated-top-level": "preserved",
   "electron-persisted-atom-state": {
-    "unrelated-setting": 42,
-    "git-always-force-push": false
-  }
+    "unrelated-setting": 42
+  },
+  "git-always-force-push": false
 }
 JSON
 
-When run bash -c 'HOME="$1" bash "$2" "$3" "$4" "$5" "$6" "$7" && jq -r ".[\"unrelated-top-level\"], .[\"electron-persisted-atom-state\"][\"unrelated-setting\"], .[\"electron-persisted-atom-state\"][\"git-always-force-push\"], .[\"electron-persisted-atom-state\"][\"git-pull-request-merge-method\"], .[\"electron-persisted-atom-state\"][\"worktree-keep-count\"]" "$1/.codex/.codex-global-state.json"' _ "$TMP_HOME" "$SCRIPT" "$CONFIG_TOML" "$HOOKS_JSON" "$DESKTOP_SETTINGS_JSON" "$(command -v jq)" "$SYNC_SCRIPT"
+When run bash -c 'HOME="$1" bash "$2" "$3" "$4" "$5" "$6" "$7" && jq -r ".[\"unrelated-top-level\"], .[\"electron-persisted-atom-state\"][\"unrelated-setting\"], .[\"git-always-force-push\"], .[\"git-pull-request-merge-method\"], .[\"worktree-keep-count\"]" "$1/.codex/.codex-global-state.json"' _ "$TMP_HOME" "$SCRIPT" "$CONFIG_TOML" "$HOOKS_JSON" "$DESKTOP_SETTINGS_JSON" "$(command -v jq)" "$SYNC_SCRIPT"
 The status should be success
 The line 1 should eq 'preserved'
 The line 2 should eq '42'
@@ -61,7 +61,7 @@ The line 4 should eq 'squash'
 The line 5 should eq '300'
 End
 
-It 'restores managed Desktop settings after the app replaces its state'
+It 'restores managed top-level Desktop settings after the app replaces its state'
 TMP_HOME="$(mktemp -d)"
 mkdir -p "$TMP_HOME/.codex"
 cat >"$TMP_HOME/.codex/.codex-global-state.json" <<'JSON'
@@ -73,7 +73,7 @@ cat >"$TMP_HOME/.codex/.codex-global-state.json" <<'JSON'
 }
 JSON
 
-When run bash -c 'HOME="$1" bash "$2" "$3" "$4" && jq -r ".[\"unrelated-top-level\"], .[\"electron-persisted-atom-state\"][\"unrelated-setting\"], .[\"electron-persisted-atom-state\"][\"git-branch-prefix\"], .[\"electron-persisted-atom-state\"][\"worktree-keep-count\"]" "$1/.codex/.codex-global-state.json"' _ "$TMP_HOME" "$SYNC_SCRIPT" "$DESKTOP_SETTINGS_JSON" "$(command -v jq)"
+When run bash -c 'HOME="$1" bash "$2" "$3" "$4" && jq -r ".[\"unrelated-top-level\"], .[\"electron-persisted-atom-state\"][\"unrelated-setting\"], .[\"git-branch-prefix\"], .[\"worktree-keep-count\"]" "$1/.codex/.codex-global-state.json"' _ "$TMP_HOME" "$SYNC_SCRIPT" "$DESKTOP_SETTINGS_JSON" "$(command -v jq)"
 The status should be success
 The line 1 should eq 'preserved'
 The line 2 should eq '42'
@@ -81,10 +81,32 @@ The line 3 should eq 'codex/'
 The line 4 should eq '300'
 End
 
+It 'removes legacy nested copies of managed Desktop settings'
+TMP_HOME="$(mktemp -d)"
+mkdir -p "$TMP_HOME/.codex"
+cat >"$TMP_HOME/.codex/.codex-global-state.json" <<'JSON'
+{
+  "electron-persisted-atom-state": {
+    "unrelated-setting": 42,
+    "git-branch-prefix": "legacy/",
+    "worktree-keep-count": 15
+  }
+}
+JSON
+
+When run bash -c 'HOME="$1" bash "$2" "$3" "$4" && jq -r ".[\"electron-persisted-atom-state\"][\"unrelated-setting\"], (.[\"electron-persisted-atom-state\"] | has(\"git-branch-prefix\")), (.[\"electron-persisted-atom-state\"] | has(\"worktree-keep-count\")), .[\"git-branch-prefix\"], .[\"worktree-keep-count\"]" "$1/.codex/.codex-global-state.json"' _ "$TMP_HOME" "$SYNC_SCRIPT" "$DESKTOP_SETTINGS_JSON" "$(command -v jq)"
+The status should be success
+The line 1 should eq '42'
+The line 2 should eq 'false'
+The line 3 should eq 'false'
+The line 4 should eq 'codex/'
+The line 5 should eq '300'
+End
+
 It 'does not rewrite state when managed Desktop settings already match'
 TMP_HOME="$(mktemp -d)"
 mkdir -p "$TMP_HOME/.codex"
-printf '%s\n' '{"electron-persisted-atom-state": {}}' >"$TMP_HOME/.codex/.codex-global-state.json"
+cp -f "$DESKTOP_SETTINGS_JSON" "$TMP_HOME/.codex/.codex-global-state.json"
 
 When run bash -c 'HOME="$1" bash "$2" "$3" "$4" && before=$(ls -di "$1/.codex/.codex-global-state.json") && before=${before%% *} && HOME="$1" bash "$2" "$3" "$4" && after=$(ls -di "$1/.codex/.codex-global-state.json") && after=${after%% *} && test "$before" = "$after" && printf "%s\\n" unchanged' _ "$TMP_HOME" "$SYNC_SCRIPT" "$DESKTOP_SETTINGS_JSON" "$(command -v jq)"
 The status should be success


### PR DESCRIPTION
## Summary

- migrate managed Codex Desktop Git/worktree preferences to top-level global-state keys
- remove stale legacy copies from `electron-persisted-atom-state` while preserving unrelated state
- cover top-level restore, legacy migration, and no-op synchronization behavior

## Validation

- `shellspec` (700+ examples)
- `shellcheck config/codex/sync-desktop-settings.sh`
- `nixfmt --check config/codex/default.nix`
- live LaunchAgent run: top-level `worktree-keep-count = 300`, legacy nested key absent, exit code 0

## Activation note

The Codex-specific Home Manager activation and LaunchAgent replacement succeeded. The broader `make nix-switch` later encountered unrelated existing Cargo-global failures for worktrunk/yek; tracked as `shunkakinokisoftware-uvkd`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure Codex Desktop Git/worktree settings persist by promoting them to top-level global-state keys and cleaning up legacy nested copies. This prevents unnecessary rewrites and preserves unrelated state.

- **Bug Fixes**
  - Promote managed settings to top-level keys in `.codex-global-state.json`.
  - Remove legacy duplicates under `electron-persisted-atom-state` without touching unrelated data.
  - Skip writes when values already match to stop launchd-triggered churn.

<sup>Written for commit 5d94b6543a950f4f1d56ba4a43bea195538d6804. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

