### PR TITLE
fix(openclaw): drop google/ prefix from gemma fallback model name

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -236,7 +236,7 @@
         "primary": "cliproxy/deepseek-v4-pro",
         "fallbacks": [
           "cliproxy/deepseek-v4-flash",
-          "cliproxy/google/gemma-4-31b-it",
+          "cliproxy/gemma-4-31b-it",
           "cliproxy/glm-4.7",
           "cliproxy/free"
         ]

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -236,7 +236,7 @@
         "primary": "cliproxy/__DEEPSEEK_PRO__",
         "fallbacks": [
           "cliproxy/__DEEPSEEK_FLASH__",
-          "cliproxy/google/gemma-4-31b-it",
+          "cliproxy/gemma-4-31b-it",
           "cliproxy/glm-4.7",
           "cliproxy/free"
         ]


### PR DESCRIPTION
## Summary

- Cliproxy aliases `@preset/gemma-4-31b-it` as `gemma-4-31b-it`, not `google/gemma-4-31b-it`
- The `google/` prefix causes cliproxy to return 502 "unknown provider for model google/gemma-4-31b-it"
- Fixes the fallback name in both template files

## Test plan

- [x] Verified `gemma-4-31b-it` resolves correctly via `curl` to cliproxy
- [x] Verified `google/gemma-4-31b-it` returns 502
- [x] Updated live openclaw config and confirmed fallback chain works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix OpenClaw fallback model name: replace `cliproxy/google/gemma-4-31b-it` with `cliproxy/gemma-4-31b-it` in both template configs. This matches `cliproxy` aliases, prevents 502 "unknown provider" errors, and restores the fallback chain.

<sup>Written for commit 34c9daf50876ea6108a4d40c045d309b0bcc7d78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

