### PR TITLE
fix(rust): disable self-contained linker for rustc 1.97+

### DIFF
--- a/home-manager/programs/rust/cargo.toml
+++ b/home-manager/programs/rust/cargo.toml
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-self-contained=no", "-C", "linker=cc"]

--- a/home-manager/programs/rust/default.nix
+++ b/home-manager/programs/rust/default.nix
@@ -3,4 +3,6 @@
   home.packages = with pkgs; [
     rustup
   ];
+
+  home.file.".cargo/config.toml".source = ./cargo.toml;
 }


### PR DESCRIPTION
## Summary

- Adds `~/.cargo/config.toml` via home-manager to disable rustc 1.97+'s self-contained linker on Linux
- Fixes `cannot find 'ld'` / `self-contained linker was requested` build failures for all Cargo projects (frankensqlite, franken_agent_detection, cass, etc.)
- The Nix-packaged rustup toolchain is missing `lib/self-contained/` CRT objects, so `-C link-self-contained=no -C linker=cc` falls back to the system linker

## Test plan

- [x] `rustc` compiles successfully with the config
- [x] `cargo build --release` succeeds on a test project
- [x] `make format` passes clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable `rustc` 1.97+ self-contained linker on Linux to fix missing CRT/ld errors with Nix `rustup`. Adds a Home Manager `~/.cargo/config.toml` that forces the system linker (`-C link-self-contained=no`, `-C linker=cc`).

- **Bug Fixes**
  - Fixes "cannot find 'ld'" and "self-contained linker was requested" build failures across `cargo` projects.

<sup>Written for commit 451c8c8ec535addd22fdab47f7a60a81fc4aa153. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

