### PR TITLE
fix(roborev): keep local reviews on every host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1255,7 +1255,13 @@ launchctl-ollama: ## Restart ollama launchd agent.
 .PHONY: launchctl-roborev
 launchctl-roborev: ## Restart roborev launchd agent.
 	@echo "🔄 Restarting roborev..."
-	@echo "Skipping roborev launchd agent (RoboRev is enabled only on Kyber)"
+	@if [ "$(DETECTED_HOST)" = "galactica" ] || [ "$(HOST)" = "galactica" ]; then \
+		launchctl unload ~/Library/LaunchAgents/org.nix-community.home.roborev.plist 2>/dev/null || true; \
+		sleep 3; \
+		launchctl load ~/Library/LaunchAgents/org.nix-community.home.roborev.plist; \
+	else \
+		echo "Skipping roborev launchd agent (host not galactica)"; \
+	fi
 	@echo "✅ roborev restarted"
 
 .PHONY: launchctl-tmux-session-logger
@@ -1388,11 +1394,11 @@ systemctl-openclaw: ## Restart OpenClaw gateway systemd user service.
 .PHONY: systemctl-roborev
 systemctl-roborev: ## Restart roborev systemd user service.
 	@echo "🔄 Restarting roborev..."
-	@if [ "$(DETECTED_HOST)" = "kyber" ] || [ "$(HOST)" = "kyber" ]; then \
+	@if [ "$(DETECTED_HOST)" = "matic" ] || [ "$(HOST)" = "matic" ] || [ "$(DETECTED_HOST)" = "kyber" ] || [ "$(HOST)" = "kyber" ]; then \
 		systemctl --user daemon-reload; \
 		systemctl --user restart roborev.service; \
 	else \
-		echo "Skipping roborev.service (RoboRev is enabled only on Kyber)"; \
+		echo "Skipping roborev.service (host not matic or kyber)"; \
 	fi
 	@echo "✅ roborev restarted"
 

--- a/config/roborev/default.nix
+++ b/config/roborev/default.nix
@@ -6,9 +6,11 @@
   ...
 }:
 let
+  ciEnabled = if inputs.host.isKyber then "true" else "false";
   hydrateScript =
     let
       vars = {
+        ciEnabled = if inputs.host.isKyber then "true" else "false";
         sed = "${pkgs.gnused}/bin/sed";
         template = "${./config.template.toml}";
       };
@@ -20,7 +22,7 @@ let
       )
     );
 in
-lib.mkIf inputs.host.isKyber {
+{
   home.activation.hydrateRoborevConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     export PATH="${lib.makeBinPath [ pkgs.git ]}:$PATH"
     ${pkgs.bash}/bin/bash "${hydrateScript}" || true

--- a/config/roborev/hydrate.sh
+++ b/config/roborev/hydrate.sh
@@ -16,6 +16,7 @@ if [ -f "$ENV_FILE" ]; then
 fi
 
 ROBOREV_REPOS="${ROBOREV_REPOS:-}"
+ROBOREV_CI_ENABLED="@ciEnabled@"
 if [ -z "$ROBOREV_REPOS" ] && [ -n "${ROBOREV_CI_REPOS:-}" ]; then
   ROBOREV_REPOS="$ROBOREV_CI_REPOS"
   echo "Warning: ROBOREV_CI_REPOS is deprecated; rename it to ROBOREV_REPOS" >&2
@@ -55,6 +56,7 @@ fi
 mkdir -p "$CONFIG_DIR"
 
 @sed@ \
+  -e "s/^enabled = true$/enabled = ${ROBOREV_CI_ENABLED}/" \
   -e "s|\"__ROBOREV_REPOS__\"|${TOML_REPOS}|g" \
   "$TEMPLATE" >"$CONFIG"
 chmod 600 "$CONFIG"

--- a/home-manager/services/roborev/default.nix
+++ b/home-manager/services/roborev/default.nix
@@ -6,12 +6,12 @@
   ...
 }:
 let
-  inherit (inputs.host) isKyber;
+  inherit (inputs.host) isGalactica isKyber isMatic;
   homeDir = config.home.homeDirectory;
   roborevBin = "${homeDir}/.local/bin/roborev";
   dataDir = "${homeDir}/.roborev";
   serverAddr = "127.0.0.1:7373";
-  enabled = isKyber;
+  enabled = isGalactica || isKyber || isMatic;
 in
 lib.mkIf enabled {
   home.activation.roborevSetup = config.lib.dag.entryAfter [ "writeBoundary" ] ''

--- a/spec/activate_roborev_spec.sh
+++ b/spec/activate_roborev_spec.sh
@@ -47,14 +47,14 @@ End
 End
 
 Describe 'home-manager/services/roborev/default.nix'
-It 'enables only on kyber'
-When run bash -c "grep 'enabled = isKyber;' '$PWD/home-manager/services/roborev/default.nix'"
-The output should include 'enabled = isKyber;'
+It 'enables on galactica, kyber, and matic'
+When run bash -c "grep 'isGalactica || isKyber || isMatic' '$PWD/home-manager/services/roborev/default.nix'"
+The output should include 'isGalactica || isKyber || isMatic'
 End
 
-It 'hydrates the config only on kyber'
-When run bash -c "grep 'lib.mkIf inputs.host.isKyber' '$PWD/config/roborev/default.nix'"
-The output should include 'lib.mkIf inputs.host.isKyber'
+It 'selects CI polling by host'
+When run bash -c "grep 'ciEnabled = if inputs.host.isKyber then \"true\" else \"false\";' '$PWD/config/roborev/default.nix'"
+The output should include 'ciEnabled = if inputs.host.isKyber then "true" else "false";'
 End
 
 It 'runs roborev daemon run'


### PR DESCRIPTION
## What changed

The Kyber-only daemon change in #2285 was too broad: local post-commit reviews also use the per-host daemon.

This follow-up keeps the RoboRev daemon and local hooks enabled on Galactica, Kyber, and Matic, while setting `[ci].enabled` only on Kyber during config hydration:

- Galactica/Matic: local post-commit and agent-hook reviews remain available; CI/PR polling is disabled.
- Kyber: local reviews and CI/PR polling remain enabled.

This preserves local feedback without having multiple hosts poll the same PR/CI queue.

## Verification

- `shellspec spec/activate_roborev_spec.sh`
- `make nix-format-check`
- `make build`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep RoboRev local post-commit reviews enabled on Galactica, Kyber, and Matic, while limiting CI/PR polling to Kyber. Preserves local feedback without multiple hosts polling the same queues.

- **Bug Fixes**
  - Enable RoboRev daemon and local hooks on Galactica, Kyber, and Matic.
  - Set `[ci].enabled` via `hydrate.sh` per host: true on Kyber, false elsewhere.
  - Start the `home-manager` RoboRev service on all three hosts.
  - Update Makefile tasks to restart RoboRev only on relevant hosts.
  - Refresh specs to validate the new host behavior.

<sup>Written for commit 2b2d0b1be1c8a80ca5910b0974a779b1c242500e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

