### PR TITLE
fix(caam): snapshot Claude credentials on session end

### DIFF
--- a/config/claude/default.nix
+++ b/config/claude/default.nix
@@ -17,6 +17,12 @@
     force = true;
   };
 
+  home.file.".claude/hooks/caam-snapshot.sh" = {
+    source = ./hooks/caam-snapshot.sh;
+    executable = true;
+    force = true;
+  };
+
   home.file.".claude/hooks/pushover.sh" = {
     source = ./hooks/pushover.sh;
     executable = true;

--- a/config/claude/hooks/caam-snapshot.sh
+++ b/config/claude/hooks/caam-snapshot.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Preserve Claude's rotated OAuth credential in the matching local CAAM profile.
+# SessionEnd hooks are best-effort: authentication and CAAM failures must never
+# prevent Claude from exiting.
+
+set -u
+
+# Consume the hook payload even though the authenticated identity is read from
+# Claude's credential store rather than inferred from session metadata.
+cat >/dev/null
+
+for command_name in caam claude jq; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    exit 0
+  fi
+done
+
+AUTH_STATUS=$(claude auth status --json 2>/dev/null) || exit 0
+EMAIL=$(printf '%s' "$AUTH_STATUS" | jq -r '
+  if .loggedIn == true then (.email // empty) else empty end
+' 2>/dev/null) || exit 0
+
+# Only update an existing email-named profile. This prevents a malformed or
+# unauthenticated status response from creating a new vault entry.
+case "$EMAIL" in
+*@*.*) ;;
+*) exit 0 ;;
+esac
+
+if ! caam ls claude --json 2>/dev/null | jq -e --arg email "$EMAIL" '
+  any(.profiles[]?; .name == $email)
+' >/dev/null 2>&1; then
+  exit 0
+fi
+
+caam backup claude "$EMAIL" >/dev/null 2>&1 || true
+exit 0

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -373,6 +373,16 @@
             "type": "command"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "async": false,
+            "command": "$HOME/.claude/hooks/caam-snapshot.sh",
+            "timeout": 10,
+            "type": "command"
+          }
+        ]
       }
     ],
     "SessionStart": [

--- a/spec/caam_snapshot_spec.sh
+++ b/spec/caam_snapshot_spec.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329,SC2016,SC2089,SC2090
+
+Describe 'Claude CAAM session snapshot hook'
+SCRIPT="$PWD/config/claude/hooks/caam-snapshot.sh"
+DEFAULT_NIX="$PWD/config/claude/default.nix"
+SETTINGS="$PWD/config/claude/settings.json"
+
+setup() {
+  MOCK_BIN=$(mktemp -d)
+  MOCK_LOG="$MOCK_BIN/mock.log"
+  ORIGINAL_PATH=${PATH:-}
+  export MOCK_BIN MOCK_LOG ORIGINAL_PATH
+  export PATH="$MOCK_BIN:$ORIGINAL_PATH"
+  : >"$MOCK_LOG"
+
+  cat >"$MOCK_BIN/claude" <<'EOF'
+#!/usr/bin/env bash
+if [[ -n ${CLAUDE_AUTH_STATUS:-} ]]; then
+  printf '%s\n' "$CLAUDE_AUTH_STATUS"
+else
+  printf '%s\n' '{"loggedIn":false}'
+fi
+EOF
+  cat >"$MOCK_BIN/caam" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$MOCK_LOG"
+if [[ "$1 $2 $3" == "ls claude --json" ]]; then
+  if [[ -n ${CAAM_PROFILES:-} ]]; then
+    printf '%s\n' "$CAAM_PROFILES"
+  else
+    printf '%s\n' '{"profiles":[]}'
+  fi
+fi
+if [[ "$1 $2" == "backup claude" ]]; then
+  exit "${CAAM_BACKUP_EXIT_CODE:-0}"
+fi
+exit 0
+EOF
+  chmod +x "$MOCK_BIN/claude" "$MOCK_BIN/caam"
+}
+
+cleanup() {
+  export PATH="$ORIGINAL_PATH"
+  rm -rf "$MOCK_BIN"
+  unset MOCK_BIN MOCK_LOG ORIGINAL_PATH CLAUDE_AUTH_STATUS CAAM_PROFILES CAAM_BACKUP_EXIT_CODE
+}
+
+Before 'setup'
+After 'cleanup'
+
+It 'backs up the authenticated existing email profile'
+CLAUDE_AUTH_STATUS='{"loggedIn":true,"email":"work@example.com"}'
+CAAM_PROFILES='{"profiles":[{"name":"work@example.com"}]}'
+export CLAUDE_AUTH_STATUS CAAM_PROFILES
+When run bash -c 'echo "{\"hook_event_name\":\"SessionEnd\"}" | bash "$1"; cat "$2"' _ "$SCRIPT" "$MOCK_LOG"
+The status should be success
+The output should include 'ls claude --json'
+The output should include 'backup claude work@example.com'
+End
+
+It 'does not create a profile for an unauthenticated session'
+CLAUDE_AUTH_STATUS='{"loggedIn":false,"email":"work@example.com"}'
+export CLAUDE_AUTH_STATUS
+When run bash -c 'echo "{}" | bash "$1"; cat "$2"' _ "$SCRIPT" "$MOCK_LOG"
+The status should be success
+The output should eq ''
+End
+
+It 'does not create an unknown profile'
+CLAUDE_AUTH_STATUS='{"loggedIn":true,"email":"other@example.com"}'
+CAAM_PROFILES='{"profiles":[{"name":"work@example.com"}]}'
+export CLAUDE_AUTH_STATUS CAAM_PROFILES
+When run bash -c 'echo "{}" | bash "$1"; cat "$2"' _ "$SCRIPT" "$MOCK_LOG"
+The status should be success
+The output should include 'ls claude --json'
+The output should not include 'backup claude'
+End
+
+It 'keeps CAAM backup failures non-blocking'
+CLAUDE_AUTH_STATUS='{"loggedIn":true,"email":"work@example.com"}'
+CAAM_PROFILES='{"profiles":[{"name":"work@example.com"}]}'
+CAAM_BACKUP_EXIT_CODE=1
+export CLAUDE_AUTH_STATUS CAAM_PROFILES CAAM_BACKUP_EXIT_CODE
+When run bash -c 'echo "{}" | bash "$1"; cat "$2"' _ "$SCRIPT" "$MOCK_LOG"
+The status should be success
+The output should include 'backup claude work@example.com'
+End
+
+It 'is deployed by Home Manager'
+When run bash -c 'grep -F '\''home.file.".claude/hooks/caam-snapshot.sh"'\'' "$1" >/dev/null' _ "$DEFAULT_NIX"
+The status should be success
+End
+
+It 'is registered as a synchronous SessionEnd hook'
+When run bash -c 'jq -e '\''.hooks.SessionEnd[]?.hooks[]? | select(.command == "$HOME/.claude/hooks/caam-snapshot.sh" and .async == false)'\'' "$1" >/dev/null' _ "$SETTINGS"
+The status should be success
+End
+
+End

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -25,6 +25,10 @@ It 'has spec file for config/claude/hooks/auto-switch.sh'
 The path "spec/auto_switch_spec.sh" should be exist
 End
 
+It 'has spec file for config/claude/hooks/caam-snapshot.sh'
+The path "spec/caam_snapshot_spec.sh" should be exist
+End
+
 It 'has spec file for config/claude/hooks/security.sh'
 The path "spec/security_spec.sh" should be exist
 End
@@ -407,6 +411,7 @@ config/ccs/hydrate.sh
 config/claude/hooks/notify.sh
 config/claude/hooks/pushover.sh
 config/claude/hooks/auto-switch.sh
+config/claude/hooks/caam-snapshot.sh
 config/claude/hooks/security.sh
 config/claude/hooks/atuin-history.sh
 config/claude/hooks/statusline.sh


### PR DESCRIPTION
## Summary
- deploy a synchronous Claude SessionEnd hook that snapshots refreshed credentials into CAAM
- update only the matching existing email profile and keep shutdown failures non-blocking
- add focused hook and declarative wiring coverage

## Validation
- `shellcheck config/claude/hooks/caam-snapshot.sh spec/caam_snapshot_spec.sh`
- `shellspec spec/caam_snapshot_spec.sh spec/auto_switch_spec.sh spec/activate_config_spec.sh spec/coverage_spec.sh` (170 examples, 0 failures)
- `make build`
- full ShellSpec: 1839 examples, 0 failures; full Fish suite retains 14 unrelated baseline failures (13 Grok mock expectations and 1 OpenCode XDG path assertion)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Snapshots refreshed Claude OAuth credentials into CAAM when a Claude session ends. Updates only an existing email-matched profile and never blocks logout.

- **Bug Fixes**
  - Added synchronous SessionEnd hook `$HOME/.claude/hooks/caam-snapshot.sh` to back up `claude` credentials to `caam` with safeguards: require `claude`/`caam`/`jq`, read `claude auth status`, update only if the profile exists, ignore failures.
  - Wired via Home Manager (`config/claude/default.nix`) and registered in `config/claude/settings.json` with `async:false` and a 10s timeout; added `spec/caam_snapshot_spec.sh` and coverage updates.

<sup>Written for commit f9e3605761542b0530c700e1cbe97819e1bfe0dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

