### PR TITLE
feat(caam): enable rotation across all hosts

### DIFF
--- a/config/caam/default.nix
+++ b/config/caam/default.nix
@@ -1,4 +1,5 @@
 {
+  config,
   lib,
   pkgs,
   ...
@@ -22,7 +23,7 @@ in
 {
   # Hydrate mutable CAAM rotation settings on every host. The vault remains
   # runtime-owned and outside dotfiles.
-  home.activation.hydrateCaamConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.hydrateCaamConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     ${pkgs.bash}/bin/bash "${hydrateScript}"
   '';
 }

--- a/config/caam/default.nix
+++ b/config/caam/default.nix
@@ -1,17 +1,15 @@
 {
-  inputs,
   lib,
   pkgs,
   ...
 }:
 let
-  managedHost = inputs.host.isKyber || inputs.host.isMatic;
   hydrateScript =
     let
       vars = {
         sed = "${pkgs.gnused}/bin/sed";
         template = "${./config.template.yaml}";
-        autoRotate = if managedHost then "true" else "false";
+        autoRotate = "true";
       };
       names = builtins.attrNames vars;
     in
@@ -21,9 +19,9 @@ let
       ) names) (builtins.readFile ./hydrate.sh)
     );
 in
-lib.mkIf managedHost {
-  # Hydrate a mutable CAAM config only on Kyber and Matic. The credential vault
-  # under ~/.local/share/caam remains runtime-owned and outside dotfiles.
+{
+  # Hydrate mutable CAAM rotation settings on every host. The vault remains
+  # runtime-owned and outside dotfiles.
   home.activation.hydrateCaamConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     ${pkgs.bash}/bin/bash "${hydrateScript}"
   '';

--- a/config/ccs/default.nix
+++ b/config/ccs/default.nix
@@ -20,7 +20,7 @@ in
   # Hydrate CCS settings templates with secrets from .env
   # ANTHROPIC_AUTH_TOKEN is substituted from CLIPROXY_API_KEY at activation time
   # Processes all *.settings.template.json files in config/ccs/
-  home.activation.hydrateCcsSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.hydrateCcsSettings = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     ${pkgs.bash}/bin/bash ${hydrateScript} || true
   '';
 }

--- a/config/claude/activate.sh
+++ b/config/claude/activate.sh
@@ -7,7 +7,8 @@ SETTINGS_JSON="$1"
 mkdir -p ~/.claude
 _TMP=$(mktemp)
 jq --arg host "$(hostname)" '
-  . * (.hostOverrides[$host] // {}) | del(.hostOverrides)
+  . * (.hostOverrides[$host] // {})
+  | del(.hostOverrides)
 ' "$SETTINGS_JSON" >"$_TMP"
 mv "$_TMP" ~/.claude/settings.json
 chmod 644 ~/.claude/settings.json

--- a/config/claude/default.nix
+++ b/config/claude/default.nix
@@ -1,8 +1,13 @@
-{ lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 {
   # Use activation script for settings.json instead of symlink
   # git-ai install-hooks needs write access, which breaks with Nix store symlinks
-  home.activation.claudeConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.claudeConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${./settings.json}"
   '';
 

--- a/config/claude/default.nix
+++ b/config/claude/default.nix
@@ -6,6 +6,12 @@
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${./settings.json}"
   '';
 
+  home.file.".claude/hooks/auto-switch.sh" = {
+    source = ./hooks/auto-switch.sh;
+    executable = true;
+    force = true;
+  };
+
   home.file.".claude/hooks/pushover.sh" = {
     source = ./hooks/pushover.sh;
     executable = true;

--- a/config/claude/hooks/auto-switch.sh
+++ b/config/claude/hooks/auto-switch.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Auto-switch Claude account on rate limit via claude-swap (cswap).
+# Auto-switch Claude account on rate limit via CAAM.
 # Triggered by the StopFailure hook when Claude Code hits a rate limit.
 #
 # Reads hook input from stdin: { error, error_details, ... }
@@ -7,13 +7,13 @@
 
 set -euo pipefail
 
-# Require cswap
-if ! command -v cswap &>/dev/null; then
+# Require CAAM
+if ! command -v caam &>/dev/null; then
   exit 0
 fi
 
 # Require at least 2 managed accounts
-ACCOUNT_COUNT=$(cswap --list 2>/dev/null | grep -c '^\s*[0-9]' || true)
+ACCOUNT_COUNT=$(caam ls claude --json 2>/dev/null | jq -r '[.profiles[] | select(.name | startswith("_") | not)] | length' 2>/dev/null || echo 0)
 if [ "$ACCOUNT_COUNT" -lt 2 ]; then
   exit 0
 fi
@@ -26,7 +26,8 @@ ERROR_DETAILS=$(echo "$INPUT" | jq -r '.error_details // empty' 2>/dev/null) || 
 # Check if the error is rate-limit related
 case "${ERROR}${ERROR_DETAILS}" in
 *rate_limit* | *rate-limit* | *rate\ limit* | *overloaded* | *too_many_requests* | *429* | *quota* | *capacity*)
-  echo "[$(date)] Auto-switching Claude account due to rate limit" >&2
-  cswap --switch 2>&1 | head -5 >&2
+  echo "[$(date)] Auto-switching Claude account through CAAM due to rate limit" >&2
+  caam cooldown set claude --notes "Claude StopFailure rate limit" 2>&1 | head -5 >&2
+  caam activate claude --auto 2>&1 | head -5 >&2
   ;;
 esac

--- a/config/codex/default.nix
+++ b/config/codex/default.nix
@@ -13,7 +13,7 @@ in
 {
   # Use activation script instead of home.file symlink
   # Codex CLI uses atomic writes that break symlinks, so we force-copy on each switch
-  home.activation.codexConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.codexConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" \
       "${./config.toml}" \
       "${./hooks.json}" \
@@ -48,7 +48,7 @@ in
   # setupLaunchAgents. Self-heal after that phase so a missed registration
   # cannot leave the app free to replace the managed settings permanently.
   home.activation.codexDesktopSettingsAgent = lib.mkIf pkgs.stdenv.isDarwin (
-    lib.hm.dag.entryAfter [ "setupLaunchAgents" ] ''
+    config.lib.dag.entryAfter [ "setupLaunchAgents" ] ''
       $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${ensureDesktopSettingsAgent}" \
         "${desktopSettingsAgentLabel}" \
         "$newGenPath/LaunchAgents/${desktopSettingsAgentLabel}.plist" \

--- a/config/copilot/default.nix
+++ b/config/copilot/default.nix
@@ -1,7 +1,12 @@
-{ lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 {
   # Copilot CLI mutates config.json, so copy the managed file into place.
-  home.activation.copilotConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.copilotConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${./config.json}"
   '';
 }

--- a/config/cursor/default.nix
+++ b/config/cursor/default.nix
@@ -1,8 +1,13 @@
-{ lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 {
   # Use activation script instead of symlink
   # git-ai install-hooks needs write access, which breaks with Nix store symlinks
-  home.activation.cursorHooks = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.cursorHooks = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${./hooks.json}"
   '';
 

--- a/config/dcg/default.nix
+++ b/config/dcg/default.nix
@@ -1,6 +1,11 @@
-{ lib, pkgs, ... }:
 {
-  home.activation.dcgConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  home.activation.dcgConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${./config.toml}"
   '';
 }

--- a/config/gemini/default.nix
+++ b/config/gemini/default.nix
@@ -7,7 +7,7 @@
 {
   # Use activation script to copy settings.json instead of symlinking
   # This allows ruler and other tools to modify the file
-  home.activation.geminiSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.geminiSettings = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${./settings.json}"
   '';
 }

--- a/config/git-ai/default.nix
+++ b/config/git-ai/default.nix
@@ -1,6 +1,11 @@
-{ pkgs, lib, ... }:
 {
-  home.activation.gitAiConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+{
+  home.activation.gitAiConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${./config.json}" "${pkgs.git}/bin/git"
   '';
 }

--- a/config/grok/default.nix
+++ b/config/grok/default.nix
@@ -1,4 +1,9 @@
-{ lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 {
   # Use activation script instead of a home.file symlink.
   # Grok performs atomic writes to config.toml that break symlinks, so force-copy on each switch.
@@ -7,7 +12,7 @@
   # hooks. Grok has no user-scoped ~/.grok/hooks/ directory (native hooks are project-scoped
   # under .grok/hooks/ and trust-gated), but it loads user plugins from ~/.grok/plugins/, and
   # plugins provide hooks via hooks/hooks.json.
-  home.activation.grokConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.grokConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${./config.toml}" "${./plugin}"
   '';
 }

--- a/config/handy/default.nix
+++ b/config/handy/default.nix
@@ -1,4 +1,9 @@
-{ lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   hydrateScript = pkgs.writeText "handy-hydrate.sh" (
     builtins.replaceStrings [ "@sed@" ] [ "${pkgs.gnused}/bin/sed" ] (builtins.readFile ./hydrate.sh)
@@ -8,7 +13,7 @@ in
   # Handy mutates settings_store.json at runtime (UI changes), so we copy via
   # activation rather than symlinking the read-only Nix store. The template
   # holds an __OPENROUTER_API_KEY__ placeholder hydrated from ~/dotfiles/.env.
-  home.activation.hydrateHandy = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.hydrateHandy = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     ${pkgs.bash}/bin/bash ${hydrateScript} || true
   '';
 }

--- a/config/hermes/default.nix
+++ b/config/hermes/default.nix
@@ -29,7 +29,7 @@ let
     );
 in
 {
-  home.activation.hydrateHermesConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.hydrateHermesConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     ${pkgs.bash}/bin/bash "${hydrateScript}" || true
   '';
 }

--- a/config/k3s/default.nix
+++ b/config/k3s/default.nix
@@ -104,13 +104,13 @@ in
   '';
 
   home.activation.k3s-server = lib.mkIf isKyber (
-    lib.hm.dag.entryAfter [ "setupK3s" ] ''
+    config.lib.dag.entryAfter [ "setupK3s" ] ''
       $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${serverActivateScript}"
     ''
   );
 
   home.activation.k3s-client = lib.mkIf isGalactica (
-    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    config.lib.dag.entryAfter [ "writeBoundary" ] ''
       $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-client.sh}"
     ''
   );

--- a/config/obsidian/default.nix
+++ b/config/obsidian/default.nix
@@ -11,7 +11,7 @@ let
 in
 {
   home.activation.obsidianConfig = lib.mkIf enabled (
-    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    config.lib.dag.entryAfter [ "writeBoundary" ] ''
       $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" \
         "${./obsidian.json}" \
         "${config.home.homeDirectory}" \

--- a/config/omp/default.nix
+++ b/config/omp/default.nix
@@ -1,8 +1,13 @@
-{ lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 {
   # Use activation script instead of home.file symlink.
   # Keep only the tracked config.yml in dotfiles and leave runtime state untouched.
-  home.activation.ompConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.ompConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${./config.yml}"
   '';
 

--- a/config/openclaw/default.nix
+++ b/config/openclaw/default.nix
@@ -44,7 +44,7 @@ in
 {
   # Hydrate OpenClaw config from .env secrets
   # Gateway mode on Kyber, client mode everywhere else
-  home.activation.hydrateOpenclawConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.hydrateOpenclawConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     ${pkgs.bash}/bin/bash "${hydrateScript}" || true
   '';
 }

--- a/config/roborev/default.nix
+++ b/config/roborev/default.nix
@@ -20,7 +20,7 @@ let
     );
 in
 {
-  home.activation.hydrateRoborevConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.hydrateRoborevConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     ${pkgs.bash}/bin/bash "${hydrateScript}" || true
   '';
 }

--- a/config/serena/default.nix
+++ b/config/serena/default.nix
@@ -8,7 +8,7 @@ let
   serenaConfigDest = "${config.home.homeDirectory}/.serena/serena_config.yml";
 in
 {
-  home.activation.serenaConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.serenaConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${./serena_config.yml}" "${serenaConfigDest}"
   '';
 }

--- a/home-manager/modules/bin-shells/default.nix
+++ b/home-manager/modules/bin-shells/default.nix
@@ -1,10 +1,15 @@
-{ lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   inherit (pkgs.stdenv) isLinux;
 in
 {
   config = lib.mkIf isLinux {
-    home.activation.binShells = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    home.activation.binShells = config.lib.dag.entryAfter [ "writeBoundary" ] ''
       $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${pkgs.bash}/bin/bash" "${pkgs.fish}/bin/fish" "${pkgs.zsh}/bin/zsh"
     '';
   };

--- a/home-manager/modules/cargo-globals/default.nix
+++ b/home-manager/modules/cargo-globals/default.nix
@@ -14,7 +14,7 @@ let
 in
 {
   # Install cargo global packages from Cargo.toml using home-manager activation
-  home.activation.installCargoGlobals = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.installCargoGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     export PATH=${pkgs.rustup}/bin:${pkgs.cargo}/bin:${pkgs.rustc}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:${pkgs.perl}/bin:$PATH
     export CARGO_HOME="$HOME/.cargo"
     export PKG_CONFIG_PATH="${pkgs.openssl.dev}/lib/pkgconfig${libiconvPkgConfigPath}''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"

--- a/home-manager/modules/local-binaries/default.nix
+++ b/home-manager/modules/local-binaries/default.nix
@@ -9,7 +9,7 @@
   home.file.".local/bin/.keep".text = "";
 
   # Symlink local binaries during activation
-  home.activation.symlinkLocalBinaries = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.symlinkLocalBinaries = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./sync-local-binaries.sh}"
   '';
 }

--- a/home-manager/modules/npm-globals/default.nix
+++ b/home-manager/modules/npm-globals/default.nix
@@ -9,7 +9,7 @@ let
 in
 {
   # Install npm global packages from package.json using home-manager activation
-  home.activation.installNpmGlobals = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.installNpmGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     export PATH=${pkgs.bun}/bin:${pkgs.jq}/bin:$PATH
     export BUN_INSTALL="$HOME/.bun"
     ${lib.optionalString (!isDarwin) ''export SYSTEMCTL_BIN="${pkgs.systemd}/bin/systemctl"''}

--- a/home-manager/modules/secure-dotenv/default.nix
+++ b/home-manager/modules/secure-dotenv/default.nix
@@ -12,7 +12,7 @@ let
   };
 in
 {
-  home.activation.secureDotenv = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.secureDotenv = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${script}" "${homeDir}"
   '';
 }

--- a/home-manager/modules/tailscale/default.nix
+++ b/home-manager/modules/tailscale/default.nix
@@ -201,7 +201,7 @@ in
       Install.WantedBy = [ "default.target" ];
     };
 
-    home.activation.createTailscaleDirs = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    home.activation.createTailscaleDirs = config.lib.dag.entryAfter [ "writeBoundary" ] ''
       $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-create-dirs.sh}" \
         "${config.xdg.dataHome}/tailscale" \
         "$(dirname "${cfg.tailscaled.socketPath}")"
@@ -210,7 +210,7 @@ in
     # Install system-level tailscaled service (requires sudo)
     # Uses nix-generated service file for full declarative config
     home.activation.installTailscaleService = mkIf cfg.installSystemService (
-      lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      config.lib.dag.entryAfter [ "writeBoundary" ] ''
         $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-install-service.sh}" \
           "${tailscaledServiceFile}" \
           "${config.home.homeDirectory}"

--- a/home-manager/modules/uv-globals/default.nix
+++ b/home-manager/modules/uv-globals/default.nix
@@ -11,7 +11,7 @@ in
 {
   # Install uv global tools from pyproject.toml using home-manager activation
   home.activation.installUvGlobals = lib.mkIf (!isRunner) (
-    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    config.lib.dag.entryAfter [ "writeBoundary" ] ''
       export PATH=${pkgs.uv}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.yq}/bin:$PATH
       ${lib.optionalString (!isDarwin) ''export SYSTEMCTL_BIN="${pkgs.systemd}/bin/systemctl"''}
       $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./install-uv-globals.sh}"

--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -27,6 +27,8 @@
     ];
 
     sessionVariables = {
+      CAAM_ROTATION_ENABLED = "1";
+
       # Go configuration
       GOPATH = "$HOME/go";
 

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -13,6 +13,8 @@
       # transitively hoisted `bun`/`bunx` npm stub can never shadow the real binary.
       set -gx PATH $HOME/.bun/bin $HOME/.bun/install/global/node_modules/.bin $HOME/.cargo/bin $HOME/.local/bin $PATH
 
+      set -gx CAAM_ROTATION_ENABLED 1
+
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
       if test (uname) = "Linux"
           set -gx XDG_RUNTIME_DIR /run/user/(id -u)
@@ -242,6 +244,7 @@
         "__tmux_bootstrap_default_session"
         "_brew_update_function"
         "_caf_function"
+        "_caam_exec_function"
         "_cawxe_function"
         "_cawxeh_function"
         "_caxe_function"

--- a/home-manager/programs/fish/functions/_caam_exec_function.fish
+++ b/home-manager/programs/fish/functions/_caam_exec_function.fish
@@ -1,0 +1,15 @@
+function _caam_exec_function --description "Run an agent launcher through CAAM when rotation is enabled"
+  set -l executable $argv[1]
+  set -e argv[1]
+
+  set -l tool $executable
+  if test "$executable" = cursor-agent
+    set tool cursor
+  end
+
+  if test "$CAAM_ROTATION_ENABLED" = "1"; and type -q caam
+    caam run $tool -- $argv
+  else
+    $executable $argv
+  end
+end

--- a/home-manager/programs/fish/functions/_cawxe_function.fish
+++ b/home-manager/programs/fish/functions/_cawxe_function.fish
@@ -3,11 +3,11 @@ function _cawxe_function --description "Run Cursor Agent with a free-form prompt
   # Usage: cawxe [<prompt words...>]
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
-    cursor-agent --force --worktree --resume $argv[2..]
+    _caam_exec_function cursor-agent --force --worktree --resume $argv[2..]
   else if test (count $argv) -eq 0
-    cursor-agent --force --worktree
+    _caam_exec_function cursor-agent --force --worktree
   else
     set -l prompt (string join " " -- $argv)
-    cursor-agent --force --worktree --print -- "$prompt"
+    _caam_exec_function cursor-agent --force --worktree --print -- "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_cawxeh_function.fish
+++ b/home-manager/programs/fish/functions/_cawxeh_function.fish
@@ -14,5 +14,5 @@ function _cawxeh_function --description "Run Cursor Agent headlessly with a prom
     return 1
   end
 
-  cursor-agent --force --worktree --print -- "$prompt"
+  _caam_exec_function cursor-agent --force --worktree --print -- "$prompt"
 end

--- a/home-manager/programs/fish/functions/_caxe_function.fish
+++ b/home-manager/programs/fish/functions/_caxe_function.fish
@@ -3,11 +3,11 @@ function _caxe_function --description "Run Cursor Agent with a free-form prompt 
   # Usage: caxe [--resume | -r] [<prompt words...>]
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
-    cursor-agent --force --resume $argv[2..]
+    _caam_exec_function cursor-agent --force --resume $argv[2..]
   else if test (count $argv) -eq 0
-    cursor-agent --force
+    _caam_exec_function cursor-agent --force
   else
     set -l prompt (string join " " -- $argv)
-    cursor-agent --force --print -- "$prompt"
+    _caam_exec_function cursor-agent --force --print -- "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_caxeh_function.fish
+++ b/home-manager/programs/fish/functions/_caxeh_function.fish
@@ -14,5 +14,5 @@ function _caxeh_function --description "Run Cursor Agent headlessly with a promp
     return 1
   end
 
-  cursor-agent --force --print -- "$prompt"
+  _caam_exec_function cursor-agent --force --print -- "$prompt"
 end

--- a/home-manager/programs/fish/functions/_coxe_function.fish
+++ b/home-manager/programs/fish/functions/_coxe_function.fish
@@ -3,11 +3,11 @@ function _coxe_function --description "Run Codex with a free-form prompt"
   # Usage: cxe [<prompt words...>]
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
-    codex --dangerously-bypass-approvals-and-sandbox resume $argv[2]
+    _caam_exec_function codex --dangerously-bypass-approvals-and-sandbox resume $argv[2]
   else if test (count $argv) -eq 0
-    codex --dangerously-bypass-approvals-and-sandbox --model 'gpt-5.6-sol' -c model_reasoning_summary_format=experimental
+    _caam_exec_function codex --dangerously-bypass-approvals-and-sandbox --model 'gpt-5.6-sol' -c model_reasoning_summary_format=experimental
   else
     set -l prompt (string join " " -- $argv)
-    codex --dangerously-bypass-approvals-and-sandbox exec --model 'gpt-5.6-sol' -c model_reasoning_summary_format=experimental -- "$prompt"
+    _caam_exec_function codex --dangerously-bypass-approvals-and-sandbox exec --model 'gpt-5.6-sol' -c model_reasoning_summary_format=experimental -- "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_coxe_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_coxe_function.tpl.fish
@@ -3,11 +3,11 @@ function _coxe_function --description "Run Codex with a free-form prompt"
   # Usage: cxe [<prompt words...>]
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
-    codex --dangerously-bypass-approvals-and-sandbox resume $argv[2]
+    _caam_exec_function codex --dangerously-bypass-approvals-and-sandbox resume $argv[2]
   else if test (count $argv) -eq 0
-    codex --dangerously-bypass-approvals-and-sandbox --model '__GPT__' -c model_reasoning_summary_format=experimental
+    _caam_exec_function codex --dangerously-bypass-approvals-and-sandbox --model '__GPT__' -c model_reasoning_summary_format=experimental
   else
     set -l prompt (string join " " -- $argv)
-    codex --dangerously-bypass-approvals-and-sandbox exec --model '__GPT__' -c model_reasoning_summary_format=experimental -- "$prompt"
+    _caam_exec_function codex --dangerously-bypass-approvals-and-sandbox exec --model '__GPT__' -c model_reasoning_summary_format=experimental -- "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_coxeh_function.fish
+++ b/home-manager/programs/fish/functions/_coxeh_function.fish
@@ -14,5 +14,5 @@ function _coxeh_function --description "Run Codex headlessly with a prompted inp
     return 1
   end
 
-  codex --dangerously-bypass-approvals-and-sandbox exec --model 'gpt-5.6-sol' -c model_reasoning_summary_format=experimental -- "$prompt"
+  _caam_exec_function codex --dangerously-bypass-approvals-and-sandbox exec --model 'gpt-5.6-sol' -c model_reasoning_summary_format=experimental -- "$prompt"
 end

--- a/home-manager/programs/fish/functions/_coxeh_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_coxeh_function.tpl.fish
@@ -14,5 +14,5 @@ function _coxeh_function --description "Run Codex headlessly with a prompted inp
     return 1
   end
 
-  codex --dangerously-bypass-approvals-and-sandbox exec --model '__GPT__' -c model_reasoning_summary_format=experimental -- "$prompt"
+  _caam_exec_function codex --dangerously-bypass-approvals-and-sandbox exec --model '__GPT__' -c model_reasoning_summary_format=experimental -- "$prompt"
 end

--- a/home-manager/programs/fish/functions/_grwxe_function.fish
+++ b/home-manager/programs/fish/functions/_grwxe_function.fish
@@ -3,11 +3,11 @@ function _grwxe_function --description "Run Grok with a free-form prompt while a
   # Usage: grwxe [<prompt words...>]
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
-    grok --always-approve --worktree --resume $argv[2..]
+    _caam_exec_function grok --always-approve --worktree --resume $argv[2..]
   else if test (count $argv) -eq 0
-    grok --always-approve --worktree
+    _caam_exec_function grok --always-approve --worktree
   else
     set -l prompt (string join " " -- $argv)
-    grok --always-approve --worktree --single "$prompt"
+    _caam_exec_function grok --always-approve --worktree --single "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_grwxeh_function.fish
+++ b/home-manager/programs/fish/functions/_grwxeh_function.fish
@@ -14,5 +14,5 @@ function _grwxeh_function --description "Run Grok headlessly with a prompted inp
     return 1
   end
 
-  grok --always-approve --worktree --single "$prompt"
+  _caam_exec_function grok --always-approve --worktree --single "$prompt"
 end

--- a/home-manager/programs/fish/functions/_grxe_function.fish
+++ b/home-manager/programs/fish/functions/_grxe_function.fish
@@ -3,11 +3,11 @@ function _grxe_function --description "Run Grok with a free-form prompt while au
   # Usage: grxe [--resume | -r] [<prompt words...>]
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
-    grok --always-approve --resume $argv[2..]
+    _caam_exec_function grok --always-approve --resume $argv[2..]
   else if test (count $argv) -eq 0
-    grok --always-approve
+    _caam_exec_function grok --always-approve
   else
     set -l prompt (string join " " -- $argv)
-    grok --always-approve --single "$prompt"
+    _caam_exec_function grok --always-approve --single "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_grxeh_function.fish
+++ b/home-manager/programs/fish/functions/_grxeh_function.fish
@@ -14,5 +14,5 @@ function _grxeh_function --description "Run Grok headlessly with a prompted inpu
     return 1
   end
 
-  grok --always-approve --single "$prompt"
+  _caam_exec_function grok --always-approve --single "$prompt"
 end

--- a/home-manager/programs/fish/functions/_ocxe_function.fish
+++ b/home-manager/programs/fish/functions/_ocxe_function.fish
@@ -4,14 +4,14 @@ function _ocxe_function --description "Run OpenCode with a free-form prompt"
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
     if test (count $argv) -gt 1
-      opencode -m 'cliproxyapi/glm-4.7' --session "$argv[2]"
+      _caam_exec_function opencode -m 'cliproxyapi/glm-4.7' --session "$argv[2]"
     else
-      opencode -m 'cliproxyapi/glm-4.7' --continue
+      _caam_exec_function opencode -m 'cliproxyapi/glm-4.7' --continue
     end
   else if test (count $argv) -eq 0
-    opencode -m 'cliproxyapi/glm-4.7'
+    _caam_exec_function opencode -m 'cliproxyapi/glm-4.7'
   else
     set -l prompt (string join " " -- $argv)
-    opencode run "$prompt" -m 'cliproxyapi/glm-4.7'
+    _caam_exec_function opencode run "$prompt" -m 'cliproxyapi/glm-4.7'
   end
 end

--- a/home-manager/programs/fish/functions/_ocxe_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_ocxe_function.tpl.fish
@@ -4,14 +4,14 @@ function _ocxe_function --description "Run OpenCode with a free-form prompt"
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
     if test (count $argv) -gt 1
-      opencode -m 'cliproxyapi/__GLM__' --session "$argv[2]"
+      _caam_exec_function opencode -m 'cliproxyapi/__GLM__' --session "$argv[2]"
     else
-      opencode -m 'cliproxyapi/__GLM__' --continue
+      _caam_exec_function opencode -m 'cliproxyapi/__GLM__' --continue
     end
   else if test (count $argv) -eq 0
-    opencode -m 'cliproxyapi/__GLM__'
+    _caam_exec_function opencode -m 'cliproxyapi/__GLM__'
   else
     set -l prompt (string join " " -- $argv)
-    opencode run "$prompt" -m 'cliproxyapi/__GLM__'
+    _caam_exec_function opencode run "$prompt" -m 'cliproxyapi/__GLM__'
   end
 end

--- a/home-manager/programs/fish/functions/_ocxeh_function.fish
+++ b/home-manager/programs/fish/functions/_ocxeh_function.fish
@@ -14,5 +14,5 @@ function _ocxeh_function --description "Run OpenCode headlessly with a prompted 
     return 1
   end
 
-  opencode run "$prompt" -m 'cliproxyapi/glm-4.7'
+  _caam_exec_function opencode run "$prompt" -m 'cliproxyapi/glm-4.7'
 end

--- a/home-manager/programs/fish/functions/_ocxeh_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_ocxeh_function.tpl.fish
@@ -14,5 +14,5 @@ function _ocxeh_function --description "Run OpenCode headlessly with a prompted 
     return 1
   end
 
-  opencode run "$prompt" -m 'cliproxyapi/__GLM__'
+  _caam_exec_function opencode run "$prompt" -m 'cliproxyapi/__GLM__'
 end

--- a/home-manager/programs/fnm/default.nix
+++ b/home-manager/programs/fnm/default.nix
@@ -21,7 +21,7 @@ in
   '';
 
   # Pre-install node versions and set default
-  home.activation.fnmSetup = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.fnmSetup = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     export PATH="${pkgs.fnm}/bin:$PATH"
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" \
       "${pkgs.fnm}/bin/fnm" \

--- a/home-manager/programs/neovim/default.nix
+++ b/home-manager/programs/neovim/default.nix
@@ -40,11 +40,11 @@ in
     force = true;
   };
 
-  home.activation.copyNvimPackLock = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.copyNvimPackLock = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-copy-pack-lock.sh}" "${nvimPackLockJson}"
   '';
 
-  home.activation.buildNvimNativePlugins = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.buildNvimNativePlugins = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     export PATH="${lib.makeBinPath buildTools}:$PATH"
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-build-plugins.sh}" "${packDir}" "${libExt}"
   '';

--- a/home-manager/programs/ssh/default.nix
+++ b/home-manager/programs/ssh/default.nix
@@ -1,10 +1,15 @@
-{ lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 {
   home.file.".ssh/rc" = {
     source = ./rc;
     force = true;
   };
-  home.activation.caamKnownHosts = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.caamKnownHosts = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     ${pkgs.bash}/bin/bash ${./pin-known-hosts.sh} ${./known_hosts}
   '';
 

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -34,6 +34,8 @@
       # Local binaries must be available to non-interactive zsh commands too.
       export PATH="$HOME/.bun/install/global/node_modules/.bin:$HOME/.bun/bin:$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
 
+      export CAAM_ROTATION_ENABLED=1
+
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
       if [ "$(uname)" = "Linux" ]; then
           export XDG_RUNTIME_DIR="/run/user/$(id -u)"

--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -54,7 +54,7 @@ let
 in
 {
   # Hydrate auth cache after home-manager switch
-  home.activation.hydrateCliproxyAuths = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.hydrateCliproxyAuths = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     ${pkgs.bash}/bin/bash ${hydrateScript} || true
   '';
 

--- a/home-manager/services/firewall/default.nix
+++ b/home-manager/services/firewall/default.nix
@@ -14,7 +14,7 @@ let
   };
 in
 lib.mkIf host.isKyber {
-  home.activation.setupFirewall = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.setupFirewall = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${activateScript}"
   '';
 }

--- a/home-manager/services/hermes/default.nix
+++ b/home-manager/services/hermes/default.nix
@@ -10,7 +10,7 @@ let
   homeDir = config.home.homeDirectory;
 in
 lib.mkIf host.isKyber {
-  home.activation.hermesSetup = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.hermesSetup = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${homeDir}"
   '';
 

--- a/home-manager/services/k3s/default.nix
+++ b/home-manager/services/k3s/default.nix
@@ -25,7 +25,7 @@ let
   smartdServiceFile = "${homeDir}/.config/k3s/kyber-smartd.service";
 in
 lib.mkIf (pkgs.stdenv.isLinux && host.isKyber) {
-  home.activation.setupK3s = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.setupK3s = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     ${pkgs.bash}/bin/bash "${setupScript}" \
       "${serviceFile}" \
       "${homeDir}/.kube" \

--- a/home-manager/services/openclaw/default.nix
+++ b/home-manager/services/openclaw/default.nix
@@ -12,7 +12,7 @@ in
 # Only enable on kyber (gateway host)
 lib.mkIf host.isKyber {
   # Ensure OpenClaw directories exist with correct permissions
-  home.activation.openclawSetup = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.openclawSetup = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${homeDir}"
   '';
 

--- a/home-manager/services/qmd/default.nix
+++ b/home-manager/services/qmd/default.nix
@@ -13,7 +13,7 @@ let
   enabled = isKyber || isGalactica;
 in
 lib.mkIf enabled {
-  home.activation.qmdSetup = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.qmdSetup = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     export PATH="${pkgs.nodejs}/bin:${homeDir}/.bun/bin:$PATH"
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${qmdBin}" "${wikiDir}"
   '';

--- a/home-manager/services/roborev/default.nix
+++ b/home-manager/services/roborev/default.nix
@@ -13,7 +13,7 @@ let
   enabled = isGalactica || isMatic;
 in
 lib.mkIf enabled {
-  home.activation.roborevSetup = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+  home.activation.roborevSetup = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${dataDir}"
   '';
 

--- a/home-manager/services/tokscale/default.nix
+++ b/home-manager/services/tokscale/default.nix
@@ -54,7 +54,7 @@ in
 
   # Linux (cron)
   home.activation.installTokscaleCron = lib.mkIf pkgs.stdenv.isLinux (
-    lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    config.lib.dag.entryAfter [ "writeBoundary" ] ''
       $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-cron.sh}" ${lib.escapeShellArg cronCommand}
     ''
   );

--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -157,15 +157,17 @@ let
     inputs.home-manager.nixosModules.home-manager
     {
       home-manager.backupFileExtension = "hm-backup";
-      home-manager.extraSpecialArgs = { inherit inputs isRunner; };
+      home-manager.extraSpecialArgs = {
+        inherit
+          inputs
+          isRunner
+          pkgs
+          username
+          ;
+      };
       home-manager.useGlobalPkgs = true;
       home-manager.useUserPackages = true;
-      home-manager.users."${username}" = import ../../home-manager {
-        inherit inputs username isRunner;
-        inherit (inputs.nixpkgs) lib;
-        inherit pkgs;
-        config = { };
-      };
+      home-manager.users."${username}" = ../../home-manager;
     }
   ];
 in

--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -164,7 +164,6 @@ let
           pkgs
           username
           ;
-        lib = pkgs.lib // inputs.home-manager.lib;
       };
       home-manager.useGlobalPkgs = true;
       home-manager.useUserPackages = true;

--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -164,6 +164,7 @@ let
           pkgs
           username
           ;
+        lib = pkgs.lib // inputs.home-manager.lib;
       };
       home-manager.useGlobalPkgs = true;
       home-manager.useUserPackages = true;

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -420,7 +420,7 @@ import ../../hosts/nixos {
       {
         home-manager.backupFileExtension = "hm-backup";
         home-manager.extraSpecialArgs = {
-          inherit pkgs;
+          inherit pkgs username;
           isRunner = false;
           inputs = inputs // {
             host = (import ../../lib/host.nix) // {
@@ -440,17 +440,7 @@ import ../../hosts/nixos {
           }:
           {
             imports = [
-              (import ../../home-manager {
-                inherit username pkgs;
-                inputs = inputs // {
-                  host = (import ../../lib/host.nix) // {
-                    isDesktop = true;
-                    isMatic = true;
-                  };
-                };
-                inherit (inputs.nixpkgs) lib;
-                config = { };
-              })
+              ../../home-manager
             ];
 
             # Animated wallpaper via Wallpaper Engine

--- a/spec/auto_switch_spec.sh
+++ b/spec/auto_switch_spec.sh
@@ -3,8 +3,24 @@
 
 Describe 'auto-switch.sh'
 SCRIPT="$PWD/config/claude/hooks/auto-switch.sh"
+DEFAULT_NIX="$PWD/config/claude/default.nix"
+ACTIVATE_SCRIPT="$PWD/config/claude/activate.sh"
+SETTINGS="$PWD/config/claude/settings.json"
 
-Describe 'when cswap is not installed'
+Describe 'universal wiring'
+It 'enables the CAAM hook on every host'
+When run cat "$DEFAULT_NIX"
+The output should not include 'inputs.host'
+The output should include 'home.file.".claude/hooks/auto-switch.sh"'
+End
+
+It 'hydrates StopFailure on every host'
+When run bash -c 'temp_home=$(mktemp -d); HOME="$temp_home" bash "'"$ACTIVATE_SCRIPT"'" "'"$SETTINGS"'"; jq -e ".hooks.StopFailure | length > 0" "$temp_home/.claude/settings.json" >/dev/null'
+The status should be success
+End
+End
+
+Describe 'when caam is not installed'
 It 'exits 0 silently'
 When run bash -c 'echo "{}" | PATH="/usr/bin:/bin" bash '"$SCRIPT"
 The status should be success
@@ -12,17 +28,17 @@ The output should eq ''
 End
 End
 
-Describe 'when cswap has fewer than 2 accounts'
+Describe 'when caam has fewer than 2 accounts'
 setup() {
-  mock_bin_setup cswap
-  cat >"$MOCK_BIN/cswap" <<'EOF'
+  mock_bin_setup caam
+  cat >"$MOCK_BIN/caam" <<'EOF'
 #!/usr/bin/env bash
-if [[ "$1" == "--list" ]]; then
-  echo "  1) account-a (active)"
+if [[ "$1 $2 $3" == "ls claude --json" ]]; then
+  echo '{"profiles":[{"name":"account-a"}]}'
 fi
 exit 0
 EOF
-  chmod +x "$MOCK_BIN/cswap"
+  chmod +x "$MOCK_BIN/caam"
 }
 cleanup() {
   mock_bin_cleanup
@@ -37,7 +53,7 @@ The output should eq ''
 End
 End
 
-Describe 'when cswap has 2+ accounts'
+Describe 'when caam has 2+ accounts'
 setup() {
   MOCK_BIN="$(mktemp -d)"
   MOCK_LOG="$MOCK_BIN/mock.log"
@@ -46,16 +62,19 @@ setup() {
   export MOCK_BIN MOCK_LOG MOCK_ORIGINAL_PATH
   export PATH="$MOCK_BIN:$MOCK_ORIGINAL_PATH"
 
-  cat >"$MOCK_BIN/cswap" <<'EOF'
+  cat >"$MOCK_BIN/caam" <<'EOF'
 #!/usr/bin/env bash
-if [[ "$1" == "--list" ]]; then
-  printf '  1) account-a (active)\n  2) account-b\n'
-elif [[ "$1" == "--switch" ]]; then
+printf '%s\n' "$*" >>"$MOCK_LOG"
+if [[ "$1 $2 $3" == "ls claude --json" ]]; then
+  echo '{"profiles":[{"name":"account-a"},{"name":"account-b"}]}'
+elif [[ "$1 $2 $3" == "cooldown set claude" ]]; then
+  echo "Cooldown set"
+elif [[ "$1 $2 $3" == "activate claude --auto" ]]; then
   echo "Switched to account-b"
 fi
 exit 0
 EOF
-  chmod +x "$MOCK_BIN/cswap"
+  chmod +x "$MOCK_BIN/caam"
 }
 cleanup() {
   if [[ -n ${MOCK_ORIGINAL_PATH:-} ]]; then
@@ -80,6 +99,13 @@ It 'switches on rate_limit error'
 When run bash -c 'echo "{\"error\": \"rate_limit\"}" | bash '"$SCRIPT"
 The status should be success
 The error should include 'Auto-switching'
+End
+
+It 'cools down the active profile and activates the next profile'
+When run bash -c 'echo "{\"error\": \"rate_limit\"}" | bash '"$SCRIPT"' 2>/dev/null; cat "$MOCK_LOG"'
+The status should be success
+The output should include 'cooldown set claude --notes Claude StopFailure rate limit'
+The output should include 'activate claude --auto'
 End
 
 It 'switches on 429 in error_details'

--- a/spec/caam_config_spec.sh
+++ b/spec/caam_config_spec.sh
@@ -5,26 +5,36 @@ Describe 'config/caam'
 DEFAULT_NIX="$PWD/config/caam/default.nix"
 SCRIPT="$PWD/config/caam/hydrate.sh"
 TEMPLATE="$PWD/config/caam/config.template.yaml"
+FISH_NIX="$PWD/home-manager/programs/fish/default.nix"
+BASH_NIX="$PWD/home-manager/programs/bash/default.nix"
+ZSH_NIX="$PWD/home-manager/programs/zsh/default.nix"
 
 It 'is imported by the shared config module'
 When run grep -F './caam' "$PWD/config/default.nix"
 The output should include './caam'
 End
 
-It 'hydrates only on Kyber and Matic'
+It 'hydrates on every host'
 When run cat "$DEFAULT_NIX"
-The output should include 'inputs.host.isKyber || inputs.host.isMatic'
-The output should include 'lib.mkIf managedHost'
+The output should not include 'inputs.host'
+The output should not include 'lib.mkIf'
 End
 
-It 'passes the host-derived rotation value to the hydrator'
+It 'always enables automatic rotation'
 When run cat "$DEFAULT_NIX"
-The output should include 'autoRotate = if managedHost then "true" else "false"'
+The output should include 'autoRotate = "true"'
 End
 
-It 'leaves shell integration unmanaged'
-When run grep -F 'programs.fish.interactiveShellInit' "$DEFAULT_NIX"
+It 'keeps shell environment ownership outside the CAAM module'
+When run grep -F 'CAAM_ROTATION_ENABLED' "$DEFAULT_NIX"
 The status should be failure
+End
+
+It 'exports the rotation flag from each shell module'
+When run bash -c "cat '$FISH_NIX' '$BASH_NIX' '$ZSH_NIX'"
+The output should include 'set -gx CAAM_ROTATION_ENABLED 1'
+The output should include 'CAAM_ROTATION_ENABLED = "1"'
+The output should include 'export CAAM_ROTATION_ENABLED=1'
 End
 
 It 'does not manage credential vault data'

--- a/spec/fish/_caam_exec_function_test.fish
+++ b/spec/fish/_caam_exec_function_test.fish
@@ -1,0 +1,24 @@
+set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
+
+set direct_log (mktemp)
+function codex; echo $argv >> $direct_log; end
+
+_caam_exec_function codex exec hello
+
+@test "runs the native executable when rotation is disabled" (cat $direct_log) = "exec hello"
+
+set caam_log (mktemp)
+function caam; echo $argv >> $caam_log; end
+set -gx CAAM_ROTATION_ENABLED 1
+
+_caam_exec_function codex exec hello
+
+@test "routes through caam when rotation is enabled" (cat $caam_log) = "run codex -- exec hello"
+
+_caam_exec_function cursor-agent --print hello
+
+@test "maps cursor-agent to the cursor profile" (tail -n 1 $caam_log) = "run cursor -- --print hello"
+
+set -e CAAM_ROTATION_ENABLED
+rm -f $direct_log $caam_log

--- a/spec/fish/_cawxe_function_test.fish
+++ b/spec/fish/_cawxe_function_test.fish
@@ -1,4 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_cawxe_function.fish
 
 # ── no args: interactive mode ─────────────────────────────

--- a/spec/fish/_cawxeh_function_test.fish
+++ b/spec/fish/_cawxeh_function_test.fish
@@ -1,4 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_cawxeh_function.fish
 
 set log1 (mktemp)

--- a/spec/fish/_caxe_function_test.fish
+++ b/spec/fish/_caxe_function_test.fish
@@ -1,4 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_caxe_function.fish
 
 # ── no args: interactive mode ─────────────────────────────

--- a/spec/fish/_caxeh_function_test.fish
+++ b/spec/fish/_caxeh_function_test.fish
@@ -1,4 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_caxeh_function.fish
 
 set log1 (mktemp)

--- a/spec/fish/_coxe_function.tpl_test.fish
+++ b/spec/fish/_coxe_function.tpl_test.fish
@@ -1,4 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_coxe_function.tpl.fish
 
 # ── no args: interactive mode ─────────────────────────────

--- a/spec/fish/_coxe_function_test.fish
+++ b/spec/fish/_coxe_function_test.fish
@@ -1,4 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_coxe_function.fish
 
 # ── no args: interactive mode ─────────────────────────────

--- a/spec/fish/_coxeh_function.tpl_test.fish
+++ b/spec/fish/_coxeh_function.tpl_test.fish
@@ -1,4 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_coxeh_function.tpl.fish
 
 @test "empty prompt rejects" (echo "" | _coxeh_function 2>&1) = "No prompt provided, aborting."

--- a/spec/fish/_coxeh_function_test.fish
+++ b/spec/fish/_coxeh_function_test.fish
@@ -1,4 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_coxeh_function.fish
 
 @test "empty prompt rejects" (echo "" | _coxeh_function 2>&1) = "No prompt provided, aborting."

--- a/spec/fish/_grwxe_function_test.fish
+++ b/spec/fish/_grwxe_function_test.fish
@@ -1,4 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_grwxe_function.fish
 
 # ── no args: interactive mode ─────────────────────────────

--- a/spec/fish/_grwxeh_function_test.fish
+++ b/spec/fish/_grwxeh_function_test.fish
@@ -1,4 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_grwxeh_function.fish
 
 set log1 (mktemp)

--- a/spec/fish/_grxe_function_test.fish
+++ b/spec/fish/_grxe_function_test.fish
@@ -1,4 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_grxe_function.fish
 
 # ── no args: interactive mode ─────────────────────────────

--- a/spec/fish/_grxeh_function_test.fish
+++ b/spec/fish/_grxeh_function_test.fish
@@ -1,4 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_grxeh_function.fish
 
 set log1 (mktemp)

--- a/spec/fish/_ocxe_function.tpl_test.fish
+++ b/spec/fish/_ocxe_function.tpl_test.fish
@@ -1,4 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_ocxe_function.tpl.fish
 
 # ── no args: interactive mode ─────────────────────────────

--- a/spec/fish/_ocxe_function_test.fish
+++ b/spec/fish/_ocxe_function_test.fish
@@ -1,4 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_ocxe_function.fish
 
 # ── no args: interactive mode ─────────────────────────────

--- a/spec/fish/_ocxeh_function.tpl_test.fish
+++ b/spec/fish/_ocxeh_function.tpl_test.fish
@@ -1,4 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_ocxeh_function.tpl.fish
 
 @test "empty prompt rejects" (echo "" | _ocxeh_function 2>&1) = "No prompt provided, aborting."

--- a/spec/fish/_ocxeh_function_test.fish
+++ b/spec/fish/_ocxeh_function_test.fish
@@ -1,4 +1,5 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_ocxeh_function.fish
 
 @test "empty prompt rejects" (echo "" | _ocxeh_function 2>&1) = "No prompt provided, aborting."


### PR DESCRIPTION
CAAM now owns automatic account rotation on every dotfiles host, including Galactica. Claude's `StopFailure` hook cools down the exhausted profile and activates the next one, while Codex, Grok, OpenCode, and Cursor launcher functions route through a shared static helper.

The rotation flag lives in the Fish, Bash, and Zsh modules. Credentials remain runtime-owned, and launchers still call the native executable when CAAM isn't installed.

Universal hydration also exposed two NixOS integration issues. The generic builder now imports each Home Manager user as a real module, and activation entries use Home Manager's `config.lib.dag` API so embedded NixOS configurations evaluate with the correct `config`, `lib`, and `pkgs`.

Validated with the full shell test suite, local flake checks, full activation evaluation for generic and runner NixOS users, exact Nix evaluation for Galactica/Kyber/Matic, and a successful Galactica `make build`.