### PR TITLE
fix(tokscale): expose crontab during activation

### DIFF
--- a/home-manager/services/tokscale/default.nix
+++ b/home-manager/services/tokscale/default.nix
@@ -10,6 +10,16 @@ let
     pkgs.bash
     pkgs.coreutils
   ];
+  activationPath = lib.concatStringsSep ":" [
+    "/run/wrappers/bin"
+    "/run/current-system/sw/bin"
+    (lib.makeBinPath [
+      pkgs.coreutils
+      pkgs.gawk
+    ])
+    "/usr/bin"
+    "/bin"
+  ];
   # Every 3 hours, aligned to the wall clock.
   calendarHours = [
     0
@@ -55,7 +65,8 @@ in
   # Linux (cron)
   home.activation.installTokscaleCron = lib.mkIf pkgs.stdenv.isLinux (
     config.lib.dag.entryAfter [ "writeBoundary" ] ''
-      $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-cron.sh}" ${lib.escapeShellArg cronCommand}
+      $DRY_RUN_CMD ${pkgs.coreutils}/bin/env PATH=${lib.escapeShellArg activationPath} \
+        ${pkgs.bash}/bin/bash "${./activate-cron.sh}" ${lib.escapeShellArg cronCommand}
     ''
   );
 }


### PR DESCRIPTION
## Summary

- give the Tokscale Home Manager activation hook an explicit NixOS-safe PATH
- include the system wrapper/profile paths where `crontab` is exposed
- keep the cron installer and generated schedule unchanged

## Validation

- `nixfmt --check home-manager/services/tokscale/default.nix`
- NixOS/Home Manager switch completed successfully on the target host
- the later `dotagents-sync` failure is unrelated and is already tracked by #2203

Closes `shunkakinokisoftware-bb87`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set an explicit NixOS-safe PATH during Home Manager activation so `crontab` is found and cron setup doesn’t fail. Keeps the existing installer and schedule; resolves `shunkakinokisoftware-bb87`.

- **Bug Fixes**
  - Add `activationPath` including `/run/wrappers/bin`, `/run/current-system/sw/bin`, `lib.makeBinPath` for `coreutils` and `gawk`, plus `/usr/bin` and `/bin`.
  - Run `activate-cron.sh` via `env PATH=$activationPath` before `bash`, leaving `cronCommand` unchanged.

<sup>Written for commit aa1fa3dc739d57d7808686a53339c8d7f3b6a80a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

