### PR TITLE
feat(caam): add sync discovery and persistent daemon/sync services

### DIFF
--- a/home-manager/services/caam/default.nix
+++ b/home-manager/services/caam/default.nix
@@ -1,0 +1,113 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  homeDir = config.home.homeDirectory;
+  caamBin = "${homeDir}/.local/bin/caam";
+  pathEnv = "${homeDir}/.local/bin:${homeDir}/.nix-profile/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
+  # Every 15 minutes keeps vaults aligned without hammering SSH.
+  syncIntervalSeconds = 900;
+in
+{
+  # On every home-manager activation: discover SSH peers into the sync pool
+  # and enable auto-sync after backup/refresh.
+  home.activation.caamSyncSetup = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./setup.sh}"
+  '';
+
+  # Persistent token-refresh daemon (foreground under launchd/systemd supervision).
+  launchd.agents.caam-daemon = lib.mkIf pkgs.stdenv.isDarwin {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        caamBin
+        "daemon"
+        "start"
+        "--fg"
+      ];
+      KeepAlive = true;
+      RunAtLoad = true;
+      EnvironmentVariables = {
+        HOME = homeDir;
+        PATH = pathEnv;
+      };
+      StandardOutPath = "/tmp/caam-daemon.log";
+      StandardErrorPath = "/tmp/caam-daemon.error.log";
+    };
+  };
+
+  # Periodic peer sync (freshness-based push/pull).
+  launchd.agents.caam-sync = lib.mkIf pkgs.stdenv.isDarwin {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "${pkgs.bash}/bin/bash"
+        "${./sync.sh}"
+      ];
+      StartInterval = syncIntervalSeconds;
+      RunAtLoad = true;
+      EnvironmentVariables = {
+        HOME = homeDir;
+        PATH = pathEnv;
+      };
+      StandardOutPath = "/tmp/caam-sync.log";
+      StandardErrorPath = "/tmp/caam-sync.error.log";
+    };
+  };
+
+  systemd.user.services.caam-daemon = lib.mkIf pkgs.stdenv.isLinux {
+    Unit = {
+      Description = "CAAM token refresh daemon";
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
+    };
+    Service = {
+      Type = "simple";
+      ExecStart = "${caamBin} daemon start --fg";
+      Restart = "always";
+      RestartSec = 10;
+      Environment = [
+        "HOME=${homeDir}"
+        "PATH=${pathEnv}"
+      ];
+    };
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
+
+  systemd.user.services.caam-sync = lib.mkIf pkgs.stdenv.isLinux {
+    Unit = {
+      Description = "CAAM multi-machine vault sync";
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
+      X-SwitchMethod = "keep-old";
+    };
+    Service = {
+      Type = "oneshot";
+      ExecStart = "${pkgs.bash}/bin/bash ${./sync.sh}";
+      Environment = [
+        "HOME=${homeDir}"
+        "PATH=${pathEnv}"
+      ];
+    };
+  };
+
+  systemd.user.timers.caam-sync = lib.mkIf pkgs.stdenv.isLinux {
+    Unit = {
+      Description = "Periodic CAAM vault sync";
+    };
+    Timer = {
+      OnBootSec = "2min";
+      OnUnitActiveSec = "${toString syncIntervalSeconds}s";
+      Persistent = true;
+      Unit = "caam-sync.service";
+    };
+    Install = {
+      WantedBy = [ "timers.target" ];
+    };
+  };
+}

--- a/home-manager/services/caam/setup.sh
+++ b/home-manager/services/caam/setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Idempotent CAAM sync pool bootstrap for every host:
+# discover peers from ~/.ssh/config, add them to the pool, enable auto-sync.
+set -euo pipefail
+
+CAAM="${CAAM:-$HOME/.local/bin/caam}"
+
+if [[ ! -x "$CAAM" ]]; then
+  echo "caam not found at $CAAM; skipping sync setup" >&2
+  exit 0
+fi
+
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin${PATH:+:$PATH}"
+
+echo "Discovering CAAM sync peers from SSH config..."
+"$CAAM" sync discover --add || true
+
+# localhost is useless in a multi-machine pool; drop it if discover added it.
+"$CAAM" sync remove localhost >/dev/null 2>&1 || true
+
+echo "Enabling CAAM auto-sync after backup/refresh..."
+"$CAAM" sync enable
+
+"$CAAM" sync status || true

--- a/home-manager/services/caam/sync.sh
+++ b/home-manager/services/caam/sync.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Periodic CAAM vault sync with peers in the sync pool.
+set -euo pipefail
+
+CAAM="${CAAM:-$HOME/.local/bin/caam}"
+
+if [[ ! -x "$CAAM" ]]; then
+  echo "caam not found at $CAAM; skipping sync" >&2
+  exit 0
+fi
+
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin${PATH:+:$PATH}"
+
+# Prefer the user agent when available so SSH to kyber/matic works headlessly.
+if [[ -z "${SSH_AUTH_SOCK:-}" ]]; then
+  for sock in \
+    "$HOME/.ssh/agent.sock" \
+    /run/user/"$(id -u)"/ssh-agent.socket \
+    /run/user/"$(id -u)"/keyring/ssh; do
+    if [[ -S "$sock" ]]; then
+      export SSH_AUTH_SOCK="$sock"
+      break
+    fi
+  done
+fi
+
+exec "$CAAM" sync

--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -7,6 +7,7 @@
 }:
 let
   brewUpgrader = import ./brew-upgrader { inherit pkgs; };
+  caam = import ./caam;
   cass = import ./cass { inherit pkgs; };
   cliproxyapi = import ./cliproxyapi;
   cpaManagerPlus = ./cpa-manager-plus;
@@ -36,6 +37,7 @@ let
 in
 [
   brewUpgrader
+  caam
   cass
   cliproxyapi
   cpaManagerPlus

--- a/spec/caam_sync_service_spec.sh
+++ b/spec/caam_sync_service_spec.sh
@@ -1,0 +1,64 @@
+Describe 'home-manager/services/caam'
+  SETUP="$PWD/home-manager/services/caam/setup.sh"
+  SYNC="$PWD/home-manager/services/caam/sync.sh"
+  NIX="$PWD/home-manager/services/caam/default.nix"
+  SERVICES_DEFAULT="$PWD/home-manager/services/default.nix"
+
+  It 'defines setup.sh'
+  The path "$SETUP" should be exist
+  End
+
+  It 'defines sync.sh'
+  The path "$SYNC" should be exist
+  End
+
+  It 'wires caam into services/default.nix'
+  When run bash -c "grep -E 'caam = import|^\s*caam$' '$SERVICES_DEFAULT'"
+  The output should include 'caam'
+  The status should be success
+  End
+
+  It 'runs sync discover --add during setup'
+  When run bash -c "grep -F 'sync discover --add' '$SETUP'"
+  The output should include 'sync discover --add'
+  The status should be success
+  End
+
+  It 'enables auto-sync during setup'
+  When run bash -c "grep -F 'sync enable' '$SETUP'"
+  The output should include 'sync enable'
+  The status should be success
+  End
+
+  It 'skips setup when caam binary is missing'
+  When run bash -c "grep -F 'caam not found' '$SETUP'"
+  The output should include 'caam not found'
+  The status should be success
+  End
+
+  It 'defines darwin launchd agents for daemon and sync'
+  When run bash -c "grep -E 'caam-daemon|caam-sync' '$NIX'"
+  The output should include 'caam-daemon'
+  The output should include 'caam-sync'
+  The status should be success
+  End
+
+  It 'defines linux systemd units for daemon and sync timer'
+  When run bash -c "grep -E 'systemd.user.(services|timers).caam' '$NIX'"
+  The output should include 'caam-daemon'
+  The output should include 'caam-sync'
+  The status should be success
+  End
+
+  It 'bootstraps the pool on home-manager activation'
+  When run bash -c "grep -F 'caamSyncSetup' '$NIX'"
+  The output should include 'caamSyncSetup'
+  The status should be success
+  End
+
+  It 'skips periodic sync when caam binary is missing'
+  When run env CAAM=/nonexistent/caam bash "$SYNC"
+  The stderr should include 'caam not found'
+  The status should be success
+  End
+End

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -57,6 +57,14 @@ It 'has spec file for home-manager/services/cass/daily.sh'
 The path "spec/cass_indexer_spec.sh" should be exist
 End
 
+It 'has spec file for home-manager/services/caam/setup.sh'
+The path "spec/caam_sync_service_spec.sh" should be exist
+End
+
+It 'has spec file for home-manager/services/caam/sync.sh'
+The path "spec/caam_sync_service_spec.sh" should be exist
+End
+
 It 'has spec file for home-manager/services/brew-upgrader/upgrade.sh'
 The path "spec/brew_upgrader_spec.sh" should be exist
 End
@@ -493,6 +501,8 @@ home-manager/programs/neovim/run_tests.sh
 home-manager/programs/ssh/pin-known-hosts.sh
 home-manager/programs/tmux/session-logger.sh
 home-manager/services/brew-upgrader/upgrade.sh
+home-manager/services/caam/setup.sh
+home-manager/services/caam/sync.sh
 home-manager/services/cass/daily.sh
 home-manager/services/cpa-manager-plus/docker-start.sh
 home-manager/services/cpa-manager-plus/start.sh


### PR DESCRIPTION
## Summary
- On HM activation: `caam sync discover --add` + `caam sync enable` (idempotent; drops localhost)
- Persistent `caam-daemon` (launchd KeepAlive / systemd Restart=always)
- Periodic `caam-sync` every 15 minutes on all machines
- Wired into `home-manager/services/default.nix` for every host

## Test plan
- [x] `shellspec spec/caam_sync_service_spec.sh`
- [ ] `make switch` on galactica starts launchd agents
- [ ] After switch: `caam sync status` shows kyber/matic in pool, auto-sync enabled
- [ ] Linux hosts get `caam-daemon.service` + `caam-sync.timer`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a persistent `caam` daemon and a 15‑minute sync service on macOS and Linux, with automatic peer discovery and auto‑sync on `home-manager` activation. This keeps vaults aligned across machines without manual setup.

- **New Features**
  - Bootstraps sync pool on `home-manager` activation: `caam sync discover --add`, drop `localhost`, then `caam sync enable`.
  - Adds persistent `caam-daemon` and periodic `caam-sync` (15 min): `launchd` agents on macOS; `systemd` user service + timer on Linux.
  - Adds `setup.sh` and `sync.sh` (detects `SSH_AUTH_SOCK`) and wires `caam` into `home-manager/services/default.nix`.
  - Adds shellspec tests for service wiring and missing-binary handling.

<sup>Written for commit 7f0cc3b2ed76f33f81ff137161d4ab5cd1b12e99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

