### PR TITLE
fix(caam): share OpenCode provider config

### DIFF
--- a/home-manager/programs/fish/functions/_caam_exec_function.fish
+++ b/home-manager/programs/fish/functions/_caam_exec_function.fish
@@ -13,6 +13,12 @@ function _caam_exec_function --description "Run an agent launcher through CAAM w
       if test $status -eq 0
         set -l profile (string join \n $precheck | jq -r '.recommended.name // empty')
         if test -n "$profile"
+          # OpenCode keeps credentials under XDG_DATA_HOME but its declarative
+          # providers and plugins under XDG_CONFIG_HOME. Share only the real
+          # host config while CAAM keeps the profile's data and auth isolated.
+          if test "$tool" = opencode; and test -z "$XDG_CONFIG_HOME"
+            set -fx XDG_CONFIG_HOME "$HOME/.config"
+          end
           caam exec "$tool" "$profile" -- $argv
           return $status
         end

--- a/spec/fish/_caam_exec_function_test.fish
+++ b/spec/fish/_caam_exec_function_test.fish
@@ -1,5 +1,6 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
 source $fn/_caam_exec_function.fish
+set -e CAAM_ROTATION_ENABLED
 
 set direct_log (mktemp)
 function codex; echo $argv >> $direct_log; end
@@ -9,10 +10,13 @@ _caam_exec_function codex exec hello
 @test "runs the native executable when rotation is disabled" (cat $direct_log) = "exec hello"
 
 set caam_log (mktemp)
+set xdg_log (mktemp)
 function caam
   echo $argv >> $caam_log
   if test "$argv[1]" = precheck
     echo '{"recommended":{"name":"work@example.com"}}'
+  else if test "$argv[1]" = exec
+    echo "$XDG_CONFIG_HOME" >> $xdg_log
   end
 end
 set -gx CAAM_ROTATION_ENABLED 1
@@ -31,6 +35,7 @@ _caam_exec_function opencode run hello
 
 @test "prechecks opencode when rotation is enabled" (tail -n 2 $caam_log | head -n 1) = "precheck opencode --format json"
 @test "executes the recommended isolated opencode profile" (tail -n 1 $caam_log) = "exec opencode work@example.com -- run hello"
+@test "shares the host XDG config with isolated opencode" (tail -n 1 $xdg_log) = "$HOME/.config"
 
 function caam; return 1; end
 _caam_exec_function codex exec fallback
@@ -38,4 +43,4 @@ _caam_exec_function codex exec fallback
 @test "falls back to native codex when precheck fails" (tail -n 1 $direct_log) = "exec fallback"
 
 set -e CAAM_ROTATION_ENABLED
-rm -f $direct_log $caam_log
+rm -f $direct_log $caam_log $xdg_log


### PR DESCRIPTION
## Summary
- export the host XDG config only while launching isolated OpenCode profiles
- keep OpenCode auth and mutable data isolated under the CAAM profile home
- make the Fish launcher test deterministic when rotation is globally enabled

## Root cause
CAAM isolates OpenCode by replacing `HOME`. That correctly isolates `~/.local/share/opencode/auth.json`, but it also hid the Nix-managed `~/.config/opencode/opencode.jsonc`, so remote launchers could not resolve the `cliproxyapi` provider.

## Validation
- focused fishtape: 9/9 pass
- pre-fix remote proof: `Provider not found: cliproxyapi` on Kyber and Matic
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share the host OpenCode config with CAAM-isolated profiles so remote launchers can resolve the `cliproxyapi` provider, while keeping auth and mutable data isolated. Also makes the Fish launcher test deterministic.

- **Bug Fixes**
  - When rotation is enabled and running `opencode`, set `XDG_CONFIG_HOME` to `$HOME/.config` (if unset) before `caam exec`. This preserves provider/plugin config from the host and fixes “Provider not found: cliproxyapi”.
  - Tests: unset `CAAM_ROTATION_ENABLED` to avoid global interference and assert the shared `XDG_CONFIG_HOME`.

<sup>Written for commit 70c9090f54f096efc87689a32af9d1ae74747545. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

