### PR TITLE
fix(kyber): restart gateway services after Home Manager changes

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -222,7 +222,9 @@
   "memory": {
     "backend": "qmd",
     "qmd": {
-      "update": { "startup": "immediate" },
+      "update": {
+        "startup": "immediate"
+      },
       "scope": {
         "default": "allow"
       }

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -222,7 +222,9 @@
   "memory": {
     "backend": "qmd",
     "qmd": {
-      "update": { "startup": "immediate" },
+      "update": {
+        "startup": "immediate"
+      },
       "scope": {
         "default": "allow"
       }

--- a/home-manager/services/cpa-manager-plus/default.nix
+++ b/home-manager/services/cpa-manager-plus/default.nix
@@ -29,12 +29,12 @@ lib.mkIf (pkgs.stdenv.isLinux && host.isKyber) {
         "docker.service"
         "cliproxyapi.service"
       ];
+      X-SwitchMethod = "restart";
       StartLimitIntervalSec = 300;
       StartLimitBurst = 10;
     };
     Service = {
       Type = "simple";
-      "X-RestartIfChanged" = true;
       ExecStart = "${pkgs.bash}/bin/bash ${dockerStartScript}";
       Environment = "PATH=${
         lib.makeBinPath [

--- a/home-manager/services/cpa-manager-plus/default.nix
+++ b/home-manager/services/cpa-manager-plus/default.nix
@@ -34,6 +34,7 @@ lib.mkIf (pkgs.stdenv.isLinux && host.isKyber) {
     };
     Service = {
       Type = "simple";
+      "X-RestartIfChanged" = true;
       ExecStart = "${pkgs.bash}/bin/bash ${dockerStartScript}";
       Environment = "PATH=${
         lib.makeBinPath [

--- a/home-manager/services/openclaw/default.nix
+++ b/home-manager/services/openclaw/default.nix
@@ -30,6 +30,7 @@ lib.mkIf host.isKyber {
     };
     Service = {
       Type = "simple";
+      "X-RestartIfChanged" = true;
       ExecStart = "${homeDir}/.bun/bin/openclaw gateway --port 18789 --bind loopback";
       Restart = "always";
       RestartSec = "5s";
@@ -57,6 +58,7 @@ lib.mkIf host.isKyber {
     };
     Service = {
       Type = "simple";
+      "X-RestartIfChanged" = true;
       ExecStart = "${pkgs.socat}/bin/socat TCP4-LISTEN:18789,bind=10.42.0.1,reuseaddr,fork TCP4:127.0.0.1:18789";
       Restart = "always";
       RestartSec = "5s";

--- a/home-manager/services/openclaw/default.nix
+++ b/home-manager/services/openclaw/default.nix
@@ -25,12 +25,12 @@ lib.mkIf host.isKyber {
         "install-npm-globals.service"
       ];
       Wants = [ "network-online.target" ];
+      X-SwitchMethod = "restart";
       StartLimitIntervalSec = 300;
       StartLimitBurst = 10;
     };
     Service = {
       Type = "simple";
-      "X-RestartIfChanged" = true;
       ExecStart = "${homeDir}/.bun/bin/openclaw gateway --port 18789 --bind loopback";
       Restart = "always";
       RestartSec = "5s";
@@ -55,10 +55,10 @@ lib.mkIf host.isKyber {
       Description = "OpenClaw k3s bridge proxy";
       After = [ "openclaw-gateway.service" ];
       Requires = [ "openclaw-gateway.service" ];
+      X-SwitchMethod = "restart";
     };
     Service = {
       Type = "simple";
-      "X-RestartIfChanged" = true;
       ExecStart = "${pkgs.socat}/bin/socat TCP4-LISTEN:18789,bind=10.42.0.1,reuseaddr,fork TCP4:127.0.0.1:18789";
       Restart = "always";
       RestartSec = "5s";

--- a/spec/activate_paperclip_openclaw_spec.sh
+++ b/spec/activate_paperclip_openclaw_spec.sh
@@ -46,6 +46,11 @@ It 'orders the k3s bridge proxy after the loopback gateway'
 When run bash -c "grep -F 'After = [ \"openclaw-gateway.service\" ]' '$PWD/home-manager/services/openclaw/default.nix'"
 The output should include 'openclaw-gateway.service'
 End
+
+It 'restarts the gateway and bridge when Home Manager changes the units'
+When run grep -c 'X-RestartIfChanged' "$PWD/home-manager/services/openclaw/default.nix"
+The output should equal 2
+End
 End
 
 Describe 'home-manager/services/hermes/activate.sh'

--- a/spec/activate_paperclip_openclaw_spec.sh
+++ b/spec/activate_paperclip_openclaw_spec.sh
@@ -47,9 +47,14 @@ When run bash -c "grep -F 'After = [ \"openclaw-gateway.service\" ]' '$PWD/home-
 The output should include 'openclaw-gateway.service'
 End
 
-It 'restarts the gateway and bridge when Home Manager changes the units'
-When run grep -c 'X-RestartIfChanged' "$PWD/home-manager/services/openclaw/default.nix"
-The output should equal 2
+It 'restarts the gateway when Home Manager changes the unit'
+When run bash -c "sed -n '/systemd.user.services.openclaw-gateway =/,/Install = {/p' '$PWD/home-manager/services/openclaw/default.nix' | grep -F 'X-SwitchMethod = \"restart\";'"
+The output should include 'X-SwitchMethod = "restart";'
+End
+
+It 'restarts the bridge when Home Manager changes the unit'
+When run bash -c "sed -n '/systemd.user.services.openclaw-k3s-proxy =/,/Install = {/p' '$PWD/home-manager/services/openclaw/default.nix' | grep -F 'X-SwitchMethod = \"restart\";'"
+The output should include 'X-SwitchMethod = "restart";'
 End
 End
 

--- a/spec/cpa_manager_plus_spec.sh
+++ b/spec/cpa_manager_plus_spec.sh
@@ -24,8 +24,8 @@ The output should include 'TimeoutStopSec = 45'
 End
 
 It 'restarts when Home Manager changes the unit'
-When run grep 'X-RestartIfChanged' "$NIX_MODULE"
-The output should include 'X-RestartIfChanged'
+When run bash -c "sed -n '/systemd.user.services.cpa-manager-plus =/,/Install.WantedBy/p' '$NIX_MODULE'"
+The output should include 'X-SwitchMethod = "restart";'
 End
 
 It 'falls back to the host Docker group wrappers'

--- a/spec/cpa_manager_plus_spec.sh
+++ b/spec/cpa_manager_plus_spec.sh
@@ -22,6 +22,11 @@ The output should include 'dockerStartScript'
 The output should include 'TimeoutStopSec = 45'
 End
 
+It 'restarts when Home Manager changes the unit'
+When run grep 'X-RestartIfChanged' "$NIX_MODULE"
+The output should include 'X-RestartIfChanged'
+End
+
 It 'falls back to the host Docker group wrappers'
 When run grep -E '/run/wrappers/bin/sg|/usr/bin/sg' "$DOCKER_START_SCRIPT"
 The output should include '/run/wrappers/bin/sg'

--- a/spec/dotfiles_updater_spec.sh
+++ b/spec/dotfiles_updater_spec.sh
@@ -25,7 +25,7 @@ End
 Describe 'service host identity'
 It 'passes the canonical named host to automatic updates'
 When run bash -c "grep 'HOST=\${canonicalHost}' '$MODULE'"
-The output should include 'HOST=${canonicalHost}'
+The output should include "HOST=\${canonicalHost}"
 End
 
 It 'derives the canonical host from named-host flags'


### PR DESCRIPTION
## Summary
- restart CPA Manager Plus when its Home Manager unit changes
- restart the OpenClaw gateway and k3s bridge when their units change
- add regression coverage for all three restart markers

## Root cause
A Kyber Home Manager activation stopped the enabled CPA Manager Plus and OpenClaw units at 03:45 UTC but did not restart them. The missing `X-RestartIfChanged` service metadata left the units enabled but dead, producing connection refusals from the management and OpenClaw ingress backends.

## Validation
- focused CPA/OpenClaw ShellSpec: 23 examples, 0 failures
- `make nix-test`: passed
- `nix-instantiate --parse` for both changed Nix modules: passed
- full `make shell-test`: 1,869 shell examples ran; pre-existing unrelated fish/CAAM environment failures remain (14 failures)

Live recovery was performed by starting the already-declaratively-enabled services; CPA management and OpenClaw ingress are responding again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use Home Manager’s restart switch policy so CPA Manager Plus and the OpenClaw gateway/k3s bridge auto-restart after activations, preventing dead services and connection refusals. Also fixes a shellcheck expectation in the dotfiles updater spec to keep CI green.

- **Bug Fixes**
  - Set X-SwitchMethod = "restart" for CPA Manager Plus, OpenClaw gateway, and k3s bridge units.
  - Added ShellSpec tests to verify the restart policy for all three units.
  - Updated `spec/dotfiles_updater_spec.sh` quoting to satisfy shellcheck’s canonical host check.

- **Refactors**
  - Reformatted the QMD memory "update" block in `config/openclaw/openclaw.template.json` and `config/openclaw/openclaw.tpl.json` for readability (no behavior change).

<sup>Written for commit 50b4c61b50a57eac688002c166482dffed7eedb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

