### PR TITLE
fix(fish): avoid hung caam run for interactive Codex TUI

### DIFF
--- a/home-manager/programs/fish/functions/_caam_exec_function.fish
+++ b/home-manager/programs/fish/functions/_caam_exec_function.fish
@@ -29,9 +29,15 @@ function _caam_exec_function --description "Run an agent launcher through CAAM w
       end
     end
 
-    # Vault-backed run (SmartRunner + PTY). Prefer this over `caam exec` so Codex
-    # keeps a real TTY and uses global vault auth. Requires CAAM with #64
-    # (SmartRunner honors UseGlobalEnv).
+    # Interactive TUIs: vault-activate then run the binary on the real TTY.
+    # `caam run` uses SmartRunner's PTY wrapper, which can hang for interactive
+    # Codex (lock held, no child). Non-TTY/scripted runs keep `caam run`.
+    if isatty stdout
+      caam activate $tool --auto >/dev/null
+      $executable $argv
+      return $status
+    end
+
     caam run $tool --precheck -- $argv
   else
     $executable $argv

--- a/spec/fish/_caam_exec_function_test.fish
+++ b/spec/fish/_caam_exec_function_test.fish
@@ -15,9 +15,10 @@ function caam
 end
 set -gx CAAM_ROTATION_ENABLED 1
 
+# fishtape has no TTY, so the non-interactive caam run path is exercised here.
 _caam_exec_function codex exec hello
 
-@test "runs vault-backed caam run for codex" (tail -n 1 $caam_log) = "run codex --precheck -- exec hello"
+@test "runs vault-backed caam run for non-TTY codex" (tail -n 1 $caam_log) = "run codex --precheck -- exec hello"
 
 _caam_exec_function cursor-agent --print hello
 
@@ -26,6 +27,32 @@ _caam_exec_function cursor-agent --print hello
 _caam_exec_function opencode run hello
 
 @test "runs vault-backed caam run for opencode" (tail -n 1 $caam_log) = "run opencode --precheck -- run hello"
+
+# Interactive TTY path: activate --auto then run the binary directly.
+set direct_env_log (mktemp)
+functions -e isatty
+function isatty
+  test "$argv[1]" = stdout
+end
+functions -e codex
+function codex
+  echo $argv >> $direct_env_log
+end
+set caam_log (mktemp)
+functions -e caam
+function caam
+  echo $argv >> $caam_log
+end
+
+_caam_exec_function codex --dangerously-bypass-approvals-and-sandbox
+
+@test "activates vault profile for interactive TTY codex" (cat $caam_log) = "activate codex --auto"
+@test "runs codex directly on interactive TTY" \
+  (cat $direct_env_log) = "--dangerously-bypass-approvals-and-sandbox"
+
+functions -e isatty
+function isatty; builtin isatty $argv; end
+rm -f $direct_env_log
 
 functions -e caam
 set claude_swap_log (mktemp)


### PR DESCRIPTION
## Summary
- Interactive Codex was hanging on `caam run` (SmartRunner held a profile lock with no child process)
- On a real TTY, activate the vault profile then run the binary directly
- Keep `caam run --precheck` for non-TTY/scripted launches

## Test plan
- [x] `fishtape spec/fish/_caam_exec_function_test.fish`
- [ ] Kill any stuck `caam run codex`, then `_coxe_function` opens the TUI
- [ ] Prompted `_coxe_function "hi"` still works


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoids hung Codex TUI launches by detecting a real TTY and running the tool directly after `caam activate`. Non-TTY/scripted runs still use `caam run --precheck`.

- **Bug Fixes**
  - In `_caam_exec_function`, if `isatty stdout`: `caam activate $tool --auto` then execute `$executable $argv`.
  - Keep non-TTY path: `caam run $tool --precheck -- $argv`.
  - Tests updated to verify both interactive and non-interactive paths.

<sup>Written for commit a2104e09ebe01f95ac2ec3dc8c8eee590fa54ff3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

