### PR TITLE
fix(caam): make remote Claude sync reliable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,14 @@ sync: dotagents-sync codex-security-sync rtk-rewrite-sync ## Sync all components
 
 .PHONY: dotagents-sync
 dotagents-sync: ## Sync dotagents (commands, skills, MCP configuration).
-	@$(MAKE) -C dotagents sync
+	@status=0; \
+		$(MAKE) -C dotagents sync || status=$$?; \
+		$(SHELL) "$(CURDIR)/config/claude/activate.sh" "$(CURDIR)/config/claude/settings.json"; \
+		exit $$status
+
+.PHONY: caam-sync-claude
+caam-sync-claude: ## Export Galactica's Claude CAAM profiles to Matic and Kyber.
+	@$(SHELL) "$(CURDIR)/config/caam/sync-claude-remotes.sh"
 
 .PHONY: codex-security-sync
 codex-security-sync: ## Sync Codex security deny patterns from Claude settings.

--- a/config/caam/sync-claude-remotes.sh
+++ b/config/caam/sync-claude-remotes.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Bootstrap or recover Claude CAAM vault profiles on managed remote hosts.
+# Galactica is the one-way source; runtime token rotation remains host-local.
+set -euo pipefail
+umask 077
+
+SOURCE_HOST="${CAAM_SYNC_SOURCE_HOST:-${HOSTNAME:-}}"
+TARGETS="${CAAM_SYNC_TARGETS:-matic kyber}"
+PROFILES="${CAAM_SYNC_PROFILES:-shunkakinoki@gmail.com shunkakinoki@shunkakinoki.com}"
+ACTIVE_PROFILE="${CAAM_SYNC_ACTIVE_PROFILE:-shunkakinoki@shunkakinoki.com}"
+VERIFY="${CAAM_SYNC_VERIFY:-0}"
+
+if [[ -z $SOURCE_HOST ]] && command -v scutil >/dev/null 2>&1; then
+  SOURCE_HOST=$(scutil --get LocalHostName 2>/dev/null || true)
+fi
+if [[ -z $SOURCE_HOST ]] && command -v hostname >/dev/null 2>&1; then
+  SOURCE_HOST=$(hostname -s 2>/dev/null || true)
+fi
+SOURCE_HOST=${SOURCE_HOST,,}
+SOURCE_HOST=${SOURCE_HOST%%.*}
+
+if [[ $SOURCE_HOST != galactica ]]; then
+  echo "Refusing CAAM credential export from '$SOURCE_HOST'; run this on Galactica." >&2
+  exit 1
+fi
+
+for command_name in caam claude ssh jq; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Required command not found: $command_name" >&2
+    exit 1
+  fi
+done
+
+AUTH_STATUS=$(claude auth status --json 2>/dev/null || true)
+if ! jq -e --arg active "$ACTIVE_PROFILE" '
+  .loggedIn == true and .email == $active
+' <<<"$AUTH_STATUS" >/dev/null; then
+  echo "Galactica is not logged in to the preferred Claude account: $ACTIVE_PROFILE" >&2
+  echo "Run 'claude auth login --email $ACTIVE_PROFILE', then retry the sync." >&2
+  exit 1
+fi
+
+# Capture the currently provider-validated credential before exporting anything.
+caam backup claude "$ACTIVE_PROFILE" >/dev/null
+
+if ! caam ls claude --json | jq -e --arg active "$ACTIVE_PROFILE" '
+  any(.profiles[]?; .name == $active)
+' >/dev/null; then
+  echo "Active Claude profile is not present in Galactica's CAAM vault: $ACTIVE_PROFILE" >&2
+  exit 1
+fi
+
+ARCHIVE_DIR=$(mktemp -d)
+trap 'rm -rf "$ARCHIVE_DIR"' EXIT
+chmod 0700 "$ARCHIVE_DIR"
+
+for profile in $PROFILES; do
+  if ! caam ls claude --json | jq -e --arg profile "$profile" '
+    any(.profiles[]?; .name == $profile)
+  ' >/dev/null; then
+    echo "Claude profile is not present in Galactica's CAAM vault: $profile" >&2
+    exit 1
+  fi
+
+  archive="$ARCHIVE_DIR/${profile//[^a-zA-Z0-9._-]/_}.tar.gz"
+  caam export "claude/$profile" --output "$archive" >/dev/null
+
+  for target in $TARGETS; do
+    echo "Importing Claude profile '$profile' on $target..." >&2
+    ssh -o BatchMode=yes "$target" 'caam import - --force >/dev/null' <"$archive"
+  done
+done
+
+for target in $TARGETS; do
+  echo "Activating Claude profile '$ACTIVE_PROFILE' on $target..." >&2
+  ssh -o BatchMode=yes "$target" \
+    "caam activate claude '$ACTIVE_PROFILE' --force >/dev/null"
+
+  if [[ $VERIFY == 1 ]]; then
+    echo "Verifying Claude authentication on $target..." >&2
+    ssh -o BatchMode=yes "$target" \
+      "timeout 90 fish -lc '_clxe_function \"Reply exactly OK\"'"
+  fi
+done
+
+echo "Claude CAAM profiles synced from Galactica to: $TARGETS" >&2

--- a/config/claude/default.nix
+++ b/config/claude/default.nix
@@ -17,7 +17,13 @@ in
   # Use activation script for settings.json instead of symlink
   # git-ai install-hooks needs write access, which breaks with Nix store symlinks
   home.activation.claudeConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
-    $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${./settings.json}"
+    PATH=${
+      lib.makeBinPath [
+        pkgs.coreutils
+        pkgs.jq
+      ]
+    }:$PATH \
+      $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${./settings.json}"
   '';
 
   home.file.".claude/hooks/auto-switch.sh" = {

--- a/spec/caam_sync_spec.sh
+++ b/spec/caam_sync_spec.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016,SC2329
+
+Describe 'Galactica Claude CAAM sync'
+SCRIPT="$PWD/config/caam/sync-claude-remotes.sh"
+MAKEFILE="$PWD/Makefile"
+
+setup() {
+  MOCK_BIN=$(mktemp -d)
+  TEST_HOME=$(mktemp -d)
+  MOCK_LOG="$MOCK_BIN/mock.log"
+  ORIGINAL_PATH=${PATH:-}
+  export MOCK_BIN MOCK_LOG TEST_HOME ORIGINAL_PATH
+  export PATH="$MOCK_BIN:$ORIGINAL_PATH"
+  : >"$MOCK_LOG"
+
+  cat >"$MOCK_BIN/caam" <<'EOF'
+#!/usr/bin/env bash
+printf 'caam %s\n' "$*" >>"$MOCK_LOG"
+if [[ "$1 $2 $3" == "ls claude --json" ]]; then
+  printf '%s\n' '{"profiles":[{"name":"first@example.com"},{"name":"second@example.com"}]}'
+elif [[ $1 == export ]]; then
+  while (($#)); do
+    if [[ $1 == --output ]]; then
+      printf archive >"$2"
+      break
+    fi
+    shift
+  done
+fi
+EOF
+  cat >"$MOCK_BIN/ssh" <<'EOF'
+#!/usr/bin/env bash
+printf 'ssh %s\n' "$*" >>"$MOCK_LOG"
+cat >/dev/null
+EOF
+  cat >"$MOCK_BIN/claude" <<'EOF'
+#!/usr/bin/env bash
+if [[ ${MOCK_CLAUDE_LOGGED_IN:-1} == 1 ]]; then
+  jq -n --arg email "${CAAM_SYNC_ACTIVE_PROFILE:-second@example.com}" \
+    '{loggedIn: true, email: $email}'
+else
+  printf '%s\n' '{"loggedIn":false,"authMethod":"none"}'
+fi
+EOF
+  chmod +x "$MOCK_BIN/caam" "$MOCK_BIN/claude" "$MOCK_BIN/ssh"
+
+  cat >"$MOCK_BIN/failing-make" <<'EOF'
+#!/usr/bin/env bash
+exit 17
+EOF
+  chmod +x "$MOCK_BIN/failing-make"
+}
+
+cleanup() {
+  export PATH="$ORIGINAL_PATH"
+  rm -rf "$MOCK_BIN" "$TEST_HOME"
+  unset MOCK_BIN MOCK_LOG TEST_HOME ORIGINAL_PATH
+  unset CAAM_SYNC_SOURCE_HOST CAAM_SYNC_TARGETS CAAM_SYNC_PROFILES
+  unset CAAM_SYNC_ACTIVE_PROFILE CAAM_SYNC_VERIFY
+  unset MOCK_CLAUDE_LOGGED_IN
+}
+
+Before 'setup'
+After 'cleanup'
+
+It 'refuses to export credentials away from Galactica'
+CAAM_SYNC_SOURCE_HOST=matic
+export CAAM_SYNC_SOURCE_HOST
+When run bash "$SCRIPT"
+The status should be failure
+The stderr should include 'run this on Galactica'
+End
+
+It 'refuses to overwrite remotes from a provider-invalid source login'
+CAAM_SYNC_SOURCE_HOST=galactica
+CAAM_SYNC_ACTIVE_PROFILE='second@example.com'
+MOCK_CLAUDE_LOGGED_IN=0
+export CAAM_SYNC_SOURCE_HOST CAAM_SYNC_ACTIVE_PROFILE MOCK_CLAUDE_LOGGED_IN
+When run bash "$SCRIPT"
+The status should be failure
+The stderr should include 'not logged in to the preferred Claude account'
+The stderr should include 'claude auth login --email second@example.com'
+End
+
+It 'imports each profile and activates the preferred account on each target'
+CAAM_SYNC_SOURCE_HOST=galactica
+CAAM_SYNC_TARGETS='matic kyber'
+CAAM_SYNC_PROFILES='first@example.com second@example.com'
+CAAM_SYNC_ACTIVE_PROFILE='second@example.com'
+export CAAM_SYNC_SOURCE_HOST CAAM_SYNC_TARGETS CAAM_SYNC_PROFILES CAAM_SYNC_ACTIVE_PROFILE
+When run bash -c 'bash "$1" 2>/dev/null; cat "$2"' _ "$SCRIPT" "$MOCK_LOG"
+The status should be success
+The output should include 'caam backup claude second@example.com'
+The output should include 'caam export claude/first@example.com'
+The output should include 'caam export claude/second@example.com'
+The output should include 'ssh -o BatchMode=yes matic caam import - --force >/dev/null'
+The output should include 'ssh -o BatchMode=yes kyber caam import - --force >/dev/null'
+The output should include "ssh -o BatchMode=yes matic caam activate claude 'second@example.com' --force >/dev/null"
+The output should include "ssh -o BatchMode=yes kyber caam activate claude 'second@example.com' --force >/dev/null"
+End
+
+It 'offers explicit provider verification through the managed launcher'
+CAAM_SYNC_SOURCE_HOST=galactica
+CAAM_SYNC_TARGETS=matic
+CAAM_SYNC_PROFILES='first@example.com second@example.com'
+CAAM_SYNC_ACTIVE_PROFILE='second@example.com'
+CAAM_SYNC_VERIFY=1
+export CAAM_SYNC_SOURCE_HOST CAAM_SYNC_TARGETS CAAM_SYNC_PROFILES CAAM_SYNC_ACTIVE_PROFILE CAAM_SYNC_VERIFY
+When run bash -c 'bash "$1" 2>/dev/null; cat "$2"' _ "$SCRIPT" "$MOCK_LOG"
+The status should be success
+The output should include '_clxe_function "Reply exactly OK"'
+End
+
+It 'rehydrates Nix-owned Claude settings after dotagents sync'
+When run grep -A5 '^dotagents-sync:' "$MAKEFILE"
+The output should include 'config/claude/activate.sh'
+The output should include 'exit $$status'
+End
+
+It 'rehydrates Claude settings even when dotagents sync fails'
+When run bash -c 'set +e; HOME="$1" make -f "$2" dotagents-sync MAKE="$3" >/dev/null 2>&1; result=$?; test "$result" -ne 0 && printf "sync_failed=true\n"; jq -r '\''[.hooks.SessionEnd[]?.hooks[]? | select(.command == "caam-claude-snapshot")] | length'\'' "$1/.claude/settings.json"' _ "$TEST_HOME" "$MAKEFILE" "$MOCK_BIN/failing-make"
+The status should be success
+The output should include 'sync_failed=true'
+The output should include '1'
+End
+
+It 'exposes a make target for explicit credential sync'
+When run grep -A2 '^caam-sync-claude:' "$MAKEFILE"
+The output should include 'config/caam/sync-claude-remotes.sh'
+End
+
+End

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -29,6 +29,10 @@ It 'has spec file for config/claude/hooks/caam-snapshot.sh'
 The path "spec/caam_snapshot_spec.sh" should be exist
 End
 
+It 'has spec file for config/caam/sync-claude-remotes.sh'
+The path "spec/caam_sync_spec.sh" should be exist
+End
+
 It 'has spec file for config/claude/hooks/security.sh'
 The path "spec/security_spec.sh" should be exist
 End
@@ -406,6 +410,7 @@ It 'covers all non-spec shell scripts in the repository'
 # List of all shell scripts that should have tests
 # Update this list when adding new shell scripts
 covered_scripts="config/caam/hydrate.sh
+config/caam/sync-claude-remotes.sh
 config/claude/activate.sh
 config/ccs/hydrate.sh
 config/claude/hooks/notify.sh


### PR DESCRIPTION
## Summary
- add a guarded one-way Galactica to Matic/Kyber Claude CAAM sync command
- rehydrate Nix-owned Claude settings after dotagents sync, including its failure path
- provide required activation PATH tools on every host

## Validation
- `shellcheck config/caam/sync-claude-remotes.sh spec/caam_sync_spec.sh config/claude/activate.sh`
- `shellspec spec/caam_sync_spec.sh spec/caam_config_spec.sh spec/caam_snapshot_spec.sh spec/activate_config_spec.sh spec/coverage_spec.sh` (178 examples)
- `git diff --check`
- `make build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes remote Claude credential sync reliable by adding a guarded, one-way CAAM export from Galactica to Matic/Kyber and ensuring Claude settings rehydrate after `dotagents` sync. Adds a `make` target, fixes activation PATH, and includes tests.

- **New Features**
  - Added `caam-sync-claude` target that runs `config/caam/sync-claude-remotes.sh` to export/ import/activate Claude CAAM profiles from Galactica to Matic and Kyber.
  - Guarded flow: refuses non-Galactica sources, checks preferred login, backs up before export, and supports optional remote verification.
  - Profiles, targets, and active account are configurable via `CAAM_SYNC_*` env vars.

- **Bug Fixes**
  - `dotagents-sync` now always runs `config/claude/activate.sh` to rehydrate Nix-owned settings, even when sync fails, while preserving the original exit code.
  - Ensured `config/claude/activate.sh` has `PATH` to `coreutils` and `jq` on all hosts.
  - Added specs for the new sync flow and updated coverage to include the script.

<sup>Written for commit 96005159878428f995adf8d7d530ffccb97a79b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

