### PR TITLE
fix: resolve gpg-agent.conf conflict, fix shell CI, update models

### DIFF
--- a/config/pi/models.json
+++ b/config/pi/models.json
@@ -74,8 +74,8 @@
           "maxTokens": 65536
         },
         {
-          "id": "claude-opus-4-7",
-          "name": "Claude Opus 4.7",
+          "id": "claude-opus-5-0",
+          "name": "Claude Opus 5.0",
           "reasoning": true,
           "input": [
             "text",
@@ -91,8 +91,8 @@
           "maxTokens": 32000
         },
         {
-          "id": "claude-sonnet-4-6",
-          "name": "Claude Sonnet 4.6",
+          "id": "claude-sonnet-5",
+          "name": "Claude Sonnet 5",
           "reasoning": false,
           "input": [
             "text",

--- a/home-manager/programs/gpg/default.nix
+++ b/home-manager/programs/gpg/default.nix
@@ -19,14 +19,4 @@ in
     enableSshSupport = false;
   };
 
-  # macOS: home-manager services.gpg-agent is Linux-only;
-  # configure via launchd-managed gpg-agent.conf directly.
-  home.file.".gnupg/gpg-agent.conf" = lib.mkIf isDarwin {
-    text = ''
-      pinentry-program ${lib.getExe pkgs.pinentry_mac}
-      allow-loopback-pinentry
-      default-cache-ttl 2147483647
-      max-cache-ttl 2147483647
-    '';
-  };
 }

--- a/models.json
+++ b/models.json
@@ -1,6 +1,6 @@
 {
-  "claude-opus": "claude-opus-4-7",
-  "claude-sonnet": "claude-sonnet-4-6",
+  "claude-opus": "claude-opus-5-0",
+  "claude-sonnet": "claude-sonnet-5",
   "claude-haiku": "claude-haiku-4-5-20251001",
   "gpt": "gpt-5.6-sol",
   "gpt-codex": "gpt-5.3-codex",
@@ -9,12 +9,12 @@
   "gpt-mini": "gpt-5.4-mini",
   "gpt-nano": "gpt-5.4-nano",
   "gemini-pro": "gemini-3.1-pro-preview",
-  "gemini-flash": "gemini-3.1-flash-preview",
+  "gemini-flash": "gemini-3.6-flash",
   "grok": "grok-4.5",
   "glm": "glm-4.7",
-  "minimax": "minimax-m2.7",
+  "minimax": "minimax-m3",
   "gemma": "gemma-4-31b-it",
-  "kimi": "kimi-2.6",
+  "kimi": "kimi-k3",
   "qwen": "qwen3.6-plus",
   "qwen-local": "qwen3.5-0.8b-optiq"
 }

--- a/spec/roborev_hydrate_spec.sh
+++ b/spec/roborev_hydrate_spec.sh
@@ -81,7 +81,7 @@ The output should not include '__ROBOREV_CI_REPOS__'
 End
 
 It 'restricts config file permissions to the owner'
-When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; stat -f "%OLp" "'"$TEMP_HOME"'/.roborev/config.toml" 2>/dev/null || stat -c "%a" "'"$TEMP_HOME"'/.roborev/config.toml"'
+When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; stat -c "%a" "'"$TEMP_HOME"'/.roborev/config.toml" 2>/dev/null || stat -f "%OLp" "'"$TEMP_HOME"'/.roborev/config.toml"'
 The output should eq '600'
 End
 End


### PR DESCRIPTION
## Summary

- Remove duplicate `home.file.".gnupg/gpg-agent.conf"` on Darwin — conflicts with `services.gpg-agent` enabled in `named-hosts/galactica/default.nix`
- Fix roborev shell spec stat order: GNU `stat -f` on Linux is a filesystem flag that exits 0 with wrong output, so the `|| stat -c "%a"` fallback never ran; swap to Linux-first
- Update model IDs to latest: `claude-opus-5-0`, `claude-sonnet-5`, `gemini-3.6-flash`, `minimax-m3`, `kimi-k3`

## Test plan

- [ ] `make build && make switch` succeeds without gpg-agent.conf conflict
- [ ] Shell CI passes `spec/roborev_hydrate_spec.sh:83` permissions test
- [ ] Model aliases resolve correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix macOS GPG agent conflicts and stabilize the CI permissions test. Also updates model aliases to the latest IDs for consistency across configs.

- **Bug Fixes**
  - macOS: Removed duplicate `home.file.".gnupg/gpg-agent.conf"` to avoid conflicts with `services.gpg-agent` (managed in `named-hosts/galactica/default.nix`).
  - CI: Switched permission check to Linux-first order (`stat -c "%a"` then `stat -f "%OLp"`) so the fallback runs correctly.

- **Dependencies**
  - Updated model IDs in `models.json` and `config/pi/models.json`: `claude-opus-5-0`, `claude-sonnet-5`, `gemini-3.6-flash`, `minimax-m3`, `kimi-k3`.

<sup>Written for commit 41f48a5af320034a232055088a2010e6e848d079. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

