### PR TITLE
fix(dcg): increase hook timeout to 3000ms

### DIFF
--- a/config/dcg/config.toml
+++ b/config/dcg/config.toml
@@ -1,3 +1,6 @@
+[general]
+hook_timeout_ms = 3000
+
 [packs]
 custom_paths = ["~/.config/dcg/packs/*.yaml"]
 


### PR DESCRIPTION
## Summary

- configure DCG hooks with a 3000 ms timeout
- preserve the existing pack configuration

## Validation

- `tomlq -r .general.hook_timeout_ms config/dcg/config.toml` → `3000`
- `git diff --check`

Bead: `shunkakinokisoftware-blzo`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase DCG hook timeout to 3000 ms to prevent premature hook failures. Keeps the existing pack configuration unchanged.

<sup>Written for commit b9245e4a3ef5e4a73232d5be8522aff96291c609. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

