### PR TITLE
fix(agents): address hook review feedback

### DIFF
--- a/config/shared/hooks/block-gh-settings.sh
+++ b/config/shared/hooks/block-gh-settings.sh
@@ -94,7 +94,7 @@ if is_control_plane_target "$command"; then
 
   if [[ -z $http_method ]] &&
     printf '%s\n' "$command" | grep -Eiq '(^|[;&|[:space:]])(http|https|xh)([[:space:]]|$)' &&
-    printf '%s\n' "$command" | grep -Eq '(^|[[:space:]])[^[:space:]=]+(:=|=)[^[:space:]]+'; then
+    printf '%s\n' "$command" | grep -Eq '(^|[[:space:]])[^-[:space:]=?:/][^[:space:]=?/]*(:=|=)[^[:space:]]+'; then
     http_method=POST
   fi
 
@@ -104,6 +104,7 @@ if is_control_plane_target "$command"; then
     http_method=POST
   fi
 
+  http_method=${http_method^^}
   if [[ $http_method =~ ^(POST|PATCH|PUT|DELETE)$ ]]; then
     block_settings "A direct $http_method request to a repository control-plane endpoint was requested."
   fi

--- a/config/shared/hooks/block-git-push.sh
+++ b/config/shared/hooks/block-git-push.sh
@@ -61,12 +61,21 @@ block_push() {
 
 check_destination() {
   local destination="$1"
-  destination=${destination#refs/remotes/}
-  if [[ $destination == */* ]]; then
-    local possible_branch=${destination#*/}
-    if is_protected_branch "$possible_branch"; then
-      block_push "$possible_branch"
-    fi
+  local possible_branch=""
+
+  if [[ $destination == refs/remotes/*/* ]]; then
+    possible_branch=${destination#refs/remotes/}
+    possible_branch=${possible_branch#*/}
+  elif [[ $destination == refs/heads/* ]]; then
+    possible_branch=${destination#refs/heads/}
+  elif [[ $destination == heads/* ]]; then
+    possible_branch=${destination#heads/}
+  elif [[ $destination == */* ]] && git remote 2>/dev/null | grep -Fxq "${destination%%/*}"; then
+    possible_branch=${destination#*/}
+  fi
+
+  if [[ -n $possible_branch ]] && is_protected_branch "$possible_branch"; then
+    block_push "$possible_branch"
   fi
   if is_protected_branch "$destination"; then
     block_push "$destination"
@@ -322,7 +331,7 @@ inspect_command() {
   while IFS= read -r segment; do
     [[ -z $segment ]] && continue
     inspect_segment "$segment" "$depth"
-  done < <(printf '%s\n' "$candidate" | sed -E 's/[;&|]+/\n/g')
+  done < <(printf '%s\n' "$candidate" | tr ';&|' '\n')
 }
 
 inspect_command "$command" 0

--- a/spec/agent_github_hook_wiring_spec.sh
+++ b/spec/agent_github_hook_wiring_spec.sh
@@ -2,6 +2,24 @@
 
 Describe 'shared GitHub guardrail wiring'
 
+registered_hook_commands() {
+  local config="$1"
+  case "$config" in
+  config/codex/hooks.json | config/claude/settings.json)
+    jq -r '.hooks.PreToolUse[] | select(.matcher == "Bash") | .hooks[]?.command' "$config"
+    ;;
+  config/cursor/hooks.json)
+    jq -r '.hooks.beforeShellExecution[]?.command' "$config"
+    ;;
+  config/copilot/config.json)
+    jq -r '.hooks.preToolUse[]?.command' "$config"
+    ;;
+  config/grok/plugin/hooks/hooks.json)
+    jq -r '.hooks.PreToolUse[] | select(.matcher | test("(^|\\|)Bash($|\\|)")) | .hooks[]?.command' "$config"
+    ;;
+  esac
+}
+
 verify_wiring() {
   local config hook
   for config in \
@@ -11,7 +29,7 @@ verify_wiring() {
     config/copilot/config.json \
     config/grok/plugin/hooks/hooks.json; do
     for hook in block-git-push.sh block-gh-settings.sh; do
-      if ! grep -Fq "config/shared/hooks/$hook" "$config"; then
+      if ! registered_hook_commands "$config" | grep -Fqx "\$HOME/dotfiles/config/shared/hooks/$hook"; then
         printf 'missing %s in %s\n' "$hook" "$config" >&2
         return 1
       fi

--- a/spec/block_gh_settings_spec.sh
+++ b/spec/block_gh_settings_spec.sh
@@ -54,6 +54,18 @@ When run bash "$SCRIPT"
 The status should be success
 End
 
+It 'allows an HTTPie GET with a query string'
+Data '{"tool_input": {"command": "http https://api.github.com/repos/owner/repo/rulesets?per_page=10"}}'
+When run bash "$SCRIPT"
+The status should be success
+End
+
+It 'allows an HTTPie GET with an equals-form option'
+Data '{"tool_input": {"command": "http --auth-type=bearer https://api.github.com/repos/owner/repo/rulesets"}}'
+When run bash "$SCRIPT"
+The status should be success
+End
+
 End
 
 Describe 'blocked gh repo subcommands'
@@ -228,6 +240,20 @@ End
 
 It 'blocks HTTPie mutations'
 Data '{"tool_input": {"command": "http DELETE https://api.github.com/repos/owner/repo/hooks/1"}}'
+When run bash "$SCRIPT"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+It 'blocks lowercase HTTPie mutations'
+Data '{"tool_input": {"command": "http delete https://api.github.com/repos/owner/repo/hooks/1"}}'
+When run bash "$SCRIPT"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+It 'blocks lowercase curl request methods'
+Data '{"tool_input": {"command": "curl --request delete https://api.github.com/repos/owner/repo/hooks/1"}}'
 When run bash "$SCRIPT"
 The status should eq 2
 The stderr should include 'BLOCKED'

--- a/spec/block_git_push_spec.sh
+++ b/spec/block_git_push_spec.sh
@@ -6,7 +6,7 @@ SCRIPT="$PWD/config/shared/hooks/block-git-push.sh"
 
 setup() {
   TEMP_REPO=$(mktemp -d)
-  git -C "$TEMP_REPO" init -q
+  git -C "$TEMP_REPO" init -q -b main
   git -C "$TEMP_REPO" config commit.gpgSign false
   git -C "$TEMP_REPO" config user.email agent@example.com
   git -C "$TEMP_REPO" config user.name Agent
@@ -16,7 +16,7 @@ setup() {
 
 setup_allowed() {
   TEMP_REPO=$(mktemp -d)
-  git -C "$TEMP_REPO" init -q
+  git -C "$TEMP_REPO" init -q -b main
   git -C "$TEMP_REPO" config commit.gpgSign false
   git -C "$TEMP_REPO" config user.email agent@example.com
   git -C "$TEMP_REPO" config user.name Agent
@@ -47,6 +47,18 @@ End
 
 It 'allows git push to feature branch'
 Data '{"tool_input": {"command": "git push origin feat/my-branch"}}'
+When run bash -c "cd '$TEMP_REPO' && bash '$SCRIPT'"
+The status should be success
+End
+
+It 'allows a feature branch whose final path component is main'
+Data '{"tool_input": {"command": "git push origin feature/main"}}'
+When run bash -c "cd '$TEMP_REPO' && bash '$SCRIPT'"
+The status should be success
+End
+
+It 'allows a feature branch whose final path component is master'
+Data '{"tool_input": {"command": "git push origin release/master"}}'
 When run bash -c "cd '$TEMP_REPO' && bash '$SCRIPT'"
 The status should be success
 End


### PR DESCRIPTION
## Summary

Follow-up to #2207, which repository automation merged before its review feedback could be incorporated.

- normalize lowercase direct HTTP mutation methods and avoid HTTPie GET false positives
- preserve feature branches ending in main or master while recognizing remote-qualified protected destinations
- make shell-alias command splitting portable to macOS
- structurally validate active hook wiring and make Git test setup independent of global default-branch configuration

## Validation

- shellspec spec/block_git_push_spec.sh spec/block_gh_settings_spec.sh spec/agent_github_hook_wiring_spec.sh (83 examples)
- shellcheck on all changed shell scripts and specs
- make shell-test-dev (1,805 ShellSpec examples and 422 Fish tests)
- make shell-check-dev
- make nix-format-check
- git diff --check

## Merge handling

This PR is intentionally a draft so repository automation does not merge it before manual review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened GitHub guardrail hooks to avoid false positives and catch more direct mutation attempts. Improves branch protection handling and cross-platform parsing, with stronger wiring and tests.

- **Bug Fixes**
  - Prevent HTTPie GET false positives; normalize method and block lowercase `http`, `curl`, and `xh` mutations.
  - Protect remote-qualified destinations across ref formats; allow feature branches ending in main/master; use portable command splitting on macOS.
  - Validate hook wiring by parsing tool configs with `jq`; tests no longer depend on global default branch and cover new cases.

<sup>Written for commit 39d347ced00d4592f8232d7839f61d7e5cca4663. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

