### PR TITLE
fix(ci): add shebang to caam sync service shellspec

### DIFF
--- a/spec/caam_sync_service_spec.sh
+++ b/spec/caam_sync_service_spec.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
 Describe 'home-manager/services/caam'
   SETUP="$PWD/home-manager/services/caam/setup.sh"
   SYNC="$PWD/home-manager/services/caam/sync.sh"


### PR DESCRIPTION
## Summary
- Add bash shebang + SC2329 disable to `spec/caam_sync_service_spec.sh` so ShellCheck on main passes after #2248

## Test plan
- [x] `make shell-check` passes locally
- [ ] Shell workflow on this PR / main is green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a bash shebang and disable SC2329 in `spec/caam_sync_service_spec.sh` so ShellCheck passes in CI. This unblocks the Shell workflow on main.

<sup>Written for commit 11bd308e7316b67868f0a789b5b9de49c48f229f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

