### PR TITLE
fix(matic): restore Tailscale MagicDNS resolution

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -63,11 +63,27 @@ import ../../hosts/nixos {
         ];
 
         # Networking
-        networking.networkmanager.wifi = {
-          powersave = true;
-          scanRandMacAddress = true;
-          macAddress = "stable-ssid";
+        networking.networkmanager = {
+          dns = lib.mkForce "systemd-resolved";
+          wifi = {
+            powersave = true;
+            scanRandMacAddress = true;
+            macAddress = "stable-ssid";
+          };
         };
+
+        networking.nameservers = [
+          "8.8.8.8"
+          "8.8.4.4"
+          "1.1.1.1"
+          "1.0.0.1"
+        ];
+
+        # The shared NixOS base pins /etc/resolv.conf to public resolvers.
+        # Release that override on matic so resolved can install its stub and
+        # Tailscale can register the tailnet's split-DNS route through D-Bus.
+        environment.etc."resolv.conf".text = lib.mkForce null;
+        services.resolved.enable = true;
 
         networking.firewall = {
           enable = true;

--- a/spec/matic_tailscale_spec.sh
+++ b/spec/matic_tailscale_spec.sh
@@ -24,6 +24,27 @@ When run bash -c "grep -F '\"--accept-dns=true\"' '$CONFIG'"
 The output should include '--accept-dns=true'
 End
 
+It 'uses systemd-resolved for Tailscale MagicDNS'
+When run bash -c "grep -F 'services.resolved.enable = true;' '$CONFIG'"
+The output should include 'services.resolved.enable = true'
+End
+
+It 'routes NetworkManager DNS through systemd-resolved'
+When run bash -c "grep -A2 -F 'networking.networkmanager = {' '$CONFIG'"
+The output should include 'systemd-resolved'
+End
+
+It 'preserves public upstream resolvers'
+When run bash -c "grep -A5 -F 'networking.nameservers = [' '$CONFIG'"
+The output should include '8.8.8.8'
+The output should include '1.1.1.1'
+End
+
+It 'releases the shared static resolv.conf override'
+When run bash -c "grep -F 'environment.etc.\"resolv.conf\".text = lib.mkForce null;' '$CONFIG'"
+The output should include 'lib.mkForce null'
+End
+
 It 'trusts the tailscale interface in the firewall'
 When run bash -c "grep -F 'trustedInterfaces = [ \"tailscale0\" ];' '$CONFIG'"
 The output should include 'tailscale0'


### PR DESCRIPTION
## Summary

- let systemd-resolved own matic DNS so Tailscale can register MagicDNS split routes
- preserve the existing public upstream resolvers
- add regression coverage for resolver ownership and Tailscale DNS integration

## Validation

- shellspec spec/matic_tailscale_spec.sh (9 examples, 0 failures)
- Nix evaluation confirms resolved enabled, NetworkManager DNS mode, stub resolver source, and upstream resolvers
- nix build .#nixosConfigurations.matic.config.system.build.toplevel --no-link

Beads: shunkakinokisoftware-qwer

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore Tailscale MagicDNS on matic by letting systemd-resolved own DNS so split-DNS routes register correctly. Keep the existing public upstream resolvers and add regression tests to prevent regressions.

- **Bug Fixes**
  - Force NetworkManager DNS to `systemd-resolved` and enable `services.resolved`.
  - Remove the shared static resolv.conf override so resolved installs its stub and Tailscale can register via D-Bus.
  - Preserve Google and Cloudflare upstream nameservers; add regression coverage for resolver ownership and Tailscale DNS integration.

<sup>Written for commit da62f1e975a41b70b759a307d09fadce75cc52ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

