### PR TITLE
fix(caam): resolve Claude snapshot hook from PATH

### DIFF
--- a/config/claude/default.nix
+++ b/config/claude/default.nix
@@ -4,7 +4,16 @@
   pkgs,
   ...
 }:
+let
+  caamClaudeSnapshot = pkgs.writeShellScriptBin "caam-claude-snapshot" (
+    builtins.readFile ./hooks/caam-snapshot.sh
+  );
+in
 {
+  # CAAM isolates HOME for each profile, so hooks invoked by a CAAM-launched
+  # Claude session must resolve from PATH rather than ~/.claude/hooks.
+  home.packages = [ caamClaudeSnapshot ];
+
   # Use activation script for settings.json instead of symlink
   # git-ai install-hooks needs write access, which breaks with Nix store symlinks
   home.activation.claudeConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
@@ -13,12 +22,6 @@
 
   home.file.".claude/hooks/auto-switch.sh" = {
     source = ./hooks/auto-switch.sh;
-    executable = true;
-    force = true;
-  };
-
-  home.file.".claude/hooks/caam-snapshot.sh" = {
-    source = ./hooks/caam-snapshot.sh;
     executable = true;
     force = true;
   };

--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -378,7 +378,7 @@
         "hooks": [
           {
             "async": false,
-            "command": "$HOME/.claude/hooks/caam-snapshot.sh",
+            "command": "caam-claude-snapshot",
             "timeout": 10,
             "type": "command"
           }

--- a/spec/caam_snapshot_spec.sh
+++ b/spec/caam_snapshot_spec.sh
@@ -87,13 +87,13 @@ The status should be success
 The output should include 'backup claude work@example.com'
 End
 
-It 'is deployed by Home Manager'
-When run bash -c 'grep -F '\''home.file.".claude/hooks/caam-snapshot.sh"'\'' "$1" >/dev/null' _ "$DEFAULT_NIX"
+It 'is installed on PATH for CAAM-isolated homes'
+When run bash -c 'grep -F '\''writeShellScriptBin "caam-claude-snapshot"'\'' "$1" >/dev/null && grep -F '\''home.packages = [ caamClaudeSnapshot ];'\'' "$1" >/dev/null' _ "$DEFAULT_NIX"
 The status should be success
 End
 
 It 'is registered as a synchronous SessionEnd hook'
-When run bash -c 'jq -e '\''.hooks.SessionEnd[]?.hooks[]? | select(.command == "$HOME/.claude/hooks/caam-snapshot.sh" and .async == false)'\'' "$1" >/dev/null' _ "$SETTINGS"
+When run bash -c 'jq -e '\''.hooks.SessionEnd[]?.hooks[]? | select(.command == "caam-claude-snapshot" and .async == false)'\'' "$1" >/dev/null' _ "$SETTINGS"
 The status should be success
 End
 


### PR DESCRIPTION
## Summary
- install the Claude CAAM snapshot hook as a Home Manager package
- invoke it by command name so it remains available when CAAM isolates `HOME`
- update focused declarative coverage

## End-to-end finding
CAAM-launched Claude rewrites `HOME` to the selected profile. The original `$HOME/.claude/hooks/caam-snapshot.sh` command therefore resolved inside the isolated profile and failed.

## Validation
- `shellcheck config/claude/hooks/caam-snapshot.sh spec/caam_snapshot_spec.sh`
- focused ShellSpec: 157 examples, 0 failures
- Nix derivation for `caam-claude-snapshot` built successfully as part of `make build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install the Claude session snapshot hook as a Home Manager package and invoke it by command so it still works when CAAM isolates HOME. Fixes snapshot failures by resolving the hook from PATH instead of ~/.claude/hooks.

- **Bug Fixes**
  - Build `caam-claude-snapshot` with `writeShellScriptBin` and add it to `home.packages`.
  - Change SessionEnd hook to call `caam-claude-snapshot` in `settings.json`.
  - Remove the per-user `~/.claude/hooks/caam-snapshot.sh` deployment.

<sup>Written for commit bcd9c9c2d991123d57ac1d9928a5c06190ff53ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

