### PR TITLE
fix(neovim): copy pack lock instead of symlinking in dev targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1005,7 +1005,8 @@ neovim-dev: ## Set up local Neovim development environment.
 	fi
 	@ln -sf "$(PWD)/home-manager/programs/neovim/init.lua" "$(HOME)/.config/nvim/init.lua"
 	@ln -sf "$(PWD)/home-manager/programs/neovim/lua" "$(HOME)/.config/nvim/lua"
-	@ln -sf "$(PWD)/home-manager/programs/neovim/nvim-pack-lock.json" "$(HOME)/.config/nvim/nvim-pack-lock.json"
+	@rm -f "$(HOME)/.config/nvim/nvim-pack-lock.json"
+	@cp "$(PWD)/home-manager/programs/neovim/nvim-pack-lock.json" "$(HOME)/.config/nvim/nvim-pack-lock.json"
 	@echo "✅ Local Neovim development environment ready"
 	@echo "🚧 To restore the Nix-managed version, run 'make switch'"
 
@@ -1024,7 +1025,8 @@ neovim-update: ## Update Neovim plugins.
 	fi
 	@ln -sf "$(PWD)/home-manager/programs/neovim/init.lua" ~/.config/nvim/init.lua
 	@ln -sf "$(PWD)/home-manager/programs/neovim/lua" ~/.config/nvim/lua
-	@ln -sf "$(PWD)/home-manager/programs/neovim/nvim-pack-lock.json" ~/.config/nvim/nvim-pack-lock.json
+	@rm -f ~/.config/nvim/nvim-pack-lock.json
+	@cp "$(PWD)/home-manager/programs/neovim/nvim-pack-lock.json" ~/.config/nvim/nvim-pack-lock.json
 	@nvim --headless +"lua vim.pack.update()" +qa
 	@echo "✅ Neovim plugins updated"
 


### PR DESCRIPTION
## Summary
- `make neovim-dev` and `make neovim-update` symlinked `nvim-pack-lock.json` into the repo, so any plugin auto-install or `vim.pack.update()` wrote through the symlink and dirtied the working tree
- Changed both targets to `rm -f` + `cp`, matching what `activate-copy-pack-lock.sh` (Nix activation) already does
- Prevents phantom diffs like `tree-sitter-manager.nvim` appearing in `git status`

## Test plan
- [ ] Run `make neovim-dev` and verify `~/.config/nvim/nvim-pack-lock.json` is a plain file, not a symlink
- [ ] Open nvim, trigger a parser install, confirm no diff in the repo
- [ ] Run `make neovim-update` and verify same behavior

https://claude.ai/code/session_011Cizgan92ddkXEoc5r7nvf

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Copy `nvim-pack-lock.json` in `make neovim-dev` and `make neovim-update` instead of symlinking to prevent plugin updates from dirtying the repo. Matches existing Nix activation behavior and removes phantom diffs.

- **Bug Fixes**
  - Replace symlink with `rm -f` + `cp` for `~/.config/nvim/nvim-pack-lock.json` in both targets.
  - Stops writes through the symlink (e.g., parser installs) from changing files in the repo.

<sup>Written for commit befbfec280b676ec33d9cea66836d0ceae993f05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

