### PR TITLE
feat(services): submit tokscale usage every 3h on all machines

### DIFF
--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -31,6 +31,7 @@ let
   screenshotClipboard = import ./screenshot-clipboard { inherit pkgs; };
   sshAgent = ./ssh-agent;
   tmuxSessionLogger = import ./tmux-session-logger { inherit pkgs; };
+  tokscale = import ./tokscale { inherit pkgs; };
 in
 [
   brewUpgrader
@@ -58,4 +59,5 @@ in
   screenshotClipboard
   sshAgent
   tmuxSessionLogger
+  tokscale
 ]

--- a/home-manager/services/tokscale/default.nix
+++ b/home-manager/services/tokscale/default.nix
@@ -1,0 +1,59 @@
+{ pkgs, ... }:
+let
+  inherit (pkgs) lib;
+  binPath = lib.makeBinPath [
+    pkgs.bun
+    pkgs.bash
+    pkgs.coreutils
+  ];
+  # Every 3 hours.
+  intervalSeconds = 10800;
+in
+{
+  # macOS (launchd)
+  launchd.agents.tokscale = lib.mkIf pkgs.stdenv.isDarwin {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "${pkgs.bash}/bin/bash"
+        "${./submit.sh}"
+      ];
+      Environment = {
+        PATH = binPath + ":/usr/bin:/bin:/usr/sbin:/sbin";
+      };
+      StartInterval = intervalSeconds;
+      StandardOutPath = "/tmp/tokscale.log";
+      StandardErrorPath = "/tmp/tokscale.error.log";
+    };
+  };
+
+  # Linux (systemd)
+  systemd.user.services.tokscale = lib.mkIf pkgs.stdenv.isLinux {
+    Unit = {
+      Description = "Submit local usage data to Tokscale";
+      Wants = [ "network-online.target" ];
+      After = [ "network-online.target" ];
+      X-SwitchMethod = "keep-old";
+    };
+    Service = {
+      Type = "oneshot";
+      Environment = "PATH=${binPath}";
+      ExecStart = "${pkgs.bash}/bin/bash ${./submit.sh}";
+    };
+  };
+
+  systemd.user.timers.tokscale = lib.mkIf pkgs.stdenv.isLinux {
+    Unit = {
+      Description = "Timer for Tokscale usage submission";
+    };
+    Timer = {
+      OnBootSec = "5min";
+      OnUnitActiveSec = "3h";
+      Persistent = true;
+      Unit = "tokscale.service";
+    };
+    Install = {
+      WantedBy = [ "timers.target" ];
+    };
+  };
+}

--- a/home-manager/services/tokscale/submit.sh
+++ b/home-manager/services/tokscale/submit.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Submit local usage data to Tokscale. Runs on a 3h schedule on all machines.
+set -euo pipefail
+
+# tokscale submit needs the network; skip silently when offline.
+if ! timeout 3 bash -c 'exec 3<>/dev/tcp/1.1.1.1/53' 2>/dev/null; then
+  echo "Network unavailable, skipping tokscale submit"
+  exit 0
+fi
+
+# tokscale is installed as a bun global (see modules/npm-globals). Invoke its
+# entrypoint through bun so we do not depend on `node` being on PATH (bin.js
+# uses an `env node` shebang).
+TOKSCALE_BIN="${HOME}/.bun/install/global/node_modules/tokscale/bin.js"
+if [ ! -f "$TOKSCALE_BIN" ]; then
+  echo "tokscale not installed at ${TOKSCALE_BIN}, skipping"
+  exit 0
+fi
+
+# stdin from /dev/null keeps submit non-interactive (skips the "star the repo"
+# prompt seen on a TTY).
+exec bun "$TOKSCALE_BIN" submit </dev/null

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -113,6 +113,10 @@ It 'has spec file for home-manager/services/neverssl-keepalive/keepalive.sh'
 The path "spec/keepalive_spec.sh" should be exist
 End
 
+It 'has spec file for home-manager/services/tokscale/submit.sh'
+The path "spec/tokscale_spec.sh" should be exist
+End
+
 It 'has spec file for home-manager/services/night-shift/apply-night-shift.sh'
 The path "spec/night_shift_spec.sh" should be exist
 End
@@ -493,6 +497,7 @@ home-manager/services/k3s/activate.sh
 home-manager/services/make-updater/update.sh
 home-manager/services/neverssl-keepalive/keepalive.sh
 home-manager/services/night-shift/apply-night-shift.sh
+home-manager/services/tokscale/submit.sh
 hosts/darwin/activate-remove-backups.sh
 hosts/linux/activate-backup-files.sh
 install.sh

--- a/spec/roborev_hydrate_spec.sh
+++ b/spec/roborev_hydrate_spec.sh
@@ -115,7 +115,7 @@ Before 'setup_no_repos'
 After 'cleanup_no_repos'
 
 It 'skips hydration when ROBOREV_CI_REPOS is unset'
-When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$PREPROCESSED_SCRIPT"'"'
+When run bash -c 'unset ROBOREV_CI_REPOS; HOME="'"$TEMP_HOME"'" bash "'"$PREPROCESSED_SCRIPT"'"'
 The status should be success
 The error should include 'ROBOREV_CI_REPOS not set'
 The path "$TEMP_HOME/.roborev/config.toml" should not be exist

--- a/spec/tokscale_spec.sh
+++ b/spec/tokscale_spec.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'tokscale/submit.sh'
+SCRIPT="$PWD/home-manager/services/tokscale/submit.sh"
+
+Describe 'script properties'
+It 'uses strict mode (set -euo pipefail)'
+When run bash -c "head -5 '$SCRIPT'"
+The output should include 'set -euo pipefail'
+End
+
+It 'has a descriptive comment mentioning Tokscale'
+When run bash -c "head -5 '$SCRIPT'"
+The output should include 'Tokscale'
+End
+
+It 'invokes tokscale submit through bun'
+When run bash -c "cat '$SCRIPT'"
+The output should include 'bun'
+The output should include 'submit'
+End
+
+It 'runs non-interactively (stdin from /dev/null)'
+When run bash -c "cat '$SCRIPT'"
+The output should include '/dev/null'
+End
+
+It 'uses the bun global tokscale entrypoint'
+When run bash -c "cat '$SCRIPT'"
+The output should include '.bun/install/global/node_modules/tokscale/bin.js'
+End
+End
+
+Describe 'network guard'
+setup() {
+  MOCK_BIN=$(mktemp -d)
+  MOCK_ORIGINAL_PATH="$PATH"
+  export PATH="$MOCK_BIN:$PATH"
+  # Force the offline branch: timeout exits non-zero.
+  cat >"$MOCK_BIN/timeout" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$MOCK_BIN/timeout"
+}
+
+cleanup() {
+  export PATH="$MOCK_ORIGINAL_PATH"
+  rm -rf "$MOCK_BIN"
+}
+
+Before 'setup'
+After 'cleanup'
+
+It 'skips and exits 0 when offline'
+When run bash "$SCRIPT"
+The output should include 'Network unavailable'
+The status should be success
+End
+End
+
+Describe 'missing tokscale guard'
+setup() {
+  MOCK_BIN=$(mktemp -d)
+  MOCK_ORIGINAL_PATH="$PATH"
+  export PATH="$MOCK_BIN:$PATH"
+  # Pass the network check so we reach the install check.
+  cat >"$MOCK_BIN/timeout" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$MOCK_BIN/timeout"
+  FAKE_HOME=$(mktemp -d)
+}
+
+cleanup() {
+  export PATH="$MOCK_ORIGINAL_PATH"
+  rm -rf "$MOCK_BIN" "$FAKE_HOME"
+}
+
+Before 'setup'
+After 'cleanup'
+
+It 'skips and exits 0 when tokscale is not installed'
+When run env HOME="$FAKE_HOME" bash "$SCRIPT"
+The output should include 'not installed'
+The status should be success
+End
+End
+
+End


### PR DESCRIPTION
## Summary
- Add a cross-platform `tokscale` service that runs `tokscale submit` every 3 hours on all machines
  - macOS: launchd agent (`StartInterval = 10800`)
  - Linux: systemd user service + timer (`OnUnitActiveSec = 3h`, `Persistent`)
- `submit.sh` invokes the bun global tokscale entrypoint via `bun` (no `node` PATH dependency), skips when offline or when tokscale is not installed, and runs non-interactively (stdin from /dev/null, avoiding the star prompt)
- Wired into `home-manager/services/default.nix`

## Tests
- New `spec/tokscale_spec.sh` (properties + network/install guards); added to `coverage_spec.sh`
- Hardened `spec/roborev_hydrate_spec.sh`: the "ROBOREV_CI_REPOS unset" case now `unset`s the var so it is hermetic regardless of the caller's environment (was failing when the var leaked in from the shell)
- Full suite: 1746 examples, 0 failures; nixfmt + shellcheck clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cross-platform service that runs `tokscale submit` every 3 hours on macOS and Linux. Uses `bun` to call the global `tokscale` entrypoint, skips when offline or not installed, and runs non-interactively.

- **New Features**
  - macOS: launchd agent with `StartInterval = 10800`.
  - Linux: systemd user service + timer (`OnUnitActiveSec = 3h`, `Persistent`, waits for network).
  - `submit.sh`: invokes via `bun`, checks network, checks `~/.bun/.../tokscale/bin.js`, stdin from `/dev/null`.
  - Integrated into `home-manager/services/default.nix`.

- **Bug Fixes**
  - Make `roborev_hydrate_spec.sh` hermetic by unsetting `ROBOREV_CI_REPOS` in the "unset" test.

<sup>Written for commit 6daf8bd807b4733478eb7f6c9c9655a8d60f857d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

