### PR TITLE
fix(factory): use tool-capable Droid model

### DIFF
--- a/config/factory/settings.json
+++ b/config/factory/settings.json
@@ -1,7 +1,7 @@
 {
   "sessionDefaultSettings": {
-    "model": "custom:gemma3:4b-0",
-    "reasoningEffort": "none"
+    "model": "deepseek-v4-pro",
+    "reasoningEffort": "high"
   },
   "customModels": [
     {

--- a/config/factory/settings.tpl.json
+++ b/config/factory/settings.tpl.json
@@ -1,6 +1,6 @@
 {
   "sessionDefaultSettings": {
-    "model": "deepseek-v4-pro",
+    "model": "__DEEPSEEK_PRO__",
     "reasoningEffort": "high"
   },
   "customModels": [

--- a/config/factory/settings.tpl.json
+++ b/config/factory/settings.tpl.json
@@ -1,7 +1,7 @@
 {
   "sessionDefaultSettings": {
-    "model": "custom:__GEMMA_LOCAL_NONDOT__-0",
-    "reasoningEffort": "none"
+    "model": "deepseek-v4-pro",
+    "reasoningEffort": "high"
   },
   "customModels": [
     {


### PR DESCRIPTION
## Summary
- default managed Factory Droid sessions to `deepseek-v4-pro`
- use the supported `high` reasoning effort
- retain the local Gemma custom model as an available option

## Verification
- `droid --settings "$PWD/config/factory/settings.json" exec "Reply with OK only."` returned `OK`
- `shellspec spec/roborev_hooks_spec.sh spec/roborev_hydrate_spec.sh` (14 examples, 0 failures)
- `git diff --check`

Refs shunkakinokisoftware-dd2c

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Factory Droid default to `deepseek-v4-pro` with reasoning effort `high` so RoboRev full-panel reviews can use tools instead of falling back to the local model. Hydrates the default via canonical `deepseek-pro` in `models.json` so `llm-update` propagates changes; keeps `custom:gemma3:4b-0` available and addresses Linear `shunkakinokisoftware-dd2c`.

<sup>Written for commit cb1dce58649171a2446b3d5721061dc68a7f3f79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

