### PR TITLE
fix(omp): default to DeepSeek Flash

### DIFF
--- a/config/omp/config.tpl.yml
+++ b/config/omp/config.tpl.yml
@@ -64,7 +64,7 @@ disabledExtensions: []
 #   slow:    openai-codex/gpt-5.3-codex:high
 modelRoles:
   # Default model role used as the fallback when no other role is selected.
-  default: "opencode-zen/__DEEPSEEK_PRO__"
+  default: "opencode-zen/__DEEPSEEK_FLASH__"
   # Smaller / dumber model for cheap lightweight work.
   smol: "openai-codex/__GPT_MINI__"
   # Strongest model in the suite for hard tasks.

--- a/config/omp/config.yml
+++ b/config/omp/config.yml
@@ -64,7 +64,7 @@ disabledExtensions: []
 #   slow:    openai-codex/gpt-5.3-codex:high
 modelRoles:
   # Default model role used as the fallback when no other role is selected.
-  default: "opencode-zen/deepseek-v4-pro"
+  default: "opencode-zen/deepseek-v4-flash"
   # Smaller / dumber model for cheap lightweight work.
   smol: "openai-codex/gpt-5.4-mini"
   # Strongest model in the suite for hard tasks.

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -108,9 +108,9 @@ When run bash -c "sed -n '/\"cliproxyapi\"/,/\"lmstudio\"/p' config/opencode/ope
 The status should be success
 End
 
-It 'generates the OMP Pro default role'
-When run bash -c "grep 'default: \"opencode-zen/deepseek-v4-pro\"' config/omp/config.yml"
-The output should include 'opencode-zen/deepseek-v4-pro'
+It 'generates the OMP Flash default role'
+When run bash -c "grep 'default: \"opencode-zen/deepseek-v4-flash\"' config/omp/config.yml"
+The output should include 'opencode-zen/deepseek-v4-flash'
 End
 
 It 'generates the DeepSeek Go routes in CliProxy'


### PR DESCRIPTION
## Summary
- default OMP to the canonical DeepSeek Flash model alias
- regenerate the hydrated OMP config
- update the LLM hydration regression spec

## Validation
- shellspec spec/llm_update_spec.sh (62 examples, 0 failures)
- ShellCheck scripts/llm-update.sh
- config hydration and activation smoke tests
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set OMP’s default model role to DeepSeek Flash using the canonical alias to make Flash the fallback. Regenerated the hydrated config and aligned the LLM hydration spec.

- **Bug Fixes**
  - Switched `default` from `__DEEPSEEK_PRO__`/`opencode-zen/deepseek-v4-pro` to `__DEEPSEEK_FLASH__`/`opencode-zen/deepseek-v4-flash` in `config/omp/config.tpl.yml` and `config/omp/config.yml`.
  - Updated `spec/llm_update_spec.sh` assertions to the new default.

<sup>Written for commit 427a5dff5db0837e28e3741f7ec3f1f1d0aebd58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

