### PR TITLE
fix: add Playwright Chromium libraries on Linux

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -158,6 +158,8 @@ with pkgs;
   keychain
   libiconv
   libsecret
+  nspr
+  nss
   opencode
   openssl
   openssl.dev

--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -68,7 +68,7 @@
           export CGO_LDFLAGS="-L${pkgs.icu.out}/lib''${CGO_LDFLAGS:+ $CGO_LDFLAGS}"
 
           # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)
-          export LD_LIBRARY_PATH="${lib.optionalString pkgs.stdenv.isLinux "${pkgs.alsa-lib}/lib:"}${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+          export LD_LIBRARY_PATH="${lib.optionalString pkgs.stdenv.isLinux "${pkgs.alsa-lib}/lib:"}${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.nspr}/lib:${pkgs.nss}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
       fi
 
       # Go configuration
@@ -121,7 +121,7 @@
           export CGO_LDFLAGS="-L${pkgs.icu.out}/lib''${CGO_LDFLAGS:+ $CGO_LDFLAGS}"
 
           # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)
-          export LD_LIBRARY_PATH="${lib.optionalString pkgs.stdenv.isLinux "${pkgs.alsa-lib}/lib:"}${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+          export LD_LIBRARY_PATH="${lib.optionalString pkgs.stdenv.isLinux "${pkgs.alsa-lib}/lib:"}${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.nspr}/lib:${pkgs.nss}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
       fi
 
       # Source .bashrc for login shells to get PATH and other settings

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -30,7 +30,7 @@
           set -gx CGO_LDFLAGS "-L${pkgs.icu.out}/lib $CGO_LDFLAGS"
 
           # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)
-          set -gx LD_LIBRARY_PATH ${lib.optionalString pkgs.stdenv.isLinux ''"${pkgs.alsa-lib}/lib"''} "${pkgs.glib.out}/lib" "${pkgs.libsecret}/lib" "${pkgs.stdenv.cc.cc.lib}/lib" "${pkgs.zlib}/lib" $LD_LIBRARY_PATH
+          set -gx LD_LIBRARY_PATH ${lib.optionalString pkgs.stdenv.isLinux ''"${pkgs.alsa-lib}/lib"''} "${pkgs.glib.out}/lib" "${pkgs.libsecret}/lib" "${pkgs.nspr}/lib" "${pkgs.nss}/lib" "${pkgs.stdenv.cc.cc.lib}/lib" "${pkgs.zlib}/lib" $LD_LIBRARY_PATH
       end
 
       # Go configuration

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -51,7 +51,7 @@
           export CGO_LDFLAGS="-L${pkgs.icu.out}/lib''${CGO_LDFLAGS:+ $CGO_LDFLAGS}"
 
           # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)
-          export LD_LIBRARY_PATH="${lib.optionalString pkgs.stdenv.isLinux "${pkgs.alsa-lib}/lib:"}${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+          export LD_LIBRARY_PATH="${lib.optionalString pkgs.stdenv.isLinux "${pkgs.alsa-lib}/lib:"}${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.nspr}/lib:${pkgs.nss}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
       fi
 
       # Define aliases in .zshenv so non-interactive zsh invocations can use them.


### PR DESCRIPTION
## Summary

- install `nspr` and `nss` in the shared Linux Home Manager package set
- expose both library directories through `LD_LIBRARY_PATH` in Bash, Zsh, and Fish

## Root cause

`playwright-chromium` downloads a foreign Chromium binary, but the existing Linux native-library configuration only covered the libraries required by Bun-installed Node addons. Chromium therefore could not resolve `libnspr4.so` and would subsequently have failed on NSS.

## Impact

Managed Linux environments including Kyber, Pod, generic Ubuntu, and Matic can resolve the NSPR and NSS libraries when launching Playwright Chromium.

## Validation

- `make nix-format-check`
- `make shell-test` — 1,725 ShellSpec examples and 420 Fish tests passed
- evaluated the `x86_64-linux` Home Manager package sets for Kyber, Pod, generic Ubuntu, and Matic and confirmed both packages are present
- evaluated generated Bash, Zsh, and Fish configuration and confirmed both library paths are exported

A complete Linux activation derivation was not cross-built locally because this host is `aarch64-darwin` and the existing `obsidian-headless` wrapper requires an `x86_64-linux` builder; the affected Linux package and shell options evaluated successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Playwright Chromium startup on Linux by installing `nspr` and `nss` and exporting their libs in shell configs. Managed Linux environments can now run `playwright-chromium` without NSPR/NSS errors.

- **Bug Fixes**
  - Added `nspr` and `nss` to the shared Linux Home Manager package set.
  - Exported their library paths in `LD_LIBRARY_PATH` for Bash, Zsh, and Fish.
  - Validated with shell tests and by evaluating Linux package sets and shell configs.

<sup>Written for commit cc2f93889eb187a6dde1b4f46c9d77e290f10983. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

