### PR TITLE
fix(caam): route Claude launchers through rotation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1395,7 +1395,6 @@ fish-test: ## Run fish function tests using fishtape.
 	XDG_CONFIG_HOME="$$fish_home/.config" \
 	XDG_STATE_HOME="$$fish_home/.local/state" \
 	XDG_DATA_HOME="$$fish_home/.local/share" \
-	CAAM_ROTATION_ENABLED= \
 	"$$fish_runner" spec/fish/*_test.fish 2>"$$fish_errors"; \
 	rc=$$?; \
 	grep -v -E '^(warning: notify_register_file_descriptor\(\) failed with status 9\.|warning: Universal variable notifications may not be received\.)$$' "$$fish_errors" >"$$fish_errors_filtered" || true; \

--- a/Makefile
+++ b/Makefile
@@ -1395,6 +1395,7 @@ fish-test: ## Run fish function tests using fishtape.
 	XDG_CONFIG_HOME="$$fish_home/.config" \
 	XDG_STATE_HOME="$$fish_home/.local/state" \
 	XDG_DATA_HOME="$$fish_home/.local/share" \
+	CAAM_ROTATION_ENABLED= \
 	"$$fish_runner" spec/fish/*_test.fish 2>"$$fish_errors"; \
 	rc=$$?; \
 	grep -v -E '^(warning: notify_register_file_descriptor\(\) failed with status 9\.|warning: Universal variable notifications may not be received\.)$$' "$$fish_errors" >"$$fish_errors_filtered" || true; \

--- a/home-manager/programs/fish/functions/_cltxe_function.fish
+++ b/home-manager/programs/fish/functions/_cltxe_function.fish
@@ -3,11 +3,11 @@ function _cltxe_function --description "Run Claude Code with a free-form prompt 
   # Usage: cltxe [<prompt words...>]
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
-    claude --dangerously-skip-permissions --worktree --tmux --resume $argv[2]
+    _caam_exec_function claude --dangerously-skip-permissions --worktree --tmux --resume $argv[2]
   else if test (count $argv) -eq 0
-    claude --dangerously-skip-permissions --worktree --tmux
+    _caam_exec_function claude --dangerously-skip-permissions --worktree --tmux
   else
     set -l prompt (string join " " -- $argv)
-    claude --dangerously-skip-permissions --worktree --tmux --print -- "$prompt"
+    _caam_exec_function claude --dangerously-skip-permissions --worktree --tmux --print -- "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_cltxeh_function.fish
+++ b/home-manager/programs/fish/functions/_cltxeh_function.fish
@@ -14,5 +14,5 @@ function _cltxeh_function --description "Run Claude Code headlessly with a promp
     return 1
   end
 
-  claude --dangerously-skip-permissions --worktree --tmux --print -- "$prompt"
+  _caam_exec_function claude --dangerously-skip-permissions --worktree --tmux --print -- "$prompt"
 end

--- a/home-manager/programs/fish/functions/_clwxe_function.fish
+++ b/home-manager/programs/fish/functions/_clwxe_function.fish
@@ -3,11 +3,11 @@ function _clwxe_function --description "Run Claude Code with a free-form prompt 
   # Usage: clwxe [<prompt words...>]
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
-    claude --dangerously-skip-permissions --worktree --resume $argv[2]
+    _caam_exec_function claude --dangerously-skip-permissions --worktree --resume $argv[2]
   else if test (count $argv) -eq 0
-    claude --dangerously-skip-permissions --worktree
+    _caam_exec_function claude --dangerously-skip-permissions --worktree
   else
     set -l prompt (string join " " -- $argv)
-    claude --dangerously-skip-permissions --worktree --print -- "$prompt"
+    _caam_exec_function claude --dangerously-skip-permissions --worktree --print -- "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_clwxeh_function.fish
+++ b/home-manager/programs/fish/functions/_clwxeh_function.fish
@@ -14,5 +14,5 @@ function _clwxeh_function --description "Run Claude Code headlessly with a promp
     return 1
   end
 
-  claude --dangerously-skip-permissions --worktree --print -- "$prompt"
+  _caam_exec_function claude --dangerously-skip-permissions --worktree --print -- "$prompt"
 end

--- a/home-manager/programs/fish/functions/_clxe_function.fish
+++ b/home-manager/programs/fish/functions/_clxe_function.fish
@@ -3,11 +3,11 @@ function _clxe_function --description "Run Claude Code with a free-form prompt w
   # Usage: clxe [--resume | -r] [<prompt words...>]
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
-    claude --dangerously-skip-permissions --resume $argv[2]
+    _caam_exec_function claude --dangerously-skip-permissions --resume $argv[2]
   else if test (count $argv) -eq 0
-    claude --dangerously-skip-permissions
+    _caam_exec_function claude --dangerously-skip-permissions
   else
     set -l prompt (string join " " -- $argv)
-    claude --dangerously-skip-permissions --print -- "$prompt"
+    _caam_exec_function claude --dangerously-skip-permissions --print -- "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_clxeh_function.fish
+++ b/home-manager/programs/fish/functions/_clxeh_function.fish
@@ -14,5 +14,5 @@ function _clxeh_function --description "Run Claude Code headlessly with a prompt
     return 1
   end
 
-  claude --dangerously-skip-permissions --print -- "$prompt"
+  _caam_exec_function claude --dangerously-skip-permissions --print -- "$prompt"
 end

--- a/spec/fish/_cltxe_function_test.fish
+++ b/spec/fish/_cltxe_function_test.fish
@@ -1,18 +1,21 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_cltxe_function.fish
+set -gx CAAM_ROTATION_ENABLED 1
 
 # ── no args: interactive mode ─────────────────────────────
 set log1 (mktemp)
-function claude; echo $argv >> $log1; end
+function caam; echo $argv >> $log1; end
 
 _cltxe_function
 
 @test "no args uses --worktree --tmux flags" (grep -c -- "--worktree" $log1) -ge 1
 @test "no args skips --print flag" (grep -c -- "--print" $log1) -eq 0
+@test "no args routes Claude through CAAM" (grep -c '^run claude -- ' $log1) -ge 1
 
 # ── with args: print mode ─────────────────────────────────
 set log2 (mktemp)
-function claude; echo $argv >> $log2; end
+function caam; echo $argv >> $log2; end
 
 _cltxe_function hello world
 
@@ -20,4 +23,5 @@ _cltxe_function hello world
 @test "with args uses --tmux flag" (grep -c -- "--tmux" $log2) -ge 1
 @test "with args builds prompt" (grep -c "hello world" $log2) -ge 1
 
+set -e CAAM_ROTATION_ENABLED
 rm -f $log1 $log2

--- a/spec/fish/_cltxeh_function_test.fish
+++ b/spec/fish/_cltxeh_function_test.fish
@@ -1,15 +1,19 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_cltxeh_function.fish
 
 @test "empty prompt rejects" (echo "" | _cltxeh_function 2>&1) = "No prompt provided, aborting."
 @test "empty prompt returns 1" (echo "" | _cltxeh_function 2>/dev/null; echo $status) = 1
 
 set log1 (mktemp)
-function claude; echo $argv >> $log1; end
+function caam; echo $argv >> $log1; end
+set -gx CAAM_ROTATION_ENABLED 1
 
 _cltxeh_function hello world
 
 @test "inline args forwards prompt" (grep -c "hello world" $log1) -ge 1
 @test "inline args uses print mode" (grep -c -- "--print" $log1) -ge 1
+@test "inline args route Claude through CAAM" (grep -c '^run claude -- ' $log1) -ge 1
 
+set -e CAAM_ROTATION_ENABLED
 rm -f $log1

--- a/spec/fish/_clwxe_function_test.fish
+++ b/spec/fish/_clwxe_function_test.fish
@@ -1,18 +1,21 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_clwxe_function.fish
+set -gx CAAM_ROTATION_ENABLED 1
 
 # ── no args: interactive mode ─────────────────────────────
 set log1 (mktemp)
-function claude; echo $argv >> $log1; end
+function caam; echo $argv >> $log1; end
 
 _clwxe_function
 
 @test "no args uses --worktree flag" (grep -c -- "--worktree" $log1) -ge 1
 @test "no args skips --print flag" (grep -c -- "--print" $log1) -eq 0
+@test "no args routes Claude through CAAM" (grep -c '^run claude -- ' $log1) -ge 1
 
 # ── with args: print mode ─────────────────────────────────
 set log2 (mktemp)
-function claude; echo $argv >> $log2; end
+function caam; echo $argv >> $log2; end
 
 _clwxe_function hello world
 
@@ -20,4 +23,5 @@ _clwxe_function hello world
 @test "with args uses --worktree flag" (grep -c -- "--worktree" $log2) -ge 1
 @test "with args builds prompt" (grep -c "hello world" $log2) -ge 1
 
+set -e CAAM_ROTATION_ENABLED
 rm -f $log1 $log2

--- a/spec/fish/_clwxeh_function_test.fish
+++ b/spec/fish/_clwxeh_function_test.fish
@@ -1,15 +1,19 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_clwxeh_function.fish
 
 @test "empty prompt rejects" (echo "" | _clwxeh_function 2>&1) = "No prompt provided, aborting."
 @test "empty prompt returns 1" (echo "" | _clwxeh_function 2>/dev/null; echo $status) = 1
 
 set log1 (mktemp)
-function claude; echo $argv >> $log1; end
+function caam; echo $argv >> $log1; end
+set -gx CAAM_ROTATION_ENABLED 1
 
 _clwxeh_function hello world
 
 @test "inline args forwards prompt" (grep -c "hello world" $log1) -ge 1
 @test "inline args uses print mode" (grep -c -- "--print" $log1) -ge 1
+@test "inline args route Claude through CAAM" (grep -c '^run claude -- ' $log1) -ge 1
 
+set -e CAAM_ROTATION_ENABLED
 rm -f $log1

--- a/spec/fish/_clxe_function_test.fish
+++ b/spec/fish/_clxe_function_test.fish
@@ -1,22 +1,26 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_clxe_function.fish
+set -gx CAAM_ROTATION_ENABLED 1
 
 # ── no args: interactive mode ─────────────────────────────
 set log1 (mktemp)
-function claude; echo $argv >> $log1; end
+function caam; echo $argv >> $log1; end
 
 _clxe_function
 
 @test "no args skips --print flag" (grep -c -- "--print" $log1) -eq 0
 @test "no args uses dangerously-skip-permissions" (grep -c "dangerously-skip-permissions" $log1) -ge 1
+@test "no args routes Claude through CAAM" (grep -c '^run claude -- ' $log1) -ge 1
 
 # ── with args: print mode ─────────────────────────────────
 set log2 (mktemp)
-function claude; echo $argv >> $log2; end
+function caam; echo $argv >> $log2; end
 
 _clxe_function hello world
 
 @test "with args uses --print flag" (grep -c -- "--print" $log2) -ge 1
 @test "with args builds prompt" (grep -c "hello world" $log2) -ge 1
 
+set -e CAAM_ROTATION_ENABLED
 rm -f $log1 $log2

--- a/spec/fish/_clxeh_function_test.fish
+++ b/spec/fish/_clxeh_function_test.fish
@@ -1,15 +1,19 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_caam_exec_function.fish
 source $fn/_clxeh_function.fish
 
 @test "empty prompt rejects" (echo "" | _clxeh_function 2>&1) = "No prompt provided, aborting."
 @test "empty prompt returns 1" (echo "" | _clxeh_function 2>/dev/null; echo $status) = 1
 
 set log1 (mktemp)
-function claude; echo $argv >> $log1; end
+function caam; echo $argv >> $log1; end
+set -gx CAAM_ROTATION_ENABLED 1
 
 _clxeh_function hello world
 
 @test "inline args forwards prompt" (grep -c "hello world" $log1) -ge 1
 @test "inline args uses print mode" (grep -c -- "--print" $log1) -ge 1
+@test "inline args route Claude through CAAM" (grep -c '^run claude -- ' $log1) -ge 1
 
+set -e CAAM_ROTATION_ENABLED
 rm -f $log1


### PR DESCRIPTION
## Summary

- route clxe, clxeh, clwxe, clwxeh, cltxe, and cltxeh through the shared CAAM executor
- preserve the existing interactive, print, worktree, tmux, and resume arguments
- sandbox Fish tests from the inherited host rotation flag and assert CAAM routing for every Claude launcher variant

## Validation

- make shell-test: 1816 ShellSpec examples and 431 Fish assertions passed
- git diff --check

Closes shunkakinokisoftware-ge6v

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route all Claude launchers through the shared CAAM executor with rotation, while keeping existing flags and behavior intact. Adds targeted tests to verify CAAM routing and isolates rotation in test runs.

- **Bug Fixes**
  - Route `clxe`, `clxeh`, `clwxe`, `clwxeh`, `cltxe`, and `cltxeh` via `_caam_exec_function` to `caam`.
  - Preserve `--worktree`, `--tmux`, `--print`, and `--resume`/`--continue` behavior.
  - Fish tests source `_caam_exec_function.fish`, stub `caam`, and set `CAAM_ROTATION_ENABLED=1` to assert routing.
  - Makefile: `make fish-test` clears `CAAM_ROTATION_ENABLED` to sandbox tests from host rotation.

<sup>Written for commit 6df28372cb75258112c4d7409db8e7d9c2abd03b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

