### PR TITLE
fix(nix): use beamPackages.elixir in make-updater PATH

### DIFF
--- a/home-manager/services/make-updater/default.nix
+++ b/home-manager/services/make-updater/default.nix
@@ -39,11 +39,11 @@ in
           lib.makeBinPath [
             pkgs.autoconf
             pkgs.bash
+            pkgs.beamPackages.elixir
             pkgs.binutils
             pkgs.cargo
             pkgs.coreutils
             pkgs.curl
-            pkgs.elixir
             pkgs.gawk
             pkgs.gcc
             pkgs.ghq


### PR DESCRIPTION
Top-level `pkgs.elixir` is deprecated and emitted `evaluation warning: 'elixir' is deprecated in favor of using the beamPackages sets` on every `nixosConfigurations` build.

`home-manager/programs/elixir` was already migrated; the make-updater systemd PATH was the last remaining top-level reference.

Verified `beamPackages.elixir` resolves in the pinned nixpkgs (elixir-1.18.4) with no warning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced deprecated `pkgs.elixir` with `pkgs.beamPackages.elixir` in the make-updater PATH to stop deprecation warnings on `nixosConfigurations` builds. Verified it resolves to Elixir 1.18.4 in pinned `nixpkgs`.

<sup>Written for commit ae3b028cf15956c3bbb884de98bbdec9d768bac5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

