### PR TITLE
feat(fish): add maticz/kyberz and unblock main CI

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -170,10 +170,12 @@
       kyberd = "_kyberd_function";
       kyberh = "_kyberh_function";
       kyberm = "_kyberm_function";
+      kyberz = "_kyberz_function";
       matic = "_matic_function";
       maticd = "_maticd_function";
       matich = "_matich_function";
       maticm = "_maticm_function";
+      maticz = "_maticz_function";
       ocxe = "_ocxe_function";
       ocxel = "_ocxel_function";
       ocxeh = "_ocxeh_function";
@@ -299,10 +301,12 @@
         "_kyberd_function"
         "_kyberh_function"
         "_kyberm_function"
+        "_kyberz_function"
         "_matic_function"
         "_maticd_function"
         "_matich_function"
         "_maticm_function"
+        "_maticz_function"
         "_ocxe_function"
         "_ocxel_function"
         "_ocxeh_function"

--- a/home-manager/programs/fish/functions/_kyberz_function.fish
+++ b/home-manager/programs/fish/functions/_kyberz_function.fish
@@ -1,0 +1,3 @@
+function _kyberz_function --description "SSH to Kyber with zellij desktop session"
+  ssh -t ubuntu@(tailscale ip -4 kyber) "zellij attach -c desktop"
+end

--- a/home-manager/programs/fish/functions/_maticz_function.fish
+++ b/home-manager/programs/fish/functions/_maticz_function.fish
@@ -1,0 +1,3 @@
+function _maticz_function --description "SSH to Matic with zellij desktop session"
+  ssh -t shunkakinoki@(tailscale ip -4 matic) "zellij attach -c desktop"
+end

--- a/spec/dotfiles_updater_spec.sh
+++ b/spec/dotfiles_updater_spec.sh
@@ -25,7 +25,7 @@ End
 Describe 'service host identity'
 It 'passes the canonical named host to automatic updates'
 When run bash -c "grep 'HOST=\${canonicalHost}' '$MODULE'"
-The output should include 'HOST=${canonicalHost}'
+The output should include "HOST=\${canonicalHost}"
 End
 
 It 'derives the canonical host from named-host flags'

--- a/spec/fish/_kyberz_function_test.fish
+++ b/spec/fish/_kyberz_function_test.fish
@@ -1,0 +1,13 @@
+set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_kyberz_function.fish
+
+set log (mktemp)
+function tailscale; echo 100.1.2.3; end
+function ssh; echo $argv >> $log; end
+
+_kyberz_function
+
+@test "calls ssh to kyber IP" (grep -c "ubuntu@100.1.2.3" $log) -ge 1
+@test "attaches to zellij desktop session" (grep -c "zellij attach -c desktop" $log) -ge 1
+
+rm -f $log

--- a/spec/fish/_maticz_function_test.fish
+++ b/spec/fish/_maticz_function_test.fish
@@ -1,0 +1,13 @@
+set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_maticz_function.fish
+
+set log (mktemp)
+function tailscale; echo 100.1.2.3; end
+function ssh; echo $argv >> $log; end
+
+_maticz_function
+
+@test "calls ssh to matic IP" (grep -c "shunkakinoki@100.1.2.3" $log) -ge 1
+@test "attaches to zellij desktop session" (grep -c "zellij attach -c desktop" $log) -ge 1
+
+rm -f $log


### PR DESCRIPTION
## Summary
- Add `maticz` / `kyberz` fish abbreviations that SSH into Matic and Kyber and attach (or create) a Zellij `desktop` session
- Fix ShellCheck SC2016 in `spec/dotfiles_updater_spec.sh` that was failing Shell CI on main
- Bump `dotagents` submodule ([shunkakinoki/dotagents#182](https://github.com/shunkakinoki/dotagents/pull/182)) so Upgrade CI can install renamed upstream skills (`node-deps-bumper`, `release-bumper`, `analytics`) and no longer depends on the empty articulate install-all source

## Test plan
- [ ] `maticz` / `kyberz` expand to the new fish functions after home-manager switch
- [ ] Shell workflow: ShellCheck and shellspec pass
- [ ] Upgrade workflow: `make skills-install` reports 0 not-yet-installed skills
- [ ] Merge [dotagents#182](https://github.com/shunkakinoki/dotagents/pull/182) (or keep submodule on that commit)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `maticz` and `kyberz` fish abbreviations to SSH into Matic/Kyber and auto-attach a `zellij` desktop session. Also fixes a ShellCheck quoting error and points `dotagents` at merged upstream so Shell and Upgrade CI pass.

- **New Features**
  - Add `maticz`/`kyberz` functions and abbreviations that run `zellij attach -c desktop`.
  - Tests validate SSH target and `zellij` attach behavior.

- **Bug Fixes**
  - Fix SC2016 quoting in `spec/dotfiles_updater_spec.sh` to unblock Shell CI.
  - Point `dotagents` submodule at merged upstream to install renamed skills and unblock Upgrade CI.

<sup>Written for commit 3393a377e5b23858166807aa1d7a15dcdd098968. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

