### PR TITLE
feat(caam): manage remote rotation config

### DIFF
--- a/config/caam/config.template.yaml
+++ b/config/caam/config.template.yaml
@@ -1,0 +1,12 @@
+version: 1
+stealth:
+  cooldown:
+    enabled: __AUTO_ROTATE__
+    default_minutes: 60
+    track_limit_hits: true
+  rotation:
+    enabled: __AUTO_ROTATE__
+    algorithm: smart
+safety:
+  auto_backup_before_switch: smart
+  max_auto_backups: 5

--- a/config/caam/default.nix
+++ b/config/caam/default.nix
@@ -1,0 +1,40 @@
+{
+  inputs,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  managedHost = inputs.host.isKyber || inputs.host.isMatic;
+  hydrateScript =
+    let
+      vars = {
+        sed = "${pkgs.gnused}/bin/sed";
+        template = "${./config.template.yaml}";
+        autoRotate = if managedHost then "true" else "false";
+      };
+      names = builtins.attrNames vars;
+    in
+    pkgs.writeText "caam-hydrate.sh" (
+      builtins.replaceStrings (map (name: "@${name}@") names) (map (
+        name: builtins.toString vars.${name}
+      ) names) (builtins.readFile ./hydrate.sh)
+    );
+in
+lib.mkIf managedHost {
+  # Hydrate a mutable CAAM config only on Kyber and Matic. The credential vault
+  # under ~/.local/share/caam remains runtime-owned and outside dotfiles.
+  home.activation.hydrateCaamConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    ${pkgs.bash}/bin/bash "${hydrateScript}"
+  '';
+
+  # Precheck selects a healthier profile before an interactive Claude session;
+  # caam run also handles rate-limit retries for non-interactive invocations.
+  programs.fish.interactiveShellInit = lib.mkAfter ''
+    if type -q caam
+        function claude
+            command caam run claude --precheck -- $argv
+        end
+    end
+  '';
+}

--- a/config/caam/default.nix
+++ b/config/caam/default.nix
@@ -27,14 +27,4 @@ lib.mkIf managedHost {
   home.activation.hydrateCaamConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     ${pkgs.bash}/bin/bash "${hydrateScript}"
   '';
-
-  # Precheck selects a healthier profile before an interactive Claude session;
-  # caam run also handles rate-limit retries for non-interactive invocations.
-  programs.fish.interactiveShellInit = lib.mkAfter ''
-    if type -q caam
-        function claude
-            command caam run claude --precheck -- $argv
-        end
-    end
-  '';
 }

--- a/config/caam/hydrate.sh
+++ b/config/caam/hydrate.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Hydrate CAAM's host-specific, non-secret runtime configuration.
+set -euo pipefail
+
+CONFIG_DIR="${HOME}/.caam"
+CONFIG_FILE="${CONFIG_DIR}/config.yaml"
+TEMPLATE="@template@"
+AUTO_ROTATE="@autoRotate@"
+TMP_FILE="$(mktemp)"
+trap 'rm -f "$TMP_FILE"' EXIT
+
+mkdir -p "$CONFIG_DIR"
+@sed@ \
+  -e "s|__AUTO_ROTATE__|${AUTO_ROTATE}|g" \
+  "$TEMPLATE" >"$TMP_FILE"
+install -m 0600 "$TMP_FILE" "$CONFIG_FILE"
+
+echo "Hydrated CAAM config at $CONFIG_FILE" >&2

--- a/config/default.nix
+++ b/config/default.nix
@@ -6,6 +6,7 @@ in
   ./aichat
   ./amp
   ./bun
+  ./caam
   ./ccs
   ./cliproxyapi
   ./codex

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -445,6 +445,7 @@ import ../../hosts/nixos {
                 inputs = inputs // {
                   host = (import ../../lib/host.nix) // {
                     isDesktop = true;
+                    isMatic = true;
                   };
                 };
                 inherit (inputs.nixpkgs) lib;

--- a/spec/caam_config_spec.sh
+++ b/spec/caam_config_spec.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016,SC2329
+
+Describe 'config/caam'
+DEFAULT_NIX="$PWD/config/caam/default.nix"
+SCRIPT="$PWD/config/caam/hydrate.sh"
+TEMPLATE="$PWD/config/caam/config.template.yaml"
+
+It 'is imported by the shared config module'
+When run grep -F './caam' "$PWD/config/default.nix"
+The output should include './caam'
+End
+
+It 'hydrates only on Kyber and Matic'
+When run cat "$DEFAULT_NIX"
+The output should include 'inputs.host.isKyber || inputs.host.isMatic'
+The output should include 'lib.mkIf managedHost'
+End
+
+It 'passes the host-derived rotation value to the hydrator'
+When run cat "$DEFAULT_NIX"
+The output should include 'autoRotate = if managedHost then "true" else "false"'
+End
+
+It 'wraps only Claude with proactive CAAM rotation'
+When run grep -F 'command caam run claude --precheck -- $argv' "$DEFAULT_NIX"
+The output should include 'command caam run claude --precheck -- $argv'
+End
+
+It 'does not manage credential vault data'
+When run grep -E 'home\.file.*vault|xdg\.dataFile.*caam' "$DEFAULT_NIX"
+The status should be failure
+End
+
+Describe 'hydrate.sh'
+setup_hydrate() {
+  TEMP_HOME=$(mktemp -d)
+  PREPROCESSED_SCRIPT="$TEMP_HOME/hydrate.sh"
+  sed \
+    -e 's|@sed@|sed|g' \
+    -e 's|@template@|'"$TEMPLATE"'|g' \
+    -e 's|@autoRotate@|true|g' \
+    "$SCRIPT" >"$PREPROCESSED_SCRIPT"
+  chmod +x "$PREPROCESSED_SCRIPT"
+}
+
+cleanup_hydrate() {
+  rm -rf "$TEMP_HOME"
+}
+
+Before 'setup_hydrate'
+After 'cleanup_hydrate'
+
+It 'uses strict mode'
+When run bash -c "head -5 '$SCRIPT'"
+The output should include 'set -euo pipefail'
+End
+
+It 'hydrates smart rotation and cooldown settings'
+When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; cat "'"$TEMP_HOME"'/.caam/config.yaml"'
+The status should be success
+The output should include 'enabled: true'
+The output should include 'algorithm: smart'
+The output should include 'track_limit_hits: true'
+The output should not include '__AUTO_ROTATE__'
+End
+
+It 'restricts config file permissions to the owner'
+When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; stat -c "%a" "'"$TEMP_HOME"'/.caam/config.yaml" 2>/dev/null || stat -f "%OLp" "'"$TEMP_HOME"'/.caam/config.yaml"'
+The output should eq '600'
+End
+End
+End

--- a/spec/caam_config_spec.sh
+++ b/spec/caam_config_spec.sh
@@ -22,9 +22,9 @@ When run cat "$DEFAULT_NIX"
 The output should include 'autoRotate = if managedHost then "true" else "false"'
 End
 
-It 'wraps only Claude with proactive CAAM rotation'
-When run grep -F 'command caam run claude --precheck -- $argv' "$DEFAULT_NIX"
-The output should include 'command caam run claude --precheck -- $argv'
+It 'leaves shell integration unmanaged'
+When run grep -F 'programs.fish.interactiveShellInit' "$DEFAULT_NIX"
+The status should be failure
 End
 
 It 'does not manage credential vault data'

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -161,6 +161,10 @@ It 'has spec file for home-manager/modules/cargo-globals/install-cargo-globals.s
 The path "spec/cargo_globals_spec.sh" should be exist
 End
 
+It 'has spec file for config/caam/hydrate.sh'
+The path "spec/caam_config_spec.sh" should be exist
+End
+
 It 'has spec file for config/handy/hydrate.sh'
 The path "spec/handy_hydrate_spec.sh" should be exist
 End
@@ -397,7 +401,8 @@ Describe 'no shell scripts are missing from coverage list'
 It 'covers all non-spec shell scripts in the repository'
 # List of all shell scripts that should have tests
 # Update this list when adding new shell scripts
-covered_scripts="config/claude/activate.sh
+covered_scripts="config/caam/hydrate.sh
+config/claude/activate.sh
 config/ccs/hydrate.sh
 config/claude/hooks/notify.sh
 config/claude/hooks/pushover.sh


### PR DESCRIPTION
## Summary

- manage CAAM YAML declaratively through the existing host hydration convention
- hydrate `~/.caam/config.yaml` only on Kyber and Matic
- enable smart automatic profile rotation and cooldown tracking on those hosts
- leave shell command integration unmanaged

## Testing

- `shellspec spec/caam_config_spec.sh spec/coverage_spec.sh`
- `make shell-check`
- `nix flake check --no-build`
- `make shell-test` (full suite before the follow-up shell-wrapper removal)