### PR TITLE
feat(ai): use DeepSeek V4 defaults

### DIFF
--- a/config/omp/config.tpl.yml
+++ b/config/omp/config.tpl.yml
@@ -64,7 +64,7 @@ disabledExtensions: []
 #   slow:    openai-codex/gpt-5.3-codex:high
 modelRoles:
   # Default model role used as the fallback when no other role is selected.
-  default: "openai-codex/__GPT__"
+  default: "opencode-zen/__DEEPSEEK_PRO__"
   # Smaller / dumber model for cheap lightweight work.
   smol: "openai-codex/__GPT_MINI__"
   # Strongest model in the suite for hard tasks.

--- a/config/omp/config.yml
+++ b/config/omp/config.yml
@@ -64,7 +64,7 @@ disabledExtensions: []
 #   slow:    openai-codex/gpt-5.3-codex:high
 modelRoles:
   # Default model role used as the fallback when no other role is selected.
-  default: "openai-codex/gpt-5.6-sol"
+  default: "opencode-zen/deepseek-v4-pro"
   # Smaller / dumber model for cheap lightweight work.
   smol: "openai-codex/gpt-5.4-mini"
   # Strongest model in the suite for hard tasks.

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "xai/grok-4.5",
+  "model": "opencode/deepseek-v4-flash",
   "small_model": "cliproxyapi/glm-4.7",
   "autoupdate": true,
   "agent": {

--- a/config/opencode/opencode.tpl.jsonc
+++ b/config/opencode/opencode.tpl.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "xai/__GROK__",
+  "model": "opencode/__DEEPSEEK_FLASH__",
   "small_model": "cliproxyapi/__GLM__",
   "autoupdate": true,
   "agent": {

--- a/home-manager/programs/fish/functions/_ocxe_function.fish
+++ b/home-manager/programs/fish/functions/_ocxe_function.fish
@@ -4,14 +4,14 @@ function _ocxe_function --description "Run OpenCode with a free-form prompt"
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
     if test (count $argv) -gt 1
-      _caam_exec_function opencode -m 'cliproxyapi/glm-4.7' --session "$argv[2]"
+      _caam_exec_function opencode -m 'opencode/deepseek-v4-flash' --session "$argv[2]"
     else
-      _caam_exec_function opencode -m 'cliproxyapi/glm-4.7' --continue
+      _caam_exec_function opencode -m 'opencode/deepseek-v4-flash' --continue
     end
   else if test (count $argv) -eq 0
-    _caam_exec_function opencode -m 'cliproxyapi/glm-4.7'
+    _caam_exec_function opencode -m 'opencode/deepseek-v4-flash'
   else
     set -l prompt (string join " " -- $argv)
-    _caam_exec_function opencode run "$prompt" -m 'cliproxyapi/glm-4.7'
+    _caam_exec_function opencode run "$prompt" -m 'opencode/deepseek-v4-flash'
   end
 end

--- a/home-manager/programs/fish/functions/_ocxe_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_ocxe_function.tpl.fish
@@ -4,14 +4,14 @@ function _ocxe_function --description "Run OpenCode with a free-form prompt"
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
     if test (count $argv) -gt 1
-      _caam_exec_function opencode -m 'cliproxyapi/__GLM__' --session "$argv[2]"
+      _caam_exec_function opencode -m 'opencode/__DEEPSEEK_FLASH__' --session "$argv[2]"
     else
-      _caam_exec_function opencode -m 'cliproxyapi/__GLM__' --continue
+      _caam_exec_function opencode -m 'opencode/__DEEPSEEK_FLASH__' --continue
     end
   else if test (count $argv) -eq 0
-    _caam_exec_function opencode -m 'cliproxyapi/__GLM__'
+    _caam_exec_function opencode -m 'opencode/__DEEPSEEK_FLASH__'
   else
     set -l prompt (string join " " -- $argv)
-    _caam_exec_function opencode run "$prompt" -m 'cliproxyapi/__GLM__'
+    _caam_exec_function opencode run "$prompt" -m 'opencode/__DEEPSEEK_FLASH__'
   end
 end

--- a/home-manager/programs/fish/functions/_ocxeh_function.fish
+++ b/home-manager/programs/fish/functions/_ocxeh_function.fish
@@ -14,5 +14,5 @@ function _ocxeh_function --description "Run OpenCode headlessly with a prompted 
     return 1
   end
 
-  _caam_exec_function opencode run "$prompt" -m 'cliproxyapi/glm-4.7'
+  _caam_exec_function opencode run "$prompt" -m 'opencode/deepseek-v4-flash'
 end

--- a/home-manager/programs/fish/functions/_ocxeh_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_ocxeh_function.tpl.fish
@@ -14,5 +14,5 @@ function _ocxeh_function --description "Run OpenCode headlessly with a prompted 
     return 1
   end
 
-  _caam_exec_function opencode run "$prompt" -m 'cliproxyapi/__GLM__'
+  _caam_exec_function opencode run "$prompt" -m 'opencode/__DEEPSEEK_FLASH__'
 end

--- a/models.json
+++ b/models.json
@@ -10,6 +10,8 @@
   "gpt-nano": "gpt-5.4-nano",
   "gemini-pro": "gemini-3.1-pro-preview",
   "gemini-flash": "gemini-3.6-flash",
+  "deepseek-flash": "deepseek-v4-flash",
+  "deepseek-pro": "deepseek-v4-pro",
   "grok": "grok-4.5",
   "glm": "glm-4.7",
   "minimax": "minimax-m3",

--- a/spec/fish/_ocxe_function.tpl_test.fish
+++ b/spec/fish/_ocxe_function.tpl_test.fish
@@ -8,7 +8,7 @@ function opencode; echo $argv >> $log1; end
 
 _ocxe_function
 
-@test "no args calls opencode with templated model" (grep -c "cliproxyapi/__GLM__" $log1) -ge 1
+@test "no args calls opencode with templated model" (grep -c "opencode/__DEEPSEEK_FLASH__" $log1) -ge 1
 @test "no args skips run subcommand" (grep -c "^run " $log1) -eq 0
 
 # ── with args: run mode ──────────────────────────────────

--- a/spec/fish/_ocxe_function_test.fish
+++ b/spec/fish/_ocxe_function_test.fish
@@ -8,7 +8,7 @@ function opencode; echo $argv >> $log1; end
 
 _ocxe_function
 
-@test "no args calls opencode with model" (grep -c "cliproxyapi/glm-4.7" $log1) -ge 1
+@test "no args calls opencode with model" (grep -c "opencode/deepseek-v4-flash" $log1) -ge 1
 @test "no args skips run subcommand" (grep -c "^run " $log1) -eq 0
 
 # ── with args: run mode ──────────────────────────────────

--- a/spec/fish/_ocxeh_function.tpl_test.fish
+++ b/spec/fish/_ocxeh_function.tpl_test.fish
@@ -12,5 +12,6 @@ _ocxeh_function hello world
 
 @test "inline args forwards prompt" (grep -c "hello world" $log1) -ge 1
 @test "inline args uses run subcommand" (grep -c "^run " $log1) -ge 1
+@test "inline args uses templated DeepSeek Flash model" (grep -c "opencode/__DEEPSEEK_FLASH__" $log1) -ge 1
 
 rm -f $log1

--- a/spec/fish/_ocxeh_function_test.fish
+++ b/spec/fish/_ocxeh_function_test.fish
@@ -12,5 +12,6 @@ _ocxeh_function hello world
 
 @test "inline args forwards prompt" (grep -c "hello world" $log1) -ge 1
 @test "inline args uses run subcommand" (grep -c "^run " $log1) -ge 1
+@test "inline args uses DeepSeek Flash model" (grep -c "opencode/deepseek-v4-flash" $log1) -ge 1
 
 rm -f $log1

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -97,6 +97,18 @@ The status should be success
 End
 End
 
+Describe 'DeepSeek defaults'
+It 'generates the OpenCode Flash default'
+When run bash -c "grep '\"model\": \"opencode/deepseek-v4-flash\"' config/opencode/opencode.jsonc"
+The output should include 'opencode/deepseek-v4-flash'
+End
+
+It 'generates the OMP Pro default role'
+When run bash -c "grep 'default: \"opencode-zen/deepseek-v4-pro\"' config/omp/config.yml"
+The output should include 'opencode-zen/deepseek-v4-pro'
+End
+End
+
 Describe 'jq pretty-printing'
 It 'defines a jq pretty function for model names'
 When run bash -c "grep 'def pretty' '$SCRIPT'"


### PR DESCRIPTION
## Summary
- add canonical DeepSeek V4 Flash and Pro entries to `models.json`
- make `opencode/deepseek-v4-flash` the OpenCode config and CAAM-backed launcher default
- make `opencode-zen/deepseek-v4-pro` the OMP default role
- regenerate committed outputs and cover both defaults in tests

## Validation
- `make llm-update` (idempotent)
- `shellspec spec/llm_update_spec.sh` (59 examples, 0 failures)
- focused fishtape suite for `ocxe`/`ocxeh` (18 tests, 0 failures)
- provider catalog checks resolve both model IDs

## Baseline note
- full `make fish-test` still has 14 unrelated Grok-wrapper failures and one existing temporary-path normalization failure; all changed OpenCode tests pass in that run.

Refs shunkakinokisoftware-bm3l

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches defaults to DeepSeek V4: OpenCode launchers now use `opencode/deepseek-v4-flash`, and OMP’s default role is `opencode-zen/deepseek-v4-pro`. Adds canonical DeepSeek entries and updates tests to assert the new defaults.

- **New Features**
  - Added `deepseek-flash` and `deepseek-pro` aliases to `models.json`.
  - Set OpenCode/CAAM default to `opencode/deepseek-v4-flash` in `opencode.jsonc`, templates, and Fish launchers.
  - Set OMP `modelRoles.default` to `opencode-zen/deepseek-v4-pro` in `config.yml` and template.
  - Regenerated committed outputs and updated tests (Fish and `llm_update`) to cover both defaults.

<sup>Written for commit 7a6b420755f029e0199359d7f1e4dcde29e12f1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

