### PR TITLE
fix(fish): use caam run for Codex after upstream #64

### DIFF
--- a/home-manager/programs/fish/functions/_caam_exec_function.fish
+++ b/home-manager/programs/fish/functions/_caam_exec_function.fish
@@ -40,6 +40,29 @@ function _caam_exec_function --description "Run an agent launcher through CAAM w
           if test "$tool" = opencode; and test -z "$XDG_CONFIG_HOME"
             set -fx XDG_CONFIG_HOME "$HOME/.config"
           end
+
+          # caam exec wraps stdout for Codex session capture, which makes stdout a
+          # non-TTY pipe. Interactive TUIs (bare `codex`, resume, etc.) then abort
+          # with "stdout is not a terminal". Keep profile isolation via env and
+          # run the binary directly when stdout is a real terminal.
+          set -l profiles_root "$HOME/.local/share/caam/profiles"
+          if set -q XDG_DATA_HOME; and test -n "$XDG_DATA_HOME"
+            set profiles_root "$XDG_DATA_HOME/caam/profiles"
+          end
+          set -l profile_dir "$profiles_root/$tool/$profile"
+          if isatty stdout; and test -d "$profile_dir"
+            # Keep CODEX_HOME set inside this block: fish locals are block-scoped,
+            # so a nested `if` would drop the export before the child runs.
+            set -lx HOME "$profile_dir/home"
+            if test "$tool" = codex
+              set -lx CODEX_HOME "$profile_dir/codex_home"
+              $executable $argv
+              return $status
+            end
+            $executable $argv
+            return $status
+          end
+
           caam exec "$tool" "$profile" -- $argv
           return $status
         end

--- a/home-manager/programs/fish/functions/_caam_exec_function.fish
+++ b/home-manager/programs/fish/functions/_caam_exec_function.fish
@@ -40,29 +40,6 @@ function _caam_exec_function --description "Run an agent launcher through CAAM w
           if test "$tool" = opencode; and test -z "$XDG_CONFIG_HOME"
             set -fx XDG_CONFIG_HOME "$HOME/.config"
           end
-
-          # caam exec wraps stdout for Codex session capture, which makes stdout a
-          # non-TTY pipe. Interactive TUIs (bare `codex`, resume, etc.) then abort
-          # with "stdout is not a terminal". Keep profile isolation via env and
-          # run the binary directly when stdout is a real terminal.
-          set -l profiles_root "$HOME/.local/share/caam/profiles"
-          if set -q XDG_DATA_HOME; and test -n "$XDG_DATA_HOME"
-            set profiles_root "$XDG_DATA_HOME/caam/profiles"
-          end
-          set -l profile_dir "$profiles_root/$tool/$profile"
-          if isatty stdout; and test -d "$profile_dir"
-            # Keep CODEX_HOME set inside this block: fish locals are block-scoped,
-            # so a nested `if` would drop the export before the child runs.
-            set -lx HOME "$profile_dir/home"
-            if test "$tool" = codex
-              set -lx CODEX_HOME "$profile_dir/codex_home"
-              $executable $argv
-              return $status
-            end
-            $executable $argv
-            return $status
-          end
-
           caam exec "$tool" "$profile" -- $argv
           return $status
         end

--- a/home-manager/programs/fish/functions/_caam_exec_function.fish
+++ b/home-manager/programs/fish/functions/_caam_exec_function.fish
@@ -29,26 +29,9 @@ function _caam_exec_function --description "Run an agent launcher through CAAM w
       end
     end
 
-    if contains -- "$tool" codex cursor opencode; and type -q jq
-      set -l precheck (caam precheck "$tool" --format json)
-      if test $status -eq 0
-        set -l profile (string join \n $precheck | jq -r '.recommended.name // empty')
-        if test -n "$profile"
-          # OpenCode keeps credentials under XDG_DATA_HOME but its declarative
-          # providers and plugins under XDG_CONFIG_HOME. Share only the real
-          # host config while CAAM keeps the profile's data and auth isolated.
-          if test "$tool" = opencode; and test -z "$XDG_CONFIG_HOME"
-            set -fx XDG_CONFIG_HOME "$HOME/.config"
-          end
-          caam exec "$tool" "$profile" -- $argv
-          return $status
-        end
-      end
-
-      $executable $argv
-      return $status
-    end
-
+    # Vault-backed run (SmartRunner + PTY). Prefer this over `caam exec` so Codex
+    # keeps a real TTY and uses global vault auth. Requires CAAM with #64
+    # (SmartRunner honors UseGlobalEnv).
     caam run $tool --precheck -- $argv
   else
     $executable $argv

--- a/spec/fish/_caam_exec_function_test.fish
+++ b/spec/fish/_caam_exec_function_test.fish
@@ -37,7 +37,51 @@ _caam_exec_function opencode run hello
 @test "executes the recommended isolated opencode profile" (tail -n 1 $caam_log) = "exec opencode work@example.com -- run hello"
 @test "shares the host XDG config with isolated opencode" (tail -n 1 $xdg_log) = "$HOME/.config"
 
+# Interactive TTY path: when stdout is a TTY and the isolated profile dir exists,
+# run the binary directly with CODEX_HOME/HOME instead of `caam exec` (which
+# wraps stdout and breaks Codex's TUI). fishtape has no TTY, so exercise the
+# branch via a fake isatty + temp profile directory.
+set fake_xdg (mktemp -d)
+set direct_env_log (mktemp)
+set -gx XDG_DATA_HOME "$fake_xdg"
+mkdir -p "$fake_xdg/caam/profiles/codex/work@example.com/home" \
+  "$fake_xdg/caam/profiles/codex/work@example.com/codex_home"
+functions -e isatty
+function isatty
+  test "$argv[1]" = stdout
+end
+functions -e codex
+function codex
+  echo "HOME=$HOME" >> $direct_env_log
+  echo "CODEX_HOME=$CODEX_HOME" >> $direct_env_log
+  echo $argv >> $direct_env_log
+end
+set caam_log (mktemp)
+functions -e caam
+function caam
+  echo $argv >> $caam_log
+  if test "$argv[1]" = precheck
+    echo '{"recommended":{"name":"work@example.com"}}'
+  end
+end
+
+_caam_exec_function codex --dangerously-bypass-approvals-and-sandbox
+
+@test "skips caam exec for interactive TTY codex" (count (cat $caam_log)) -eq 1
+@test "prechecks only for interactive TTY codex" (cat $caam_log) = "precheck codex --format json"
+@test "runs codex directly with isolated CODEX_HOME on TTY" \
+  (grep -c "CODEX_HOME=$fake_xdg/caam/profiles/codex/work@example.com/codex_home" $direct_env_log) -eq 1
+@test "runs codex directly with isolated HOME on TTY" \
+  (grep -c "HOME=$fake_xdg/caam/profiles/codex/work@example.com/home" $direct_env_log) -eq 1
+
+functions -e isatty
+set -e XDG_DATA_HOME
+rm -rf $fake_xdg
+rm -f $direct_env_log
+
 function caam; return 1; end
+functions -e codex
+function codex; echo $argv >> $direct_log; end
 _caam_exec_function codex exec fallback
 
 @test "falls back to native codex when precheck fails" (tail -n 1 $direct_log) = "exec fallback"

--- a/spec/fish/_caam_exec_function_test.fish
+++ b/spec/fish/_caam_exec_function_test.fish
@@ -37,51 +37,7 @@ _caam_exec_function opencode run hello
 @test "executes the recommended isolated opencode profile" (tail -n 1 $caam_log) = "exec opencode work@example.com -- run hello"
 @test "shares the host XDG config with isolated opencode" (tail -n 1 $xdg_log) = "$HOME/.config"
 
-# Interactive TTY path: when stdout is a TTY and the isolated profile dir exists,
-# run the binary directly with CODEX_HOME/HOME instead of `caam exec` (which
-# wraps stdout and breaks Codex's TUI). fishtape has no TTY, so exercise the
-# branch via a fake isatty + temp profile directory.
-set fake_xdg (mktemp -d)
-set direct_env_log (mktemp)
-set -gx XDG_DATA_HOME "$fake_xdg"
-mkdir -p "$fake_xdg/caam/profiles/codex/work@example.com/home" \
-  "$fake_xdg/caam/profiles/codex/work@example.com/codex_home"
-functions -e isatty
-function isatty
-  test "$argv[1]" = stdout
-end
-functions -e codex
-function codex
-  echo "HOME=$HOME" >> $direct_env_log
-  echo "CODEX_HOME=$CODEX_HOME" >> $direct_env_log
-  echo $argv >> $direct_env_log
-end
-set caam_log (mktemp)
-functions -e caam
-function caam
-  echo $argv >> $caam_log
-  if test "$argv[1]" = precheck
-    echo '{"recommended":{"name":"work@example.com"}}'
-  end
-end
-
-_caam_exec_function codex --dangerously-bypass-approvals-and-sandbox
-
-@test "skips caam exec for interactive TTY codex" (count (cat $caam_log)) -eq 1
-@test "prechecks only for interactive TTY codex" (cat $caam_log) = "precheck codex --format json"
-@test "runs codex directly with isolated CODEX_HOME on TTY" \
-  (grep -c "CODEX_HOME=$fake_xdg/caam/profiles/codex/work@example.com/codex_home" $direct_env_log) -eq 1
-@test "runs codex directly with isolated HOME on TTY" \
-  (grep -c "HOME=$fake_xdg/caam/profiles/codex/work@example.com/home" $direct_env_log) -eq 1
-
-functions -e isatty
-set -e XDG_DATA_HOME
-rm -rf $fake_xdg
-rm -f $direct_env_log
-
 function caam; return 1; end
-functions -e codex
-function codex; echo $argv >> $direct_log; end
 _caam_exec_function codex exec fallback
 
 @test "falls back to native codex when precheck fails" (tail -n 1 $direct_log) = "exec fallback"

--- a/spec/fish/_caam_exec_function_test.fish
+++ b/spec/fish/_caam_exec_function_test.fish
@@ -10,37 +10,22 @@ _caam_exec_function codex exec hello
 @test "runs the native executable when rotation is disabled" (cat $direct_log) = "exec hello"
 
 set caam_log (mktemp)
-set xdg_log (mktemp)
 function caam
   echo $argv >> $caam_log
-  if test "$argv[1]" = precheck
-    echo '{"recommended":{"name":"work@example.com"}}'
-  else if test "$argv[1]" = exec
-    echo "$XDG_CONFIG_HOME" >> $xdg_log
-  end
 end
 set -gx CAAM_ROTATION_ENABLED 1
 
 _caam_exec_function codex exec hello
 
-@test "prechecks codex when rotation is enabled" (head -n 1 $caam_log) = "precheck codex --format json"
-@test "executes the recommended isolated codex profile" (tail -n 1 $caam_log) = "exec codex work@example.com -- exec hello"
+@test "runs vault-backed caam run for codex" (tail -n 1 $caam_log) = "run codex --precheck -- exec hello"
 
 _caam_exec_function cursor-agent --print hello
 
-@test "prechecks cursor-agent as cursor" (tail -n 2 $caam_log | head -n 1) = "precheck cursor --format json"
-@test "executes the recommended isolated cursor profile" (tail -n 1 $caam_log) = "exec cursor work@example.com -- --print hello"
+@test "maps cursor-agent to cursor for caam run" (tail -n 1 $caam_log) = "run cursor --precheck -- --print hello"
 
 _caam_exec_function opencode run hello
 
-@test "prechecks opencode when rotation is enabled" (tail -n 2 $caam_log | head -n 1) = "precheck opencode --format json"
-@test "executes the recommended isolated opencode profile" (tail -n 1 $caam_log) = "exec opencode work@example.com -- run hello"
-@test "shares the host XDG config with isolated opencode" (tail -n 1 $xdg_log) = "$HOME/.config"
-
-function caam; return 1; end
-_caam_exec_function codex exec fallback
-
-@test "falls back to native codex when precheck fails" (tail -n 1 $direct_log) = "exec fallback"
+@test "runs vault-backed caam run for opencode" (tail -n 1 $caam_log) = "run opencode --precheck -- run hello"
 
 functions -e caam
 set claude_swap_log (mktemp)
@@ -73,4 +58,4 @@ _caam_exec_function claude --print primary
 
 set -e CAAM_ROTATION_ENABLED
 set -e CLAUDE_SWAP_FALLBACK_ACCOUNT MOCK_CLAUDE_HEALTH
-rm -f $direct_log $caam_log $xdg_log $claude_swap_log
+rm -f $direct_log $caam_log $claude_swap_log


### PR DESCRIPTION
## Summary
- Route Codex/Cursor/OpenCode through vault-backed `caam run --precheck` instead of isolated `caam exec`
- Relies on upstream CAAM [#64](https://github.com/Dicklesworthstone/coding_agent_account_manager/issues/64) so SmartRunner keeps the global vault env and a real TTY for interactive Codex

## Test plan
- [x] `fishtape spec/fish/_caam_exec_function_test.fish`
- [ ] `_coxe_function` launches interactive Codex TUI
- [ ] `caam run codex -- login status` succeeds with vault auth


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Codex, Cursor, and OpenCode to vault-backed `caam run --precheck` after CAAM #64 to keep global vault auth and a real TTY, fixing interactive Codex TUI.

- **Bug Fixes**
  - Restores interactive Codex TUI; removes `caam exec` profile path and the `XDG_CONFIG_HOME` hack.
  - Updates tests to expect `caam run`; verifies `cursor-agent` maps to `cursor`.

<sup>Written for commit 9691aa95b8c37ae7705e85eca32820408f337214. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

