### PR TITLE
fix(fish): use OpenSSH for kyber helper

### DIFF
--- a/home-manager/programs/fish/functions/_kyber_function.fish
+++ b/home-manager/programs/fish/functions/_kyber_function.fish
@@ -1,3 +1,3 @@
-function _kyber_function --description "SSH to Kyber server via Tailscale"
-  tailscale ssh ubuntu@kyber
+function _kyber_function --description "SSH to Kyber via OpenSSH over Tailscale"
+  ssh kyber
 end

--- a/named-hosts/kyber/README.md
+++ b/named-hosts/kyber/README.md
@@ -46,7 +46,7 @@ make decrypt-key-kyber KEY_FILE=tailscale-auth
 Once Tailscale is set up:
 
 ```bash
-kyber  # Fish abbreviation that runs: ssh ubuntu@kyber
+kyber  # Fish abbreviation that runs: ssh kyber
 ```
 
 Remote SSH should go through Tailscale. Latitude project firewall restricts

--- a/spec/fish/_kyber_function_test.fish
+++ b/spec/fish/_kyber_function_test.fish
@@ -2,10 +2,12 @@ set fn (status dirname)/../../home-manager/programs/fish/functions
 source $fn/_kyber_function.fish
 
 set log (mktemp)
-function tailscale; echo $argv >> $log; end
+function ssh; echo "ssh $argv" >> $log; end
+function tailscale; echo "tailscale $argv" >> $log; return 1; end
 
 _kyber_function
 
-@test "calls tailscale ssh to kyber" (grep -c "ssh ubuntu@kyber" $log) -ge 1
+@test "calls OpenSSH through the kyber host alias" (grep -c "^ssh kyber\$" $log) -eq 1
+@test "does not call the Tailscale SSH wrapper" (grep -c "^tailscale " $log) -eq 0
 
 rm -f $log


### PR DESCRIPTION
## Summary

- route the `kyber` Fish helper through the configured OpenSSH host alias
- stop invoking the disabled Tailscale SSH wrapper
- update the Kyber documentation and add a negative regression assertion

## Verification

- `make fish-test` (421 passed)
- `ssh -o BatchMode=yes -o ConnectTimeout=10 kyber true`
- remote banner: `OpenSSH_9.6p1`; authentication: `publickey`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the `kyber` fish helper to use OpenSSH via the `kyber` host alias, avoiding the disabled Tailscale SSH wrapper. Fixes failed connections and documents the new command, with tests to prevent regressions.

- **Bug Fixes**
  - Update `_kyber_function.fish` to run `ssh kyber` instead of `tailscale ssh ubuntu@kyber`.
  - Add tests to assert `ssh kyber` is called and `tailscale` is not; update README example.

<sup>Written for commit d49dc1291ec88a13f975f72e9b899f43aa8b5c33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

