### PR TITLE
refactor(openclaw): remove group routing

### DIFF
--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -122,6 +122,10 @@ openai-compatibility:
     api-key-entries:
       - api-key: "__OPENCODE_API_KEY__"
     models:
+      - name: "deepseek-v4-pro"
+        alias: "deepseek-v4-pro"
+      - name: "deepseek-v4-flash"
+        alias: "deepseek-v4-flash"
       - name: "minimax-m3"
         alias: "minimax-m3"
       - name: "kimi-k3"

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -122,6 +122,10 @@ openai-compatibility:
     api-key-entries:
       - api-key: "__OPENCODE_API_KEY__"
     models:
+      - name: "__DEEPSEEK_PRO__"
+        alias: "__DEEPSEEK_PRO__"
+      - name: "__DEEPSEEK_FLASH__"
+        alias: "__DEEPSEEK_FLASH__"
       - name: "__MINIMAX__"
         alias: "__MINIMAX__"
       - name: "__KIMI__"

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -167,6 +167,38 @@
             "maxTokens": 40960
           },
           {
+            "id": "deepseek-v4-pro",
+            "name": "Deepseek V4 Pro",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0.435,
+              "output": 0.87,
+              "cacheRead": 0.003625,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 384000
+          },
+          {
+            "id": "deepseek-v4-flash",
+            "name": "Deepseek V4 Flash",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0.14,
+              "output": 0.28,
+              "cacheRead": 0.0028,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 384000
+          },
+          {
             "id": "cliproxy/free",
             "name": "CliProxy Free",
             "reasoning": false,
@@ -197,14 +229,14 @@
   "agents": {
     "defaults": {
       "model": {
-        "primary": "cliproxy/minimax-m3",
+        "primary": "cliproxy/deepseek-v4-pro",
         "fallbacks": [
-          "cliproxy/glm-4.7",
+          "cliproxy/deepseek-v4-flash",
           "cliproxy/free"
         ]
       },
       "workspace": "__HOME__/.openclaw/workspace",
-      "thinkingDefault": "low",
+      "thinkingDefault": "high",
       "maxConcurrent": 4,
       "subagents": {
         "maxConcurrent": 8
@@ -765,131 +797,13 @@
       }
     ]
   },
-  "bindings": [
-    {
-      "agentId": "cicd-fixer",
-      "match": {
-        "channel": "whatsapp",
-        "peer": {
-          "kind": "group",
-          "id": "120363424741471538@g.us"
-        }
-      }
-    },
-    {
-      "agentId": "sales",
-      "match": {
-        "channel": "whatsapp",
-        "peer": {
-          "kind": "group",
-          "id": "120363406548236154@g.us"
-        }
-      }
-    },
-    {
-      "agentId": "mindset",
-      "match": {
-        "channel": "whatsapp",
-        "peer": {
-          "kind": "group",
-          "id": "120363424541382217@g.us"
-        }
-      }
-    },
-    {
-      "agentId": "routine",
-      "match": {
-        "channel": "whatsapp",
-        "peer": {
-          "kind": "group",
-          "id": "120363407129974400@g.us"
-        }
-      }
-    },
-    {
-      "agentId": "product",
-      "match": {
-        "channel": "whatsapp",
-        "peer": {
-          "kind": "group",
-          "id": "120363426303081391@g.us"
-        }
-      }
-    },
-    {
-      "agentId": "communication",
-      "match": {
-        "channel": "whatsapp",
-        "peer": {
-          "kind": "group",
-          "id": "120363424749277621@g.us"
-        }
-      }
-    },
-    {
-      "agentId": "devops",
-      "match": {
-        "channel": "whatsapp",
-        "peer": {
-          "kind": "group",
-          "id": "120363424912006821@g.us"
-        }
-      }
-    },
-    {
-      "agentId": "dev-gpt",
-      "match": {
-        "channel": "whatsapp",
-        "peer": {
-          "kind": "group",
-          "id": "120363405790595065@g.us"
-        }
-      }
-    },
-    {
-      "agentId": "dev-gpt",
-      "match": {
-        "channel": "whatsapp",
-        "peer": {
-          "kind": "group",
-          "id": "120363425572081403@g.us"
-        }
-      }
-    }
-  ],
-  "broadcast": {
-    "strategy": "parallel",
-    "120363425148909388@g.us": [
-      "code-reviewer-glm",
-      "code-reviewer-gpt",
-      "code-reviewer-gpt-codex",
-      "code-reviewer-minimax",
-      "code-formatter",
-      "security-scanner",
-      "test-coverage",
-      "docs-checker"
-    ],
-    "120363406322027123@g.us": [
-      "twitter-gpt"
-    ],
-    "120363405790595065@g.us": [
-      "dev-gpt"
-    ],
-    "120363425572081403@g.us": [
-      "dev-gpt"
-    ],
-    "120363407321327235@g.us": [
-      "strategy-gpt"
-    ]
-  },
   "session": {
     "dmScope": "per-channel-peer"
   },
   "messages": {
     "queue": {
       "mode": "interrupt"
-    },
-    "ackReactionScope": "group-mentions"
+    }
   },
   "commands": {
     "native": "auto",
@@ -903,20 +817,11 @@
       },
       "dmPolicy": "pairing",
       "botToken": "__TELEGRAM_TOKEN__",
-      "groups": {
-        "*": {
-          "requireMention": false
-        },
-        "-1003612372477": {
-          "requireMention": false,
-          "enabled": true
-        }
-      },
       "allowFrom": [
         983653361,
         2104262990
       ],
-      "groupPolicy": "allowlist",
+      "groupPolicy": "disabled",
       "reactionNotifications": "all",
       "reactionLevel": "extensive",
       "replyToMode": "first",
@@ -929,18 +834,12 @@
       "allowFrom": [
         "__WHATSAPP_ALLOW_FROM__"
       ],
-      "groupPolicy": "allowlist",
-      "groups": {
-        "*": {
-          "requireMention": false
-        }
-      },
+      "groupPolicy": "disabled",
       "sendReadReceipts": true,
       "mediaMaxMb": 50,
       "ackReaction": {
         "emoji": "👀",
-        "direct": true,
-        "group": "mentions"
+        "direct": true
       },
       "debounceMs": 300
     }
@@ -962,10 +861,7 @@
         "wakeMode": "now",
         "name": "GitHub",
         "sessionKey": "hook:github:{{delivery}}",
-        "messageTemplate": "GitHub {{headers.x-github-event}} event on {{repository.full_name}}:\n\nAction: {{action}}\nSender: {{sender.login}}\n\n{{pull_request.title}}{{issue.title}}\n\n{{pull_request.html_url}}{{issue.html_url}}",
-        "deliver": true,
-        "channel": "whatsapp",
-        "to": "120363405790595065@g.us"
+        "messageTemplate": "GitHub {{headers.x-github-event}} event on {{repository.full_name}}:\n\nAction: {{action}}\nSender: {{sender.login}}\n\n{{pull_request.title}}{{issue.title}}\n\n{{pull_request.html_url}}{{issue.html_url}}"
       }
     ]
   },

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -167,6 +167,38 @@
             "maxTokens": 40960
           },
           {
+            "id": "__DEEPSEEK_PRO__",
+            "name": "__DEEPSEEK_PRO_PRETTY__",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0.435,
+              "output": 0.87,
+              "cacheRead": 0.003625,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 384000
+          },
+          {
+            "id": "__DEEPSEEK_FLASH__",
+            "name": "__DEEPSEEK_FLASH_PRETTY__",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0.14,
+              "output": 0.28,
+              "cacheRead": 0.0028,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 384000
+          },
+          {
             "id": "cliproxy/free",
             "name": "CliProxy Free",
             "reasoning": false,
@@ -197,14 +229,14 @@
   "agents": {
     "defaults": {
       "model": {
-        "primary": "cliproxy/__MINIMAX__",
+        "primary": "cliproxy/__DEEPSEEK_PRO__",
         "fallbacks": [
-          "cliproxy/__GLM__",
+          "cliproxy/__DEEPSEEK_FLASH__",
           "cliproxy/free"
         ]
       },
       "workspace": "__HOME__/.openclaw/workspace",
-      "thinkingDefault": "low",
+      "thinkingDefault": "high",
       "maxConcurrent": 4,
       "subagents": {
         "maxConcurrent": 8
@@ -765,131 +797,13 @@
       }
     ]
   },
-  "bindings": [
-    {
-      "agentId": "cicd-fixer",
-      "match": {
-        "channel": "whatsapp",
-        "peer": {
-          "kind": "group",
-          "id": "120363424741471538@g.us"
-        }
-      }
-    },
-    {
-      "agentId": "sales",
-      "match": {
-        "channel": "whatsapp",
-        "peer": {
-          "kind": "group",
-          "id": "120363406548236154@g.us"
-        }
-      }
-    },
-    {
-      "agentId": "mindset",
-      "match": {
-        "channel": "whatsapp",
-        "peer": {
-          "kind": "group",
-          "id": "120363424541382217@g.us"
-        }
-      }
-    },
-    {
-      "agentId": "routine",
-      "match": {
-        "channel": "whatsapp",
-        "peer": {
-          "kind": "group",
-          "id": "120363407129974400@g.us"
-        }
-      }
-    },
-    {
-      "agentId": "product",
-      "match": {
-        "channel": "whatsapp",
-        "peer": {
-          "kind": "group",
-          "id": "120363426303081391@g.us"
-        }
-      }
-    },
-    {
-      "agentId": "communication",
-      "match": {
-        "channel": "whatsapp",
-        "peer": {
-          "kind": "group",
-          "id": "120363424749277621@g.us"
-        }
-      }
-    },
-    {
-      "agentId": "devops",
-      "match": {
-        "channel": "whatsapp",
-        "peer": {
-          "kind": "group",
-          "id": "120363424912006821@g.us"
-        }
-      }
-    },
-    {
-      "agentId": "dev-gpt",
-      "match": {
-        "channel": "whatsapp",
-        "peer": {
-          "kind": "group",
-          "id": "120363405790595065@g.us"
-        }
-      }
-    },
-    {
-      "agentId": "dev-gpt",
-      "match": {
-        "channel": "whatsapp",
-        "peer": {
-          "kind": "group",
-          "id": "120363425572081403@g.us"
-        }
-      }
-    }
-  ],
-  "broadcast": {
-    "strategy": "parallel",
-    "120363425148909388@g.us": [
-      "code-reviewer-glm",
-      "code-reviewer-gpt",
-      "code-reviewer-gpt-codex",
-      "code-reviewer-minimax",
-      "code-formatter",
-      "security-scanner",
-      "test-coverage",
-      "docs-checker"
-    ],
-    "120363406322027123@g.us": [
-      "twitter-gpt"
-    ],
-    "120363405790595065@g.us": [
-      "dev-gpt"
-    ],
-    "120363425572081403@g.us": [
-      "dev-gpt"
-    ],
-    "120363407321327235@g.us": [
-      "strategy-gpt"
-    ]
-  },
   "session": {
     "dmScope": "per-channel-peer"
   },
   "messages": {
     "queue": {
       "mode": "interrupt"
-    },
-    "ackReactionScope": "group-mentions"
+    }
   },
   "commands": {
     "native": "auto",
@@ -903,20 +817,11 @@
       },
       "dmPolicy": "pairing",
       "botToken": "__TELEGRAM_TOKEN__",
-      "groups": {
-        "*": {
-          "requireMention": false
-        },
-        "-1003612372477": {
-          "requireMention": false,
-          "enabled": true
-        }
-      },
       "allowFrom": [
         983653361,
         2104262990
       ],
-      "groupPolicy": "allowlist",
+      "groupPolicy": "disabled",
       "reactionNotifications": "all",
       "reactionLevel": "extensive",
       "replyToMode": "first",
@@ -929,18 +834,12 @@
       "allowFrom": [
         "__WHATSAPP_ALLOW_FROM__"
       ],
-      "groupPolicy": "allowlist",
-      "groups": {
-        "*": {
-          "requireMention": false
-        }
-      },
+      "groupPolicy": "disabled",
       "sendReadReceipts": true,
       "mediaMaxMb": 50,
       "ackReaction": {
         "emoji": "👀",
-        "direct": true,
-        "group": "mentions"
+        "direct": true
       },
       "debounceMs": 300
     }
@@ -962,10 +861,7 @@
         "wakeMode": "now",
         "name": "GitHub",
         "sessionKey": "hook:github:{{delivery}}",
-        "messageTemplate": "GitHub {{headers.x-github-event}} event on {{repository.full_name}}:\n\nAction: {{action}}\nSender: {{sender.login}}\n\n{{pull_request.title}}{{issue.title}}\n\n{{pull_request.html_url}}{{issue.html_url}}",
-        "deliver": true,
-        "channel": "whatsapp",
-        "to": "120363405790595065@g.us"
+        "messageTemplate": "GitHub {{headers.x-github-event}} event on {{repository.full_name}}:\n\nAction: {{action}}\nSender: {{sender.login}}\n\n{{pull_request.title}}{{issue.title}}\n\n{{pull_request.html_url}}{{issue.html_url}}"
       }
     ]
   },

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -107,6 +107,11 @@ It 'generates the OMP Pro default role'
 When run bash -c "grep 'default: \"opencode-zen/deepseek-v4-pro\"' config/omp/config.yml"
 The output should include 'opencode-zen/deepseek-v4-pro'
 End
+
+It 'generates the DeepSeek Go routes in CliProxy'
+When run bash -c "sed -n '/name: \"opencode\"/,/name: \"openai\"/p' config/cliproxyapi/config.template.yaml | grep -q 'name: \"deepseek-v4-pro\"' && sed -n '/name: \"opencode\"/,/name: \"openai\"/p' config/cliproxyapi/config.template.yaml | grep -q 'name: \"deepseek-v4-flash\"'"
+The status should be success
+End
 End
 
 Describe 'jq pretty-printing'

--- a/spec/openclaw_hydrate_spec.sh
+++ b/spec/openclaw_hydrate_spec.sh
@@ -4,6 +4,31 @@
 Describe 'config/openclaw/hydrate.sh'
 SCRIPT="$PWD/config/openclaw/hydrate.sh"
 
+template_uses_opencode_go_default() {
+  jq -e '
+    .agents.defaults.model.primary == "cliproxy/deepseek-v4-pro" and
+    .agents.defaults.model.fallbacks[0] == "cliproxy/deepseek-v4-flash" and
+    (.models.providers.cliproxy.models | any(.id == "deepseek-v4-pro")) and
+    (.models.providers.cliproxy.models | any(.id == "deepseek-v4-flash"))
+  ' "$PWD/config/openclaw/openclaw.template.json" >/dev/null
+}
+
+template_disables_groups() {
+  jq -e '
+    (.bindings? == null) and
+    (.broadcast? == null) and
+    (.channels.telegram.groups? == null) and
+    (.channels.telegram.groupPolicy == "disabled") and
+    (.channels.whatsapp.groups? == null) and
+    (.channels.whatsapp.groupPolicy == "disabled") and
+    (.channels.whatsapp.ackReaction.group? == null) and
+    (.messages.ackReactionScope? == null) and
+    (.hooks.mappings | all(
+      (.deliver? == null) and (.channel? == null) and (.to? == null)
+    ))
+  ' "$PWD/config/openclaw/openclaw.template.json" >/dev/null
+}
+
 Describe 'script properties'
 It 'uses bash shebang'
 When run bash -c "head -1 '$SCRIPT'"
@@ -200,6 +225,23 @@ End
 It 'creates state directory'
 When run bash -c "grep 'mkdir -p' '$SCRIPT'"
 The output should include 'STATE_DIR'
+End
+End
+
+Describe 'declarative template'
+It 'uses DeepSeek V4 Pro from OpenCode Go as the default model'
+When call template_uses_opencode_go_default
+The status should be success
+End
+
+It 'removes group routing and explicitly disables group messages'
+When call template_disables_groups
+The status should be success
+End
+
+It 'contains no configured group identifiers'
+When run bash -c "! grep -Eq '@g\\.us|\\\"kind\\\": \\\"group\\\"' '$PWD/config/openclaw/openclaw.template.json'"
+The status should be success
 End
 End
 


### PR DESCRIPTION
## Summary

- remove OpenClaw group bindings, broadcasts, identifiers, reactions, and group webhook delivery
- disable group handling while preserving direct Telegram and WhatsApp messaging
- route DeepSeek V4 Pro and Flash through the existing OpenCode Go CliProxy upstream
- make DeepSeek V4 Pro the default with Flash as the first fallback

## Validation

- `shellspec spec/openclaw_hydrate_spec.sh spec/llm_update_spec.sh` (83 examples)
- `make shell-test`
- `make test`
- `make nix-format-check`
- `make build`
- hydrated `openclaw config validate --json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed all group routing from OpenClaw and disabled group handling for Telegram and WhatsApp while keeping direct messages. Switched default LLM routing to `cliproxy` with DeepSeek V4 Pro as default and V4 Flash as first fallback.

- **Refactors**
  - Removed group bindings, broadcasts, identifiers, and group webhook delivery.
  - Set Telegram/WhatsApp `groupPolicy` to "disabled"; removed group configs and `ackReactionScope`; limited `ackReaction` to direct.
  - Added `deepseek-v4-pro` and `deepseek-v4-flash` to `cliproxy` OpenAI-compatibility models.
  - Default model now `cliproxy/deepseek-v4-pro` with fallback `cliproxy/deepseek-v4-flash`; `thinkingDefault` set to "high".
  - Updated specs to assert DeepSeek routes and group-disabled config.

- **Migration**
  - Group conversations are no longer supported; move any group workflows to direct messages.
  - Ensure `CliProxy` is configured with an OpenCode API key, then rehydrate configs and rebuild.

<sup>Written for commit 15ece0768e1205a7049024bf704647ac5f45e141. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

