### PR TITLE
fix(kyber): Detect named hosts deterministically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,11 @@ NIXOS_NAMED_HOSTS := $(filter matic viper,$(NAMED_HOSTS))
 ISO_NAMED_HOSTS := $(filter matic viper,$(NAMED_HOSTS))
 DMI_SYS_VENDOR ?= $(shell cat /sys/class/dmi/id/sys_vendor 2>/dev/null || true)
 DMI_PRODUCT_NAME ?= $(shell cat /sys/class/dmi/id/product_name 2>/dev/null || true)
+MACHINE_HOSTNAME ?= $(shell hostname 2>/dev/null || true)
+TAILSCALE_DNS_NAME ?= $(shell \
+	if command -v tailscale >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then \
+		tailscale status --json 2>/dev/null | jq -r '.Self.DNSName // "" | rtrimstr(".")' 2>/dev/null; \
+	fi)
 
 # Nix configuration system
 NIX_SYSTEM := $(shell if [ "$(OS)" = "Darwin" ] && [ "$(ARCH)" = "arm64" ]; then \
@@ -103,10 +108,14 @@ DETECTED_HOST := $(shell \
 		if [ -n "$$RUNPOD_POD_ID" ]; then \
 			echo "pod"; \
 		else \
-			hostname=$$(hostname 2>/dev/null || echo ""); \
-			if [ "$$hostname" = "kyber" ]; then \
+			hostname="$(MACHINE_HOSTNAME)"; \
+			tailscale_dns="$(TAILSCALE_DNS_NAME)"; \
+			if [ "$$hostname" = "kyber" ] \
+				|| [ "$$hostname" = "c2-small-x86-chi-1" ] \
+				|| [ "$$tailscale_dns" = "kyber.tail950b36.ts.net" ]; then \
 				echo "kyber"; \
-			elif [ "$$hostname" = "matic" ]; then \
+			elif [ "$$hostname" = "matic" ] \
+				|| [ "$$tailscale_dns" = "matic.tail950b36.ts.net" ]; then \
 				echo "matic"; \
 			elif [ "$(DMI_SYS_VENDOR)" = "Framework" ] \
 				&& echo "$(DMI_PRODUCT_NAME)" | grep -q "Laptop 13.*AMD Ryzen AI 300"; then \

--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -14,7 +14,7 @@ let
   docker = import ./docker { inherit lib pkgs; };
   firewall = ./firewall;
   dockerPostgres = ./docker-postgres;
-  dotfilesUpdater = import ./dotfiles-updater { inherit pkgs; };
+  dotfilesUpdater = import ./dotfiles-updater { inherit inputs pkgs; };
   gasTown = import ./gas-town { inherit pkgs; };
   hermes = ./hermes;
   k3s = ./k3s;

--- a/home-manager/services/dotfiles-updater/default.nix
+++ b/home-manager/services/dotfiles-updater/default.nix
@@ -1,6 +1,13 @@
-{ pkgs, ... }:
+{ inputs, pkgs, ... }:
 let
   inherit (pkgs) lib;
+  canonicalHost =
+    if inputs.host.isKyber then
+      "kyber"
+    else if inputs.host.isMatic then
+      "matic"
+    else
+      null;
 in
 {
   launchd.agents.dotfiles-updater = lib.mkIf pkgs.stdenv.isDarwin {
@@ -48,7 +55,8 @@ in
           ]
         }"
         "AUTOMATED_UPDATE=true"
-      ];
+      ]
+      ++ lib.optional (canonicalHost != null) "HOST=${canonicalHost}";
       Nice = 19;
       IOSchedulingPriority = 7;
       ExecStart = "${./update.sh}";

--- a/spec/dotfiles_updater_spec.sh
+++ b/spec/dotfiles_updater_spec.sh
@@ -3,6 +3,7 @@
 
 Describe 'dotfiles-updater/update.sh'
 SCRIPT="$PWD/home-manager/services/dotfiles-updater/update.sh"
+MODULE="$PWD/home-manager/services/dotfiles-updater/default.nix"
 
 Describe 'script properties'
 It 'uses bash shebang'
@@ -18,6 +19,19 @@ End
 It 'changes to ~/dotfiles directory'
 When run bash -c "grep 'cd ~/dotfiles' '$SCRIPT'"
 The output should include 'cd ~/dotfiles'
+End
+End
+
+Describe 'service host identity'
+It 'passes the canonical named host to automatic updates'
+When run bash -c "grep 'HOST=\${canonicalHost}' '$MODULE'"
+The output should include 'HOST=${canonicalHost}'
+End
+
+It 'derives the canonical host from named-host flags'
+When run bash -c "grep -E 'inputs.host.is(Kyber|Matic)' '$MODULE'"
+The output should include 'inputs.host.isKyber'
+The output should include 'inputs.host.isMatic'
 End
 End
 

--- a/spec/make_build_host_resolution_spec.sh
+++ b/spec/make_build_host_resolution_spec.sh
@@ -28,6 +28,27 @@ The output should include '.#darwinConfigurations.galactica.system'
 The output should not include '.#nixosConfigurations.matic.config.system.build.toplevel'
 End
 
+It 'detects kyber from its physical hostname'
+When run bash -c 'make build HOST= OS=Linux ARCH=x86_64 NIX_SYSTEM=x86_64-linux NIX_CONFIG_TYPE=homeConfigurations MACHINE_HOSTNAME=c2-small-x86-chi-1 TAILSCALE_DNS_NAME= NIX_EXEC=nix NIX_ENV=ok NIX_FLAGS= NIX_USER_TRUSTED=yes 2>/dev/null; cat "$MOCK_LOG"'
+The status should be success
+The output should include '.#homeConfigurations.kyber.activationPackage'
+The output should not include '.#homeConfigurations."ubuntu@x86_64-linux".activationPackage'
+End
+
+It 'detects kyber from Tailscale MagicDNS when the physical hostname is generic'
+When run bash -c 'make build HOST= OS=Linux ARCH=x86_64 NIX_SYSTEM=x86_64-linux NIX_CONFIG_TYPE=homeConfigurations MACHINE_HOSTNAME=generic-linux TAILSCALE_DNS_NAME=kyber.tail950b36.ts.net NIX_EXEC=nix NIX_ENV=ok NIX_FLAGS= NIX_USER_TRUSTED=yes 2>/dev/null; cat "$MOCK_LOG"'
+The status should be success
+The output should include '.#homeConfigurations.kyber.activationPackage'
+The output should not include '.#homeConfigurations."ubuntu@x86_64-linux".activationPackage'
+End
+
+It 'detects matic from Tailscale MagicDNS when the physical hostname is generic'
+When run bash -c 'make build HOST= OS=Linux ARCH=x86_64 NIX_SYSTEM=x86_64-linux NIX_CONFIG_TYPE=nixosConfigurations MACHINE_HOSTNAME=generic-linux TAILSCALE_DNS_NAME=matic.tail950b36.ts.net DMI_SYS_VENDOR=generic DMI_PRODUCT_NAME=generic NIX_EXEC=nix NIX_ENV=ok NIX_FLAGS= NIX_USER_TRUSTED=yes SUDO=env 2>/dev/null; cat "$MOCK_LOG"'
+The status should be success
+The output should include '--flake .#matic'
+The output should not include '--flake .#x86_64-linux'
+End
+
 It 'detects matic from Framework 13 AMD AI 300 DMI data when the hostname is generic'
 When run bash -c 'make build OS=Linux ARCH=x86_64 NIX_SYSTEM=x86_64-linux NIX_CONFIG_TYPE=nixosConfigurations DMI_SYS_VENDOR=Framework DMI_PRODUCT_NAME="Laptop 13 (AMD Ryzen AI 300 Series)" NIX_EXEC=nix NIX_ENV=ok NIX_FLAGS= NIX_USER_TRUSTED=yes SUDO=env 2>/dev/null; cat "$MOCK_LOG"'
 The status should be success


### PR DESCRIPTION
## Summary

- recognize Kyber from its physical VPS hostname and stable Tailscale MagicDNS name
- recognize Matic from its Tailscale MagicDNS name alongside existing hostname and DMI detection
- pass canonical named-host identity to the Linux dotfiles updater so automatic activation cannot select a generic profile
- cover physical-host, MagicDNS, and updater identity behavior with regression tests

## Validation

- `shellspec spec/make_build_host_resolution_spec.sh spec/dotfiles_updater_spec.sh` — 23 examples, 0 failures
- full ShellSpec phase from `make shell-test` — 1,848 examples, 0 failures
- `make nix-format-check`
- dry-run host resolution: physical Kyber → `kyber`, Kyber MagicDNS → `kyber`, Matic MagicDNS → `matic`

The broader Fish phase of `make shell-test` still has unrelated baseline failures caused by missing CAAM test profiles and existing GR helper fixture expectations.

Beads: `shunkakinokisoftware-sdyp`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make named-host detection deterministic for Kyber and Matic using physical hostnames and Tailscale MagicDNS. Ensures auto updates always pick the right profile by passing a canonical host, aligning with the requirement to avoid generic profiles.

- **Bug Fixes**
  - Detect `kyber` via `kyber`, `c2-small-x86-chi-1`, or `kyber.tail950b36.ts.net`; detect `matic` via `matic.tail950b36.ts.net` (keeps existing DMI check).
  - Pass canonical `HOST` to the Linux dotfiles updater from `home-manager/services/dotfiles-updater` using `inputs.host.isKyber`/`inputs.host.isMatic`; add regression tests for host resolution and updater identity.

<sup>Written for commit 9db71f04f7d8df44a33a2bcc925e865ef84bab92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

