### PR TITLE
fix(fish): only caam-activate on interactive when usage is near limit

### DIFF
--- a/home-manager/programs/fish/functions/_caam_exec_function.fish
+++ b/home-manager/programs/fish/functions/_caam_exec_function.fish
@@ -29,11 +29,49 @@ function _caam_exec_function --description "Run an agent launcher through CAAM w
       end
     end
 
-    # Interactive TUIs: vault-activate then run the binary on the real TTY.
-    # `caam run` uses SmartRunner's PTY wrapper, which can hang for interactive
-    # Codex (lock held, no child). Non-TTY/scripted runs keep `caam run`.
+    # Interactive TUIs: run on the real TTY. Avoid `caam run` (SmartRunner PTY
+    # can hang). Only vault-activate when the active profile is near its limit
+    # or critical — matches caam run --precheck default threshold (80%).
     if isatty stdout
-      caam activate $tool --auto >/dev/null
+      if type -q jq
+        set -l threshold 80
+        if set -q CAAM_PRECHECK_THRESHOLD; and test -n "$CAAM_PRECHECK_THRESHOLD"
+          set -l scaled (printf '%s\n' "$CAAM_PRECHECK_THRESHOLD" | jq -r 'tonumber | if . <= 1 then (. * 100) else . end | floor' 2>/dev/null)
+          if test -n "$scaled"
+            set threshold $scaled
+          end
+        end
+
+        set -l precheck (caam precheck "$tool" --format json 2>/dev/null)
+        if test $status -eq 0
+          set -l inventory (caam ls "$tool" --json 2>/dev/null)
+          if test $status -eq 0
+            set -l active (string join \n $inventory | jq -r \
+              '[.profiles[] | select(.active == true and ((.system // false) == false))][0].name // empty')
+            set -l active_usage (string join \n $precheck | jq -r --arg name "$active" \
+              '([.recommended] + (.backups // [])) | map(select(.name == $name)) | .[0].usage_percent // empty')
+            set -l active_health (string join \n $inventory | jq -r --arg name "$active" \
+              '[.profiles[] | select(.name == $name)][0].health.status // "unknown"')
+            set -l recommended (string join \n $precheck | jq -r '.recommended.name // empty')
+
+            set -l should_switch 0
+            if test "$active_health" = critical
+              set should_switch 1
+            else if test -n "$active_usage"; and test "$active_usage" -ge "$threshold"
+              set should_switch 1
+            end
+
+            if test $should_switch -eq 1
+              if test -n "$recommended"
+                caam activate "$tool" "$recommended" >/dev/null
+              else
+                caam activate "$tool" --auto >/dev/null
+              end
+            end
+          end
+        end
+      end
+
       $executable $argv
       return $status
     end

--- a/spec/fish/_caam_exec_function_test.fish
+++ b/spec/fish/_caam_exec_function_test.fish
@@ -28,7 +28,7 @@ _caam_exec_function opencode run hello
 
 @test "runs vault-backed caam run for opencode" (tail -n 1 $caam_log) = "run opencode --precheck -- run hello"
 
-# Interactive TTY path: activate --auto then run the binary directly.
+# Interactive TTY: only activate when active usage is near the limit.
 set direct_env_log (mktemp)
 functions -e isatty
 function isatty
@@ -39,20 +39,40 @@ function codex
   echo $argv >> $direct_env_log
 end
 set caam_log (mktemp)
+set -gx MOCK_ACTIVE_USAGE 10
 functions -e caam
 function caam
   echo $argv >> $caam_log
+  if test "$argv[1]" = precheck
+    echo '{"recommended":{"name":"backup@example.com","usage_percent":0},"backups":[{"name":"work@example.com","usage_percent":'$MOCK_ACTIVE_USAGE'}]}'
+  else if test "$argv[1]" = ls
+    echo '{"profiles":[{"name":"work@example.com","active":true,"system":false,"health":{"status":"warning"}},{"name":"backup@example.com","active":false,"system":false,"health":{"status":"healthy"}}]}'
+  end
 end
 
 _caam_exec_function codex --dangerously-bypass-approvals-and-sandbox
 
-@test "activates vault profile for interactive TTY codex" (cat $caam_log) = "activate codex --auto"
-@test "runs codex directly on interactive TTY" \
+@test "skips activate on interactive TTY when usage is low" (count (cat $caam_log)) -eq 2
+@test "prechecks before interactive TTY launch" (head -n 1 $caam_log) = "precheck codex --format json"
+@test "lists profiles before interactive TTY launch" (tail -n 1 $caam_log) = "ls codex --json"
+@test "runs codex directly on interactive TTY when usage is low" \
   (cat $direct_env_log) = "--dangerously-bypass-approvals-and-sandbox"
 
+set -gx MOCK_ACTIVE_USAGE 85
+set caam_log (mktemp)
+set direct_env_log (mktemp)
+_caam_exec_function codex --dangerously-bypass-approvals-and-sandbox
+
+@test "activates recommended profile when interactive usage is near limit" \
+  (tail -n 1 $caam_log) = "activate codex backup@example.com"
+@test "runs codex directly after near-limit activate" \
+  (cat $direct_env_log) = "--dangerously-bypass-approvals-and-sandbox"
+
+# Force non-TTY for remaining tests (claude uses caam run when stdout is not a TTY).
 functions -e isatty
-function isatty; builtin isatty $argv; end
+function isatty; return 1; end
 rm -f $direct_env_log
+set -e MOCK_ACTIVE_USAGE
 
 functions -e caam
 set claude_swap_log (mktemp)


### PR DESCRIPTION
## Summary
- Interactive `_caam_exec_function` no longer runs `caam activate --auto` on every launch
- Prechecks the active profile and activates the recommended one only when usage is >= 80% (or health is critical)
- Applies to all tools on the interactive TTY path (Codex, Cursor, OpenCode, Claude, etc.)
- Override threshold with `CAAM_PRECHECK_THRESHOLD` (0-1 or 0-100)

## Test plan
- [x] `fishtape spec/fish/_caam_exec_function_test.fish`
- [ ] `_coxe_function` keeps the current account when usage is low
- [ ] Near-limit active profile switches to the recommended one


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Only activate CAAM on interactive launches when the active profile is near its limit or in critical health, instead of every time. Reduces surprise account rotation and keeps TUIs snappy for all interactive tools.

- **Bug Fixes**
  - Prechecks the active profile and only switches at >=80% usage or critical health; override with `CAAM_PRECHECK_THRESHOLD` (0–1 or 0–100). Uses `jq` for JSON parsing and skips the precheck if `jq` is not available.
  - Still runs the binary directly on TTY to avoid `caam run` PTY hangs.

<sup>Written for commit 1c28f7abd9488d326b58930bf938c697b77d6389. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

