### PR TITLE
fix(models): correct opus id to claude-opus-5

### DIFF
--- a/config/ccs/agy.settings.template.json
+++ b/config/ccs/agy.settings.template.json
@@ -2,9 +2,9 @@
   "env": {
     "ANTHROPIC_BASE_URL": "http://127.0.0.1:8317/api/provider/agy",
     "ANTHROPIC_AUTH_TOKEN": "__CLIPROXY_API_KEY__",
-    "ANTHROPIC_MODEL": "claude-opus-4-7",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-7",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-opus-4-7",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-4-6"
+    "ANTHROPIC_MODEL": "claude-opus-5",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-5",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-opus-5",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-5"
   }
 }

--- a/config/ccs/gemini.settings.template.json
+++ b/config/ccs/gemini.settings.template.json
@@ -5,6 +5,6 @@
     "ANTHROPIC_MODEL": "gemini-3.1-pro-preview",
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "gemini-3.1-pro-preview",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "gemini-3.1-pro-preview",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gemini-3.1-flash-preview"
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gemini-3.6-flash"
   }
 }

--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -108,8 +108,8 @@ openai-compatibility:
     api-key-entries:
       - api-key: "__KIMI_API_KEY__"
     models:
-      - name: "kimi-2.6"
-        alias: "kimi-2.6"
+      - name: "kimi-k3"
+        alias: "kimi-k3"
   - name: "qwen"
     base-url: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
     api-key-entries:
@@ -122,10 +122,10 @@ openai-compatibility:
     api-key-entries:
       - api-key: "__OPENCODE_API_KEY__"
     models:
-      - name: "minimax-m2.7"
-        alias: "minimax-m2.7"
-      - name: "kimi-2.6"
-        alias: "kimi-2.6"
+      - name: "minimax-m3"
+        alias: "minimax-m3"
+      - name: "kimi-k3"
+        alias: "kimi-k3"
   - name: "openai"
     base-url: "https://api.openai.com/v1"
     api-key-entries:

--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -1,5 +1,5 @@
 model:
-  default: cliproxy/minimax-m2.7
+  default: cliproxy/minimax-m3
 providers: {}
 fallback_providers: []
 credential_pool_strategies: {}

--- a/config/llm/extra-openai-models.yaml
+++ b/config/llm/extra-openai-models.yaml
@@ -1,10 +1,10 @@
 # Custom OpenAI-compatible models for llm
 - model_id: claude-sonnet
-  model_name: claude-sonnet-4-6
+  model_name: claude-sonnet-5
   api_base: http://localhost:8317/v1
   api_key_name: cliproxyapi
 - model_id: claude-opus
-  model_name: claude-opus-4-7
+  model_name: claude-opus-5
   api_base: http://localhost:8317/v1
   api_key_name: cliproxyapi
 - model_id: claude-haiku

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -14,8 +14,8 @@
         "api": "openai-completions",
         "models": [
           {
-            "id": "claude-opus-4-7",
-            "name": "Claude Opus 4.7",
+            "id": "claude-opus-5",
+            "name": "Claude Opus 5",
             "reasoning": true,
             "input": [
               "text",
@@ -31,8 +31,8 @@
             "maxTokens": 32000
           },
           {
-            "id": "claude-sonnet-4-6",
-            "name": "Claude Sonnet 4.6",
+            "id": "claude-sonnet-5",
+            "name": "Claude Sonnet 5",
             "reasoning": false,
             "input": [
               "text",
@@ -116,8 +116,8 @@
             "maxTokens": 32000
           },
           {
-            "id": "gemini-3.1-flash-preview",
-            "name": "Gemini 3.1 Flash",
+            "id": "gemini-3.6-flash",
+            "name": "Gemini 3.6 Flash",
             "reasoning": false,
             "input": [
               "text",
@@ -150,8 +150,8 @@
             "maxTokens": 32000
           },
           {
-            "id": "minimax-m2.7",
-            "name": "Minimax M2.7",
+            "id": "minimax-m3",
+            "name": "Minimax M3",
             "reasoning": false,
             "input": [
               "text",
@@ -197,7 +197,7 @@
   "agents": {
     "defaults": {
       "model": {
-        "primary": "cliproxy/minimax-m2.7",
+        "primary": "cliproxy/minimax-m3",
         "fallbacks": [
           "cliproxy/glm-4.7",
           "cliproxy/free"
@@ -220,7 +220,7 @@
         "name": "Code Reviewer (Opus)",
         "workspace": "__HOME__/.openclaw/workspace/agents/code-review",
         "model": {
-          "primary": "cliproxy/claude-opus-4-7",
+          "primary": "cliproxy/claude-opus-5",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"
@@ -239,7 +239,7 @@
         "name": "Code Reviewer (Sonnet)",
         "workspace": "__HOME__/.openclaw/workspace/agents/code-review",
         "model": {
-          "primary": "cliproxy/claude-sonnet-4-6",
+          "primary": "cliproxy/claude-sonnet-5",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"
@@ -330,9 +330,9 @@
         "name": "Code Reviewer (Minimax)",
         "workspace": "__HOME__/.openclaw/workspace/agents/code-review",
         "model": {
-          "primary": "cliproxy/minimax-m2.7",
+          "primary": "cliproxy/minimax-m3",
           "fallbacks": [
-            "cliproxy/claude-opus-4-7",
+            "cliproxy/claude-opus-5",
             "cliproxy/glm-4.7",
             "cliproxy/free"
           ]
@@ -367,7 +367,7 @@
         "name": "Security Scanner",
         "workspace": "__HOME__/.openclaw/workspace/agents/security",
         "model": {
-          "primary": "cliproxy/minimax-m2.7",
+          "primary": "cliproxy/minimax-m3",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"
@@ -403,7 +403,7 @@
         "name": "Docs Checker",
         "workspace": "__HOME__/.openclaw/workspace/agents/docs",
         "model": {
-          "primary": "cliproxy/minimax-m2.7",
+          "primary": "cliproxy/minimax-m3",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"
@@ -460,7 +460,7 @@
         "model": {
           "primary": "cliproxy/gemini-3.1-pro-preview",
           "fallbacks": [
-            "cliproxy/minimax-m2.7",
+            "cliproxy/minimax-m3",
             "cliproxy/glm-4.7",
             "cliproxy/free"
           ]
@@ -479,7 +479,7 @@
         "model": {
           "primary": "cliproxy/gpt-5.6-sol",
           "fallbacks": [
-            "cliproxy/minimax-m2.7",
+            "cliproxy/minimax-m3",
             "cliproxy/glm-4.7",
             "cliproxy/free"
           ]
@@ -496,9 +496,9 @@
         "name": "Twitter (Opus)",
         "workspace": "__HOME__/.openclaw/workspace/agents/twitter",
         "model": {
-          "primary": "cliproxy/claude-opus-4-7",
+          "primary": "cliproxy/claude-opus-5",
           "fallbacks": [
-            "cliproxy/minimax-m2.7",
+            "cliproxy/minimax-m3",
             "cliproxy/glm-4.7",
             "cliproxy/free"
           ]
@@ -516,7 +516,7 @@
         "name": "Mindset Coach",
         "workspace": "__HOME__/.openclaw/workspace/agents/mindset",
         "model": {
-          "primary": "cliproxy/claude-opus-4-7",
+          "primary": "cliproxy/claude-opus-5",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"
@@ -535,7 +535,7 @@
         "name": "Routine Manager",
         "workspace": "__HOME__/.openclaw/workspace/agents/routine",
         "model": {
-          "primary": "cliproxy/claude-sonnet-4-6",
+          "primary": "cliproxy/claude-sonnet-5",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"
@@ -554,7 +554,7 @@
         "name": "Dev (Opus)",
         "workspace": "__HOME__/.openclaw/workspace/agents/dev",
         "model": {
-          "primary": "cliproxy/claude-opus-4-7",
+          "primary": "cliproxy/claude-opus-5",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"
@@ -635,7 +635,7 @@
         "name": "Strategy (Opus)",
         "workspace": "__HOME__/.openclaw/workspace/agents/strategy",
         "model": {
-          "primary": "cliproxy/claude-opus-4-7",
+          "primary": "cliproxy/claude-opus-5",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"
@@ -690,7 +690,7 @@
         "name": "Communication Specialist",
         "workspace": "__HOME__/.openclaw/workspace/agents/communication",
         "model": {
-          "primary": "cliproxy/claude-sonnet-4-6",
+          "primary": "cliproxy/claude-sonnet-5",
           "fallbacks": [
             "cliproxy/glm-4.7",
             "cliproxy/free"

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -24,11 +24,11 @@
         "apiKey": "{env:CLIPROXY_API_KEY}"
       },
       "models": {
-        "claude-opus-4-7": {
-          "name": "Claude Opus 4.7 (via shunkakinoki's CLIProxy)"
+        "claude-opus-5": {
+          "name": "Claude Opus 5 (via shunkakinoki's CLIProxy)"
         },
-        "claude-sonnet-4-6": {
-          "name": "Claude Sonnet 4.6 (via shunkakinoki's CLIProxy)"
+        "claude-sonnet-5": {
+          "name": "Claude Sonnet 5 (via shunkakinoki's CLIProxy)"
         },
         "claude-haiku-4-5-20251001": {
           "name": "Claude Haiku 4.5 (via shunkakinoki's CLIProxy)"
@@ -42,14 +42,14 @@
         "gemini-3.1-pro-preview": {
           "name": "Gemini 3.1 Pro (via shunkakinoki's CLIProxy)"
         },
-        "gemini-3.1-flash-preview": {
-          "name": "Gemini 3.1 Flash (via shunkakinoki's CLIProxy)"
+        "gemini-3.6-flash": {
+          "name": "Gemini 3.6 Flash (via shunkakinoki's CLIProxy)"
         },
         "z-ai/glm-4.7": {
           "name": "GLM 4.7 (via shunkakinoki's CLIProxy)"
         },
-        "kimi-2.6": {
-          "name": "Kimi 2.6 (via shunkakinoki's CLIProxy)"
+        "kimi-k3": {
+          "name": "Kimi K3 (via shunkakinoki's CLIProxy)"
         }
       }
     },
@@ -61,11 +61,11 @@
         "apiKey": "{env:CLIPROXY_API_KEY}"
       },
       "models": {
-        "claude-opus-4-7": {
-          "name": "Claude Opus 4.7 (via local CLIProxyAPI)"
+        "claude-opus-5": {
+          "name": "Claude Opus 5 (via local CLIProxyAPI)"
         },
-        "claude-sonnet-4-6": {
-          "name": "Claude Sonnet 4.6 (via local CLIProxyAPI)"
+        "claude-sonnet-5": {
+          "name": "Claude Sonnet 5 (via local CLIProxyAPI)"
         },
         "claude-haiku-4-5-20251001": {
           "name": "Claude Haiku 4.5 (via local CLIProxyAPI)"
@@ -79,17 +79,17 @@
         "gemini-3.1-pro-preview": {
           "name": "Gemini 3.1 Pro (via local CLIProxyAPI)"
         },
-        "gemini-3.1-flash-preview": {
-          "name": "Gemini 3.1 Flash (via local CLIProxyAPI)"
+        "gemini-3.6-flash": {
+          "name": "Gemini 3.6 Flash (via local CLIProxyAPI)"
         },
         "glm-4.7": {
           "name": "GLM 4.7 (via local CLIProxyAPI)"
         },
-        "minimax-m2.7": {
-          "name": "Minimax M2.7 (via local CLIProxyAPI)"
+        "minimax-m3": {
+          "name": "Minimax M3 (via local CLIProxyAPI)"
         },
-        "kimi-2.6": {
-          "name": "Kimi 2.6 (via local CLIProxyAPI)"
+        "kimi-k3": {
+          "name": "Kimi K3 (via local CLIProxyAPI)"
         }
       }
     },

--- a/config/pi/models.json
+++ b/config/pi/models.json
@@ -57,8 +57,8 @@
           "maxTokens": 65536
         },
         {
-          "id": "gemini-3.1-flash-preview",
-          "name": "Gemini 3.1 Flash",
+          "id": "gemini-3.6-flash",
+          "name": "Gemini 3.6 Flash",
           "reasoning": false,
           "input": [
             "text",
@@ -74,8 +74,8 @@
           "maxTokens": 65536
         },
         {
-          "id": "claude-opus-5-0",
-          "name": "Claude Opus 5.0",
+          "id": "claude-opus-5",
+          "name": "Claude Opus 5",
           "reasoning": true,
           "input": [
             "text",
@@ -125,8 +125,8 @@
           "maxTokens": 8192
         },
         {
-          "id": "minimax-m2.7",
-          "name": "Minimax M2.7",
+          "id": "minimax-m3",
+          "name": "Minimax M3",
           "reasoning": true,
           "input": [
             "text",

--- a/models.json
+++ b/models.json
@@ -1,5 +1,5 @@
 {
-  "claude-opus": "claude-opus-5-0",
+  "claude-opus": "claude-opus-5",
   "claude-sonnet": "claude-sonnet-5",
   "claude-haiku": "claude-haiku-4-5-20251001",
   "gpt": "gpt-5.6-sol",


### PR DESCRIPTION
## What

Fixes the Opus alias in `models.json` from the invalid `claude-opus-5-0` to `claude-opus-5`, and regenerates all templated tool configs via `scripts/llm-update.sh`.

## Why

`claude-opus-5-0` is not a valid model id. Regeneration also propagated the already-correct `claude-sonnet-5` into stale templates (e.g. `agy` profile was still on `opus-4-7` / `sonnet-4-6`).

## Changes

- `models.json`: `claude-opus-5-0` -> `claude-opus-5`
- Regenerated: aichat/ccs/cliproxy/hermes/llm/openclaw/opencode/pi configs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the invalid Opus model id by changing `claude-opus-5-0` to `claude-opus-5`, and regenerates configs so all tools use the correct Anthropic and partner model aliases. This removes stale defaults and aligns templates across `ccs`, `cliproxyapi`, `hermes`, `llm`, `openclaw`, `opencode`, and `pi`.

- **Bug Fixes**
  - Updated `models.json`: `claude-opus-5-0` → `claude-opus-5`.
  - Regenerated templates to propagate `claude-opus-5` and `claude-sonnet-5`.
  - Synced related aliases: `minimax-m3` (was `minimax-m2.7`), `kimi-k3` (was `kimi-2.6`), `gemini-3.6-flash` (was `gemini-3.1-flash-preview`); updated defaults in `openclaw`, `hermes`, `cliproxyapi`, `opencode`, and `pi`.

- **Migration**
  - If any local or env config references `claude-opus-5-0`, change it to `claude-opus-5`.

<sup>Written for commit 0a41ba247c05451f10574396ce8e9cce0fe1cce5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

