### PR TITLE
fix(ci): check all nvim invocations for errors and add weekly schedule

### DIFF
--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches:
       - main
-  schedule:
-    - cron: "0 0 * * 1"
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true

--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: "0 0 * * 1"
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true

--- a/Makefile
+++ b/Makefile
@@ -1070,11 +1070,19 @@ lua-check-neovim: ## Check Neovim configuration.
 	fi
 	@echo "📝 Validating Neovim configuration syntax..."
 	@echo "📦 Installing plugins..."
-	@nvim -u "$(PWD)/home-manager/programs/neovim/init.lua" --headless +"lua vim.pack.update()" +qa 2>&1
+	@nvim -u "$(PWD)/home-manager/programs/neovim/init.lua" --headless +"lua vim.pack.update()" +qa 2>&1 | tee /tmp/nvim-pack-update.log; \
+	if grep -q "^E[0-9]\|^Error\|module .* not found" /tmp/nvim-pack-update.log; then \
+		echo "❌ Neovim plugin installation has errors"; \
+		exit 1; \
+	fi
 	@bash $(PWD)/scripts/build-neovim-plugins.sh
 	@echo "🌳 Installing and verifying configured Treesitter parsers..."
 	@nvim -u "$(PWD)/home-manager/programs/neovim/init.lua" --headless \
-		-l "$(PWD)/home-manager/programs/neovim/verify_parsers.lua" 2>&1
+		-l "$(PWD)/home-manager/programs/neovim/verify_parsers.lua" 2>&1 | tee /tmp/nvim-ts-verify.log; \
+	if grep -q "^E[0-9]\|^Error\|module .* not found" /tmp/nvim-ts-verify.log; then \
+		echo "❌ Treesitter parser verification has errors"; \
+		exit 1; \
+	fi
 	@nvim -u "$(PWD)/home-manager/programs/neovim/init.lua" --headless -c "qa" 2>&1 | tee /tmp/nvim-check.log; \
 	if grep -q "^E[0-9]\|^Error\|module .* not found" /tmp/nvim-check.log; then \
 		echo "❌ Neovim configuration has errors"; \


### PR DESCRIPTION
## Summary

- Add error checking (grep for `^E[0-9]`, `^Error`, `module .* not found`) to plugin install and treesitter verify steps in `lua-check-neovim`
- Add weekly cron schedule (`0 0 * * 1`) to `lua.yml` to catch post-merge plugin drift

## Context

PR #2169 passed CI because it was tested against a pinned `nvim-treesitter` revision (`61df849` on `main`) that had `get_available()`/`get_installed()` APIs. After merge, `vim.pack.update()` pulled a newer revision (`42fc28ba` on `master`) where those APIs were removed, breaking startup.

CI didn't catch it because:
1. The plugin install step (line 1073) and treesitter verify step (lines 1076-1077) had **no error checking** - nvim exits 0 even on Lua errors
2. Only the final headless startup (line 1078) grepped for errors, but by then the same error was already silently passing in earlier steps
3. No scheduled CI existed to re-validate after plugin updates

## Test plan

- [ ] Verify `make lua-check-neovim` still passes on current config
- [ ] Confirm weekly schedule triggers on Mondays at 00:00 UTC

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CI now checks all `nvim` invocations in `lua-check-neovim` for errors and fails early. Also adds a weekly cron to catch plugin drift.

- **Bug Fixes**
  - Plugin install and Treesitter verify now tee output and grep for "^E[0-9]", "^Error", or "module .* not found"; exit 1 on match.

- **New Features**
  - Weekly schedule in `.github/workflows/lua.yml` (`0 0 * * 1`) to re-run checks after plugin updates.

<sup>Written for commit da0430da9c88545e85bd920900fb60c744b7b016. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

