### PR TITLE
feat(fish): wire up _brew_update_function behind bu abbr

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -113,6 +113,7 @@
       v = "nvim";
 
       # Function-based abbreviations
+      bu = "_brew_update_function";
       caf = "_caf_function";
       cawxe = "_cawxe_function";
       cawxeh = "_cawxeh_function";
@@ -242,6 +243,7 @@
       })
       [
         "__tmux_bootstrap_default_session"
+        "_brew_update_function"
         "_caf_function"
         "_cawxe_function"
         "_cawxeh_function"

--- a/home-manager/programs/fish/functions/_brew_update_function.fish
+++ b/home-manager/programs/fish/functions/_brew_update_function.fish
@@ -1,3 +1,3 @@
-function _brew_update --description "Update Homebrew"
+function _brew_update_function --description "Update Homebrew"
   brew update && brew upgrade && brew cleanup
 end

--- a/spec/fish/_brew_update_function_test.fish
+++ b/spec/fish/_brew_update_function_test.fish
@@ -7,8 +7,9 @@ function brew
     echo $argv >> $log
 end
 
-_brew_update
+_brew_update_function
 
+@test "function is defined after sourcing" (functions -q _brew_update_function; echo $status) = 0
 @test "updates homebrew" (grep -c "update" $log) -ge 1
 @test "upgrades homebrew" (grep -c "upgrade" $log) -ge 1
 @test "cleans up homebrew" (grep -c "cleanup" $log) -ge 1


### PR DESCRIPTION
## What

`home-manager/programs/fish/functions/_brew_update_function.fish` existed with a passing spec but was not referenced anywhere in `home-manager/programs/fish/default.nix` - neither in `shellAbbrs` nor in the `xdg.configFile` registration list. It was never installed or loadable.

- `default.nix`: add `bu = "_brew_update_function";` to `shellAbbrs` (`bu` was unused) and `"_brew_update_function"` to the function registration list.
- `_brew_update_function.fish`: rename the inner `function _brew_update` to `_brew_update_function`.
- `spec/fish/_brew_update_function_test.fish`: call the renamed function, plus add a `functions -q` assertion matching the convention used by the other specs.

## Why the rename is required

Fish autoloads `fish/functions/<name>.fish` only when the function defined inside matches the filename, and `_fish_shortcuts` derives names the same way (`_fish_shortcuts.fish:216`). Every sibling follows this (`_llm_update_function.fish` defines `_llm_update_function`). Registering the file without the rename would have left `bu` expanding to a command-not-found. The new `functions -q` assertion is what would have caught the original mismatch.

## Notes for reviewers

- This overlaps existing automation: `nix-darwin/config/homebrew.nix` sets `onActivation.autoUpdate` / `upgrade` / `cleanup = "zap"`, and `home-manager/services/brew-upgrader` runs `brew upgrade` on a schedule. Kept anyway as an on-demand shortcut.
- Registered unconditionally, so `bu` also exists on Linux hosts where `brew` is absent and will simply error. Can be gated behind `pkgs.stdenv.isDarwin` like the `rm` abbr if preferred.
- Function body unchanged: `brew update && brew upgrade && brew cleanup`.

## Testing

- `make fish-test` - 422 pass (was 418; +3 previously-orphaned brew tests, +1 new).
- `nix-instantiate --parse` on the edited file - OK.
- `nixfmt --check` on the edited file - clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired up `_brew_update_function` behind the `bu` `fish` abbreviation and registered it for autoloading, so `brew` update/upgrade/cleanup is available via a shortcut. Renamed the inner function to match the filename to fix autoloading, and updated the spec.

- **Bug Fixes**
  - Added `bu = "_brew_update_function"` to `home-manager` `shellAbbrs` and registered `_brew_update_function` for autoload.
  - Renamed `function _brew_update` to `_brew_update_function` to satisfy `fish` autoload rules.
  - Updated the spec to call the new name and assert `functions -q _brew_update_function`.

<sup>Written for commit a767f75629fe76cdff7a994fe358209409217ca8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

