### PR TITLE
fix(fish): pin CAAM Claude token per process

### DIFF
--- a/home-manager/programs/fish/functions/_caam_exec_function.fish
+++ b/home-manager/programs/fish/functions/_caam_exec_function.fish
@@ -56,6 +56,21 @@ function _caam_exec_function --description "Run an agent launcher through CAAM w
         end
       end
 
+      # Claude Code on macOS can prefer its Keychain credential over the
+      # file CAAM activates. Pin the selected file-backed token to this child
+      # process so inference uses the same account that CAAM reports active.
+      if test "$tool" = claude; and type -q jq
+        set -l credentials "$HOME/.claude/.credentials.json"
+        if test -r "$credentials"
+          set -l oauth_token (jq -er '.claudeAiOauth.accessToken // empty' "$credentials" 2>/dev/null)
+          if test -n "$oauth_token"
+            set -lx CLAUDE_CODE_OAUTH_TOKEN "$oauth_token"
+            $executable $argv
+            return $status
+          end
+        end
+      end
+
       $executable $argv
       return $status
     end

--- a/spec/fish/_caam_exec_function_test.fish
+++ b/spec/fish/_caam_exec_function_test.fish
@@ -84,6 +84,32 @@ _caam_exec_function codex --dangerously-bypass-approvals-and-sandbox
 @test "runs codex directly after cooldown-driven activation" \
   (cat $direct_env_log) = "--dangerously-bypass-approvals-and-sandbox"
 
+# Claude Code on macOS may prefer a stale Keychain credential. The selected
+# CAAM file token must be pinned only to the launched Claude child process.
+set test_home (mktemp -d)
+mkdir -p $test_home/.claude
+echo '{"claudeAiOauth":{"accessToken":"selected-token"}}' >$test_home/.claude/.credentials.json
+set original_home $HOME
+set -gx HOME $test_home
+set claude_env_log (mktemp)
+function claude
+  if set -q CLAUDE_CODE_OAUTH_TOKEN
+    echo "$CLAUDE_CODE_OAUTH_TOKEN|$argv" >>$claude_env_log
+  else
+    echo "unset|$argv" >>$claude_env_log
+  end
+end
+
+_caam_exec_function claude --print primary
+
+@test "pins the selected CAAM token to interactive Claude" \
+  (cat $claude_env_log) = "selected-token|--print primary"
+@test "does not export the selected Claude token to the caller" \
+  (set -q CLAUDE_CODE_OAUTH_TOKEN; echo $status) -eq 1
+
+set -gx HOME $original_home
+rm -rf $test_home $claude_env_log
+
 # Force non-TTY for remaining tests (claude uses caam run when stdout is not a TTY).
 functions -e isatty
 function isatty; return 1; end


### PR DESCRIPTION
## Summary

- export the CAAM-selected Claude OAuth token only to the launched Claude child process
- override stale macOS Keychain credentials without mutating global Keychain state
- add regression coverage for token injection and caller-scope cleanup

## Root cause

CAAM correctly activated the domain credential file, so `claude auth status` reported the domain account. Claude inference still preferred a stale `Claude Code-credentials` Keychain item and hit the Gmail session limit. A one-process `CLAUDE_CODE_OAUTH_TOKEN` proof succeeded against the domain account.

## Validation

- `make fish-test` (449 passing)
- `make shell-test` (1,934 ShellSpec examples + 449 Fish tests)
- `make nix-format-check`
- `make build`
- real TTY prompt through the patched wrapper: `WRAPPER_ROUTE_OK`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the CAAM-selected Claude OAuth token to the Claude child process on macOS so inference uses the active domain account instead of a stale Keychain credential. Adds tests to confirm per-process token injection and no leakage to the caller.

- **Bug Fixes**
  - Read token from `~/.claude/.credentials.json` and export it only to the Claude child process.
  - Prevent macOS Keychain from overriding the CAAM file-backed token during inference.
  - Add regression tests for token pinning and caller-scope cleanup.

<sup>Written for commit 3e9a79651062bd513cee7fac1c9e717d2082844b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

