### PR TITLE
fix(roborev): poll promptly without batch cancellation

### DIFF
--- a/config/roborev/config.template.toml
+++ b/config/roborev/config.template.toml
@@ -1,4 +1,7 @@
 [ci]
 enabled = true
-poll_interval = "5m"
+# Poll frequently so new pushes reach the daemon promptly.
+poll_interval = "1m"
+# Never cancel a running CI review just to post an early result.
+batch_timeout = "0"
 repos = ["__ROBOREV_CI_REPOS__"]

--- a/spec/roborev_hydrate_spec.sh
+++ b/spec/roborev_hydrate_spec.sh
@@ -41,6 +41,14 @@ The output should include '.roborev'
 End
 End
 
+Describe 'CI timing defaults'
+It 'polls promptly without canceling running reviews'
+When run bash -c "grep -E 'poll_interval = \"1m\"|batch_timeout = \"0\"' '$PWD/config/roborev/config.template.toml'"
+The output should include 'poll_interval = "1m"'
+The output should include 'batch_timeout = "0"'
+End
+End
+
 Describe 'hydration'
 setup_hydrate() {
   TEMP_HOME=$(mktemp -d)


### PR DESCRIPTION
## Summary
- reduce managed RoboRev CI polling from 5 minutes to 1 minute
- disable batch timeout cancellation so running reviews continue
- add focused hydration coverage for the timing defaults

## Validation
- shellspec spec/roborev_hydrate_spec.sh
- shellcheck config/roborev/hydrate.sh spec/roborev_hydrate_spec.sh
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
RoboRev CI now polls every 1 minute and no longer cancels running reviews on batch timeouts. This speeds up new push detection and prevents active reviews from being interrupted; a shellspec test enforces these defaults.

<sup>Written for commit 6cc9b7b689570fa98ba993bbbbf5b0917d33590a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

