### PR TITLE
fix(caam): rotate isolated Cursor profiles

### DIFF
--- a/config/caam/hydrate.sh
+++ b/config/caam/hydrate.sh
@@ -15,4 +15,37 @@ mkdir -p "$CONFIG_DIR"
   "$TEMPLATE" >"$TMP_FILE"
 install -m 0600 "$TMP_FILE" "$CONFIG_FILE"
 
+bridge_cursor_auth() {
+  local source_auth="$1"
+  local target_auth="$2"
+
+  [[ -f $source_auth ]] || return 0
+  mkdir -p "$(dirname "$target_auth")"
+
+  if [[ -e $target_auth && ! -L $target_auth ]]; then
+    if ! cmp -s "$source_auth" "$target_auth"; then
+      echo "Preserving conflicting Cursor auth file at $target_auth" >&2
+      return 0
+    fi
+    rm -f "$target_auth"
+  fi
+
+  ln -sfn ../../.cursor/auth.json "$target_auth"
+}
+
+# Cursor Agent reads the XDG path while CAAM manages ~/.cursor/auth.json.
+# Bridge both the global credential and every isolated CAAM Cursor home without
+# copying credential contents into dotfiles.
+bridge_cursor_auth \
+  "$HOME/.cursor/auth.json" \
+  "$HOME/.config/cursor/auth.json"
+
+shopt -s nullglob
+for profile_dir in "$HOME/.local/share/caam/profiles/cursor"/*; do
+  profile_home="$profile_dir/home"
+  bridge_cursor_auth \
+    "$profile_home/.cursor/auth.json" \
+    "$profile_home/.config/cursor/auth.json"
+done
+
 echo "Hydrated CAAM config at $CONFIG_FILE" >&2

--- a/config/cursor/default.nix
+++ b/config/cursor/default.nix
@@ -5,6 +5,13 @@
   ...
 }:
 {
+  # CAAM invokes Cursor by its canonical provider name. Headless Linux hosts
+  # only install Cursor Agent, so expose it at that canonical path.
+  home.file.".local/bin/cursor" = lib.mkIf pkgs.stdenv.isLinux {
+    source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.local/bin/cursor-agent";
+    force = true;
+  };
+
   # Use activation script instead of symlink
   # git-ai install-hooks needs write access, which breaks with Nix store symlinks
   home.activation.cursorHooks = config.lib.dag.entryAfter [ "writeBoundary" ] ''

--- a/home-manager/programs/fish/functions/_caam_exec_function.fish
+++ b/home-manager/programs/fish/functions/_caam_exec_function.fish
@@ -8,12 +8,12 @@ function _caam_exec_function --description "Run an agent launcher through CAAM w
   end
 
   if test "$CAAM_ROTATION_ENABLED" = "1"; and type -q caam
-    if test "$tool" = codex; and type -q jq
-      set -l precheck (caam precheck codex --format json)
+    if contains -- "$tool" codex cursor; and type -q jq
+      set -l precheck (caam precheck "$tool" --format json)
       if test $status -eq 0
         set -l profile (string join \n $precheck | jq -r '.recommended.name // empty')
         if test -n "$profile"
-          caam exec codex "$profile" -- $argv
+          caam exec "$tool" "$profile" -- $argv
           return $status
         end
       end

--- a/spec/caam_config_spec.sh
+++ b/spec/caam_config_spec.sh
@@ -8,6 +8,7 @@ TEMPLATE="$PWD/config/caam/config.template.yaml"
 FISH_NIX="$PWD/home-manager/programs/fish/default.nix"
 BASH_NIX="$PWD/home-manager/programs/bash/default.nix"
 ZSH_NIX="$PWD/home-manager/programs/zsh/default.nix"
+CURSOR_NIX="$PWD/config/cursor/default.nix"
 
 It 'is imported by the shared config module'
 When run grep -F './caam' "$PWD/config/default.nix"
@@ -40,6 +41,12 @@ End
 It 'does not manage credential vault data'
 When run grep -E 'home\.file.*vault|xdg\.dataFile.*caam' "$DEFAULT_NIX"
 The status should be failure
+End
+
+It 'exposes cursor-agent as cursor on headless Linux hosts'
+When run cat "$CURSOR_NIX"
+The output should include 'pkgs.stdenv.isLinux'
+The output should include '.local/bin/cursor-agent'
 End
 
 Describe 'hydrate.sh'
@@ -78,6 +85,24 @@ End
 It 'restricts config file permissions to the owner'
 When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; stat -c "%a" "'"$TEMP_HOME"'/.caam/config.yaml" 2>/dev/null || stat -f "%OLp" "'"$TEMP_HOME"'/.caam/config.yaml"'
 The output should eq '600'
+End
+
+It 'bridges global Cursor auth to the XDG path'
+When run bash -c 'mkdir -p "'"$TEMP_HOME"'/.cursor"; touch "'"$TEMP_HOME"'/.cursor/auth.json"; HOME="'"$TEMP_HOME"'" bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; readlink "'"$TEMP_HOME"'/.config/cursor/auth.json"'
+The status should be success
+The output should eq '../../.cursor/auth.json'
+End
+
+It 'bridges isolated Cursor profile auth to the XDG path'
+When run bash -c 'profile_home="'"$TEMP_HOME"'/.local/share/caam/profiles/cursor/work/home"; mkdir -p "$profile_home/.cursor"; touch "$profile_home/.cursor/auth.json"; HOME="'"$TEMP_HOME"'" bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; readlink "$profile_home/.config/cursor/auth.json"'
+The status should be success
+The output should eq '../../.cursor/auth.json'
+End
+
+It 'preserves a conflicting Cursor XDG credential'
+When run bash -c 'mkdir -p "'"$TEMP_HOME"'/.cursor" "'"$TEMP_HOME"'/.config/cursor"; printf source >"'"$TEMP_HOME"'/.cursor/auth.json"; printf target >"'"$TEMP_HOME"'/.config/cursor/auth.json"; HOME="'"$TEMP_HOME"'" bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; cat "'"$TEMP_HOME"'/.config/cursor/auth.json"'
+The status should be success
+The output should eq 'target'
 End
 End
 End

--- a/spec/fish/_caam_exec_function_test.fish
+++ b/spec/fish/_caam_exec_function_test.fish
@@ -24,7 +24,8 @@ _caam_exec_function codex exec hello
 
 _caam_exec_function cursor-agent --print hello
 
-@test "maps cursor-agent to the cursor profile" (tail -n 1 $caam_log) = "run cursor --precheck -- --print hello"
+@test "prechecks cursor-agent as cursor" (tail -n 2 $caam_log | head -n 1) = "precheck cursor --format json"
+@test "executes the recommended isolated cursor profile" (tail -n 1 $caam_log) = "exec cursor work@example.com -- --print hello"
 
 function caam; return 1; end
 _caam_exec_function codex exec fallback


### PR DESCRIPTION
## Summary
- select Cursor profiles with `caam precheck` and launch them with `caam exec`
- declaratively expose `cursor-agent` as `cursor` on headless Linux
- bridge CAAM global and isolated Cursor auth files to Cursor Agent XDG paths
- preserve conflicting runtime credential files instead of overwriting them

## Validation
- `env -u CAAM_ROTATION_ENABLED make fish-test` (434 passing)
- `shellspec spec/caam_config_spec.sh` (13 passing)
- `shellcheck config/caam/hydrate.sh`
- `make nix-format-check`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable automatic rotation of isolated `cursor` profiles via CAAM using `caam precheck` and `caam exec`. Bridges Cursor auth to XDG paths and exposes `cursor-agent` as `cursor` on headless Linux while preserving existing credentials.

- **New Features**
  - Fish: precheck/exec now supports `cursor` (maps `cursor-agent` to `cursor`) and runs the recommended isolated profile when available.
  - Hydration: symlinks `.config/cursor/auth.json` to `~/.cursor/auth.json` for both global and per-profile homes; preserves conflicting XDG credentials instead of overwriting.
  - Nix: exposes `cursor-agent` as `cursor` on Linux via `~/.local/bin/cursor` symlink.

<sup>Written for commit 337185fef150f768a258c0db67c58da9ed3a0e58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

