### PR TITLE
feat(darwin): add Orca cask and dock, ignore gate locks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -501,6 +501,9 @@ target
 #.idea/
 *.deb
 
+# Gate locks
+*.gate.lock
+
 # Beads / Dolt files (added by bd init)
 .dolt/
 *.db

--- a/nix-darwin/config/dock.nix
+++ b/nix-darwin/config/dock.nix
@@ -27,6 +27,8 @@
       "/Applications/OpenCode.app"
       "/Applications/Antigravity.app"
       "/Applications/Conductor.app"
+      "/Applications/OpenClaw.app"
+      "/Applications/Orca.app"
       "/Applications/Beekeeper Studio.app"
       "/Applications/Google Chrome.app"
       "/Applications/Docker.app"

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -52,6 +52,10 @@
         trusted = true;
       }
       {
+        name = "stablyai/orca";
+        trusted = true;
+      }
+      {
         name = "steipete/tap";
         trusted = true;
       }
@@ -157,6 +161,7 @@
       "open-pencil"
       "openclaw"
       "opencode-desktop"
+      "orca"
       "raycast"
       "repobar"
       "rescuetime"


### PR DESCRIPTION
## Summary
- Add `stablyai/orca` tap (trusted) + `orca` cask to Homebrew (install per https://www.onorca.dev/)
- Place `OpenClaw.app` and `Orca.app` side by side, right of Conductor in the dock
- Gitignore `*.gate.lock` (matches `.beads.gate.lock`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the trusted `stablyai/orca` tap and the `orca` cask to Homebrew. Add `OpenClaw.app` and `Orca.app` to the Dock to the right of Conductor, and ignore `*.gate.lock` files in Git.

<sup>Written for commit a08d0eac11e5088903e8c8f4fe836927a9e91e5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

