### PR TITLE
fix(caam): preserve named profile credentials

### DIFF
--- a/config/caam/config.template.yaml
+++ b/config/caam/config.template.yaml
@@ -8,5 +8,7 @@ stealth:
     enabled: __AUTO_ROTATE__
     algorithm: smart
 safety:
-  auto_backup_before_switch: smart
+  # Live OAuth files can be rewritten by an already-running CLI process. Never
+  # save that mutable state into a named profile implicitly during rotation.
+  auto_backup_before_switch: never
   max_auto_backups: 5

--- a/spec/caam_sync_service_spec.sh
+++ b/spec/caam_sync_service_spec.sh
@@ -59,6 +59,12 @@ The output should include 'caamSyncSetup'
 The status should be success
 End
 
+It 'disables implicit pre-switch backups in the CAAM template'
+When run bash -c "grep -F 'auto_backup_before_switch: never' '$PWD/config/caam/config.template.yaml'"
+The output should include 'auto_backup_before_switch: never'
+The status should be success
+End
+
 It 'skips periodic sync when caam binary is missing'
 When run env CAAM=/nonexistent/caam bash "$SYNC"
 The stderr should include 'caam not found'


### PR DESCRIPTION
## Summary
- disable implicit CAAM pre-switch backups that can save mutable live OAuth state into the wrong named profile
- preserve the existing cross-host vault sync services unchanged
- add regression coverage for the declarative safety setting

## Validation
- `shellspec spec/caam_sync_service_spec.sh`
- `make shell-test` (1,934 ShellSpec examples; 447 Fish tests)
- `make nix-format-check`
- `make build`
- live forced Gmail cooldown rotation selected `shunkakinoki@shunkakinoki.com` while profile hashes remained distinct

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent implicit CAAM pre-switch backups so live OAuth state can’t overwrite named profile credentials during rotation. Set `auto_backup_before_switch: never` in `config/caam/config.template.yaml` and added a spec to enforce it.

<sup>Written for commit 0a9c1d3d9d72c91689c715211118c92884ad0d28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

