### PR TITLE
fix(fish): load prechecked Codex profile

### DIFF
--- a/home-manager/programs/fish/functions/_caam_exec_function.fish
+++ b/home-manager/programs/fish/functions/_caam_exec_function.fish
@@ -8,6 +8,20 @@ function _caam_exec_function --description "Run an agent launcher through CAAM w
   end
 
   if test "$CAAM_ROTATION_ENABLED" = "1"; and type -q caam
+    if test "$tool" = codex; and type -q jq
+      set -l precheck (caam precheck codex --format json)
+      if test $status -eq 0
+        set -l profile (string join \n $precheck | jq -r '.recommended.name // empty')
+        if test -n "$profile"
+          caam exec codex "$profile" -- $argv
+          return $status
+        end
+      end
+
+      $executable $argv
+      return $status
+    end
+
     caam run $tool --precheck -- $argv
   else
     $executable $argv

--- a/spec/fish/_caam_exec_function_test.fish
+++ b/spec/fish/_caam_exec_function_test.fish
@@ -9,16 +9,27 @@ _caam_exec_function codex exec hello
 @test "runs the native executable when rotation is disabled" (cat $direct_log) = "exec hello"
 
 set caam_log (mktemp)
-function caam; echo $argv >> $caam_log; end
+function caam
+  echo $argv >> $caam_log
+  if test "$argv[1]" = precheck
+    echo '{"recommended":{"name":"work@example.com"}}'
+  end
+end
 set -gx CAAM_ROTATION_ENABLED 1
 
 _caam_exec_function codex exec hello
 
-@test "routes through caam precheck when rotation is enabled" (cat $caam_log) = "run codex --precheck -- exec hello"
+@test "prechecks codex when rotation is enabled" (head -n 1 $caam_log) = "precheck codex --format json"
+@test "executes the recommended isolated codex profile" (tail -n 1 $caam_log) = "exec codex work@example.com -- exec hello"
 
 _caam_exec_function cursor-agent --print hello
 
 @test "maps cursor-agent to the cursor profile" (tail -n 1 $caam_log) = "run cursor --precheck -- --print hello"
+
+function caam; return 1; end
+_caam_exec_function codex exec fallback
+
+@test "falls back to native codex when precheck fails" (tail -n 1 $direct_log) = "exec fallback"
 
 set -e CAAM_ROTATION_ENABLED
 rm -f $direct_log $caam_log


### PR DESCRIPTION
## Summary
- run Codex through `caam precheck` before launch
- execute the recommended isolated profile with `caam exec`
- fall back to native Codex if precheck cannot select a profile
- preserve the existing CAAM runner for Cursor and other tools

## Validation
- `env -u CAAM_ROTATION_ENABLED make fish-test` (433 passing)
- `git diff --check`
- live Matic inspection confirms Cursor lacks reliable quota/health precheck data and Grok lacks managed profiles

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route `codex` through `caam precheck` and run the recommended isolated profile via `caam exec` to improve reliability. Fall back to native `codex` if precheck fails; keep the existing CAAM flow for `cursor-agent` and other tools.

- **Bug Fixes**
  - Prechecks `codex` with `caam precheck codex --format json` and uses `jq` to read `.recommended.name`.
  - Executes `caam exec codex <profile> -- ...`; falls back to native `codex` when no profile is available or precheck fails.
  - Leaves `cursor-agent` and others on `caam run --precheck`; adds tests for precheck, exec, and fallback.

<sup>Written for commit 1935a9ade09441ec6643441ceae3b82f74eb0a2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

