### PR TITLE
fix(dolt): align Beads shared server storage

### DIFF
--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -9,7 +9,8 @@ let
   inherit (inputs.host) isKyber isGalactica;
   homeDir = config.home.homeDirectory;
   repoDir = "${homeDir}/dotfiles";
-  beadsDir = "${repoDir}/.beads";
+  sharedServerDir = "${homeDir}/.beads/shared-server";
+  beadsDir = "${sharedServerDir}/dolt";
   doltManifest = "${beadsDir}/beads_global/.dolt/noms/manifest";
   mirrorDir = "${homeDir}/.cache/beads-jsonl-mirror";
   remoteUrl = "https://github.com/shunkakinoki/beads";
@@ -37,6 +38,7 @@ lib.mkIf enabled {
   home.sessionVariables = {
     BEADS_DOLT_SHARED_SERVER = "1";
     BEADS_DOLT_SERVER_PORT = "3307";
+    BEADS_SHARED_SERVER_DIR = sharedServerDir;
     DOLT_CLI_USER = "root";
     DOLT_CLI_PASSWORD = "";
   };

--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -9,6 +9,7 @@ let
   inherit (inputs.host) isKyber isGalactica;
   homeDir = config.home.homeDirectory;
   repoDir = "${homeDir}/dotfiles";
+  legacyBeadsDir = "${repoDir}/.beads";
   sharedServerDir = "${homeDir}/.beads/shared-server";
   beadsDir = "${sharedServerDir}/dolt";
   doltManifest = "${beadsDir}/beads_global/.dolt/noms/manifest";
@@ -19,7 +20,7 @@ let
   # 1.86+ adds the git+https:// remote scheme used by the beads_global GitHub backup.
   doltMinVersion = "1.86";
   startScript = pkgs.replaceVars ./start.sh {
-    inherit beadsDir;
+    inherit beadsDir legacyBeadsDir;
     inherit (pkgs) dolt;
   };
   backupScript = pkgs.replaceVars ./backup-dolt-main.sh {

--- a/home-manager/services/dolt/start.sh
+++ b/home-manager/services/dolt/start.sh
@@ -1,15 +1,29 @@
 #!/usr/bin/env bash
-# @beadsDir@ and @dolt@ are substituted by pkgs.replaceVars.
+# @beadsDir@, @legacyBeadsDir@, and @dolt@ are substituted by pkgs.replaceVars.
 set -euo pipefail
 
 mkdir -p "@beadsDir@"
 
-# Legacy migration: a `dolt` directory predates the rename to `df`.
-# Only migrate when `df` does not exist yet; once `df` is in place the
-# `dolt` directory is treated as its own (possibly external) database.
-if [ -d "@beadsDir@/dolt" ] && [ ! -L "@beadsDir@/dolt" ] && [ ! -e "@beadsDir@/df" ]; then
-  mv -f "@beadsDir@/dolt" "@beadsDir@/df"
-fi
+# Move databases served by the pre-shared-server configuration into the
+# canonical root. Existing destinations win, so activation never overwrites a
+# newer clone. A legacy database named `dolt` was the old name for `df`.
+for legacy_db in "@legacyBeadsDir@"/*; do
+  if [ ! -d "$legacy_db/.dolt" ] || [ -L "$legacy_db" ]; then
+    continue
+  fi
+
+  db_name="${legacy_db##*/}"
+  target_name="$db_name"
+  if [ "$db_name" = "dolt" ] && [ ! -e "@beadsDir@/df" ]; then
+    target_name="df"
+  fi
+
+  if [ -e "@beadsDir@/$target_name" ]; then
+    continue
+  fi
+
+  mv -f -- "$legacy_db" "@beadsDir@/$target_name"
+done
 
 # Additional databases (e.g. data shared with another repo) are managed by
 # the user as real directories under @beadsDir@/<dbname>. dolt sql-server

--- a/spec/dolt_start_spec.sh
+++ b/spec/dolt_start_spec.sh
@@ -67,4 +67,23 @@ The output should include '--data-dir'
 End
 End
 
+Describe 'home-manager/services/dolt/default.nix'
+MODULE="$PWD/home-manager/services/dolt/default.nix"
+
+It 'uses the canonical Beads shared-server directory'
+When run grep -F 'sharedServerDir = "${homeDir}/.beads/shared-server";' "$MODULE"
+The output should include 'sharedServerDir = "${homeDir}/.beads/shared-server";'
+End
+
+It 'serves databases from the shared-server dolt directory'
+When run grep -F 'beadsDir = "${sharedServerDir}/dolt";' "$MODULE"
+The output should include 'beadsDir = "${sharedServerDir}/dolt";'
+End
+
+It 'exports the same shared-server directory to bd'
+When run grep -F 'BEADS_SHARED_SERVER_DIR = sharedServerDir;' "$MODULE"
+The output should include 'BEADS_SHARED_SERVER_DIR = sharedServerDir;'
+End
+End
+
 End

--- a/spec/dolt_start_spec.sh
+++ b/spec/dolt_start_spec.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2329
+# shellcheck disable=SC2016,SC2329
 
 Describe 'home-manager/services/dolt/start.sh'
 SCRIPT="$PWD/home-manager/services/dolt/start.sh"

--- a/spec/dolt_start_spec.sh
+++ b/spec/dolt_start_spec.sh
@@ -46,7 +46,8 @@ setup_migration() {
   FAKE_DOLT="$TEST_ROOT/fake-dolt"
   RENDERED_SCRIPT="$TEST_ROOT/start.sh"
   mkdir -p "$LEGACY_DIR" "$SHARED_DIR" "$FAKE_DOLT/bin"
-  ln -s "$(type -P true)" "$FAKE_DOLT/bin/dolt"
+  printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"$FAKE_DOLT/bin/dolt"
+  chmod +x "$FAKE_DOLT/bin/dolt"
   sed \
     -e "s|@legacyBeadsDir@|$LEGACY_DIR|g" \
     -e "s|@beadsDir@|$SHARED_DIR|g" \

--- a/spec/dolt_start_spec.sh
+++ b/spec/dolt_start_spec.sh
@@ -27,6 +27,11 @@ When run bash -c "grep '@beadsDir@' '$SCRIPT'"
 The output should include '@beadsDir@'
 End
 
+It 'references @legacyBeadsDir@'
+When run bash -c "grep '@legacyBeadsDir@' '$SCRIPT'"
+The output should include '@legacyBeadsDir@'
+End
+
 It 'references @dolt@'
 When run bash -c "grep '@dolt@' '$SCRIPT'"
 The output should include '@dolt@'
@@ -34,19 +39,59 @@ End
 End
 
 Describe 'dolt migration behavior'
-It 'migrates legacy dolt directory to df'
-When run bash -c "grep 'mv -f' '$SCRIPT'"
-The output should include 'mv -f'
+setup_migration() {
+  TEST_ROOT=$(mktemp -d)
+  LEGACY_DIR="$TEST_ROOT/legacy"
+  SHARED_DIR="$TEST_ROOT/shared/dolt"
+  FAKE_DOLT="$TEST_ROOT/fake-dolt"
+  RENDERED_SCRIPT="$TEST_ROOT/start.sh"
+  mkdir -p "$LEGACY_DIR" "$SHARED_DIR" "$FAKE_DOLT/bin"
+  ln -s "$(type -P true)" "$FAKE_DOLT/bin/dolt"
+  sed \
+    -e "s|@legacyBeadsDir@|$LEGACY_DIR|g" \
+    -e "s|@beadsDir@|$SHARED_DIR|g" \
+    -e "s|@dolt@|$FAKE_DOLT|g" \
+    "$SCRIPT" >"$RENDERED_SCRIPT"
+}
+
+cleanup_migration() {
+  rm -rf "$TEST_ROOT"
+}
+
+Before 'setup_migration'
+After 'cleanup_migration'
+
+It 'moves a legacy database into the shared-server root'
+mkdir -p "$LEGACY_DIR/beads/.dolt"
+When run bash "$RENDERED_SCRIPT"
+The status should be success
+The path "$SHARED_DIR/beads/.dolt" should be directory
+The path "$LEGACY_DIR/beads" should not be exist
 End
 
-It 'gates the migration on df not yet existing'
-When run bash -c "grep -- '-e \"@beadsDir@/df\"' '$SCRIPT'"
-The output should include '-e "@beadsDir@/df"'
+It 'does not overwrite an existing shared-server database'
+mkdir -p "$LEGACY_DIR/df/.dolt" "$SHARED_DIR/df/.dolt"
+touch "$LEGACY_DIR/df/.dolt/legacy-marker"
+When run bash "$RENDERED_SCRIPT"
+The status should be success
+The path "$LEGACY_DIR/df/.dolt/legacy-marker" should be file
+The path "$SHARED_DIR/df/.dolt" should be directory
 End
 
-It 'does not recreate the legacy dolt -> df symlink'
-When run bash -c "grep -c 'ln -sfn df' '$SCRIPT' || true"
-The output should equal '0'
+It 'maps the old dolt database name to df during legacy-root migration'
+mkdir -p "$LEGACY_DIR/dolt/.dolt"
+When run bash "$RENDERED_SCRIPT"
+The status should be success
+The path "$SHARED_DIR/df/.dolt" should be directory
+The path "$SHARED_DIR/dolt" should not be exist
+End
+
+It 'does not rename a legitimate dolt database in the shared-server root'
+mkdir -p "$SHARED_DIR/dolt/.dolt"
+When run bash "$RENDERED_SCRIPT"
+The status should be success
+The path "$SHARED_DIR/dolt/.dolt" should be directory
+The path "$SHARED_DIR/df" should not be exist
 End
 End
 
@@ -67,6 +112,8 @@ The output should include '--data-dir'
 End
 End
 
+End
+
 Describe 'home-manager/services/dolt/default.nix'
 MODULE="$PWD/home-manager/services/dolt/default.nix"
 
@@ -84,6 +131,4 @@ It 'exports the same shared-server directory to bd'
 When run grep -F 'BEADS_SHARED_SERVER_DIR = sharedServerDir;' "$MODULE"
 The output should include 'BEADS_SHARED_SERVER_DIR = sharedServerDir;'
 End
-End
-
 End


### PR DESCRIPTION
## Summary
- point the Home Manager Dolt service at Beads’ canonical shared-server data root
- export `BEADS_SHARED_SERVER_DIR` so `bd` and launchd resolve the same storage
- add regression coverage for both paths

## Validation
- `shellspec spec/dolt_start_spec.sh` (14 examples, 0 failures)
- `make nix-format-check`
- `make build`
- live `bd list`, `bd doctor --server --agent --json`, `bd dolt pull`, and `bd dolt push` against the repaired v59 databases

## Activation note
`make switch` activated the Nix configuration and restarted Dolt successfully. The enclosing target later failed in the unrelated `dotagents-sync` step because that project has no `sync` make target.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align Dolt’s data directory with Beads’ shared-server storage and migrate safely from repo-local databases. Ensures `bd` and `launchd` share the same data.

- **Bug Fixes**
  - Serve databases from `~/.beads/shared-server/dolt`.
  - Export `BEADS_SHARED_SERVER_DIR` so `bd` and `launchd` resolve the same path.
  - Safely migrate from `~/dotfiles/.beads` (skip symlinks, require `.dolt`, don’t overwrite; map `dolt` → `df` during migration only).
  - Expand `shellspec` for migration and path config; use a portable fake `dolt` and mark Nix literals to avoid ShellCheck noise.

<sup>Written for commit b44b899931a0e17f66d33f563cc463e12d972ffe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

