### PR TITLE
fix: avoid bun pm -g trust stalling on postinstall

### DIFF
--- a/home-manager/modules/npm-globals/install-npm-globals.sh
+++ b/home-manager/modules/npm-globals/install-npm-globals.sh
@@ -241,17 +241,16 @@ run_postinstall_if_needed() {
 echo "Installing npm global packages from package.json using bun..."
 cd "${HOME}/dotfiles"
 
-# Trust postinstall scripts for packages listed in trustedDependencies before installing
-TRUSTED_DEPS=$(jq -r '.trustedDependencies[]?' "$PACKAGE_JSON" 2>/dev/null || true)
-if [ -n "$TRUSTED_DEPS" ]; then
-  echo "Trusting postinstall scripts for: $TRUSTED_DEPS"
-  echo "$TRUSTED_DEPS" | while read -r dep; do
-    bun pm -g trust "$dep" 2>/dev/null || true
-  done
-fi
-
-# Remove packages that are no longer declared in dotfiles/package.json
+# Trust postinstall scripts by writing trustedDependencies directly into the
+# global package.json. Avoids `bun pm -g trust` which runs postinstall scripts
+# for already-installed packages, causing long downloads and lock contention.
 GLOBAL_PKG="${HOME}/.bun/install/global/package.json"
+TRUSTED_DEPS=$(jq -c '[.trustedDependencies[]?]' "$PACKAGE_JSON" 2>/dev/null || echo '[]')
+if [ "$TRUSTED_DEPS" != "[]" ] && [ -f "$GLOBAL_PKG" ]; then
+  echo "Setting trustedDependencies in global package.json..."
+  jq --argjson trusted "$TRUSTED_DEPS" '.trustedDependencies = $trusted' "$GLOBAL_PKG" >"${GLOBAL_PKG}.tmp" &&
+    mv "${GLOBAL_PKG}.tmp" "$GLOBAL_PKG"
+fi
 STALE=()
 if [ -f "$GLOBAL_PKG" ]; then
   GLOBAL_DEPS=$(jq -r '.dependencies | keys[]?' "$GLOBAL_PKG" 2>/dev/null || true)
@@ -365,7 +364,7 @@ if [ -n "$OVERRIDES" ]; then
   if [ -f "$GLOBAL_PKG" ]; then
     jq --argjson overrides "$OVERRIDES" '.overrides = $overrides' "$GLOBAL_PKG" >"${GLOBAL_PKG}.tmp" &&
       mv "${GLOBAL_PKG}.tmp" "$GLOBAL_PKG"
-    (cd "${HOME}/.bun/install/global" && bun install 2>/dev/null || true)
+    (cd "${HOME}/.bun/install/global" && timeout 600 bun install 2>/dev/null || true)
     purge_bun_npm_shim
     echo "Applied dependency overrides to global install"
   fi

--- a/home-manager/programs/fish/functions/_grs_function.fish
+++ b/home-manager/programs/fish/functions/_grs_function.fish
@@ -8,9 +8,14 @@ function _grs_function --description "Reset to origin default branch (safe: abor
 
     git fetch origin
 
-    if not git merge-base --is-ancestor HEAD origin/$default_branch
-        echo "grs: current branch is not merged into origin/$default_branch, aborting." >&2
-        return 1
+    set -l head_sha (git rev-parse HEAD)
+    set -l origin_sha (git rev-parse origin/$default_branch)
+
+    if test "$head_sha" != "$origin_sha"
+        if not git merge-base --is-ancestor HEAD origin/$default_branch
+            echo "grs: current branch is not merged into origin/$default_branch, aborting." >&2
+            return 1
+        end
     end
 
     git reset --hard origin/$default_branch

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -216,7 +216,7 @@ import ../../hosts/nixos {
               };
           };
         };
-        security.pam.services.noctalia-shell = {
+        security.pam.services.noctalia = {
           fprintAuth = true;
           rules.auth.fprintd.settings = {
             max-tries = -1;

--- a/spec/fish/_grs_function_test.fish
+++ b/spec/fish/_grs_function_test.fish
@@ -11,6 +11,10 @@ function git
         echo "refs/remotes/origin/main"
     else if test "$argv[1]" = diff
         return 0
+    else if test "$argv[1]" = rev-parse; and test "$argv[2]" = HEAD
+        echo "abc123"
+    else if test "$argv[1]" = rev-parse; and test "$argv[2]" = "origin/main"
+        echo "def456"
     else if test "$argv[1]" = merge-base
         return 0
     end
@@ -68,6 +72,10 @@ function git
         echo "refs/remotes/origin/main"
     else if test "$argv[1]" = diff
         return 0
+    else if test "$argv[1]" = rev-parse; and test "$argv[2]" = HEAD
+        echo "abc123"
+    else if test "$argv[1]" = rev-parse; and test "$argv[2]" = "origin/main"
+        echo "def456"
     else if test "$argv[1]" = merge-base
         return 1
     end
@@ -85,3 +93,30 @@ set exit_code $status
 @test "unmerged: prints warning" (grep -c "not merged" $err_log) -ge 1
 
 rm -f $call_log $err_log
+
+# --- Test: no divergence (same commit) skips merge check ---
+
+set call_log (mktemp)
+
+function git
+    echo $argv >> $call_log
+    if test "$argv[1]" = symbolic-ref
+        echo "refs/remotes/origin/main"
+    else if test "$argv[1]" = diff
+        return 0
+    else if test "$argv[1]" = rev-parse
+        echo "same_sha"
+    end
+end
+
+function sed
+    echo "main"
+end
+
+_grs_function
+
+@test "no-divergence: skips merge-base check" (grep -c "merge-base" $call_log) -eq 0
+@test "no-divergence: resets to origin" (grep -c "reset --hard origin/main" $call_log) -ge 1
+@test "no-divergence: sets upstream" (grep -c "branch --set-upstream-to=origin/main" $call_log) -ge 1
+
+rm -f $call_log


### PR DESCRIPTION
## Summary

- Replace `bun pm -g trust` loop with direct `jq` write of `trustedDependencies` into the global `package.json`
- `bun pm -g trust` runs postinstall scripts for already-installed packages, causing `@schpet/linear-cli` to download a 20MB binary on every `ing` invocation
- The download holds bun's global lock file, blocking all concurrent bun operations and deadlocking parallel runs

## Test plan

- [x] `shellcheck` passes
- [x] `make fish-test` passes (47/47)
- [x] `make shell-inline-check` passes
- [x] Verified `ing` completes in 2s (was 10+ min)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop global installs from stalling by writing trustedDependencies directly to bun’s global package.json instead of running `bun pm -g trust`. This removes lock contention from postinstall scripts (e.g. `@schpet/linear-cli`) and cuts `ing` from 10+ minutes to ~2s.

- Bug Fixes
  - Write `trustedDependencies` to `~/.bun/install/global/package.json` via `jq` to avoid triggering postinstall for already-installed packages like `@schpet/linear-cli`.
  - Apply a 10-minute timeout to `bun install` when updating overrides to prevent hangs.
  - `_grs_function.fish`: skip merge-base check when `HEAD` equals `origin/<default>`, keeping reset fast and safe; tests added.
  - Rename Nix PAM service to `security.pam.services.noctalia` to match noctalia v5.

<sup>Written for commit 3480f0561da58ad91409e3137a0acdf6aac03308. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

