### PR TITLE
fix(caam): force-remove localhost from sync pool on setup

### DIFF
--- a/home-manager/services/caam/setup.sh
+++ b/home-manager/services/caam/setup.sh
@@ -16,7 +16,7 @@ echo "Discovering CAAM sync peers from SSH config..."
 "$CAAM" sync discover --add || true
 
 # localhost is useless in a multi-machine pool; drop it if discover added it.
-"$CAAM" sync remove localhost >/dev/null 2>&1 || true
+"$CAAM" sync remove localhost --force >/dev/null 2>&1 || true
 
 echo "Enabling CAAM auto-sync after backup/refresh..."
 "$CAAM" sync enable


### PR DESCRIPTION
## Summary
- Use `caam sync remove localhost --force` in HM activation setup so the interactive prompt cannot leave localhost in the pool

## Test plan
- [x] `bash home-manager/services/caam/setup.sh` leaves only kyber/matic
- [ ] `make switch` keeps localhost out of the pool


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force-remove `localhost` from the CAAM sync pool during Home Manager activation by using `caam sync remove localhost --force`. This skips the prompt and guarantees only real peers remain in the pool.

<sup>Written for commit 18d3a78a23c9d6d8c9e33fcdfeecaf6a1073b94f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

