### PR TITLE
fix(make): harden reset against dirty submodule locks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,9 +285,12 @@ clean-all: ## Delete ALL old Nix generations and garbage collect (nuclear).
 	@echo "✅ Full cleanup complete"
 
 .PHONY: reset
-reset: git-submodule-sync ## Reset git status to clean (restore all changes and reinitialize submodules).
+reset: ## Reset git status to clean (restore all changes and reinitialize submodules).
 	@echo "🔄 Resetting git status to clean..."
-	@git checkout -- .
+	@git reset --hard HEAD
+	@git submodule foreach --recursive 'git reset --hard HEAD && git clean -fd'
+	@git submodule sync --recursive
+	@git submodule update --init --recursive --force
 	@echo "✅ Git status reset to clean"
 
 .PHONY: services
@@ -1382,7 +1385,7 @@ systemctl-tmux-session-logger: ## Restart tmux-session-logger systemd timer and 
 .PHONY: git-submodule-sync
 git-submodule-sync: ## Sync and update git submodules.
 	@echo "🔁 Syncing and updating git submodules..."
-	@git submodule sync
+	@git submodule sync --recursive
 	@git submodule update --init --recursive
 	@echo "✅ Submodules synced and updated"
 


### PR DESCRIPTION
## Summary
- Make `make reset` hard-reset and force-update submodules so a dirty `skills-lock.json` cannot block checkout
- Sync submodule URLs recursively
- Bump `dotagents` to include https://github.com/shunkakinoki/dotagents/pull/183 (stop rewriting the lock on every `skills-install`)

## Test plan
- [ ] With a dirty `dotagents/skills-lock.json`, `make reset` succeeds and leaves a clean tree
- [ ] `make git-submodule-sync` still updates submodules normally
- [ ] `make sync` no longer dirties `dotagents` when all skills are already installed


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened `make reset` so dirty submodule locks (e.g., `dotagents/skills-lock.json`) no longer block checkout and the tree ends clean. Also made submodule sync recursive and updated `dotagents` to stop unnecessary lock rewrites.

- **Bug Fixes**
  - `make reset` now hard-resets repo and submodules, cleans submodules, syncs URLs recursively, then force-updates.
  - `git-submodule-sync` now uses `git submodule sync --recursive`.

- **Dependencies**
  - Bumped `dotagents` to include the `skills-install` fix that avoids rewriting `skills-lock.json` when unchanged.

<sup>Written for commit a7dea1fb42c63dd723c7131333a3b2555141149b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

