### PR TITLE
fix(openclaw): prefer CLIProxy DeepSeek Flash

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -233,11 +233,12 @@
   "agents": {
     "defaults": {
       "model": {
-        "primary": "cliproxy/deepseek-v4-pro",
+        "primary": "cliproxy/deepseek-v4-flash",
         "fallbacks": [
-          "cliproxy/deepseek-v4-flash",
+          "cliproxy/deepseek-v4-pro",
           "cliproxy/gemma-4-31b-it",
           "cliproxy/glm-4.7",
+          "cliproxy/minimax-m3",
           "cliproxy/free"
         ]
       },

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -233,11 +233,12 @@
   "agents": {
     "defaults": {
       "model": {
-        "primary": "cliproxy/__DEEPSEEK_PRO__",
+        "primary": "cliproxy/__DEEPSEEK_FLASH__",
         "fallbacks": [
-          "cliproxy/__DEEPSEEK_FLASH__",
+          "cliproxy/__DEEPSEEK_PRO__",
           "cliproxy/gemma-4-31b-it",
           "cliproxy/glm-4.7",
+          "cliproxy/__MINIMAX__",
           "cliproxy/free"
         ]
       },

--- a/spec/openclaw_hydrate_spec.sh
+++ b/spec/openclaw_hydrate_spec.sh
@@ -4,10 +4,18 @@
 Describe 'config/openclaw/hydrate.sh'
 SCRIPT="$PWD/config/openclaw/hydrate.sh"
 
-template_uses_opencode_go_default() {
+template_uses_cliproxy_flash_default() {
   jq -e '
-    .agents.defaults.model.primary == "cliproxy/deepseek-v4-pro" and
-    .agents.defaults.model.fallbacks[0] == "cliproxy/deepseek-v4-flash" and
+    .agents.defaults.model == {
+      "primary": "cliproxy/deepseek-v4-flash",
+      "fallbacks": [
+        "cliproxy/deepseek-v4-pro",
+        "cliproxy/gemma-4-31b-it",
+        "cliproxy/glm-4.7",
+        "cliproxy/minimax-m3",
+        "cliproxy/free"
+      ]
+    } and
     (.models.providers.cliproxy.models | any(.id == "deepseek-v4-pro")) and
     (.models.providers.cliproxy.models | any(.id == "deepseek-v4-flash"))
   ' "$PWD/config/openclaw/openclaw.template.json" >/dev/null
@@ -229,8 +237,8 @@ End
 End
 
 Describe 'declarative template'
-It 'uses DeepSeek V4 Pro from OpenCode Go as the default model'
-When call template_uses_opencode_go_default
+It 'uses CLIProxy DeepSeek V4 Flash with resilient fallbacks'
+When call template_uses_cliproxy_flash_default
 The status should be success
 End
 


### PR DESCRIPTION
## Summary
- make CLIProxy DeepSeek Flash the OpenClaw primary model
- fall back through DeepSeek Pro, Gemma, GLM, MiniMax, and Free
- remove GPT/Codex/Claude/Gemini from the default fallback chain

## Validation
- shellspec spec/openclaw_hydrate_spec.sh spec/llm_update_spec.sh (85 examples, 0 failures)
- hydrated OpenClaw JSON exact-chain assertion
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `cliproxy/deepseek-v4-flash` as the default OpenClaw model and reorder the fallback chain for more resilient routing. Updated templates and the hydration spec to assert the new chain.

- **Refactors**
  - Default model is now `cliproxy/deepseek-v4-flash` (was `cliproxy/deepseek-v4-pro`).
  - Fallbacks: `cliproxy/deepseek-v4-pro` → `cliproxy/gemma-4-31b-it` → `cliproxy/glm-4.7` → `cliproxy/minimax-m3` → `cliproxy/free`.
  - Updated `openclaw.tpl.json` placeholders (`__DEEPSEEK_FLASH__`, `__MINIMAX__`) and adjusted `openclaw_hydrate_spec.sh` to validate the new chain.

<sup>Written for commit 50d00167d199b0f8c62af326a408fcbf717b5817. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

