### PR TITLE
feat(caam): add isolated Claude auth fallback

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -15,6 +15,12 @@
 
       set -gx CAAM_ROTATION_ENABLED 1
 
+      ${lib.optionalString pkgs.stdenv.isDarwin ''
+        # CAAM owns the default Claude login. Use claude-swap only as an isolated
+        # fallback when CAAM definitively reports its recommended profile critical.
+        set -gx CLAUDE_SWAP_FALLBACK_ACCOUNT shunkakinoki@shunkakinoki.com
+      ''}
+
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
       if test (uname) = "Linux"
           set -gx XDG_RUNTIME_DIR /run/user/(id -u)

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -18,7 +18,7 @@
       ${lib.optionalString pkgs.stdenv.isDarwin ''
         # CAAM owns the default Claude login. Use claude-swap only as an isolated
         # fallback when CAAM definitively reports its recommended profile critical.
-        set -gx CLAUDE_SWAP_FALLBACK_ACCOUNT shunkakinoki@shunkakinoki.com
+        set -gx CLAUDE_SWAP_FALLBACK_ACCOUNT shunkakinoki@gmail.com
       ''}
 
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)

--- a/home-manager/programs/fish/functions/_caam_exec_function.fish
+++ b/home-manager/programs/fish/functions/_caam_exec_function.fish
@@ -8,6 +8,27 @@ function _caam_exec_function --description "Run an agent launcher through CAAM w
   end
 
   if test "$CAAM_ROTATION_ENABLED" = "1"; and type -q caam
+    if test "$tool" = claude; and type -q jq
+      set -l precheck (caam precheck "$tool" --format json 2>/dev/null)
+      if test $status -eq 0
+        set -l profile (string join \n $precheck | jq -r '.recommended.name // empty')
+        if test -n "$profile"
+          set -l inventory (caam ls "$tool" --json 2>/dev/null)
+          if test $status -eq 0
+            set -l health (string join \n $inventory | jq -r --arg profile "$profile" \
+              '[.profiles[] | select(.name == $profile and ((.system // false) == false))][0].health.status // "unknown"')
+            if test "$health" = critical; \
+                and set -q CLAUDE_SWAP_FALLBACK_ACCOUNT; \
+                and test -n "$CLAUDE_SWAP_FALLBACK_ACCOUNT"; \
+                and type -q claude-swap
+              claude-swap run "$CLAUDE_SWAP_FALLBACK_ACCOUNT" -- $argv
+              return $status
+            end
+          end
+        end
+      end
+    end
+
     if contains -- "$tool" codex cursor opencode; and type -q jq
       set -l precheck (caam precheck "$tool" --format json)
       if test $status -eq 0

--- a/spec/fish/_caam_exec_function_test.fish
+++ b/spec/fish/_caam_exec_function_test.fish
@@ -42,5 +42,35 @@ _caam_exec_function codex exec fallback
 
 @test "falls back to native codex when precheck fails" (tail -n 1 $direct_log) = "exec fallback"
 
+functions -e caam
+set claude_swap_log (mktemp)
+set -gx MOCK_CLAUDE_HEALTH critical
+set -gx CLAUDE_SWAP_FALLBACK_ACCOUNT fallback@example.com
+function caam
+  echo $argv >> $caam_log
+  if test "$argv[1]" = precheck; and test "$argv[2]" = claude
+    echo '{"recommended":{"name":"primary@example.com"}}'
+  else if test "$argv[1]" = ls; and test "$argv[2]" = claude
+    echo '{"profiles":[{"name":"primary@example.com","system":false,"health":{"status":"'$MOCK_CLAUDE_HEALTH'"}}]}'
+  end
+end
+function claude-swap
+  echo $argv >> $claude_swap_log
+end
+
+_caam_exec_function claude --print fallback
+
+@test "uses isolated claude-swap when CAAM recommends a critical Claude profile" \
+  (cat $claude_swap_log) = "run fallback@example.com -- --print fallback"
+
+set -gx MOCK_CLAUDE_HEALTH healthy
+_caam_exec_function claude --print primary
+
+@test "keeps CAAM authoritative while its recommended Claude profile is usable" \
+  (tail -n 1 $caam_log) = "run claude --precheck -- --print primary"
+@test "does not invoke claude-swap for a healthy CAAM profile" \
+  (count (cat $claude_swap_log)) -eq 1
+
 set -e CAAM_ROTATION_ENABLED
-rm -f $direct_log $caam_log $xdg_log
+set -e CLAUDE_SWAP_FALLBACK_ACCOUNT MOCK_CLAUDE_HEALTH
+rm -f $direct_log $caam_log $xdg_log $claude_swap_log


### PR DESCRIPTION
## Summary
- keep CAAM authoritative for normal Claude authentication
- use `claude-swap run` only when CAAM definitively marks its recommended Claude profile critical
- keep the fallback isolated from the shared default Claude login

## Validation
- focused fishtape assertions for critical and healthy CAAM paths pass
- `make nix-format-check`
- `shellspec spec/caam_config_spec.sh`
- `make nix-test`
- `make build`

The full Fish suite retains unrelated pre-existing Grok shortcut failures and a TMPDIR double-slash assertion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an isolated Claude auth fallback. If CAAM flags the recommended Claude profile as critical, we run `claude-swap` with a fallback; otherwise CAAM keeps handling `claude`.

- **New Features**
  - Fallback triggers only when CAAM’s recommended Claude profile health is `critical`, `CLAUDE_SWAP_FALLBACK_ACCOUNT` is set, and `claude-swap` is available.
  - On macOS, set `CLAUDE_SWAP_FALLBACK_ACCOUNT` to `shunkakinoki@gmail.com` to keep the fallback isolated from the default login.
  - Tests cover both critical and healthy paths to confirm behavior.

<sup>Written for commit 188f2f21a35d850fffd1df2af949f6880adb716d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

