### PR TITLE
fix(gpg): mkDefault cache TTLs so hosts can override

### DIFF
--- a/home-manager/programs/gpg/default.nix
+++ b/home-manager/programs/gpg/default.nix
@@ -13,8 +13,8 @@ in
 
   services.gpg-agent = lib.mkIf isLinux {
     enable = true;
-    defaultCacheTtl = 2147483647;
-    maxCacheTtl = 2147483647;
+    defaultCacheTtl = lib.mkDefault 2147483647;
+    maxCacheTtl = lib.mkDefault 2147483647;
     pinentry.package = lib.mkDefault pkgs.pinentry-curses;
     enableSshSupport = false;
   };


### PR DESCRIPTION
## Problem

`nix-linux` / `Build Host kyber` fails on main ([run 30590961352](https://github.com/shunkakinoki/dotfiles/actions/runs/30590961352/job/91032975783)):

```
error: The option `services.gpg-agent.defaultCacheTtl' has conflicting definition values:
- In `.../home-manager/default.nix': 2147483647
- In `<unknown-file>': 94608000
```

The shared module [home-manager/programs/gpg/default.nix](home-manager/programs/gpg/default.nix) sets `defaultCacheTtl`/`maxCacheTtl` at normal priority, and [named-hosts/kyber/default.nix:119](named-hosts/kyber/default.nix:119) sets 94608000 (3 years) at the same priority. #2185 applied `mkDefault` to `pinentry.package` only, leaving the TTLs conflicting.

## Fix

Wrap both TTLs in `lib.mkDefault`, same as `pinentry.package`.

## Verification

```
nix eval .#homeConfigurations.kyber...defaultCacheTtl                 -> 94608000
nix eval .#homeConfigurations."ubuntu@x86_64-linux"...defaultCacheTtl -> 2147483647
nix eval .#nixosConfigurations.matic...defaultCacheTtl                -> 2147483647
```

`nixfmt --check` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrap `services.gpg-agent.defaultCacheTtl` and `maxCacheTtl` in `lib.mkDefault` to let host configs override TTLs without conflicts. This fixes the kyber build error and preserves defaults for other hosts.

- **Bug Fixes**
  - Updated `home-manager/programs/gpg/default.nix` to set TTLs with `lib.mkDefault`, matching `pinentry.package`.
  - Kyber can use 94608000 (3 years) while others keep 2147483647, eliminating the "conflicting definition values" error.

<sup>Written for commit 6f3765c8d42f601d42eab1fc5cc87855e4963c13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

