### PR TITLE
fix(roborev): load CLIProxy key in daemon

### DIFF
--- a/home-manager/services/roborev/default.nix
+++ b/home-manager/services/roborev/default.nix
@@ -22,10 +22,9 @@ lib.mkIf enabled {
     enable = true;
     config = {
       ProgramArguments = [
+        "${pkgs.bash}/bin/bash"
+        "${./start.sh}"
         roborevBin
-        "daemon"
-        "run"
-        "--addr"
         serverAddr
       ];
       KeepAlive = true;
@@ -48,7 +47,7 @@ lib.mkIf enabled {
     };
     Service = {
       Type = "notify";
-      ExecStart = "${roborevBin} daemon run --addr ${serverAddr}";
+      ExecStart = "${pkgs.bash}/bin/bash ${./start.sh} ${roborevBin} ${serverAddr}";
       Restart = "on-failure";
       RestartSec = 5;
       Environment = [

--- a/home-manager/services/roborev/start.sh
+++ b/home-manager/services/roborev/start.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROBOREV_BIN="$1"
+SERVER_ADDR="$2"
+ENV_FILE="${HOME}/dotfiles/.env"
+
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$ENV_FILE"
+  set +a
+fi
+
+exec "$ROBOREV_BIN" daemon run --addr "$SERVER_ADDR"

--- a/spec/activate_roborev_spec.sh
+++ b/spec/activate_roborev_spec.sh
@@ -18,6 +18,32 @@ The output should include 'chmod 700'
 End
 End
 
+Describe 'home-manager/services/roborev/start.sh'
+SCRIPT="$PWD/home-manager/services/roborev/start.sh"
+
+setup() {
+  TEMP_HOME=$(mktemp -d)
+  mkdir -p "$TEMP_HOME/dotfiles"
+  printf 'CLIPROXY_API_KEY=test-key\n' >"$TEMP_HOME/dotfiles/.env"
+  printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$CLIPROXY_API_KEY" "$*"\n' >"$TEMP_HOME/roborev"
+  chmod +x "$TEMP_HOME/roborev"
+}
+
+cleanup() {
+  rm -rf "$TEMP_HOME"
+}
+
+Before 'setup'
+After 'cleanup'
+
+It 'loads the shared CLIProxy key before starting the daemon'
+When run env -u CLIPROXY_API_KEY HOME="$TEMP_HOME" bash "$SCRIPT" "$TEMP_HOME/roborev" '127.0.0.1:7373'
+The status should be success
+The line 1 of output should equal 'test-key'
+The line 2 of output should equal 'daemon run --addr 127.0.0.1:7373'
+End
+End
+
 Describe 'home-manager/services/roborev/default.nix'
 It 'enables on galactica, kyber, and matic'
 When run bash -c "grep 'isGalactica || isKyber || isMatic' '$PWD/home-manager/services/roborev/default.nix'"
@@ -25,8 +51,8 @@ The output should include 'isGalactica || isKyber || isMatic'
 End
 
 It 'runs roborev daemon run'
-When run bash -c "grep 'daemon' '$PWD/home-manager/services/roborev/default.nix'"
-The output should include '"daemon"'
+When run bash -c "grep 'start.sh' '$PWD/home-manager/services/roborev/default.nix'"
+The output should include 'start.sh'
 End
 
 It 'passes data dir to activate script'

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -501,6 +501,7 @@ home-manager/services/obsidian/obsidian-headless.sh
 home-manager/services/openclaw/activate.sh
 home-manager/services/qmd/activate.sh
 home-manager/services/roborev/activate.sh
+home-manager/services/roborev/start.sh
 home-manager/modules/tailscale/activate-create-dirs.sh
 home-manager/modules/tailscale/activate-install-service.sh
 home-manager/modules/uv-globals/install-uv-globals.sh


### PR DESCRIPTION
## Summary
- start RoboRev through a managed wrapper that loads ~/dotfiles/.env
- use the same wrapper for launchd and systemd
- cover credential propagation and script tracking

## Root cause
The daemon was launched outside the interactive shell, so OpenCode resolved the configured CLIProxy model but sent no CLIPROXY_API_KEY and received HTTP 401.

## Validation
- shellspec spec/activate_roborev_spec.sh spec/coverage_spec.sh
- nix fmt -- home-manager/services/roborev/default.nix
- make build
- live job 217: OpenCode completed with zero retries after removing the temporary launchd key and restarting the managed service

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Launch RoboRev using a managed `start.sh` that sources `~/dotfiles/.env` so `CLIPROXY_API_KEY` reaches the daemon in non-interactive `launchd`/`systemd` runs. Fixes `CLIProxy` HTTP 401s and stabilizes OpenCode jobs.

- **Bug Fixes**
  - Switch `launchd` and `systemd` services to run `bash` `start.sh` instead of calling the daemon directly.
  - Add shellspec tests for env propagation and include the script in coverage.

<sup>Written for commit af1ef77db0bf915b1fc6a3aee67c406f646bf725. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

