### PR TITLE
fix(caam): load prechecked OpenCode profile

### DIFF
--- a/home-manager/programs/fish/functions/_caam_exec_function.fish
+++ b/home-manager/programs/fish/functions/_caam_exec_function.fish
@@ -8,7 +8,7 @@ function _caam_exec_function --description "Run an agent launcher through CAAM w
   end
 
   if test "$CAAM_ROTATION_ENABLED" = "1"; and type -q caam
-    if contains -- "$tool" codex cursor; and type -q jq
+    if contains -- "$tool" codex cursor opencode; and type -q jq
       set -l precheck (caam precheck "$tool" --format json)
       if test $status -eq 0
         set -l profile (string join \n $precheck | jq -r '.recommended.name // empty')

--- a/spec/fish/_caam_exec_function_test.fish
+++ b/spec/fish/_caam_exec_function_test.fish
@@ -27,6 +27,11 @@ _caam_exec_function cursor-agent --print hello
 @test "prechecks cursor-agent as cursor" (tail -n 2 $caam_log | head -n 1) = "precheck cursor --format json"
 @test "executes the recommended isolated cursor profile" (tail -n 1 $caam_log) = "exec cursor work@example.com -- --print hello"
 
+_caam_exec_function opencode run hello
+
+@test "prechecks opencode when rotation is enabled" (tail -n 2 $caam_log | head -n 1) = "precheck opencode --format json"
+@test "executes the recommended isolated opencode profile" (tail -n 1 $caam_log) = "exec opencode work@example.com -- run hello"
+
 function caam; return 1; end
 _caam_exec_function codex exec fallback
 


### PR DESCRIPTION
## Summary
- route OpenCode launchers through CAAM precheck and isolated profile execution
- preserve the native executable fallback when precheck fails
- cover OpenCode routing in the Fish launcher test

## CAAM native support
- OpenCode auth-file vault backup/restore and isolated `auth import`/`exec` are supported
- OpenCode real-time quota fetching and provider-specific mid-session handoff are not currently supported

## Validation
- `make fish-test`: new OpenCode tests pass; suite reports 13 unrelated existing Grok launcher failures
- isolated `caam exec opencode shunkakinoki@gmail.com -- auth list` succeeds on Galactica, Kyber, and Matic
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
OpenCode launchers now run through CAAM rotation precheck and use the recommended isolated profile. Native execution fallback remains when precheck fails.

- **Bug Fixes**
  - Include `opencode` in the `caam` precheck gate in `_caam_exec_function.fish`, enabling isolated `exec`.
  - Add Fish tests to verify OpenCode precheck and isolated execution.

<sup>Written for commit f8452b17f3ff7e12ac828fbc11f5652eda9584d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

