### PR TITLE
fix(neovim): break pack-lock symlink on activation to stop repo churn

### DIFF
--- a/home-manager/programs/neovim/activate-copy-pack-lock.sh
+++ b/home-manager/programs/neovim/activate-copy-pack-lock.sh
@@ -5,5 +5,11 @@ set -euo pipefail
 PACK_LOCK_JSON="$1"
 
 mkdir -p "$HOME/.config/nvim"
+# Remove any existing file/symlink first. `make neovim-dev`/`neovim-update`
+# symlink this path back into the repo; without the rm, `cp -f` follows that
+# symlink and writes through to the repo working tree, so every plugin change
+# nvim makes shows up as an uncommitted diff. rm breaks the symlink so we get
+# a plain local copy that nvim can dirty without touching the repo.
+rm -f "$HOME/.config/nvim/nvim-pack-lock.json"
 cp -f "$PACK_LOCK_JSON" "$HOME/.config/nvim/nvim-pack-lock.json"
 chmod 644 "$HOME/.config/nvim/nvim-pack-lock.json"


### PR DESCRIPTION
## Problem
`make neovim-dev` / `make neovim-update` symlink `~/.config/nvim/nvim-pack-lock.json` back into the repo (so `vim.pack.update()` can capture new plugin revs). The symlink persisted after those workflows, and the activation script's `cp -f` *followed* it - so every plugin `vim.pack` touched during normal nvim use wrote straight into the git working tree (e.g. an undeclared `tree-sitter-manager.nvim` entry kept reappearing).

## Fix
`rm -f` the destination before `cp` in `activate-copy-pack-lock.sh`, so activation breaks any symlink and always lays down a plain local copy. Daily nvim use now dirties only the local copy; `make neovim-update` still captures intentional lock updates for committing.

## Testing
- `shellspec spec/activate_neovim_spec.sh` - 15 examples, 0 failures
- `shellcheck` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delete any existing `~/.config/nvim/nvim-pack-lock.json` before activation and copy a plain local file, so plugin changes stop writing into the repo. Normal use now only dirties the local copy, while `make neovim-update` still captures intended lock updates.

<sup>Written for commit af018ffe1ec39fd2849cce2c2dcbd4e54aaaf9ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

