### PR TITLE
fix(beads): align agent hooks with official integrations

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -33,9 +33,12 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Upgrade
-        run: make upgrade-dev
+        run: |
+          git config --global url."https://x-access-token:${PAT_TOKEN}@github.com/".insteadOf "https://github.com/"
+          make upgrade-dev
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
           SKIP_HOME_MANAGER_SWITCH: "true"
       - name: Create Pull Request
         if: github.event_name != 'pull_request'

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -406,6 +406,15 @@
             "type": "command"
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "command": "bd prime --hook-json",
+            "type": "command"
+          }
+        ]
       }
     ],
     "Stop": [

--- a/config/codex/hooks.json
+++ b/config/codex/hooks.json
@@ -23,6 +23,30 @@
         "matcher": "Bash"
       }
     ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "command": "bd codex-hook PostCompact",
+            "statusMessage": "Scheduling Beads context refresh",
+            "type": "command"
+          }
+        ],
+        "matcher": "manual|auto"
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "command": "bd codex-hook PreCompact",
+            "statusMessage": "Checking Beads context",
+            "type": "command"
+          }
+        ],
+        "matcher": "manual|auto"
+      }
+    ],
     "PreToolUse": [
       {
         "hooks": [
@@ -122,6 +146,16 @@
             "type": "command"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "bd codex-hook SessionStart",
+            "statusMessage": "Loading Beads context",
+            "type": "command"
+          }
+        ],
+        "matcher": "startup|resume|clear"
       }
     ],
     "Stop": [
@@ -165,6 +199,15 @@
         "hooks": [
           {
             "command": "moshi-hook codex-hook",
+            "type": "command"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "bd codex-hook UserPromptSubmit",
+            "statusMessage": "Refreshing Beads context",
             "type": "command"
           }
         ]

--- a/config/cursor/hooks.json
+++ b/config/cursor/hooks.json
@@ -14,6 +14,21 @@
         "command": "moshi-hook cursor-hook"
       }
     ],
+    "postToolUse": [
+      {
+        "command": "bd cursor-hook postToolUse"
+      }
+    ],
+    "preCompact": [
+      {
+        "command": "bd cursor-hook preCompact"
+      }
+    ],
+    "sessionStart": [
+      {
+        "command": "bd cursor-hook sessionStart"
+      }
+    ],
     "beforeMCPExecution": [
       {
         "command": "moshi-hook cursor-hook"

--- a/config/gemini/settings.json
+++ b/config/gemini/settings.json
@@ -75,6 +75,15 @@
           }
         ],
         "matcher": "*"
+      },
+      {
+        "hooks": [
+          {
+            "command": "bd prime --hook-json",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
       }
     ]
   },

--- a/spec/beads_agent_hooks_spec.sh
+++ b/spec/beads_agent_hooks_spec.sh
@@ -1,0 +1,65 @@
+Describe 'Beads agent hook configuration'
+
+CLAUDE_SETTINGS="$PWD/config/claude/settings.json"
+CODEX_HOOKS="$PWD/config/codex/hooks.json"
+CURSOR_HOOKS="$PWD/config/cursor/hooks.json"
+GEMINI_SETTINGS="$PWD/config/gemini/settings.json"
+
+has_session_start_hook() {
+  jq -e '[.hooks.SessionStart[]?.hooks[]?.command] | any(. == "bd prime --hook-json")' "$1" >/dev/null
+}
+
+has_codex_hook() {
+  jq -e --arg event "$1" --arg command "$2" '[.hooks[$event][]?.hooks[]?.command] | any(. == $command)' "$CODEX_HOOKS" >/dev/null
+}
+
+has_cursor_hook() {
+  jq -e --arg event "$1" --arg command "$2" '[.hooks[$event][]?.command] | any(. == $command)' "$CURSOR_HOOKS" >/dev/null
+}
+
+It 'uses the JSON envelope for Claude session context'
+When call has_session_start_hook "$CLAUDE_SETTINGS"
+The status should be success
+End
+
+It 'uses the JSON envelope for Gemini session context'
+When call has_session_start_hook "$GEMINI_SETTINGS"
+The status should be success
+End
+
+It 'installs the Codex compaction recovery lifecycle'
+When call has_codex_hook 'SessionStart' 'bd codex-hook SessionStart'
+The status should be success
+End
+
+It 'checks Beads context before Codex compaction'
+When call has_codex_hook 'PreCompact' 'bd codex-hook PreCompact'
+The status should be success
+End
+
+It 'refreshes Beads context after Codex compaction'
+When call has_codex_hook 'PostCompact' 'bd codex-hook PostCompact'
+The status should be success
+End
+
+It 'injects Beads context on the first Codex prompt after compaction'
+When call has_codex_hook 'UserPromptSubmit' 'bd codex-hook UserPromptSubmit'
+The status should be success
+End
+
+It 'installs the Cursor session context hook'
+When call has_cursor_hook 'sessionStart' 'bd cursor-hook sessionStart'
+The status should be success
+End
+
+It 'installs the Cursor compaction recovery hooks'
+When call has_cursor_hook 'preCompact' 'bd cursor-hook preCompact'
+The status should be success
+End
+
+It 're-injects Cursor context after compaction'
+When call has_cursor_hook 'postToolUse' 'bd cursor-hook postToolUse'
+The status should be success
+End
+
+End

--- a/spec/beads_agent_hooks_spec.sh
+++ b/spec/beads_agent_hooks_spec.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 Describe 'Beads agent hook configuration'
 
 CLAUDE_SETTINGS="$PWD/config/claude/settings.json"


### PR DESCRIPTION
## Summary
- add the official Beads SessionStart JSON-context hooks for Claude Code and Gemini CLI
- add Codex session/compaction recovery lifecycle hooks and Cursor lifecycle hooks
- cover the Beads hook contracts with a focused ShellSpec suite

## Validation
- `shellspec spec/activate_config_spec.sh spec/auto_switch_spec.sh spec/agent_github_hook_wiring_spec.sh spec/beads_agent_hooks_spec.sh`
- rendered all four Home Manager activation outputs into an isolated home and asserted each Beads hook
- `make nix-format-check`

## Known baseline
- `make shell-test` ran 1,825 ShellSpec examples successfully, then its Fish suite failed 51 existing CAAM-profile-dependent tests; this patch does not touch those functions or tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Beads agent hooks with the official Claude Code, Gemini CLI, Codex, and Cursor integrations. Adds session priming and compaction recovery so context stays accurate across runs.

- **New Features**
  - Claude/Gemini: `SessionStart` primes context via `bd prime --hook-json`.
  - Codex: added `PreCompact`, `PostCompact`, `SessionStart`, and `UserPromptSubmit` hooks using `bd codex-hook <Event>` with status messages.
  - Cursor: added `sessionStart`, `preCompact`, and `postToolUse` hooks via `bd cursor-hook <event>`.
  - Tests: new ShellSpec suite (`spec/beads_agent_hooks_spec.sh`) verifies hook wiring.

- **Bug Fixes**
  - CI: upgrade workflow authenticates GitHub fetches via `PAT_TOKEN`.
  - Tests: declared bash shell in the hook spec for stable CI runs.

<sup>Written for commit 2da0836c397f516d4deb67d7afd75b6e0b060404. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

