### PR TITLE
fix(tokscale): align submissions to wall clock

### DIFF
--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -31,7 +31,7 @@ let
   screenshotClipboard = import ./screenshot-clipboard { inherit pkgs; };
   sshAgent = ./ssh-agent;
   tmuxSessionLogger = import ./tmux-session-logger { inherit pkgs; };
-  tokscale = import ./tokscale { inherit pkgs; };
+  tokscale = import ./tokscale { inherit config lib pkgs; };
 in
 [
   brewUpgrader

--- a/home-manager/services/tokscale/activate-cron.sh
+++ b/home-manager/services/tokscale/activate-cron.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Install the managed Tokscale entry in the current user's crontab.
+set -euo pipefail
+
+CRON_COMMAND="${1:?usage: activate-cron.sh <command>}"
+BEGIN_MARKER="# BEGIN home-manager tokscale"
+END_MARKER="# END home-manager tokscale"
+
+if ! command -v crontab >/dev/null 2>&1; then
+  echo "crontab is required for the Tokscale schedule" >&2
+  exit 1
+fi
+
+existing_crontab="$(crontab -l 2>/dev/null || true)"
+filtered_crontab="$({
+  printf '%s\n' "$existing_crontab"
+} | awk -v begin="$BEGIN_MARKER" -v end="$END_MARKER" '
+  $0 == begin { managed = 1; next }
+  $0 == end { managed = 0; next }
+  !managed { print }
+')"
+
+{
+  if [ -n "$filtered_crontab" ]; then
+    printf '%s\n' "$filtered_crontab"
+  fi
+  printf '%s\n' "$BEGIN_MARKER"
+  printf '0 */3 * * * %s\n' "$CRON_COMMAND"
+  printf '%s\n' "$END_MARKER"
+} | crontab -

--- a/home-manager/services/tokscale/default.nix
+++ b/home-manager/services/tokscale/default.nix
@@ -1,13 +1,35 @@
-{ pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
-  inherit (pkgs) lib;
   binPath = lib.makeBinPath [
     pkgs.bun
     pkgs.bash
     pkgs.coreutils
   ];
-  # Every 3 hours.
-  intervalSeconds = 10800;
+  # Every 3 hours, aligned to the wall clock.
+  calendarHours = [
+    0
+    3
+    6
+    9
+    12
+    15
+    18
+    21
+  ];
+  cronCommand = lib.concatStringsSep " " [
+    "env"
+    "HOME=${lib.escapeShellArg config.home.homeDirectory}"
+    "PATH=${lib.escapeShellArg binPath}"
+    "${pkgs.bash}/bin/bash"
+    "${./submit.sh}"
+    ">>/tmp/tokscale.log"
+    "2>>/tmp/tokscale.error.log"
+  ];
 in
 {
   # macOS (launchd)
@@ -21,39 +43,19 @@ in
       Environment = {
         PATH = binPath + ":/usr/bin:/bin:/usr/sbin:/sbin";
       };
-      StartInterval = intervalSeconds;
+      StartCalendarInterval = map (hour: {
+        Hour = hour;
+        Minute = 0;
+      }) calendarHours;
       StandardOutPath = "/tmp/tokscale.log";
       StandardErrorPath = "/tmp/tokscale.error.log";
     };
   };
 
-  # Linux (systemd)
-  systemd.user.services.tokscale = lib.mkIf pkgs.stdenv.isLinux {
-    Unit = {
-      Description = "Submit local usage data to Tokscale";
-      Wants = [ "network-online.target" ];
-      After = [ "network-online.target" ];
-      X-SwitchMethod = "keep-old";
-    };
-    Service = {
-      Type = "oneshot";
-      Environment = "PATH=${binPath}";
-      ExecStart = "${pkgs.bash}/bin/bash ${./submit.sh}";
-    };
-  };
-
-  systemd.user.timers.tokscale = lib.mkIf pkgs.stdenv.isLinux {
-    Unit = {
-      Description = "Timer for Tokscale usage submission";
-    };
-    Timer = {
-      OnBootSec = "5min";
-      OnUnitActiveSec = "3h";
-      Persistent = true;
-      Unit = "tokscale.service";
-    };
-    Install = {
-      WantedBy = [ "timers.target" ];
-    };
-  };
+  # Linux (cron)
+  home.activation.installTokscaleCron = lib.mkIf pkgs.stdenv.isLinux (
+    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-cron.sh}" ${lib.escapeShellArg cronCommand}
+    ''
+  );
 }

--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -43,6 +43,7 @@ let
       ];
 
       programs.fish.enable = true;
+      services.cron.enable = true;
 
       users.users.${username} = {
         isNormalUser = true;

--- a/named-hosts/kyber/setup.sh
+++ b/named-hosts/kyber/setup.sh
@@ -11,21 +11,29 @@ set -e
 
 echo "🚀 Setting up Kyber server..."
 
-# 1. Install Tailscale
+# 1. Install cron
+echo "📦 Installing cron..."
+if ! command -v crontab &>/dev/null; then
+  sudo apt-get update
+  sudo apt-get install -y cron
+fi
+sudo systemctl enable --now cron
+
+# 2. Install Tailscale
 echo "📦 Installing Tailscale..."
 if ! command -v tailscale &>/dev/null; then
   echo "Fetching Tailscale installer (verify vendor checksums for production)..."
   curl -fsSL https://tailscale.com/install.sh | sh
 fi
 
-# 2. Enable and start Tailscale daemon
+# 3. Enable and start Tailscale daemon
 echo "🔧 Enabling Tailscale daemon..."
 sudo systemctl enable --now tailscaled
 
-# 3. Connect to Tailscale (will prompt for auth)
+# 4. Connect to Tailscale (will prompt for auth)
 echo "🔗 Connecting to Tailscale..."
 sudo tailscale up
 
-# 4. Verify Tailscale connection
+# 5. Verify Tailscale connection
 echo "✅ Tailscale status:"
 tailscale status

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -502,6 +502,7 @@ home-manager/services/k3s/activate.sh
 home-manager/services/make-updater/update.sh
 home-manager/services/neverssl-keepalive/keepalive.sh
 home-manager/services/night-shift/apply-night-shift.sh
+home-manager/services/tokscale/activate-cron.sh
 home-manager/services/tokscale/submit.sh
 hosts/darwin/activate-remove-backups.sh
 hosts/linux/activate-backup-files.sh

--- a/spec/kyber_setup_spec.sh
+++ b/spec/kyber_setup_spec.sh
@@ -16,6 +16,18 @@ The output should include 'set -e'
 End
 End
 
+Describe 'cron installation logic'
+It 'installs cron when crontab is unavailable'
+When run bash -c "grep -A3 'command -v crontab' '$SCRIPT'"
+The output should include 'apt-get install -y cron'
+End
+
+It 'enables and starts the cron daemon'
+When run bash -c "grep 'systemctl enable --now cron' '$SCRIPT'"
+The output should include 'systemctl enable --now cron'
+End
+End
+
 Describe 'Tailscale installation logic'
 It 'checks if tailscale command exists'
 When run bash -c "grep 'command -v tailscale' '$SCRIPT'"

--- a/spec/tokscale_spec.sh
+++ b/spec/tokscale_spec.sh
@@ -90,3 +90,86 @@ End
 End
 
 End
+
+Describe 'tokscale service schedule'
+CONFIG="$PWD/home-manager/services/tokscale/default.nix"
+
+It 'uses fixed three-hour calendar slots on macOS'
+When run bash -c "awk '/calendarHours = \\[/,/\\];/' '$CONFIG' | grep -Eo '[0-9]+' | paste -sd, -"
+The output should equal '0,3,6,9,12,15,18,21'
+End
+
+It 'maps the fixed hours to launchd calendar intervals at minute zero'
+When run bash -c "grep -A4 -F 'StartCalendarInterval = map' '$CONFIG'"
+The output should include 'Hour = hour;'
+The output should include 'Minute = 0;'
+End
+
+It 'does not use a load-relative interval on macOS'
+When run bash -c "grep -F 'StartInterval' '$CONFIG'"
+The status should be failure
+End
+
+It 'installs the Linux cron schedule during Home Manager activation'
+When run bash -c "grep -F 'installTokscaleCron' '$CONFIG'"
+The output should include 'installTokscaleCron'
+End
+
+It 'does not define a systemd service or timer'
+When run bash -c "grep -F 'systemd.user' '$CONFIG'"
+The status should be failure
+End
+
+End
+
+Describe 'tokscale cron activation'
+ACTIVATOR="$PWD/home-manager/services/tokscale/activate-cron.sh"
+
+setup() {
+  MOCK_BIN=$(mktemp -d)
+  CRONTAB_STATE=$(mktemp)
+  export CRONTAB_STATE
+  MOCK_ORIGINAL_PATH="$PATH"
+  export PATH="$MOCK_BIN:$PATH"
+  cat >"$MOCK_BIN/crontab" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  -l)
+    cat "$CRONTAB_STATE"
+    ;;
+  -)
+    cat >"$CRONTAB_STATE"
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+EOF
+  chmod +x "$MOCK_BIN/crontab"
+}
+
+cleanup() {
+  export PATH="$MOCK_ORIGINAL_PATH"
+  rm -rf "$MOCK_BIN"
+  rm -f "$CRONTAB_STATE"
+}
+
+Before 'setup'
+After 'cleanup'
+
+It 'installs the fixed three-hour cron expression and preserves existing entries'
+echo 'MAILTO=ops@example.com' >"$CRONTAB_STATE"
+When run bash -c "'$ACTIVATOR' 'echo submit' && cat '$CRONTAB_STATE'"
+The output should include 'MAILTO=ops@example.com'
+The output should include '0 */3 * * * echo submit'
+The status should be success
+End
+
+It 'replaces its managed block idempotently'
+When run bash -c "'$ACTIVATOR' 'echo old' && '$ACTIVATOR' 'echo new' && grep -c '^# BEGIN home-manager tokscale$' '$CRONTAB_STATE' && grep -c 'echo new$' '$CRONTAB_STATE'"
+The line 1 of output should eq '1'
+The line 2 of output should eq '1'
+The status should be success
+End
+
+End


### PR DESCRIPTION
## Summary

- schedule Galactica Tokscale submissions at fixed 00:00, 03:00, ..., 21:00 launchd calendar slots
- replace the Linux systemd timer with an idempotent `0 */3 * * *` user cron entry
- enable cron for managed NixOS hosts and install/start it in the Kyber bootstrap
- add regression coverage for both schedulers and managed crontab replacement

## Validation

- `make shell-test` (1761 ShellSpec examples, 422 fish tests)
- `shellspec spec/tokscale_spec.sh spec/kyber_setup_spec.sh spec/coverage_spec.sh` (122 examples)
- `nixfmt --check home-manager/services/default.nix home-manager/services/tokscale/default.nix hosts/nixos/default.nix`
- `shellcheck home-manager/services/tokscale/activate-cron.sh home-manager/services/tokscale/submit.sh named-hosts/kyber/setup.sh spec/tokscale_spec.sh spec/kyber_setup_spec.sh`
- `make build` (Galactica)
- inspected the built plist: eight `StartCalendarInterval` entries and no `StartInterval`
- evaluated Kyber activation command and Matic `services.cron.enable`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align Tokscale submissions to fixed wall-clock times and switch Linux scheduling to a managed cron entry so runs occur at 00:00, 03:00, ..., 21:00 consistently. Enables cron on managed NixOS and adds tests for the scheduler and activation.

- **Bug Fixes**
  - macOS: use `StartCalendarInterval` for hours 0,3,6,9,12,15,18,21 at minute 0; remove `StartInterval`.
  - Linux: replace `systemd` timer with idempotent user `cron` entry `0 */3 * * *`, installed during Home Manager activation; logs to `/tmp/tokscale*.log`.
  - NixOS: enable `services.cron`; Kyber bootstrap installs and starts `cron`.
  - Tests: add coverage for launchd schedule, cron activation, and NixOS/Kyber changes.

<sup>Written for commit 2326f8736be511137550ea90a088e3450399b03d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

