### PR TITLE
feat: add roborev CI poller config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,5 @@ OPENCODE_API_KEY=your-opencode-api-key-here
 XAI_API_KEY=xai-your-key-here
 # Paperclip database URL
 DATABASE_URL=postgres://user:password@host:5432/paperclip
+# Roborev CI repos (comma-separated, quoted for TOML array)
+ROBOREV_CI_REPOS="org/repo1", "org/repo2"

--- a/.env.example
+++ b/.env.example
@@ -17,5 +17,5 @@ OPENCODE_API_KEY=your-opencode-api-key-here
 XAI_API_KEY=xai-your-key-here
 # Paperclip database URL
 DATABASE_URL=postgres://user:password@host:5432/paperclip
-# Roborev CI repos (comma-separated, quoted for TOML array)
-ROBOREV_CI_REPOS="org/repo1", "org/repo2"
+# Roborev CI repos (comma-separated)
+ROBOREV_CI_REPOS=org/repo1,org/repo2

--- a/config/default.nix
+++ b/config/default.nix
@@ -40,6 +40,7 @@ in
   ./opencode
   ./pi
   ./pnpm
+  ./roborev
   ./serena
   ./starship
   ./tmuxinator

--- a/config/roborev/config.template.toml
+++ b/config/roborev/config.template.toml
@@ -1,4 +1,4 @@
 [ci]
 enabled = true
 poll_interval = "5m"
-repos = [__ROBOREV_CI_REPOS__]
+repos = ["__ROBOREV_CI_REPOS__"]

--- a/config/roborev/config.template.toml
+++ b/config/roborev/config.template.toml
@@ -1,0 +1,4 @@
+[ci]
+enabled = true
+poll_interval = "5m"
+repos = [__ROBOREV_CI_REPOS__]

--- a/config/roborev/default.nix
+++ b/config/roborev/default.nix
@@ -1,0 +1,26 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  hydrateScript =
+    let
+      vars = {
+        sed = "${pkgs.gnused}/bin/sed";
+        template = "${./config.template.toml}";
+      };
+      names = builtins.attrNames vars;
+    in
+    pkgs.writeText "hydrate-roborev.sh" (
+      builtins.replaceStrings (map (n: "@${n}@") names) (map (n: builtins.toString vars.${n}) names) (
+        builtins.readFile ./hydrate.sh
+      )
+    );
+in
+{
+  home.activation.hydrateRoborevConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    ${pkgs.bash}/bin/bash "${hydrateScript}" || true
+  '';
+}

--- a/config/roborev/hydrate.sh
+++ b/config/roborev/hydrate.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Hydrate roborev config from .env secrets
+# ROBOREV_CI_REPOS: comma-separated list of repos (e.g. "org/repo1,org/repo2")
 # shellcheck source=/dev/null
 set -euo pipefail
 
@@ -21,10 +22,21 @@ if [ -z "$ROBOREV_CI_REPOS" ]; then
   exit 0
 fi
 
+# Build TOML array from comma-separated list
+IFS=',' read -ra REPOS <<<"$ROBOREV_CI_REPOS"
+TOML_REPOS=""
+for i in "${!REPOS[@]}"; do
+  repo="$(echo "${REPOS[$i]}" | xargs)"
+  if [ "$i" -gt 0 ]; then
+    TOML_REPOS+=", "
+  fi
+  TOML_REPOS+="\"${repo}\""
+done
+
 mkdir -p "$CONFIG_DIR"
 
 @sed@ \
-  -e "s|__ROBOREV_CI_REPOS__|${ROBOREV_CI_REPOS}|g" \
+  -e "s|\"__ROBOREV_CI_REPOS__\"|${TOML_REPOS}|g" \
   "$TEMPLATE" >"$CONFIG"
 chmod 600 "$CONFIG"
 

--- a/config/roborev/hydrate.sh
+++ b/config/roborev/hydrate.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Hydrate roborev config from .env secrets
+# shellcheck source=/dev/null
+set -euo pipefail
+
+CONFIG_DIR="${HOME}/.roborev"
+CONFIG="${CONFIG_DIR}/config.toml"
+TEMPLATE="@template@"
+ENV_FILE="${HOME}/dotfiles/.env"
+
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  . "$ENV_FILE"
+  set +a
+fi
+
+ROBOREV_CI_REPOS="${ROBOREV_CI_REPOS:-}"
+
+if [ -z "$ROBOREV_CI_REPOS" ]; then
+  echo "Warning: ROBOREV_CI_REPOS not set, skipping roborev hydration" >&2
+  exit 0
+fi
+
+mkdir -p "$CONFIG_DIR"
+
+@sed@ \
+  -e "s|__ROBOREV_CI_REPOS__|${ROBOREV_CI_REPOS}|g" \
+  "$TEMPLATE" >"$CONFIG"
+chmod 600 "$CONFIG"
+
+echo "Generated roborev config at $CONFIG" >&2


### PR DESCRIPTION
## Summary
- Add roborev config hydration module (`config/roborev/`) following the existing openclaw pattern
- Template config with `ROBOREV_CI_REPOS` env var substitution from `~/dotfiles/.env`
- Wire into home-manager activation via `config/default.nix`
- Add `ROBOREV_CI_REPOS` to `.env.example`

## Test plan
- [ ] Verify `home-manager switch` runs hydration without error
- [ ] Confirm `~/.roborev/config.toml` is generated with correct repos
- [ ] Confirm `roborev daemon start` picks up the config

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `roborev` CI poller config that hydrates from `~/dotfiles/.env` during `home-manager` activation. It generates `~/.roborev/config.toml` with repos to poll so the `roborev` daemon picks it up.

- **New Features**
  - New `config/roborev` module with `hydrate.sh` to render `config.template.toml` using `ROBOREV_CI_REPOS` (comma-separated list) into a valid TOML array.
  - Integrated via `config/default.nix` so hydration runs on activation; `.env.example` documents `ROBOREV_CI_REPOS`.

- **Migration**
  - Set `ROBOREV_CI_REPOS` in `~/dotfiles/.env` (e.g., org/repo1,org/repo2), then run `home-manager switch`.
  - Verify `~/.roborev/config.toml` exists and start the daemon: `roborev daemon start`.

<sup>Written for commit 82152370008c80ed5da6feb199521b2bef18a24a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

