### PR TITLE
fix(roborev): expose git during hook hydration

### DIFF
--- a/config/roborev/default.nix
+++ b/config/roborev/default.nix
@@ -21,6 +21,7 @@ let
 in
 {
   home.activation.hydrateRoborevConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    export PATH="${lib.makeBinPath [ pkgs.git ]}:$PATH"
     ${pkgs.bash}/bin/bash "${hydrateScript}" || true
   '';
 }


### PR DESCRIPTION
## Summary
- add Nix-managed `git` to the RoboRev Home Manager activation PATH
- let the existing `roborev install-hook` call resolve configured repository roots
- leave RoboRev and hook scripts unchanged

## Verification
- `shellspec spec/roborev_hydrate_spec.sh spec/roborev_hooks_spec.sh` (14 examples, 0 failures)
- `make build HOST=galactica`
- live `roborev install-hook` installed `post-commit` and `post-rewrite` while preserving Entire hooks

Refs shunkakinokisoftware-citi

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose Nix-managed `git` in the Home Manager activation PATH so `roborev install-hook` can resolve repository roots during hook hydration. This fixes hook installation for `post-commit` and `post-rewrite` without changing RoboRev or hook scripts.

<sup>Written for commit 6671278512845ed30dee793bdf81583b9e9cbc93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

