### PR TITLE
fix(switch): handle platform plugins and dotagents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,37 +200,42 @@ nvim-plugins-install: ## Download/build missing Neovim native plugin binaries (f
 		if [ -d "$$d" ]; then FFF_DIR="$$d"; break; fi; \
 	done; \
 	if [ -n "$$FFF_DIR" ]; then \
-		FFF_BINARY="$$FFF_DIR/target/libfff_nvim.so"; \
-		if [ ! -f "$$FFF_BINARY" ]; then \
-			echo "Downloading fff.nvim native binary..."; \
-			FFF_VERSION=$$(git -C "$$FFF_DIR" rev-parse --short HEAD 2>/dev/null || echo ""); \
-			if [ -n "$$FFF_VERSION" ]; then \
-				_ARCH=$$(uname -m); \
+		_ARCH=$$(uname -m); \
+		case "$$_ARCH" in arm64) _ARCH="aarch64" ;; amd64) _ARCH="x86_64" ;; esac; \
+		case "$$(uname -s)" in \
+			Darwin) _LIB_EXT="dylib"; _TRIPLE="$${_ARCH}-apple-darwin" ;; \
+			Linux) \
 				_LDD=$$(ldd --version 2>&1 || echo ""); \
-				if echo "$$_LDD" | grep -q musl; then \
-					_TRIPLE="$${_ARCH}-unknown-linux-musl"; \
+				if echo "$$_LDD" | grep -q musl; then _TRIPLE="$${_ARCH}-unknown-linux-musl"; else _TRIPLE="$${_ARCH}-unknown-linux-gnu"; fi; \
+				_LIB_EXT="so" ;; \
+			*) _LIB_EXT=""; _TRIPLE=""; echo "fff.nvim: unsupported platform, skipping download" ;; \
+		esac; \
+		if [ -n "$$_LIB_EXT" ]; then \
+			FFF_BINARY="$$FFF_DIR/target/libfff_nvim.$$_LIB_EXT"; \
+			if [ ! -f "$$FFF_BINARY" ]; then \
+				echo "Downloading fff.nvim native binary..."; \
+				FFF_VERSION=$$(git -C "$$FFF_DIR" rev-parse --short HEAD 2>/dev/null || echo ""); \
+				if [ -n "$$FFF_VERSION" ]; then \
+					mkdir -p "$$FFF_DIR/target"; \
+					echo "Fetching https://github.com/dmtrKovalenko/fff.nvim/releases/download/$$FFF_VERSION/$${_TRIPLE}.$${_LIB_EXT}"; \
+					curl --fail --location --silent --show-error \
+						-o "$$FFF_BINARY" \
+						"https://github.com/dmtrKovalenko/fff.nvim/releases/download/$$FFF_VERSION/$${_TRIPLE}.$${_LIB_EXT}" \
+						&& echo "fff.nvim binary downloaded successfully" \
+						|| echo "fff.nvim binary download failed"; \
 				else \
-					_TRIPLE="$${_ARCH}-unknown-linux-gnu"; \
+					echo "fff.nvim: could not determine version, skipping"; \
 				fi; \
-				mkdir -p "$$FFF_DIR/target"; \
-				echo "Fetching https://github.com/dmtrKovalenko/fff.nvim/releases/download/$$FFF_VERSION/$${_TRIPLE}.so"; \
-				curl --fail --location --silent --show-error \
-					-o "$$FFF_BINARY" \
-					"https://github.com/dmtrKovalenko/fff.nvim/releases/download/$$FFF_VERSION/$${_TRIPLE}.so" \
-					&& echo "fff.nvim binary downloaded successfully" \
-					|| echo "fff.nvim binary download failed"; \
 			else \
-				echo "fff.nvim: could not determine version, skipping"; \
+				echo "fff.nvim binary already present"; \
 			fi; \
-		else \
-			echo "fff.nvim binary already present"; \
 		fi; \
 	else \
 		echo "fff.nvim plugin directory not found, skipping"; \
 	fi
 
 .PHONY: switch
-switch: nix-switch services nvim-plugins-install dotagents-sync ## Apply Nix config, refresh services/plugins, and refresh agent daemons.
+switch: nix-switch services nvim-plugins-install dotagents-switch-sync ## Apply Nix config, refresh services/plugins, and refresh agent daemons.
 	@$(MAKE) refresh
 
 .PHONY: refresh
@@ -334,13 +339,29 @@ upgrade-dev: ## Upgrade inside the Nix dev shell (mirrors CI).
 sync: dotagents-sync codex-security-sync rtk-rewrite-sync ## Sync all components (dotagents, Codex security patterns, rtk-rewrite.sh).
 
 .PHONY: dotagents-sync
-dotagents-sync: ## Sync dotagents (commands, skills, MCP configuration).
+dotagents-sync: dotagents-prepare ## Sync dotagents (commands, skills, MCP configuration).
 	@if [ "$$CI" = "true" ]; then \
 		echo "⏭️ Skipping external dotagents skill installation in CI"; \
 		$(MAKE) -C dotagents DOTAGENTS_SKIP_SYNC=1 ruler-prepare commands-sync skills-sync mcp-sync ruler-dotdirs-sync; \
 	else \
-		$(MAKE) -C dotagents sync; \
+		$(MAKE) -C dotagents DOTAGENTS_SKIP_SYNC= sync; \
 	fi
+
+.PHONY: dotagents-prepare
+dotagents-prepare: ## Initialize the dotagents submodule when needed.
+	@if [ ! -f dotagents/Makefile ]; then \
+		echo "🔁 Initializing dotagents submodule..."; \
+		git submodule update --init dotagents; \
+	fi
+	@if [ ! -f dotagents/Makefile ]; then \
+		echo "❌ dotagents submodule is unavailable"; \
+		exit 1; \
+	fi
+
+.PHONY: dotagents-switch-sync
+dotagents-switch-sync: dotagents-prepare ## Sync checked-in dotagents content during switch.
+	@echo "🔄 Syncing checked-in dotagents content..."
+	@$(MAKE) -C dotagents DOTAGENTS_SKIP_SYNC=1 ruler-prepare commands-sync skills-sync mcp-sync ruler-dotdirs-sync
 
 .PHONY: codex-security-sync
 codex-security-sync: ## Sync Codex security deny patterns from Claude settings.

--- a/home-manager/programs/neovim/activate-build-plugins.sh
+++ b/home-manager/programs/neovim/activate-build-plugins.sh
@@ -33,19 +33,38 @@ if [ -n "$fff_dir" ]; then
     fff_version=$(git -C "$fff_dir" rev-parse --short HEAD 2>/dev/null || echo "")
     if [ -n "$fff_version" ]; then
       _arch=$(uname -m)
-      _ldd=$(ldd --version 2>&1 || echo "")
-      if echo "$_ldd" | grep -q musl; then
-        _triple="${_arch}-unknown-linux-musl"
-      else
-        _triple="${_arch}-unknown-linux-gnu"
+      case "$_arch" in
+      arm64) _arch="aarch64" ;;
+      amd64) _arch="x86_64" ;;
+      esac
+
+      case "$(uname -s)" in
+      Darwin)
+        _triple="${_arch}-apple-darwin"
+        ;;
+      Linux)
+        _ldd=$(ldd --version 2>&1 || echo "")
+        if echo "$_ldd" | grep -q musl; then
+          _triple="${_arch}-unknown-linux-musl"
+        else
+          _triple="${_arch}-unknown-linux-gnu"
+        fi
+        ;;
+      *)
+        _triple=""
+        echo "fff.nvim: unsupported platform, skipping download"
+        ;;
+      esac
+
+      if [ -n "$_triple" ]; then
+        mkdir -p "$fff_dir/target"
+        echo "Fetching https://github.com/dmtrKovalenko/fff.nvim/releases/download/$fff_version/${_triple}.${LIB_EXT}"
+        curl --fail --location --silent --show-error \
+          -o "$fff_binary" \
+          "https://github.com/dmtrKovalenko/fff.nvim/releases/download/$fff_version/${_triple}.${LIB_EXT}" &&
+          echo "fff.nvim binary downloaded successfully" ||
+          echo "fff.nvim binary download failed (will fall back to build on first use)"
       fi
-      mkdir -p "$fff_dir/target"
-      echo "Fetching https://github.com/dmtrKovalenko/fff.nvim/releases/download/$fff_version/${_triple}.${LIB_EXT}"
-      curl --fail --location --silent --show-error \
-        -o "$fff_binary" \
-        "https://github.com/dmtrKovalenko/fff.nvim/releases/download/$fff_version/${_triple}.${LIB_EXT}" &&
-        echo "fff.nvim binary downloaded successfully" ||
-        echo "fff.nvim binary download failed (will fall back to build on first use)"
     else
       echo "fff.nvim: could not determine version, skipping download"
     fi

--- a/home-manager/programs/neovim/default.nix
+++ b/home-manager/programs/neovim/default.nix
@@ -19,7 +19,7 @@ let
         pkgs.gnumake
         pkgs.gcc
       ];
-  libExt = "so";
+  libExt = if pkgs.stdenv.isDarwin then "dylib" else "so";
 in
 {
   programs.neovim = {

--- a/spec/activate_neovim_spec.sh
+++ b/spec/activate_neovim_spec.sh
@@ -63,6 +63,16 @@ When run bash -c "grep 'uname -m' '$SCRIPT'"
 The output should include 'uname -m'
 End
 
+It 'normalizes Apple Silicon architecture'
+When run grep 'aarch64' "$SCRIPT"
+The output should include 'aarch64'
+End
+
+It 'uses the Darwin fff.nvim target triple'
+When run grep 'apple-darwin' "$SCRIPT"
+The output should include 'apple-darwin'
+End
+
 It 'uses curl for download'
 When run bash -c "grep 'curl' '$SCRIPT'"
 The output should include 'curl'
@@ -90,6 +100,11 @@ End
 It 'quotes the pack directory argument for plugin builds'
 When run cat "$PWD/home-manager/programs/neovim/default.nix"
 The output should include '"${packDir}" "${libExt}"'
+End
+
+It 'uses the Darwin shared-library extension'
+When run grep 'dylib' "$PWD/home-manager/programs/neovim/default.nix"
+The output should include 'dylib'
 End
 End
 End

--- a/spec/make_switch_spec.sh
+++ b/spec/make_switch_spec.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016,SC2329
+
+Describe 'Makefile switch post-activation dependencies'
+MAKEFILE="$PWD/Makefile"
+
+It 'uses a switch-specific checked-in dotagents sync'
+When run grep 'dotagents-switch-sync' "$MAKEFILE"
+The output should include 'dotagents-switch-sync'
+End
+
+It 'initializes dotagents before syncing it'
+When run bash -c "grep -A8 '^dotagents-prepare:' '$MAKEFILE'"
+The output should include 'git submodule update --init dotagents'
+End
+
+It 'does not require the optional dotagents sync target during switch'
+When run bash -c "grep -A2 '^dotagents-switch-sync:' '$MAKEFILE'"
+The output should include 'DOTAGENTS_SKIP_SYNC=1'
+End
+End


### PR DESCRIPTION
## Summary

- Use fff.nvim's Darwin target triple and `.dylib` extension, including Apple Silicon normalization, in activation and post-switch plugin paths.
- Initialize the dotagents submodule when needed and use a checked-in-content sync for `make switch`, keeping optional external skill installation on the explicit `make sync` path.
- Add focused ShellSpec coverage for both switch boundaries.

## Validation

- `shellspec spec/activate_neovim_spec.sh spec/make_switch_spec.sh` (21 examples, 0 failures)
- `shellcheck home-manager/programs/neovim/activate-build-plugins.sh`
- `make nix-format-check`
- `make nix-lint`
- `make nix-flake-check` reaches the Darwin configurations successfully but cannot build required x86_64-Linux derivations from this aarch64-Darwin host (`docker.service.drv`, exit 2).
- Probed the pinned fff release: `aarch64-apple-darwin.dylib` returns 200; the previously requested `arm64-unknown-linux-gnu.so` returns 404.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes platform handling for `fff.nvim` by using the Darwin target and `.dylib` on macOS, and updates switch behavior to sync only checked-in `dotagents` content after auto-initializing the submodule.

- **Bug Fixes**
  - `fff.nvim`: Normalize arch to `aarch64`/`x86_64`, use `apple-darwin` on macOS, and select `.dylib` vs `.so` in the Makefile and activation script.
  - `dotagents`: Add `dotagents-prepare` to init the submodule; `switch` uses `dotagents-switch-sync` with `DOTAGENTS_SKIP_SYNC=1`. Full external skill install remains on `make sync` (skipped in CI).
  - Tests: Add ShellSpec for Darwin triple and `.dylib`, and for `switch` using `dotagents-switch-sync` and submodule init.

<sup>Written for commit 115440e975ff2ddde8308de1cd68c83b39c1b91c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

