### PR TITLE
fix(tokscale): set SSL_CERT_FILE for NixOS CA cert discovery

### DIFF
--- a/home-manager/services/tokscale/submit.sh
+++ b/home-manager/services/tokscale/submit.sh
@@ -8,6 +8,10 @@ if ! timeout 3 bash -c 'exec 3<>/dev/tcp/1.1.1.1/53' 2>/dev/null; then
   exit 0
 fi
 
+# Workaround for junhoyeo/tokscale#1002: the Rust binary's TLS stack cannot
+# locate NixOS CA certs without an explicit pointer.
+export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+
 # tokscale is installed as a bun global (see modules/npm-globals). Invoke its
 # entrypoint through bun so we do not depend on `node` being on PATH (bin.js
 # uses an `env node` shebang).


### PR DESCRIPTION
## Summary

- `tokscale submit` fails on NixOS with `error decoding response body` because the Rust binary's TLS stack can't locate CA certs
- Root cause: `SSL_CERT_FILE` is not set in systemd user service context on NixOS
- Fix: export `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt` in submit.sh before invoking tokscale

Upstream: junhoyeo/tokscale#1002

## Test plan

- [x] Verified `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt tokscale submit` succeeds
- [x] Verified without it, submit fails with `LiteLLM JSON parse failed: error decoding response body`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exported SSL_CERT_FILE in the `tokscale` submit script to point to /etc/ssl/certs/ca-certificates.crt on NixOS so the Rust TLS stack can find CA certs. Fixes TLS failures (“error decoding response body”) when running `tokscale submit` under a systemd user service.

<sup>Written for commit d3e52a2f9a28fd254289e377b193cce65f20828d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

