### PR TITLE
feat(caam): precheck Fish agent launchers

### DIFF
--- a/home-manager/programs/fish/functions/_caam_exec_function.fish
+++ b/home-manager/programs/fish/functions/_caam_exec_function.fish
@@ -8,7 +8,7 @@ function _caam_exec_function --description "Run an agent launcher through CAAM w
   end
 
   if test "$CAAM_ROTATION_ENABLED" = "1"; and type -q caam
-    caam run $tool -- $argv
+    caam run $tool --precheck -- $argv
   else
     $executable $argv
   end

--- a/spec/fish/_caam_exec_function_test.fish
+++ b/spec/fish/_caam_exec_function_test.fish
@@ -14,11 +14,11 @@ set -gx CAAM_ROTATION_ENABLED 1
 
 _caam_exec_function codex exec hello
 
-@test "routes through caam when rotation is enabled" (cat $caam_log) = "run codex -- exec hello"
+@test "routes through caam precheck when rotation is enabled" (cat $caam_log) = "run codex --precheck -- exec hello"
 
 _caam_exec_function cursor-agent --print hello
 
-@test "maps cursor-agent to the cursor profile" (tail -n 1 $caam_log) = "run cursor -- --print hello"
+@test "maps cursor-agent to the cursor profile" (tail -n 1 $caam_log) = "run cursor --precheck -- --print hello"
 
 set -e CAAM_ROTATION_ENABLED
 rm -f $direct_log $caam_log

--- a/spec/fish/_cltxe_function_test.fish
+++ b/spec/fish/_cltxe_function_test.fish
@@ -11,7 +11,7 @@ _cltxe_function
 
 @test "no args uses --worktree --tmux flags" (grep -c -- "--worktree" $log1) -ge 1
 @test "no args skips --print flag" (grep -c -- "--print" $log1) -eq 0
-@test "no args routes Claude through CAAM" (grep -c '^run claude -- ' $log1) -ge 1
+@test "no args routes Claude through CAAM" (grep -c '^run claude --precheck -- ' $log1) -ge 1
 
 # ── with args: print mode ─────────────────────────────────
 set log2 (mktemp)

--- a/spec/fish/_cltxeh_function_test.fish
+++ b/spec/fish/_cltxeh_function_test.fish
@@ -13,7 +13,7 @@ _cltxeh_function hello world
 
 @test "inline args forwards prompt" (grep -c "hello world" $log1) -ge 1
 @test "inline args uses print mode" (grep -c -- "--print" $log1) -ge 1
-@test "inline args route Claude through CAAM" (grep -c '^run claude -- ' $log1) -ge 1
+@test "inline args route Claude through CAAM" (grep -c '^run claude --precheck -- ' $log1) -ge 1
 
 set -e CAAM_ROTATION_ENABLED
 rm -f $log1

--- a/spec/fish/_clwxe_function_test.fish
+++ b/spec/fish/_clwxe_function_test.fish
@@ -11,7 +11,7 @@ _clwxe_function
 
 @test "no args uses --worktree flag" (grep -c -- "--worktree" $log1) -ge 1
 @test "no args skips --print flag" (grep -c -- "--print" $log1) -eq 0
-@test "no args routes Claude through CAAM" (grep -c '^run claude -- ' $log1) -ge 1
+@test "no args routes Claude through CAAM" (grep -c '^run claude --precheck -- ' $log1) -ge 1
 
 # ── with args: print mode ─────────────────────────────────
 set log2 (mktemp)

--- a/spec/fish/_clwxeh_function_test.fish
+++ b/spec/fish/_clwxeh_function_test.fish
@@ -13,7 +13,7 @@ _clwxeh_function hello world
 
 @test "inline args forwards prompt" (grep -c "hello world" $log1) -ge 1
 @test "inline args uses print mode" (grep -c -- "--print" $log1) -ge 1
-@test "inline args route Claude through CAAM" (grep -c '^run claude -- ' $log1) -ge 1
+@test "inline args route Claude through CAAM" (grep -c '^run claude --precheck -- ' $log1) -ge 1
 
 set -e CAAM_ROTATION_ENABLED
 rm -f $log1

--- a/spec/fish/_clxe_function_test.fish
+++ b/spec/fish/_clxe_function_test.fish
@@ -11,7 +11,7 @@ _clxe_function
 
 @test "no args skips --print flag" (grep -c -- "--print" $log1) -eq 0
 @test "no args uses dangerously-skip-permissions" (grep -c "dangerously-skip-permissions" $log1) -ge 1
-@test "no args routes Claude through CAAM" (grep -c '^run claude -- ' $log1) -ge 1
+@test "no args routes Claude through CAAM" (grep -c '^run claude --precheck -- ' $log1) -ge 1
 
 # ── with args: print mode ─────────────────────────────────
 set log2 (mktemp)

--- a/spec/fish/_clxeh_function_test.fish
+++ b/spec/fish/_clxeh_function_test.fish
@@ -13,7 +13,7 @@ _clxeh_function hello world
 
 @test "inline args forwards prompt" (grep -c "hello world" $log1) -ge 1
 @test "inline args uses print mode" (grep -c -- "--print" $log1) -ge 1
-@test "inline args route Claude through CAAM" (grep -c '^run claude -- ' $log1) -ge 1
+@test "inline args route Claude through CAAM" (grep -c '^run claude --precheck -- ' $log1) -ge 1
 
 set -e CAAM_ROTATION_ENABLED
 rm -f $log1


### PR DESCRIPTION
## Summary
- enable CAAM usage prechecks in the shared Fish agent launcher helper
- apply the policy to every helper-backed Claude, Codex, Cursor, Grok, and OpenCode launcher
- update launcher tests for the generated CAAM command

## Testing
- `env -u CAAM_ROTATION_ENABLED make fish-test` (431 passing)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CAAM prechecks to Fish agent launchers by running `caam run <tool> --precheck -- ...` when `CAAM_ROTATION_ENABLED=1` and `caam` is available. Applies across helper-backed Claude, Codex, Cursor, Grok, and OpenCode launchers; tests updated to match.

<sup>Written for commit f9b636d5f3f0cd3283197cce5d342f54e561ca4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

