### PR TITLE
fix(caam): remove local host from sync pool

### DIFF
--- a/home-manager/services/caam/setup.sh
+++ b/home-manager/services/caam/setup.sh
@@ -15,8 +15,24 @@ export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin${PA
 echo "Discovering CAAM sync peers from SSH config..."
 "$CAAM" sync discover --add || true
 
-# localhost is useless in a multi-machine pool; drop it if discover added it.
+# Local hosts are useless in a multi-machine pool; drop them if discovery
+# added localhost, the full hostname, or its short form from SSH config.
 "$CAAM" sync remove localhost --force >/dev/null 2>&1 || true
+
+local_hostname="$(hostname 2>/dev/null || true)"
+local_short_hostname="${local_hostname%%.*}"
+
+if [[ -n "$local_hostname" && "$local_hostname" != "localhost" ]]; then
+  "$CAAM" sync remove "$local_hostname" --force >/dev/null 2>&1 || true
+fi
+
+if [[
+  -n "$local_short_hostname" &&
+    "$local_short_hostname" != "localhost" &&
+    "$local_short_hostname" != "$local_hostname"
+]]; then
+  "$CAAM" sync remove "$local_short_hostname" --force >/dev/null 2>&1 || true
+fi
 
 echo "Enabling CAAM auto-sync after backup/refresh..."
 "$CAAM" sync enable

--- a/spec/caam_sync_service_spec.sh
+++ b/spec/caam_sync_service_spec.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2329
+# shellcheck disable=SC2016,SC2329
 
 Describe 'home-manager/services/caam'
   SETUP="$PWD/home-manager/services/caam/setup.sh"
@@ -63,5 +63,57 @@ Describe 'home-manager/services/caam'
   When run env CAAM=/nonexistent/caam bash "$SYNC"
   The stderr should include 'caam not found'
   The status should be success
+  End
+
+  Describe 'setup peer filtering'
+    setup_peer_filtering() {
+      mock_bin_setup
+      TEMP_HOME="$(mktemp -d)"
+      mkdir -p "$TEMP_HOME/.local/bin"
+
+      cat >"$MOCK_BIN/caam" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$MOCK_LOG"
+EOF
+      chmod +x "$MOCK_BIN/caam"
+
+      cat >"$TEMP_HOME/.local/bin/hostname" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ ${MOCK_HOSTNAME_FAIL:-0} == 1 ]]; then
+  exit 1
+fi
+printf '%s\n' "${MOCK_HOSTNAME_VALUE:-matic.example}"
+EOF
+      chmod +x "$TEMP_HOME/.local/bin/hostname"
+      export TEMP_HOME
+    }
+
+    cleanup_peer_filtering() {
+      rm -rf "$TEMP_HOME"
+      mock_bin_cleanup
+      unset TEMP_HOME MOCK_HOSTNAME_FAIL MOCK_HOSTNAME_VALUE
+    }
+
+    Before 'setup_peer_filtering'
+    After 'cleanup_peer_filtering'
+
+    It 'removes the full and short local hostnames while preserving remote peers'
+    When run bash -c 'HOME="$1" CAAM="$2" MOCK_HOSTNAME_VALUE=matic.example bash "$3" >/dev/null; cat "$4"' _ "$TEMP_HOME" "$MOCK_BIN/caam" "$SETUP" "$MOCK_LOG"
+    The output should include 'sync discover --add'
+    The output should include 'sync remove localhost --force'
+    The output should include 'sync remove matic.example --force'
+    The output should include 'sync remove matic --force'
+    The output should not include 'sync remove kyber --force'
+    The status should be success
+    End
+
+    It 'keeps setup successful when the local hostname is unavailable'
+    When run bash -c 'HOME="$1" CAAM="$2" MOCK_HOSTNAME_FAIL=1 bash "$3" >/dev/null; cat "$4"' _ "$TEMP_HOME" "$MOCK_BIN/caam" "$SETUP" "$MOCK_LOG"
+    The output should include 'sync remove localhost --force'
+    The output should not include 'sync remove matic --force'
+    The status should be success
+    End
   End
 End


### PR DESCRIPTION
## Summary

- remove localhost plus the full and short local hostnames after CAAM SSH peer discovery
- keep hostname lookup failures non-blocking during Home Manager activation
- add ShellSpec coverage for self-peer filtering and remote-peer preservation

## Validation

- shellspec spec/caam_sync_service_spec.sh
- shellcheck home-manager/services/caam/setup.sh spec/caam_sync_service_spec.sh
- bash -n home-manager/services/caam/setup.sh
- git diff --check

Full ShellSpec baseline: 1907 examples, with 3 unrelated existing PATH-environment failures in auto_switch_spec.sh, code_syncer_spec.sh, and obsidian_git_trigger_spec.sh.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove local hosts from the CAAM sync pool to prevent self-peering and keep only remote peers. Home Manager activation now tolerates hostname lookup failures.

- **Bug Fixes**
  - After discovery, remove `localhost`, the full hostname, and its short form from peers.
  - Keep activation non-blocking when `hostname` fails.
  - Add ShellSpec tests for self-peer filtering and remote-peer preservation.

<sup>Written for commit ed9df759e39ea592cc49a55fc2823d923d23fb59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

