### PR TITLE
fix(roborev): expose Nix profile to daemon

### DIFF
--- a/home-manager/services/roborev/default.nix
+++ b/home-manager/services/roborev/default.nix
@@ -30,7 +30,7 @@ lib.mkIf enabled {
       EnvironmentVariables = {
         HOME = homeDir;
         ROBOREV_DATA_DIR = dataDir;
-        PATH = "${homeDir}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
+        PATH = "${homeDir}/.local/bin:/etc/profiles/per-user/${config.home.username}/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
       };
       StandardOutPath = "/tmp/roborev.log";
       StandardErrorPath = "/tmp/roborev.error.log";
@@ -51,7 +51,7 @@ lib.mkIf enabled {
       Environment = [
         "HOME=${homeDir}"
         "ROBOREV_DATA_DIR=${dataDir}"
-        "PATH=${homeDir}/.local/bin:${homeDir}/.nix-profile/bin:/usr/local/bin:/usr/bin:/bin"
+        "PATH=${homeDir}/.local/bin:/etc/profiles/per-user/${config.home.username}/bin:${homeDir}/.nix-profile/bin:/usr/local/bin:/usr/bin:/bin"
       ];
     };
     Install = {

--- a/spec/activate_roborev_spec.sh
+++ b/spec/activate_roborev_spec.sh
@@ -34,4 +34,9 @@ When run cat "$PWD/home-manager/services/roborev/default.nix"
 # shellcheck disable=SC2016
 The output should include '"${./activate.sh}" "${dataDir}"'
 End
+
+It 'includes the Nix profile in the daemon PATH'
+When run grep -F '/etc/profiles/per-user/${config.home.username}/bin' "$PWD/home-manager/services/roborev/default.nix"
+The output should include '/etc/profiles/per-user/${config.home.username}/bin'
+End
 End


### PR DESCRIPTION
## Summary
- include the managed Nix per-user profile directory in RoboRev daemon PATH
- allow launchd/systemd RoboRev to resolve `gh` for GitHub authentication
- add focused service configuration coverage

## Validation
- shellspec spec/activate_roborev_spec.sh
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix GitHub auth in the RoboRev daemon by making `gh` resolvable under `launchd`/`systemd`. Adds focused service config test coverage.

- **Bug Fixes**
  - Include `/etc/profiles/per-user/${config.home.username}/bin` in PATH for both unit types.
  - Add a shellspec asserting the daemon PATH includes the Nix per-user profile.

<sup>Written for commit e52dda387ab5ec005f69d941bf6ce6fe20654a8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

