### PR TITLE
fix(gpg): use mkDefault for pinentry.package to allow host overrides

### DIFF
--- a/home-manager/programs/gpg/default.nix
+++ b/home-manager/programs/gpg/default.nix
@@ -15,7 +15,7 @@ in
     enable = true;
     defaultCacheTtl = 2147483647;
     maxCacheTtl = 2147483647;
-    pinentry.package = pkgs.pinentry-curses;
+    pinentry.package = lib.mkDefault pkgs.pinentry-curses;
     enableSshSupport = false;
   };
 


### PR DESCRIPTION
## Summary

- `home-manager/programs/gpg/default.nix` sets `pinentry.package = pkgs.pinentry-curses` for all Linux hosts
- `matic` sets `pinentry-gnome3` and `kyber` sets `pinentry-tty` — two definitions with equal priority causes `defined multiple times` error in `nix flake check`
- Fix: wrap base definition in `lib.mkDefault` so host-specific values win

## Test plan

- [ ] `nix flake check` passes (nix-flake and nix-test CI jobs)
- [ ] matic uses pinentry-gnome3, kyber uses pinentry-tty, other Linux hosts fall back to pinentry-curses

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `lib.mkDefault` for `pinentry.package` so host-specific overrides win, fixing the "defined multiple times" error in `nix flake check`. `matic` uses `pinentry-gnome3`, `kyber` uses `pinentry-tty`, and other Linux hosts default to `pkgs.pinentry-curses`.

<sup>Written for commit 66b00d3132875e0e92e3f05a8c66f2acbc051292. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

