### PR TITLE
fix: switch memory backend to QMD

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -220,7 +220,9 @@
     }
   },
   "memory": {
+    "backend": "qmd",
     "qmd": {
+      "update": { "startup": "immediate" },
       "scope": {
         "default": "allow"
       }

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -220,7 +220,9 @@
     }
   },
   "memory": {
+    "backend": "qmd",
     "qmd": {
+      "update": { "startup": "immediate" },
       "scope": {
         "default": "allow"
       }


### PR DESCRIPTION
## What
- Set `memory.backend` to `"qmd"` — was defaulting to builtin which requires OpenAI embeddings (broken billing)
- Set `memory.qmd.update.startup` to `"immediate"` so QMD initializes on gateway start instead of waiting for first memory use

## Why
OpenAI billing is not active, causing `openclaw memory index --force` to fail with 429 errors across all agents. QMD is already configured and installed (v2.5.3) but wasn't being used because the backend wasn't explicitly set.

## Files changed
- `config/openclaw/openclaw.tpl.json`
- `config/openclaw/openclaw.template.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the memory backend to `qmd` and initializes it on gateway start to prevent OpenAI embedding failures and restore reliable memory indexing.

- **Bug Fixes**
  - Set `memory.backend` to `qmd` in both OpenClaw configs.
  - Set `memory.qmd.update.startup` to `immediate` so QMD initializes on boot.

<sup>Written for commit 1a9bb6da28fdd84f6479138e9458f7f585fe2164. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

