### PR TITLE
fix(agents): share CLIProxy API key

### DIFF
--- a/config/aichat/config.tpl.yaml
+++ b/config/aichat/config.tpl.yaml
@@ -2,6 +2,7 @@
 model: cliproxy:__GLM__
 clients:
   - type: openai-compatible
+    # Aichat derives CLIPROXY_API_KEY from this client name.
     name: cliproxy
     api_base: https://cliproxy.shunkakinoki.com/v1
     models:

--- a/config/aichat/config.yaml
+++ b/config/aichat/config.yaml
@@ -2,6 +2,7 @@
 model: cliproxy:glm-4.7
 clients:
   - type: openai-compatible
+    # Aichat derives CLIPROXY_API_KEY from this client name.
     name: cliproxy
     api_base: https://cliproxy.shunkakinoki.com/v1
     models:

--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -79,6 +79,7 @@ max_threads = 10
 [model_providers.cliproxyapi]
 name = "CLIProxyAPI"
 base_url = "https://cliproxy.shunkakinoki.com/v1"
+env_key = "CLIPROXY_API_KEY"
 
 [model_providers.openrouter]
 name = "OpenRouter"

--- a/config/codex/config.tpl.toml
+++ b/config/codex/config.tpl.toml
@@ -79,6 +79,7 @@ max_threads = 10
 [model_providers.cliproxyapi]
 name = "CLIProxyAPI"
 base_url = "https://cliproxy.shunkakinoki.com/v1"
+env_key = "CLIPROXY_API_KEY"
 
 [model_providers.openrouter]
 name = "OpenRouter"

--- a/config/llm/default.nix
+++ b/config/llm/default.nix
@@ -1,4 +1,15 @@
-{ pkgs, ... }:
+{
+  config,
+  pkgs,
+  ...
+}:
+let
+  hydrateScript = pkgs.writeText "llm-hydrate.sh" (
+    builtins.replaceStrings [ "@awk@" "@jq@" ] [ "${pkgs.gawk}/bin/awk" "${pkgs.jq}/bin/jq" ] (
+      builtins.readFile ./hydrate.sh
+    )
+  );
+in
 {
   home.file."Library/Application Support/io.datasette.llm/extra-openai-models.yaml" = {
     enable = pkgs.stdenv.isDarwin;
@@ -23,4 +34,10 @@
     source = ./default_model.txt;
     force = true;
   };
+
+  # LLM extra models only support stored key aliases, so keep the existing
+  # cliproxyapi alias synchronized from the shared CLIProxy credential.
+  home.activation.hydrateLlmCliproxyKey = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    ${pkgs.bash}/bin/bash "${hydrateScript}" || true
+  '';
 }

--- a/config/llm/default.nix
+++ b/config/llm/default.nix
@@ -5,7 +5,7 @@
 }:
 let
   hydrateScript = pkgs.writeText "llm-hydrate.sh" (
-    builtins.replaceStrings [ "@awk@" "@jq@" ] [ "${pkgs.gawk}/bin/awk" "${pkgs.jq}/bin/jq" ] (
+    builtins.replaceStrings [ "@jq@" "@yq@" ] [ "${pkgs.jq}/bin/jq" "${pkgs.yq}/bin/yq" ] (
       builtins.readFile ./hydrate.sh
     )
   );

--- a/config/llm/hydrate.sh
+++ b/config/llm/hydrate.sh
@@ -58,7 +58,11 @@ KEYS_FILE="${LLM_DIR}/keys.json"
 TMP="$(mktemp "${LLM_DIR}/.keys.json.XXXXXX")"
 trap 'rm -f "$TMP"' EXIT
 
-if [ -f "$KEYS_FILE" ] && @jq@ empty "$KEYS_FILE" >/dev/null 2>&1; then
+if [ -f "$KEYS_FILE" ]; then
+  if ! @jq@ empty "$KEYS_FILE" >/dev/null 2>&1; then
+    echo "Warning: LLM keys file is malformed, leaving it unchanged: $KEYS_FILE" >&2
+    exit 0
+  fi
   @jq@ '. + {"cliproxyapi": env.CLIPROXY_API_KEY}' "$KEYS_FILE" >"$TMP"
 else
   @jq@ -n '{"// Note": "This file stores secret API credentials. Do not share!", "cliproxyapi": env.CLIPROXY_API_KEY}' >"$TMP"

--- a/config/llm/hydrate.sh
+++ b/config/llm/hydrate.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Synchronize CLIPROXY_API_KEY into LLM's cliproxyapi key alias.
+# shellcheck source=/dev/null
+set -euo pipefail
+
+ENV_FILE="${HOME}/dotfiles/.env"
+CLIPROXY_CONFIG="${CLIPROXY_CONFIG_PATH:-${HOME}/.cli-proxy-api/config.yaml}"
+CLIPROXY_KEY_FILE="${HOME}/.config/openclaw/cliproxy-key"
+
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  . "$ENV_FILE"
+  set +a
+fi
+
+read_cliproxy_api_key_from_config() {
+  local config_file="$1"
+  [ -f "$config_file" ] || return 0
+
+  # shellcheck disable=SC2016
+  @awk@ '
+    /^api-keys:/ { in_api_keys = 1; next }
+    in_api_keys && /^  - / {
+      value = $0
+      sub(/^  - "/, "", value)
+      sub(/"$/, "", value)
+      print value
+      exit
+    }
+    in_api_keys && /^[^[:space:]]/ { exit }
+  ' "$config_file"
+}
+
+CLIPROXY_API_KEY="${CLIPROXY_API_KEY:-}"
+if [ -z "$CLIPROXY_API_KEY" ]; then
+  CLIPROXY_API_KEY="$(read_cliproxy_api_key_from_config "$CLIPROXY_CONFIG")"
+fi
+if [ -z "$CLIPROXY_API_KEY" ] && [ -f "$CLIPROXY_KEY_FILE" ]; then
+  CLIPROXY_API_KEY="$(tr -d '\n\r' <"$CLIPROXY_KEY_FILE")"
+fi
+if [ -z "$CLIPROXY_API_KEY" ]; then
+  echo "Warning: CLIPROXY_API_KEY not found, skipping LLM key hydration" >&2
+  exit 0
+fi
+export CLIPROXY_API_KEY
+
+case "$(uname -s)" in
+Darwin) LLM_DIR="${LLM_USER_PATH:-${HOME}/Library/Application Support/io.datasette.llm}" ;;
+Linux) LLM_DIR="${LLM_USER_PATH:-${XDG_CONFIG_HOME:-${HOME}/.config}/io.datasette.llm}" ;;
+*)
+  echo "llm hydrate: unsupported OS $(uname -s)" >&2
+  exit 0
+  ;;
+esac
+
+mkdir -p "$LLM_DIR"
+KEYS_FILE="${LLM_DIR}/keys.json"
+TMP="$(mktemp "${LLM_DIR}/.keys.json.XXXXXX")"
+trap 'rm -f "$TMP"' EXIT
+
+if [ -f "$KEYS_FILE" ] && @jq@ empty "$KEYS_FILE" >/dev/null 2>&1; then
+  @jq@ '. + {"cliproxyapi": env.CLIPROXY_API_KEY}' "$KEYS_FILE" >"$TMP"
+else
+  @jq@ -n '{"// Note": "This file stores secret API credentials. Do not share!", "cliproxyapi": env.CLIPROXY_API_KEY}' >"$TMP"
+fi
+
+chmod 600 "$TMP"
+mv "$TMP" "$KEYS_FILE"
+trap - EXIT
+echo "Hydrated LLM cliproxyapi key from CLIPROXY_API_KEY" >&2

--- a/config/llm/hydrate.sh
+++ b/config/llm/hydrate.sh
@@ -17,19 +17,7 @@ fi
 read_cliproxy_api_key_from_config() {
   local config_file="$1"
   [ -f "$config_file" ] || return 0
-
-  # shellcheck disable=SC2016
-  @awk@ '
-    /^api-keys:/ { in_api_keys = 1; next }
-    in_api_keys && /^  - / {
-      value = $0
-      sub(/^  - "/, "", value)
-      sub(/"$/, "", value)
-      print value
-      exit
-    }
-    in_api_keys && /^[^[:space:]]/ { exit }
-  ' "$config_file"
+  @yq@ -r '.["api-keys"][0] // ""' "$config_file"
 }
 
 if [ -z "$CLIPROXY_API_KEY" ]; then

--- a/config/llm/hydrate.sh
+++ b/config/llm/hydrate.sh
@@ -6,8 +6,9 @@ set -euo pipefail
 ENV_FILE="${HOME}/dotfiles/.env"
 CLIPROXY_CONFIG="${CLIPROXY_CONFIG_PATH:-${HOME}/.cli-proxy-api/config.yaml}"
 CLIPROXY_KEY_FILE="${HOME}/.config/openclaw/cliproxy-key"
+CLIPROXY_API_KEY="${CLIPROXY_API_KEY:-}"
 
-if [ -f "$ENV_FILE" ]; then
+if [ -z "$CLIPROXY_API_KEY" ] && [ -f "$ENV_FILE" ]; then
   set -a
   . "$ENV_FILE"
   set +a
@@ -31,7 +32,6 @@ read_cliproxy_api_key_from_config() {
   ' "$config_file"
 }
 
-CLIPROXY_API_KEY="${CLIPROXY_API_KEY:-}"
 if [ -z "$CLIPROXY_API_KEY" ]; then
   CLIPROXY_API_KEY="$(read_cliproxy_api_key_from_config "$CLIPROXY_CONFIG")"
 fi
@@ -69,6 +69,6 @@ else
 fi
 
 chmod 600 "$TMP"
-mv "$TMP" "$KEYS_FILE"
+mv -f "$TMP" "$KEYS_FILE"
 trap - EXIT
 echo "Hydrated LLM cliproxyapi key from CLIPROXY_API_KEY" >&2

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -468,6 +468,7 @@ config/k3s/activate-client.sh
 config/k3s/activate.sh
 config/k3s/kyber-host-alert.sh
 config/k3s/kyber-host-health.sh
+config/llm/hydrate.sh
 config/noctalia/ac-idle-inhibit.sh
 config/noctalia/lock-before-sleep.sh
 config/noctalia/quit-active-app.sh

--- a/spec/llm_hydrate_spec.sh
+++ b/spec/llm_hydrate_spec.sh
@@ -7,7 +7,7 @@ SCRIPT="$PWD/config/llm/hydrate.sh"
 setup() {
   TEMP_HOME=$(mktemp -d)
   PREPROCESSED_SCRIPT="$TEMP_HOME/hydrate.sh"
-  sed -e 's|@awk@|awk|g' -e 's|@jq@|jq|g' "$SCRIPT" >"$PREPROCESSED_SCRIPT"
+  sed -e 's|@jq@|jq|g' -e 's|@yq@|yq|g' "$SCRIPT" >"$PREPROCESSED_SCRIPT"
   chmod +x "$PREPROCESSED_SCRIPT"
 }
 
@@ -46,6 +46,12 @@ It 'falls back to the CLIProxy config key'
 When run bash -c 'mkdir -p "'"$TEMP_HOME"'/.cli-proxy-api"; printf '\''api-keys:\n  - "config-key"\n'\'' >"'"$TEMP_HOME"'/.cli-proxy-api/config.yaml"; HOME="'"$TEMP_HOME"'" LLM_USER_PATH="'"$TEMP_HOME"'/llm" env -u CLIPROXY_API_KEY bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; jq -r .cliproxyapi "'"$TEMP_HOME"'/llm/keys.json"'
 The status should be success
 The output should equal 'config-key'
+End
+
+It 'reads a flow-style CLIProxy key list'
+When run bash -c 'mkdir -p "'"$TEMP_HOME"'/.cli-proxy-api"; printf '\''api-keys: [flow-key]\n'\'' >"'"$TEMP_HOME"'/.cli-proxy-api/config.yaml"; HOME="'"$TEMP_HOME"'" LLM_USER_PATH="'"$TEMP_HOME"'/llm" env -u CLIPROXY_API_KEY bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; jq -r .cliproxyapi "'"$TEMP_HOME"'/llm/keys.json"'
+The status should be success
+The output should equal 'flow-key'
 End
 
 End

--- a/spec/llm_hydrate_spec.sh
+++ b/spec/llm_hydrate_spec.sh
@@ -24,6 +24,12 @@ The status should be success
 The output should equal 'shared-key'
 End
 
+It 'prefers an inherited key over the dotenv value'
+When run bash -c 'mkdir -p "'"$TEMP_HOME"'/dotfiles"; printf '\''CLIPROXY_API_KEY=dotenv-key\n'\'' >"'"$TEMP_HOME"'/dotfiles/.env"; HOME="'"$TEMP_HOME"'" LLM_USER_PATH="'"$TEMP_HOME"'/llm" CLIPROXY_API_KEY="inherited-key" bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; jq -r .cliproxyapi "'"$TEMP_HOME"'/llm/keys.json"'
+The status should be success
+The output should equal 'inherited-key'
+End
+
 It 'preserves existing LLM keys'
 When run bash -c 'mkdir -p "'"$TEMP_HOME"'/llm"; printf '\''{"openai":"existing"}\n'\'' >"'"$TEMP_HOME"'/llm/keys.json"; HOME="'"$TEMP_HOME"'" LLM_USER_PATH="'"$TEMP_HOME"'/llm" CLIPROXY_API_KEY="shared-key" bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; jq -r .openai "'"$TEMP_HOME"'/llm/keys.json"'
 The status should be success

--- a/spec/llm_hydrate_spec.sh
+++ b/spec/llm_hydrate_spec.sh
@@ -30,6 +30,12 @@ The status should be success
 The output should equal 'existing'
 End
 
+It 'leaves a malformed existing keys file unchanged'
+When run bash -c 'mkdir -p "'"$TEMP_HOME"'/llm"; printf '\''{malformed\n'\'' >"'"$TEMP_HOME"'/llm/keys.json"; HOME="'"$TEMP_HOME"'" LLM_USER_PATH="'"$TEMP_HOME"'/llm" CLIPROXY_API_KEY="shared-key" bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; cat "'"$TEMP_HOME"'/llm/keys.json"'
+The status should be success
+The output should equal '{malformed'
+End
+
 It 'falls back to the CLIProxy config key'
 When run bash -c 'mkdir -p "'"$TEMP_HOME"'/.cli-proxy-api"; printf '\''api-keys:\n  - "config-key"\n'\'' >"'"$TEMP_HOME"'/.cli-proxy-api/config.yaml"; HOME="'"$TEMP_HOME"'" LLM_USER_PATH="'"$TEMP_HOME"'/llm" env -u CLIPROXY_API_KEY bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; jq -r .cliproxyapi "'"$TEMP_HOME"'/llm/keys.json"'
 The status should be success

--- a/spec/llm_hydrate_spec.sh
+++ b/spec/llm_hydrate_spec.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'config/llm/hydrate.sh'
+SCRIPT="$PWD/config/llm/hydrate.sh"
+
+setup() {
+  TEMP_HOME=$(mktemp -d)
+  PREPROCESSED_SCRIPT="$TEMP_HOME/hydrate.sh"
+  sed -e 's|@awk@|awk|g' -e 's|@jq@|jq|g' "$SCRIPT" >"$PREPROCESSED_SCRIPT"
+  chmod +x "$PREPROCESSED_SCRIPT"
+}
+
+cleanup() {
+  rm -rf "$TEMP_HOME"
+}
+
+Before 'setup'
+After 'cleanup'
+
+It 'hydrates the cliproxyapi alias from CLIPROXY_API_KEY'
+When run bash -c 'HOME="'"$TEMP_HOME"'" LLM_USER_PATH="'"$TEMP_HOME"'/llm" CLIPROXY_API_KEY="shared-key" bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; jq -r .cliproxyapi "'"$TEMP_HOME"'/llm/keys.json"'
+The status should be success
+The output should equal 'shared-key'
+End
+
+It 'preserves existing LLM keys'
+When run bash -c 'mkdir -p "'"$TEMP_HOME"'/llm"; printf '\''{"openai":"existing"}\n'\'' >"'"$TEMP_HOME"'/llm/keys.json"; HOME="'"$TEMP_HOME"'" LLM_USER_PATH="'"$TEMP_HOME"'/llm" CLIPROXY_API_KEY="shared-key" bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; jq -r .openai "'"$TEMP_HOME"'/llm/keys.json"'
+The status should be success
+The output should equal 'existing'
+End
+
+It 'falls back to the CLIProxy config key'
+When run bash -c 'mkdir -p "'"$TEMP_HOME"'/.cli-proxy-api"; printf '\''api-keys:\n  - "config-key"\n'\'' >"'"$TEMP_HOME"'/.cli-proxy-api/config.yaml"; HOME="'"$TEMP_HOME"'" LLM_USER_PATH="'"$TEMP_HOME"'/llm" env -u CLIPROXY_API_KEY bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; jq -r .cliproxyapi "'"$TEMP_HOME"'/llm/keys.json"'
+The status should be success
+The output should equal 'config-key'
+End
+
+End

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -98,9 +98,9 @@ End
 End
 
 Describe 'DeepSeek defaults'
-It 'generates the CLIProxyAPI DeepSeek Flash default'
-When run bash -c "grep '\"model\": \"cliproxyapi/deepseek-v4-flash\"' config/opencode/opencode.jsonc"
-The output should include 'cliproxyapi/deepseek-v4-flash'
+It 'generates the remote CLIProxyAPI DeepSeek Flash default'
+When run bash -c "grep '\"model\": \"shunkakinoki/deepseek-v4-flash\"' config/opencode/opencode.jsonc"
+The output should include 'shunkakinoki/deepseek-v4-flash'
 End
 
 It 'generates the CLIProxyAPI DeepSeek models'


### PR DESCRIPTION
## Summary

- configure the remote Codex CLIProxy provider to read `CLIPROXY_API_KEY`
- document Aichat’s native `CLIPROXY_API_KEY` lookup from the `cliproxy` client name
- hydrate LLM’s required `cliproxyapi` key alias from the shared credential without replacing existing stored keys
- keep OpenCode’s explicit localhost provider unchanged
- update the generated OpenCode default assertion to match the merged remote provider

## Validation

- `shellspec` (1,923 examples, 0 failures)
- `nix flake check --no-build --impure`
- `shellcheck config/llm/hydrate.sh`
- `nix-instantiate --parse config/llm/default.nix`
- `./scripts/llm-update.sh`
- repository-wide audit of `https://cliproxy.shunkakinoki.com` and `localhost:8317` references

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share a single `CLIPROXY_API_KEY` across Codex, Aichat, and LLM to prevent auth mismatches, while keeping OpenCode’s localhost provider unchanged. LLM now hydrates its `cliproxyapi` key from the shared credential and reads CLIProxy YAML config if needed.

- **Bug Fixes**
  - Codex: set `env_key = "CLIPROXY_API_KEY"` for the `CLIProxyAPI` provider (template and generated).
  - Aichat: clarify that `CLIPROXY_API_KEY` is derived from the `cliproxy` client name.
  - LLM: add `hydrate.sh` and home activation to sync the `cliproxyapi` key; preserves existing keys; prefers inherited env var over `.env`; leaves malformed `keys.json` unchanged; works on macOS/Linux; reads `~/.cli-proxy-api/config.yaml` YAML `api-keys` (block or flow) and falls back to `~/.config/openclaw/cliproxy-key` if env var is unset.
  - Tests: add hydration specs (precedence, malformed store, YAML keys); update OpenCode default assertion to `shunkakinoki/deepseek-v4-flash`.

<sup>Written for commit 5a13ce20a12b93aae8613fb5744a1814089c936f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

