### PR TITLE
feat(homebrew): add t3-code, remove openclaw from dock

### DIFF
--- a/nix-darwin/config/dock.nix
+++ b/nix-darwin/config/dock.nix
@@ -27,7 +27,6 @@
       "/Applications/OpenCode.app"
       "/Applications/Antigravity.app"
       "/Applications/Conductor.app"
-      "/Applications/OpenClaw.app"
       "/Applications/Beekeeper Studio.app"
       "/Applications/Google Chrome.app"
       "/Applications/Docker.app"

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -163,6 +163,7 @@
       "screen-studio"
       "sf-symbols"
       "slack"
+      "t3-code"
       "tailscale-app"
       "telegram-desktop"
       "trae"


### PR DESCRIPTION
## Summary
- Add `t3-code` cask (minimal GUI for AI code agents) to Homebrew
- Remove OpenClaw from dock persistent apps

## Test plan
- [ ] `darwin-rebuild switch` completes successfully
- [ ] T3 Code installs via Homebrew
- [ ] Dock no longer shows OpenClaw

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `t3-code` to Homebrew casks and remove OpenClaw from the persistent Dock apps. This installs T3 Code via nix-darwin and cleans up the Dock.

<sup>Written for commit 87a86370518e28f1494f3c4c4e5f0b8ca519b338. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

