### PR TITLE
chore(deps): add git-remote-s3 to uv tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.13"
 tools = [
   "aider-chat>=0.86.2",
   "claude-swap>=0.21.0",
+  "git-remote-s3>=0.3.2",
   "graphifyy>=0.9.12",
   "huggingface-hub[mcp]>=1.23.0",
   "marker-pdf>=1.10.2",


### PR DESCRIPTION
## Summary

- add `git-remote-s3>=0.3.2` to the managed uv global tools
- make the S3 Git remote helper reproducible through Home Manager activation

## Why

The wiki repository will use Cloudflare R2 through its S3-compatible API as a secondary Git remote. Managing the helper in dotfiles keeps the CLI available consistently across machines.

## Validation

- `git diff --check`
- `make nix-format-check`
- `make build`
- isolated `uv tool install 'git-remote-s3>=0.3.2' --python 3.13`
- live install verified as `git-remote-s3 v0.3.2` with all four expected executables

## Activation note

The package itself installed successfully. The broader `make switch` later encountered unrelated existing Cargo-global and `dotagents-sync` failures; those are outside this one-line dependency change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `git-remote-s3>=0.3.2` to the managed `uv` global tools so Git can push/pull to S3-compatible remotes (e.g., Cloudflare R2) across machines. Home Manager activation ensures the helper is installed consistently.

<sup>Written for commit 9a5a35a8eef92e9874c7e62213c0aea9a50a2eb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

