### PR TITLE
fix(roborev): run review daemon only on Kyber

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1255,13 +1255,7 @@ launchctl-ollama: ## Restart ollama launchd agent.
 .PHONY: launchctl-roborev
 launchctl-roborev: ## Restart roborev launchd agent.
 	@echo "🔄 Restarting roborev..."
-	@if [ "$(DETECTED_HOST)" = "galactica" ] || [ "$(HOST)" = "galactica" ]; then \
-		launchctl unload ~/Library/LaunchAgents/org.nix-community.home.roborev.plist 2>/dev/null || true; \
-		sleep 3; \
-		launchctl load ~/Library/LaunchAgents/org.nix-community.home.roborev.plist; \
-	else \
-		echo "Skipping roborev launchd agent (host not galactica)"; \
-	fi
+	@echo "Skipping roborev launchd agent (RoboRev is enabled only on Kyber)"
 	@echo "✅ roborev restarted"
 
 .PHONY: launchctl-tmux-session-logger
@@ -1394,11 +1388,11 @@ systemctl-openclaw: ## Restart OpenClaw gateway systemd user service.
 .PHONY: systemctl-roborev
 systemctl-roborev: ## Restart roborev systemd user service.
 	@echo "🔄 Restarting roborev..."
-	@if [ "$(DETECTED_HOST)" = "matic" ] || [ "$(HOST)" = "matic" ] || [ "$(DETECTED_HOST)" = "kyber" ] || [ "$(HOST)" = "kyber" ]; then \
+	@if [ "$(DETECTED_HOST)" = "kyber" ] || [ "$(HOST)" = "kyber" ]; then \
 		systemctl --user daemon-reload; \
 		systemctl --user restart roborev.service; \
 	else \
-		echo "Skipping roborev.service (host not matic or kyber)"; \
+		echo "Skipping roborev.service (RoboRev is enabled only on Kyber)"; \
 	fi
 	@echo "✅ roborev restarted"
 

--- a/config/roborev/default.nix
+++ b/config/roborev/default.nix
@@ -1,5 +1,6 @@
 {
   config,
+  inputs,
   lib,
   pkgs,
   ...
@@ -19,7 +20,7 @@ let
       )
     );
 in
-{
+lib.mkIf inputs.host.isKyber {
   home.activation.hydrateRoborevConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     export PATH="${lib.makeBinPath [ pkgs.git ]}:$PATH"
     ${pkgs.bash}/bin/bash "${hydrateScript}" || true

--- a/home-manager/services/roborev/default.nix
+++ b/home-manager/services/roborev/default.nix
@@ -6,12 +6,12 @@
   ...
 }:
 let
-  inherit (inputs.host) isGalactica isKyber isMatic;
+  inherit (inputs.host) isKyber;
   homeDir = config.home.homeDirectory;
   roborevBin = "${homeDir}/.local/bin/roborev";
   dataDir = "${homeDir}/.roborev";
   serverAddr = "127.0.0.1:7373";
-  enabled = isGalactica || isKyber || isMatic;
+  enabled = isKyber;
 in
 lib.mkIf enabled {
   home.activation.roborevSetup = config.lib.dag.entryAfter [ "writeBoundary" ] ''

--- a/spec/activate_roborev_spec.sh
+++ b/spec/activate_roborev_spec.sh
@@ -47,9 +47,14 @@ End
 End
 
 Describe 'home-manager/services/roborev/default.nix'
-It 'enables on galactica, kyber, and matic'
-When run bash -c "grep 'isGalactica || isKyber || isMatic' '$PWD/home-manager/services/roborev/default.nix'"
-The output should include 'isGalactica || isKyber || isMatic'
+It 'enables only on kyber'
+When run bash -c "grep 'enabled = isKyber;' '$PWD/home-manager/services/roborev/default.nix'"
+The output should include 'enabled = isKyber;'
+End
+
+It 'hydrates the config only on kyber'
+When run bash -c "grep 'lib.mkIf inputs.host.isKyber' '$PWD/config/roborev/default.nix'"
+The output should include 'lib.mkIf inputs.host.isKyber'
 End
 
 It 'runs roborev daemon run'


### PR DESCRIPTION
## What changed

- Enable the RoboRev daemon only when `inputs.host.isKyber` is true.
- Hydrate RoboRev CI configuration and install review hooks only on Kyber.
- Align launchd/systemd restart targets with the Kyber-only topology.

This prevents independent local daemons on Galactica and Matic from processing the same review-triggering work.

## Verification

- `shellspec spec/activate_roborev_spec.sh`
- `make nix-format-check`
- `make build`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit RoboRev to run only on Kyber to prevent duplicate review processing on Galactica and Matic. Align configs and restart targets with a Kyber-only topology.

- **Bug Fixes**
  - Gate CI config hydration with `lib.mkIf inputs.host.isKyber`.
  - Enable the home-manager service only on Kyber (`enabled = isKyber`).
  - Restrict `systemctl-roborev` to Kyber and skip launchd on other hosts; update shellspec to match.

<sup>Written for commit d4710c33d838d51b129f7da38b31434af95929a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

