### PR TITLE
fix(tokscale): expose crontab during activation

### DIFF
--- a/home-manager/services/tokscale/default.nix
+++ b/home-manager/services/tokscale/default.nix
@@ -10,6 +10,16 @@ let
     pkgs.bash
     pkgs.coreutils
   ];
+  activationPath = lib.concatStringsSep ":" [
+    "/run/wrappers/bin"
+    "/run/current-system/sw/bin"
+    (lib.makeBinPath [
+      pkgs.coreutils
+      pkgs.gawk
+    ])
+    "/usr/bin"
+    "/bin"
+  ];
   # Every 3 hours, aligned to the wall clock.
   calendarHours = [
     0
@@ -55,7 +65,8 @@ in
   # Linux (cron)
   home.activation.installTokscaleCron = lib.mkIf pkgs.stdenv.isLinux (
     config.lib.dag.entryAfter [ "writeBoundary" ] ''
-      $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-cron.sh}" ${lib.escapeShellArg cronCommand}
+      $DRY_RUN_CMD ${pkgs.coreutils}/bin/env PATH=${lib.escapeShellArg activationPath} \
+        ${pkgs.bash}/bin/bash "${./activate-cron.sh}" ${lib.escapeShellArg cronCommand}
     ''
   );
 }


### PR DESCRIPTION
Matic reached Home Manager activation, but the system service could not find `/run/wrappers/bin/crontab` in its sanitized PATH.

This gives the Tokscale activation step an explicit cross-host PATH covering NixOS wrappers, the active system profile, Nix utilities, and standard Linux paths. The scheduled Tokscale command itself is unchanged.

## Test Plan

- `nix build --no-link --impure .#checks.x86_64-linux.eval-nixos-matic`
- `nix eval --impure --raw .#nixosConfigurations.matic.config.home-manager.users.shunkakinoki.home.activation.installTokscaleCron.data`
- `shellcheck home-manager/services/tokscale/activate-cron.sh`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Tokscale cron activation on NixOS by setting an explicit PATH so `crontab` is found. Prevents Home Manager activation failures caused by a sanitized service PATH.

- **Bug Fixes**
  - Define `activationPath` covering `/run/wrappers/bin`, `/run/current-system/sw/bin`, bins from `coreutils` and `gawk`, plus `/usr/bin` and `/bin`.
  - Run `activate-cron.sh` via `env PATH=$activationPath` to expose `crontab`; the scheduled Tokscale command stays the same.

<sup>Written for commit aa1fa3dc739d57d7808686a53339c8d7f3b6a80a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

