### PR TITLE
fix(fish): honor CAAM account cooldowns

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -15,12 +15,6 @@
 
       set -gx CAAM_ROTATION_ENABLED 1
 
-      ${lib.optionalString pkgs.stdenv.isDarwin ''
-        # CAAM owns the default Claude login. Use claude-swap only as an isolated
-        # fallback when CAAM definitively reports its recommended profile critical.
-        set -gx CLAUDE_SWAP_FALLBACK_ACCOUNT shunkakinoki@gmail.com
-      ''}
-
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
       if test (uname) = "Linux"
           set -gx XDG_RUNTIME_DIR /run/user/(id -u)

--- a/home-manager/programs/fish/functions/_caam_exec_function.fish
+++ b/home-manager/programs/fish/functions/_caam_exec_function.fish
@@ -8,30 +8,10 @@ function _caam_exec_function --description "Run an agent launcher through CAAM w
   end
 
   if test "$CAAM_ROTATION_ENABLED" = "1"; and type -q caam
-    if test "$tool" = claude; and type -q jq
-      set -l precheck (caam precheck "$tool" --format json 2>/dev/null)
-      if test $status -eq 0
-        set -l profile (string join \n $precheck | jq -r '.recommended.name // empty')
-        if test -n "$profile"
-          set -l inventory (caam ls "$tool" --json 2>/dev/null)
-          if test $status -eq 0
-            set -l health (string join \n $inventory | jq -r --arg profile "$profile" \
-              '[.profiles[] | select(.name == $profile and ((.system // false) == false))][0].health.status // "unknown"')
-            if test "$health" = critical; \
-                and set -q CLAUDE_SWAP_FALLBACK_ACCOUNT; \
-                and test -n "$CLAUDE_SWAP_FALLBACK_ACCOUNT"; \
-                and type -q claude-swap
-              claude-swap run "$CLAUDE_SWAP_FALLBACK_ACCOUNT" -- $argv
-              return $status
-            end
-          end
-        end
-      end
-    end
-
     # Interactive TUIs: run on the real TTY. Avoid `caam run` (SmartRunner PTY
     # can hang). Only vault-activate when the active profile is near its limit
-    # or critical — matches caam run --precheck default threshold (80%).
+    # or critical, or CAAM has placed it in cooldown. The usage threshold
+    # matches caam run --precheck's default (80%).
     if isatty stdout
       if type -q jq
         set -l threshold 80
@@ -52,10 +32,14 @@ function _caam_exec_function --description "Run an agent launcher through CAAM w
               '([.recommended] + (.backups // [])) | map(select(.name == $name)) | .[0].usage_percent // empty')
             set -l active_health (string join \n $inventory | jq -r --arg name "$active" \
               '[.profiles[] | select(.name == $name)][0].health.status // "unknown"')
+            set -l active_in_cooldown (string join \n $precheck | jq -r --arg name "$active" \
+              'any(.in_cooldown[]?; .name == $name)')
             set -l recommended (string join \n $precheck | jq -r '.recommended.name // empty')
 
             set -l should_switch 0
-            if test "$active_health" = critical
+            if test "$active_in_cooldown" = true
+              set should_switch 1
+            else if test "$active_health" = critical
               set should_switch 1
             else if test -n "$active_usage"; and test "$active_usage" -ge "$threshold"
               set should_switch 1

--- a/spec/fish/_caam_exec_function_test.fish
+++ b/spec/fish/_caam_exec_function_test.fish
@@ -40,11 +40,16 @@ function codex
 end
 set caam_log (mktemp)
 set -gx MOCK_ACTIVE_USAGE 10
+set -gx MOCK_ACTIVE_COOLDOWN 0
 functions -e caam
 function caam
   echo $argv >> $caam_log
   if test "$argv[1]" = precheck
-    echo '{"recommended":{"name":"backup@example.com","usage_percent":0},"backups":[{"name":"work@example.com","usage_percent":'$MOCK_ACTIVE_USAGE'}]}'
+    set -l cooldowns '[]'
+    if test "$MOCK_ACTIVE_COOLDOWN" = 1
+      set cooldowns '[{"name":"work@example.com"}]'
+    end
+    echo '{"recommended":{"name":"backup@example.com","usage_percent":0},"backups":[{"name":"work@example.com","usage_percent":'$MOCK_ACTIVE_USAGE'}],"in_cooldown":'$cooldowns'}'
   else if test "$argv[1]" = ls
     echo '{"profiles":[{"name":"work@example.com","active":true,"system":false,"health":{"status":"warning"}},{"name":"backup@example.com","active":false,"system":false,"health":{"status":"healthy"}}]}'
   end
@@ -68,41 +73,32 @@ _caam_exec_function codex --dangerously-bypass-approvals-and-sandbox
 @test "runs codex directly after near-limit activate" \
   (cat $direct_env_log) = "--dangerously-bypass-approvals-and-sandbox"
 
+set -gx MOCK_ACTIVE_USAGE 10
+set -gx MOCK_ACTIVE_COOLDOWN 1
+set caam_log (mktemp)
+set direct_env_log (mktemp)
+_caam_exec_function codex --dangerously-bypass-approvals-and-sandbox
+
+@test "activates recommended profile when the active profile is in cooldown" \
+  (tail -n 1 $caam_log) = "activate codex backup@example.com"
+@test "runs codex directly after cooldown-driven activation" \
+  (cat $direct_env_log) = "--dangerously-bypass-approvals-and-sandbox"
+
 # Force non-TTY for remaining tests (claude uses caam run when stdout is not a TTY).
 functions -e isatty
 function isatty; return 1; end
 rm -f $direct_env_log
-set -e MOCK_ACTIVE_USAGE
+set -e MOCK_ACTIVE_USAGE MOCK_ACTIVE_COOLDOWN
 
+# CAAM remains authoritative for Claude launches.
 functions -e caam
-set claude_swap_log (mktemp)
-set -gx MOCK_CLAUDE_HEALTH critical
-set -gx CLAUDE_SWAP_FALLBACK_ACCOUNT fallback@example.com
 function caam
   echo $argv >> $caam_log
-  if test "$argv[1]" = precheck; and test "$argv[2]" = claude
-    echo '{"recommended":{"name":"primary@example.com"}}'
-  else if test "$argv[1]" = ls; and test "$argv[2]" = claude
-    echo '{"profiles":[{"name":"primary@example.com","system":false,"health":{"status":"'$MOCK_CLAUDE_HEALTH'"}}]}'
-  end
 end
-function claude-swap
-  echo $argv >> $claude_swap_log
-end
-
-_caam_exec_function claude --print fallback
-
-@test "uses isolated claude-swap when CAAM recommends a critical Claude profile" \
-  (cat $claude_swap_log) = "run fallback@example.com -- --print fallback"
-
-set -gx MOCK_CLAUDE_HEALTH healthy
 _caam_exec_function claude --print primary
 
-@test "keeps CAAM authoritative while its recommended Claude profile is usable" \
+@test "runs non-interactive Claude through CAAM precheck" \
   (tail -n 1 $caam_log) = "run claude --precheck -- --print primary"
-@test "does not invoke claude-swap for a healthy CAAM profile" \
-  (count (cat $claude_swap_log)) -eq 1
 
 set -e CAAM_ROTATION_ENABLED
-set -e CLAUDE_SWAP_FALLBACK_ACCOUNT MOCK_CLAUDE_HEALTH
-rm -f $direct_log $caam_log $claude_swap_log
+rm -f $direct_log $caam_log


### PR DESCRIPTION
## Summary

- keep CAAM authoritative for Claude account routing
- remove the hard-coded Claude Swap Gmail fallback
- rotate interactive agent launches when CAAM reports the active profile in cooldown
- add regression coverage for cooldown-driven activation

## Verification

- `make shell-test` (1,931 ShellSpec examples; 447 Fish tests)
- `make nix-format-check`
- `make build` (Galactica)
- repaired and verified distinct CAAM Claude profiles locally
- forced the cooled-down Gmail profile active, invoked the patched launcher in a real TTY, and verified Claude launched as `shunkakinoki@shunkakinoki.com`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors CAAM cooldowns for Claude routing in fish. Interactive sessions now switch away from cooled-down, critical, or near-limit profiles; removed the `claude-swap` Gmail fallback so CAAM stays authoritative.

- **Bug Fixes**
  - Rotate interactive launches when the active profile is in cooldown, critical, or >=80% usage (matches `caam run --precheck`).
  - Keep non-interactive Claude runs under CAAM precheck; no `claude-swap` invocation.
  - Remove Darwin `CLAUDE_SWAP_FALLBACK_ACCOUNT` export and the fallback code path.
  - Add regression tests for cooldown-driven activation.

<sup>Written for commit 2498d5a01c1ed05163b7be658dd9c0e8b679d198. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

