### PR TITLE
fix(openclaw): bridge Kyber gateway to k3s

### DIFF
--- a/home-manager/services/openclaw/default.nix
+++ b/home-manager/services/openclaw/default.nix
@@ -45,4 +45,25 @@ lib.mkIf host.isKyber {
       WantedBy = [ "default.target" ];
     };
   };
+
+  # Keep the gateway loopback-only while making it reachable from k3s. The
+  # proxy binds exclusively to Kyber's CNI bridge, so port 18789 is not exposed
+  # on the public or Tailscale interfaces.
+  systemd.user.services.openclaw-k3s-proxy = {
+    Unit = {
+      Description = "OpenClaw k3s bridge proxy";
+      After = [ "openclaw-gateway.service" ];
+      Requires = [ "openclaw-gateway.service" ];
+    };
+    Service = {
+      Type = "simple";
+      ExecStart = "${pkgs.socat}/bin/socat TCP4-LISTEN:18789,bind=10.42.0.1,reuseaddr,fork TCP4:127.0.0.1:18789";
+      Restart = "always";
+      RestartSec = "5s";
+      NoNewPrivileges = true;
+    };
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
 }

--- a/spec/activate_paperclip_openclaw_spec.sh
+++ b/spec/activate_paperclip_openclaw_spec.sh
@@ -35,6 +35,17 @@ It 'forces loopback bind on the gateway unit'
 When run bash -c "grep -- '--bind loopback' '$PWD/home-manager/services/openclaw/default.nix'"
 The output should include '--bind loopback'
 End
+
+It 'proxies the loopback gateway only through the k3s bridge'
+When run bash -c "grep -F 'TCP4-LISTEN:18789,bind=10.42.0.1' '$PWD/home-manager/services/openclaw/default.nix'"
+The output should include 'TCP4-LISTEN:18789,bind=10.42.0.1'
+The output should not include 'bind=0.0.0.0'
+End
+
+It 'orders the k3s bridge proxy after the loopback gateway'
+When run bash -c "grep -F 'After = [ \"openclaw-gateway.service\" ]' '$PWD/home-manager/services/openclaw/default.nix'"
+The output should include 'openclaw-gateway.service'
+End
 End
 
 Describe 'home-manager/services/hermes/activate.sh'


### PR DESCRIPTION
## Summary
- preserve the OpenClaw gateway loopback bind
- add a Kyber-only socat proxy bound to the k3s CNI bridge
- cover the bind and service ordering in ShellSpec

## Verification
- shellspec spec/activate_paperclip_openclaw_spec.sh
- make nix-format-check
- make build
- live ingress-controller probe to the recovery proxy returned HTTP 200

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bridge the loopback-only OpenClaw gateway to `k3s` by adding a Kyber-only `socat` proxy bound to the CNI bridge (10.42.0.1) on port 18789. Keeps the gateway off public/Tailscale interfaces and adds ShellSpec checks for binds and unit ordering.

- **Bug Fixes**
  - Added `openclaw-k3s-proxy` systemd user service forwarding 10.42.0.1:18789 → 127.0.0.1:18789 with restart policy and After/Requires on `openclaw-gateway.service`.
  - Preserved `--bind loopback` on the gateway.
  - Added ShellSpec tests for bridge bind and service ordering.

<sup>Written for commit 0795dcf7f105ceadfb3cdcbc33709206ae46d20e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

