### PR TITLE
fix(tokscale): Preserve actual launchd submission result

### DIFF
--- a/home-manager/services/tokscale/default.nix
+++ b/home-manager/services/tokscale/default.nix
@@ -50,7 +50,7 @@ in
         "${pkgs.bash}/bin/bash"
         "${./submit.sh}"
       ];
-      Environment = {
+      EnvironmentVariables = {
         PATH = binPath + ":/usr/bin:/bin:/usr/sbin:/sbin";
       };
       StartCalendarInterval = map (hour: {

--- a/home-manager/services/tokscale/submit.sh
+++ b/home-manager/services/tokscale/submit.sh
@@ -2,12 +2,6 @@
 # Submit local usage data to Tokscale. Runs on a 3h schedule on all machines.
 set -euo pipefail
 
-# tokscale submit needs the network; skip silently when offline.
-if ! timeout 3 bash -c 'exec 3<>/dev/tcp/1.1.1.1/53' 2>/dev/null; then
-  echo "Network unavailable, skipping tokscale submit"
-  exit 0
-fi
-
 # Workaround for junhoyeo/tokscale#1002: the Rust binary's TLS stack cannot
 # locate NixOS CA certs without an explicit pointer.
 export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt

--- a/spec/tokscale_spec.sh
+++ b/spec/tokscale_spec.sh
@@ -32,51 +32,20 @@ The output should include '.bun/install/global/node_modules/tokscale/bin.js'
 End
 End
 
-Describe 'network guard'
-setup() {
-  MOCK_BIN=$(mktemp -d)
-  MOCK_ORIGINAL_PATH="$PATH"
-  export PATH="$MOCK_BIN:$PATH"
-  # Force the offline branch: timeout exits non-zero.
-  cat >"$MOCK_BIN/timeout" <<'EOF'
-#!/usr/bin/env bash
-exit 1
-EOF
-  chmod +x "$MOCK_BIN/timeout"
-}
-
-cleanup() {
-  export PATH="$MOCK_ORIGINAL_PATH"
-  rm -rf "$MOCK_BIN"
-}
-
-Before 'setup'
-After 'cleanup'
-
-It 'skips and exits 0 when offline'
-When run bash "$SCRIPT"
-The output should include 'Network unavailable'
-The status should be success
+Describe 'network handling'
+It 'does not gate Tokscale on an unrelated endpoint'
+When run grep -F '1.1.1.1' "$SCRIPT"
+The status should be failure
 End
 End
 
 Describe 'missing tokscale guard'
 setup() {
-  MOCK_BIN=$(mktemp -d)
-  MOCK_ORIGINAL_PATH="$PATH"
-  export PATH="$MOCK_BIN:$PATH"
-  # Pass the network check so we reach the install check.
-  cat >"$MOCK_BIN/timeout" <<'EOF'
-#!/usr/bin/env bash
-exit 0
-EOF
-  chmod +x "$MOCK_BIN/timeout"
   FAKE_HOME=$(mktemp -d)
 }
 
 cleanup() {
-  export PATH="$MOCK_ORIGINAL_PATH"
-  rm -rf "$MOCK_BIN" "$FAKE_HOME"
+  rm -rf "$FAKE_HOME"
 }
 
 Before 'setup'
@@ -91,6 +60,38 @@ End
 
 End
 
+Describe 'submission failure'
+SCRIPT="$PWD/home-manager/services/tokscale/submit.sh"
+setup() {
+  MOCK_BIN=$(mktemp -d)
+  MOCK_ORIGINAL_PATH="$PATH"
+  export PATH="$MOCK_BIN:$PATH"
+  FAKE_HOME=$(mktemp -d)
+  mkdir -p "$FAKE_HOME/.bun/install/global/node_modules/tokscale"
+  touch "$FAKE_HOME/.bun/install/global/node_modules/tokscale/bin.js"
+  cat >"$MOCK_BIN/bun" <<'EOF'
+#!/usr/bin/env bash
+echo 'actual Tokscale failure' >&2
+exit 42
+EOF
+  chmod +x "$MOCK_BIN/bun"
+}
+
+cleanup() {
+  export PATH="$MOCK_ORIGINAL_PATH"
+  rm -rf "$MOCK_BIN" "$FAKE_HOME"
+}
+
+Before 'setup'
+After 'cleanup'
+
+It 'propagates the real Tokscale exit status'
+When run env HOME="$FAKE_HOME" bash "$SCRIPT"
+The stderr should include 'actual Tokscale failure'
+The status should be failure
+End
+End
+
 Describe 'tokscale service schedule'
 CONFIG="$PWD/home-manager/services/tokscale/default.nix"
 
@@ -103,6 +104,16 @@ It 'maps the fixed hours to launchd calendar intervals at minute zero'
 When run bash -c "grep -A4 -F 'StartCalendarInterval = map' '$CONFIG'"
 The output should include 'Hour = hour;'
 The output should include 'Minute = 0;'
+End
+
+It 'sets the macOS PATH through the launchd environment key'
+When run bash -c "grep -F 'EnvironmentVariables = {' '$CONFIG'"
+The output should include 'EnvironmentVariables'
+End
+
+It 'does not use the ignored Environment key'
+When run bash -c "grep -F 'Environment = {' '$CONFIG'"
+The status should be failure
 End
 
 It 'does not use a load-relative interval on macOS'


### PR DESCRIPTION
Tokscale's launchd job now runs the real submission once and preserves its exit status.

The agent used `Environment`, which launchd ignores, so its Nix `PATH` never loaded. The wrapper then treated any failure of an unrelated `1.1.1.1:53` probe as an offline machine and returned 0, hiding skipped submissions.

This switches the plist to `EnvironmentVariables`, removes the external preflight, and adds regression coverage for the launchd key and real submission failures.

## Validation

- `make build`
- `shellcheck home-manager/services/tokscale/submit.sh spec/tokscale_spec.sh`
- `shellspec spec/tokscale_spec.sh` — 17 examples, 0 failures
- Live launchd kickstart — exit 0 with Tokscale's success marker

The aggregate shell test also ran all 1,819 ShellSpec examples successfully. Its separate Fish suite still has unrelated existing CAAM and command-wrapper expectation failures.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the real Tokscale submission exit status and fixes PATH loading in the macOS launchd job. Also adds regression tests to prevent regressions.

- **Bug Fixes**
  - Use launchd `EnvironmentVariables` instead of `Environment` so `PATH` includes Nix binaries.
  - Remove the `1.1.1.1:53` network probe; do not mask failures by exiting 0 on probe errors.
  - Propagate the actual `tokscale`/`bun` exit code from the submission.
  - Add ShellSpec coverage for the env key, no network gate, and failure propagation.

<sup>Written for commit 1ff72913b0435ded52dd89f3ddb1d4da2dd9edc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

