### PR TITLE
fix(kyber): force OpenSSH for Codex remote tunnels

### DIFF
--- a/named-hosts/kyber/README.md
+++ b/named-hosts/kyber/README.md
@@ -62,7 +62,7 @@ Activation converges:
 - `/etc/ssh/sshd_config.d/99-kyber-hardening.conf` — pubkey-only, no root,
   `AllowUsers ubuntu`
 - OpenClaw gateway forced `--bind loopback`
-- Tailscale `--advertise-exit-node` without `--ssh` (OpenSSH over Tailscale)
+- Tailscale `--advertise-exit-node` with `--ssh=false` (OpenSSH over Tailscale)
 
 Still intentional / follow-up:
 

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -142,9 +142,11 @@ home-manager.lib.homeManagerConfiguration {
           installSystemService = true;
           # Auth key will be provided via agenix secret
           # authKeyFile = config.age.secrets."keys/tailscale-auth.age".path;
-          # Exit node kept; Tailscale SSH omitted — OpenSSH over Tailscale + Latitude SG.
+          # Exit node kept; explicitly disable Tailscale SSH so long-lived Codex
+          # tunnels use OpenSSH over Tailscale instead of the Tailscale SSH proxy.
           extraUpArgs = [
             "--reset"
+            "--ssh=false"
             "--accept-dns=false"
             "--advertise-exit-node"
           ];

--- a/spec/activate_kyber_spec.sh
+++ b/spec/activate_kyber_spec.sh
@@ -113,6 +113,11 @@ It 'does not enable Tailscale SSH'
 When run bash -c "grep -F '\"--ssh\"' '$PWD/named-hosts/kyber/default.nix' || true"
 The output should equal ''
 End
+
+It 'explicitly disables Tailscale SSH'
+When run bash -c "grep -F '\"--ssh=false\"' '$PWD/named-hosts/kyber/default.nix'"
+The output should include '--ssh=false'
+End
 End
 End
 


### PR DESCRIPTION
## Summary

- explicitly disable Tailscale SSH on Kyber
- keep Codex remote tunnels on key-authenticated OpenSSH over Tailscale
- document and test the intended transport

## Verification

- `shellspec spec/activate_kyber_spec.sh` (27 examples, 0 failures)
- Kyber reports `RunSSH: false`
- Codex Desktop reports Kyber connected with successful `thread/list` responses and no post-fix transport closure

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force Codex remote tunnels on Kyber to use key-authenticated OpenSSH over Tailscale by explicitly disabling Tailscale SSH (`--ssh=false`) for a stable, long-lived transport. Updated the Kyber README and added a spec to verify the flag and behavior.

<sup>Written for commit a1b27390b20f8c2cc9dae3a08e2fd396657a99da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

