### PR TITLE
feat(gpg): configure gpg-agent with pinentry and indefinite cache

### DIFF
--- a/home-manager/programs/default.nix
+++ b/home-manager/programs/default.nix
@@ -22,6 +22,7 @@ let
   gh = import ./gh { inherit pkgs; };
   ghq = import ./ghq;
   git = import ./git;
+  gpg = import ./gpg;
   go = import ./go;
   grafana = import ./grafana;
   haskell = import ./haskell;
@@ -76,6 +77,7 @@ in
   gh
   ghq
   git
+  gpg
   go
   grafana
   haskell

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -39,6 +39,8 @@
       # Foundry configuration
       set -gx FOUNDRY_DISABLE_NIGHTLY_WARNING 1
 
+      set -gx GPG_TTY (tty)
+
       direnv hook fish | source
     '';
     loginShellInit = ''

--- a/home-manager/programs/gpg/default.nix
+++ b/home-manager/programs/gpg/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (pkgs.stdenv) isLinux isDarwin;
+in
+{
+  programs.gpg = {
+    enable = true;
+  };
+
+  services.gpg-agent = lib.mkIf isLinux {
+    enable = true;
+    defaultCacheTtl = 2147483647;
+    maxCacheTtl = 2147483647;
+    pinentryPackage = pkgs.pinentry-curses;
+    enableSshSupport = false;
+  };
+
+  # macOS: home-manager services.gpg-agent is Linux-only;
+  # configure via launchd-managed gpg-agent.conf directly.
+  home.file.".gnupg/gpg-agent.conf" = lib.mkIf isDarwin {
+    text = ''
+      pinentry-program ${lib.getExe pkgs.pinentry_mac}
+      allow-loopback-pinentry
+      default-cache-ttl 2147483647
+      max-cache-ttl 2147483647
+    '';
+  };
+}


### PR DESCRIPTION
## Summary
- Add `home-manager/programs/gpg` module with `services.gpg-agent` (Linux) and `gpg-agent.conf` (macOS)
- Configure pinentry-curses (Linux) / pinentry-mac (macOS) with max 32-bit TTL for indefinite passphrase caching
- Export `GPG_TTY` in fish `shellInit` so GPG can find the terminal for passphrase prompts

Fixes `gpg: signing failed: Inappropriate ioctl for device` when commit signing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configure GPG agent on Linux and macOS with proper pinentry and an indefinite (32-bit max) cache to make GPG/Git signing reliable. Also export `GPG_TTY` in `fish` so prompts attach to the terminal.

- **New Features**
  - Added `home-manager/programs/gpg` module to enable `programs.gpg`.
  - Linux: enabled `services.gpg-agent` with `pinentry-curses` and max TTLs.
  - macOS: generated `~/.gnupg/gpg-agent.conf` with `pinentry_mac`, loopback allowed, and max TTLs.

- **Bug Fixes**
  - Fixes "gpg: signing failed: Inappropriate ioctl for device" by setting `GPG_TTY` and configuring pinentry.

<sup>Written for commit 80e17c095806522df5e96c09f7e464bbd414c0cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

