### PR TITLE
fix(openclaw): add gemma and glm fallbacks before free tier

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -236,6 +236,8 @@
         "primary": "cliproxy/deepseek-v4-pro",
         "fallbacks": [
           "cliproxy/deepseek-v4-flash",
+          "cliproxy/google/gemma-4-31b-it",
+          "cliproxy/glm-4.7",
           "cliproxy/free"
         ]
       },

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -236,6 +236,8 @@
         "primary": "cliproxy/__DEEPSEEK_PRO__",
         "fallbacks": [
           "cliproxy/__DEEPSEEK_FLASH__",
+          "cliproxy/google/gemma-4-31b-it",
+          "cliproxy/glm-4.7",
           "cliproxy/free"
         ]
       },


### PR DESCRIPTION
## Summary

- Adds `cliproxy/google/gemma-4-31b-it` and `cliproxy/glm-4.7` as fallback models before `cliproxy/free`
- OpenRouter's free tier has a content moderation filter that flags large agent system prompts as "prompt injection patterns detected" (403), making it unreliable as a direct fallback
- Gemma and GLM don't have this filter, so they'll handle requests that deepseek-v4-flash can't serve before falling through to the flaky free tier

## Test plan

- [x] Verified fallback order applied to live config via `openclaw models fallbacks`
- [x] Confirmed `cliproxy/free` still works for simple prompts via direct curl test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `cliproxy/google/gemma-4-31b-it` and `cliproxy/glm-4.7` as fallback models before `cliproxy/free` to improve reliability when `deepseek-v4-flash` can’t serve requests. This avoids 403s from the free tier’s moderation filter on long agent system prompts.

- **Bug Fixes**
  - Adjusted fallback order in `config/openclaw/openclaw.template.json` and `config/openclaw/openclaw.tpl.json` to insert the two models before the free tier.
  - Verified the order via `openclaw models fallbacks` and confirmed `cliproxy/free` still works for simple prompts.

<sup>Written for commit d2660c4c9835f6d72442e982fc5aeaea13d8168e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

