### PR TITLE
feat(cliproxy): run CPA Manager Plus analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ MY_SECRET=replace-me
 # GITHUB_TOKEN=ghp_your_token_here
 CLIPROXY_API_KEY=your-api-key-here
 CLIPROXY_MANAGEMENT_PASSWORD=your-management-key-here
+# Stable login key for the CPA Manager Plus analytics panel.
+# Generate one locally, for example: printf 'cpamp_%s\n' "$(openssl rand -hex 32)"
+CPA_MANAGER_ADMIN_KEY=cpamp_your-long-random-admin-key-here
 # OpenClaw configuration
 # Get Telegram bot token from @BotFather: https://t.me/BotFather
 OPENCLAW_TELEGRAM_TOKEN=123456789:ABCdefGHIjklMNOpqrsTUVwxyz

--- a/Makefile
+++ b/Makefile
@@ -1229,7 +1229,7 @@ launchctl-tmux-session-logger: ## Restart tmux-session-logger launchd agent.
 ##@ Systemd Services (Linux)
 
 .PHONY: systemctl
-systemctl: systemctl-docker systemctl-cliproxyapi systemctl-cliproxyapi-backup systemctl-code-syncer systemctl-docker-postgres systemctl-dolt systemctl-dotfiles-updater systemctl-make-updater systemctl-neverssl-keepalive systemctl-noctalia-shell systemctl-obsidian systemctl-ollama systemctl-openclaw systemctl-roborev systemctl-tmux-session-logger ## Restart all systemd user services.
+systemctl: systemctl-docker systemctl-cliproxyapi systemctl-cpa-manager-plus systemctl-cliproxyapi-backup systemctl-code-syncer systemctl-docker-postgres systemctl-dolt systemctl-dotfiles-updater systemctl-make-updater systemctl-neverssl-keepalive systemctl-noctalia-shell systemctl-obsidian systemctl-ollama systemctl-openclaw systemctl-roborev systemctl-tmux-session-logger ## Restart all systemd user services.
 
 .PHONY: systemctl-docker
 systemctl-docker: ## Start Docker daemon.
@@ -1249,6 +1249,13 @@ systemctl-cliproxyapi-backup: ## Restart cliproxyapi-backup systemd user service
 	@echo "🔄 Restarting cliproxyapi-backup..."
 	@systemctl --user restart cliproxyapi-backup.service || true
 	@echo "✅ cliproxyapi-backup restarted"
+
+.PHONY: systemctl-cpa-manager-plus
+systemctl-cpa-manager-plus: ## Restart CPA Manager Plus systemd user service.
+	@echo "🔄 Restarting CPA Manager Plus..."
+	@systemctl --user daemon-reload
+	@systemctl --user restart cpa-manager-plus.service || true
+	@echo "✅ CPA Manager Plus restarted"
 
 .PHONY: systemctl-code-syncer
 systemctl-code-syncer: ## Restart code-syncer systemd user service.

--- a/Makefile
+++ b/Makefile
@@ -1238,7 +1238,7 @@ launchctl-tmux-session-logger: ## Restart tmux-session-logger launchd agent.
 ##@ Systemd Services (Linux)
 
 .PHONY: systemctl
-systemctl: systemctl-docker systemctl-cliproxyapi systemctl-cpa-manager-plus systemctl-cliproxyapi-backup systemctl-code-syncer systemctl-docker-postgres systemctl-dolt systemctl-dotfiles-updater systemctl-make-updater systemctl-neverssl-keepalive systemctl-noctalia-shell systemctl-obsidian systemctl-ollama systemctl-openclaw systemctl-roborev systemctl-tmux-session-logger ## Restart all systemd user services.
+systemctl: systemctl-docker systemctl-cliproxyapi systemctl-cliproxyapi-backup systemctl-cpa-manager-plus systemctl-code-syncer systemctl-docker-postgres systemctl-dolt systemctl-dotfiles-updater systemctl-make-updater systemctl-neverssl-keepalive systemctl-noctalia-shell systemctl-obsidian systemctl-ollama systemctl-openclaw systemctl-roborev systemctl-tmux-session-logger ## Restart all systemd user services.
 
 .PHONY: systemctl-docker
 systemctl-docker: ## Start Docker daemon.

--- a/Makefile
+++ b/Makefile
@@ -1262,8 +1262,12 @@ systemctl-cliproxyapi-backup: ## Restart cliproxyapi-backup systemd user service
 .PHONY: systemctl-cpa-manager-plus
 systemctl-cpa-manager-plus: ## Restart CPA Manager Plus systemd user service.
 	@echo "🔄 Restarting CPA Manager Plus..."
-	@systemctl --user daemon-reload
-	@systemctl --user restart cpa-manager-plus.service || true
+	@if [ "$(DETECTED_HOST)" = "kyber" ] || [ "$(HOST)" = "kyber" ]; then \
+		systemctl --user daemon-reload; \
+		systemctl --user restart cpa-manager-plus.service; \
+	else \
+		echo "Skipping cpa-manager-plus.service (host not kyber)"; \
+	fi
 	@echo "✅ CPA Manager Plus restarted"
 
 .PHONY: systemctl-code-syncer

--- a/home-manager/services/cpa-manager-plus/default.nix
+++ b/home-manager/services/cpa-manager-plus/default.nix
@@ -9,6 +9,11 @@ let
   startScript = pkgs.replaceVars ./start.sh {
     docker = "${pkgs.docker}/bin/docker";
   };
+  dockerStartScript = pkgs.replaceVars ./docker-start.sh {
+    inherit (pkgs) bash;
+    docker = "${pkgs.docker}/bin/docker";
+    start_script = startScript;
+  };
 in
 lib.mkIf (pkgs.stdenv.isLinux && host.isKyber) {
   systemd.user.services.cpa-manager-plus = {
@@ -29,7 +34,7 @@ lib.mkIf (pkgs.stdenv.isLinux && host.isKyber) {
     };
     Service = {
       Type = "simple";
-      ExecStart = "${pkgs.bash}/bin/bash ${startScript}";
+      ExecStart = "${pkgs.bash}/bin/bash ${dockerStartScript}";
       Environment = "PATH=${
         lib.makeBinPath [
           pkgs.bash
@@ -37,7 +42,7 @@ lib.mkIf (pkgs.stdenv.isLinux && host.isKyber) {
           pkgs.docker
         ]
       }:/usr/bin:/usr/sbin";
-      TimeoutStopSec = 30;
+      TimeoutStopSec = 45;
       Restart = "always";
       RestartSec = 5;
     };

--- a/home-manager/services/cpa-manager-plus/default.nix
+++ b/home-manager/services/cpa-manager-plus/default.nix
@@ -1,0 +1,46 @@
+{
+  inputs,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (inputs) host;
+  startScript = pkgs.replaceVars ./start.sh {
+    docker = "${pkgs.docker}/bin/docker";
+  };
+in
+lib.mkIf (pkgs.stdenv.isLinux && host.isKyber) {
+  systemd.user.services.cpa-manager-plus = {
+    Unit = {
+      Description = "CPA Manager Plus analytics and management server";
+      After = [
+        "network-online.target"
+        "docker.service"
+        "cliproxyapi.service"
+      ];
+      Wants = [
+        "network-online.target"
+        "docker.service"
+        "cliproxyapi.service"
+      ];
+      StartLimitIntervalSec = 300;
+      StartLimitBurst = 10;
+    };
+    Service = {
+      Type = "simple";
+      ExecStart = "${pkgs.bash}/bin/bash ${startScript}";
+      Environment = "PATH=${
+        lib.makeBinPath [
+          pkgs.bash
+          pkgs.coreutils
+          pkgs.docker
+        ]
+      }:/usr/bin:/usr/sbin";
+      TimeoutStopSec = 30;
+      Restart = "always";
+      RestartSec = 5;
+    };
+    Install.WantedBy = [ "default.target" ];
+  };
+}

--- a/home-manager/services/cpa-manager-plus/docker-start.sh
+++ b/home-manager/services/cpa-manager-plus/docker-start.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT="@bash@/bin/bash @start_script@"
+
+if @docker@ info >/dev/null 2>&1; then
+  exec $SCRIPT
+fi
+
+if [ -x /run/wrappers/bin/sg ]; then
+  exec /run/wrappers/bin/sg docker -c "$SCRIPT"
+elif [ -x /usr/bin/sg ]; then
+  exec /usr/bin/sg docker -c "$SCRIPT"
+else
+  echo "ERROR: Cannot access Docker. User not in docker group and no sg binary found." >&2
+  exit 1
+fi

--- a/home-manager/services/cpa-manager-plus/start.sh
+++ b/home-manager/services/cpa-manager-plus/start.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONTAINER_NAME="cpa-manager-plus"
+IMAGE="${CPA_MANAGER_PLUS_IMAGE:-seakee/cpa-manager-plus:latest}"
+DATA_DIR="${CPA_MANAGER_PLUS_DATA_DIR:-${HOME}/.cpa-manager-plus}"
+ENV_FILE="${HOME}/dotfiles/.env"
+
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$ENV_FILE"
+  set +a
+fi
+
+umask 077
+mkdir -p "$DATA_DIR"
+chmod 700 "$DATA_DIR"
+
+ensure_container_removed() {
+  @docker@ rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  for _ in 1 2 3 4 5; do
+    if ! @docker@ inspect "$CONTAINER_NAME" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+    @docker@ rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  done
+  ! @docker@ inspect "$CONTAINER_NAME" >/dev/null 2>&1
+}
+
+child_pid=""
+trap '
+  @docker@ stop --time 15 "$CONTAINER_NAME" >/dev/null 2>&1 || @docker@ rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  if [ -n "$child_pid" ]; then
+    wait "$child_pid" 2>/dev/null || true
+  fi
+' TERM INT
+
+if @docker@ info >/dev/null 2>&1; then
+  echo "Pulling CPA Manager Plus image..."
+  @docker@ pull "$IMAGE" || true
+else
+  echo "Docker is not accessible" >&2
+  exit 1
+fi
+
+if ! ensure_container_removed; then
+  echo "Failed to remove stale CPA Manager Plus container" >&2
+  exit 1
+fi
+
+docker_args=(
+  run
+  --rm
+  --name "$CONTAINER_NAME"
+  --network host
+  --ulimit nofile=65536:65536
+  -v "$DATA_DIR:/data"
+  -e "HTTP_ADDR=0.0.0.0:18317"
+  -e "USAGE_DB_PATH=/data/usage.sqlite"
+  -e "CPA_MANAGER_DATA_KEY_PATH=/data/data.key"
+  -e "USAGE_COLLECTOR_MODE=auto"
+  -e "USAGE_BATCH_SIZE=100"
+  -e "USAGE_POLL_INTERVAL_MS=500"
+  -e "USAGE_QUERY_LIMIT=50000"
+)
+
+if [ -n "${CPA_MANAGER_ADMIN_KEY:-}" ]; then
+  docker_args+=(-e "CPA_MANAGER_ADMIN_KEY=${CPA_MANAGER_ADMIN_KEY}")
+fi
+
+management_key="${CLIPROXY_MANAGEMENT_PASSWORD:-${CLIPROXY_MANAGEMENT_KEY:-}}"
+if [ -n "$management_key" ]; then
+  docker_args+=(
+    -e "CPA_UPSTREAM_URL=http://127.0.0.1:8317"
+    -e "CPA_MANAGEMENT_KEY=${management_key}"
+  )
+fi
+
+@docker@ "${docker_args[@]}" "$IMAGE" &
+child_pid=$!
+wait "$child_pid"

--- a/home-manager/services/cpa-manager-plus/start.sh
+++ b/home-manager/services/cpa-manager-plus/start.sh
@@ -57,6 +57,8 @@ docker_args=(
   --network host
   --ulimit nofile=65536:65536
   -v "$DATA_DIR:/data"
+  # Kubernetes reaches this host port through a selectorless Service. CPA
+  # Manager Plus protects the UI with the configured or first-run admin key.
   -e "HTTP_ADDR=0.0.0.0:18317"
   -e "USAGE_DB_PATH=/data/usage.sqlite"
   -e "CPA_MANAGER_DATA_KEY_PATH=/data/data.key"

--- a/home-manager/services/cpa-manager-plus/start.sh
+++ b/home-manager/services/cpa-manager-plus/start.sh
@@ -2,8 +2,6 @@
 set -euo pipefail
 
 CONTAINER_NAME="cpa-manager-plus"
-IMAGE="${CPA_MANAGER_PLUS_IMAGE:-seakee/cpa-manager-plus:latest}"
-DATA_DIR="${CPA_MANAGER_PLUS_DATA_DIR:-${HOME}/.cpa-manager-plus}"
 ENV_FILE="${HOME}/dotfiles/.env"
 
 if [ -f "$ENV_FILE" ]; then
@@ -12,6 +10,9 @@ if [ -f "$ENV_FILE" ]; then
   . "$ENV_FILE"
   set +a
 fi
+
+IMAGE="${CPA_MANAGER_PLUS_IMAGE:-seakee/cpa-manager-plus:latest}"
+DATA_DIR="${CPA_MANAGER_PLUS_DATA_DIR:-${HOME}/.cpa-manager-plus}"
 
 umask 077
 mkdir -p "$DATA_DIR"
@@ -69,14 +70,16 @@ docker_args=(
 )
 
 if [ -n "${CPA_MANAGER_ADMIN_KEY:-}" ]; then
-  docker_args+=(-e "CPA_MANAGER_ADMIN_KEY=${CPA_MANAGER_ADMIN_KEY}")
+  export CPA_MANAGER_ADMIN_KEY
+  docker_args+=(-e CPA_MANAGER_ADMIN_KEY)
 fi
 
 management_key="${CLIPROXY_MANAGEMENT_PASSWORD:-${CLIPROXY_MANAGEMENT_KEY:-}}"
 if [ -n "$management_key" ]; then
+  export CPA_MANAGEMENT_KEY="$management_key"
   docker_args+=(
     -e "CPA_UPSTREAM_URL=http://127.0.0.1:8317"
-    -e "CPA_MANAGEMENT_KEY=${management_key}"
+    -e CPA_MANAGEMENT_KEY
   )
 fi
 

--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -9,6 +9,7 @@ let
   brewUpgrader = import ./brew-upgrader { inherit pkgs; };
   cass = import ./cass { inherit pkgs; };
   cliproxyapi = import ./cliproxyapi;
+  cpaManagerPlus = ./cpa-manager-plus;
   codeSyncer = import ./code-syncer { inherit pkgs; };
   dolt = ./dolt;
   docker = import ./docker { inherit lib pkgs; };
@@ -37,6 +38,7 @@ in
   brewUpgrader
   cass
   cliproxyapi
+  cpaManagerPlus
   codeSyncer
   dolt
   docker

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -217,6 +217,10 @@ It 'has spec file for home-manager/services/cliproxyapi/scripts/docker-start.sh'
 The path "spec/cliproxyapi_docker_start_spec.sh" should be exist
 End
 
+It 'has spec file for home-manager/services/cpa-manager-plus/start.sh'
+The path "spec/cpa_manager_plus_spec.sh" should be exist
+End
+
 It 'has spec file for home-manager/services/docker/setup-docker.sh'
 The path "spec/docker_setup_spec.sh" should be exist
 End
@@ -486,6 +490,7 @@ home-manager/programs/ssh/pin-known-hosts.sh
 home-manager/programs/tmux/session-logger.sh
 home-manager/services/brew-upgrader/upgrade.sh
 home-manager/services/cass/daily.sh
+home-manager/services/cpa-manager-plus/start.sh
 home-manager/services/cliproxyapi/scripts/backup.sh
 home-manager/services/cliproxyapi/scripts/common.sh
 home-manager/services/cliproxyapi/scripts/docker-start.sh

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -221,6 +221,10 @@ It 'has spec file for home-manager/services/cpa-manager-plus/start.sh'
 The path "spec/cpa_manager_plus_spec.sh" should be exist
 End
 
+It 'has spec file for home-manager/services/cpa-manager-plus/docker-start.sh'
+The path "spec/cpa_manager_plus_spec.sh" should be exist
+End
+
 It 'has spec file for home-manager/services/docker/setup-docker.sh'
 The path "spec/docker_setup_spec.sh" should be exist
 End
@@ -490,6 +494,7 @@ home-manager/programs/ssh/pin-known-hosts.sh
 home-manager/programs/tmux/session-logger.sh
 home-manager/services/brew-upgrader/upgrade.sh
 home-manager/services/cass/daily.sh
+home-manager/services/cpa-manager-plus/docker-start.sh
 home-manager/services/cpa-manager-plus/start.sh
 home-manager/services/cliproxyapi/scripts/backup.sh
 home-manager/services/cliproxyapi/scripts/common.sh

--- a/spec/cpa_manager_plus_spec.sh
+++ b/spec/cpa_manager_plus_spec.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+Describe 'CPA Manager Plus service'
+NIX_MODULE="$PWD/home-manager/services/cpa-manager-plus/default.nix"
+START_SCRIPT="$PWD/home-manager/services/cpa-manager-plus/start.sh"
+
+It 'is enabled only on Kyber Linux'
+When run grep 'pkgs.stdenv.isLinux && host.isKyber' "$NIX_MODULE"
+The output should include 'pkgs.stdenv.isLinux && host.isKyber'
+End
+
+It 'starts after Docker and CLIProxyAPI'
+When run grep -A 8 'After = ' "$NIX_MODULE"
+The output should include 'docker.service'
+The output should include 'cliproxyapi.service'
+End
+
+It 'runs the published manager image on the host network'
+When run grep -E 'seakee/cpa-manager-plus:latest|--network host' "$START_SCRIPT"
+The output should include 'seakee/cpa-manager-plus:latest'
+The output should include '--network host'
+End
+
+It 'persists SQLite and the encryption key under the data mount'
+When run grep -E 'USAGE_DB_PATH=/data/usage.sqlite|CPA_MANAGER_DATA_KEY_PATH=/data/data.key' "$START_SCRIPT"
+The output should include 'USAGE_DB_PATH=/data/usage.sqlite'
+The output should include 'CPA_MANAGER_DATA_KEY_PATH=/data/data.key'
+End
+
+It 'restricts the persistent data directory to the service user'
+When run grep -E 'umask 077|chmod 700' "$START_SCRIPT"
+The output should include 'umask 077'
+The output should include 'chmod 700'
+End
+
+It 'connects to the local CPA without exposing the management key'
+When run grep -E 'CPA_UPSTREAM_URL=http://127.0.0.1:8317|CPA_MANAGEMENT_KEY=' "$START_SCRIPT"
+The output should include 'CPA_UPSTREAM_URL=http://127.0.0.1:8317'
+The output should include 'CPA_MANAGEMENT_KEY='
+End
+End

--- a/spec/cpa_manager_plus_spec.sh
+++ b/spec/cpa_manager_plus_spec.sh
@@ -47,8 +47,9 @@ The output should include 'chmod 700'
 End
 
 It 'connects to the local CPA without exposing the management key'
-When run grep -E 'CPA_UPSTREAM_URL=http://127.0.0.1:8317|CPA_MANAGEMENT_KEY=' "$START_SCRIPT"
+When run grep -E 'CPA_UPSTREAM_URL=http://127.0.0.1:8317|-e CPA_MANAGEMENT_KEY' "$START_SCRIPT"
 The output should include 'CPA_UPSTREAM_URL=http://127.0.0.1:8317'
-The output should include 'CPA_MANAGEMENT_KEY='
+The output should include '-e CPA_MANAGEMENT_KEY'
+The output should not include 'CPA_MANAGEMENT_KEY=${management_key}'
 End
 End

--- a/spec/cpa_manager_plus_spec.sh
+++ b/spec/cpa_manager_plus_spec.sh
@@ -3,6 +3,7 @@
 Describe 'CPA Manager Plus service'
 NIX_MODULE="$PWD/home-manager/services/cpa-manager-plus/default.nix"
 START_SCRIPT="$PWD/home-manager/services/cpa-manager-plus/start.sh"
+DOCKER_START_SCRIPT="$PWD/home-manager/services/cpa-manager-plus/docker-start.sh"
 
 It 'is enabled only on Kyber Linux'
 When run grep 'pkgs.stdenv.isLinux && host.isKyber' "$NIX_MODULE"
@@ -13,6 +14,18 @@ It 'starts after Docker and CLIProxyAPI'
 When run grep -A 8 'After = ' "$NIX_MODULE"
 The output should include 'docker.service'
 The output should include 'cliproxyapi.service'
+End
+
+It 'uses the Docker group wrapper and allows a clean shutdown window'
+When run grep -E 'dockerStartScript|TimeoutStopSec = 45' "$NIX_MODULE"
+The output should include 'dockerStartScript'
+The output should include 'TimeoutStopSec = 45'
+End
+
+It 'falls back to the host Docker group wrappers'
+When run grep -E '/run/wrappers/bin/sg|/usr/bin/sg' "$DOCKER_START_SCRIPT"
+The output should include '/run/wrappers/bin/sg'
+The output should include '/usr/bin/sg'
 End
 
 It 'runs the published manager image on the host network'


### PR DESCRIPTION
## Summary
- run CPA Manager Plus on Kyber as a Home Manager systemd user service
- persist its SQLite database and encryption key under `~/.cpa-manager-plus`
- connect it to the local CLIProxyAPI service using the existing local management credential
- document the separate CPAMP admin key and add service coverage

## Verification
- `shellspec spec/cpa_manager_plus_spec.sh spec/coverage_spec.sh`
- `shellcheck home-manager/services/cpa-manager-plus/start.sh`
- `make nix-format-check`
- `make nix-lint`
- `make nix-test`

The full fish suite has unrelated existing CAAM/profile fixture failures; the 1,851 ShellSpec examples pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CPA Manager Plus analytics as a systemd user service on Kyber, running in Docker and wired to the local `CLIProxyAPI`. Stores data and the key in `~/.cpa-manager-plus` and avoids leaking admin/management secrets in argv.

- **New Features**
  - Home Manager module and start script to run `seakee/cpa-manager-plus:latest` on the host network (Kyber Linux only).
  - Persists SQLite at `/data/usage.sqlite` and key at `/data/data.key` under `~/.cpa-manager-plus` (700 perms).
  - `make systemctl` includes `systemctl-cpa-manager-plus`; optional `CPA_MANAGER_ADMIN_KEY` in `.env`.

- **Bug Fixes**
  - Hardened startup/lifecycle: verify Docker or use `sg docker`, pre-pull image, remove stale containers, graceful stop; ordered after `docker.service`, `cliproxyapi.service`, and network-online.
  - Prevent secret leaks by exporting admin/management keys and passing via env, not literal args.

<sup>Written for commit 55890b08e0918820c671490b34bb6e606ffd0c40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

