### PR TITLE
fix(fnm): pin managed Node defaults

### DIFF
--- a/home-manager/programs/fnm/activate.sh
+++ b/home-manager/programs/fnm/activate.sh
@@ -20,11 +20,11 @@ done
 # Set default version
 "$FNM_BIN" default "$DEFAULT_VERSION" || true
 
-# Create stable symlink for systemd services
+# Create a stable symlink to the configured default for non-interactive services.
 if [ -d "$FNM_DIR/node-versions" ]; then
-  latest_v22=$(ls -d "$FNM_DIR/node-versions/v22"* 2>/dev/null | head -1)
-  if [ -n "$latest_v22" ] && [ -d "$latest_v22/installation/bin" ]; then
+  default_node=$(ls -d "$FNM_DIR/node-versions/v${DEFAULT_VERSION}"* 2>/dev/null | head -1)
+  if [ -n "$default_node" ] && [ -d "$default_node/installation/bin" ]; then
     mkdir -p "$HOME/.local/bin"
-    ln -sf "$latest_v22/installation/bin/node" "$HOME/.local/bin/node"
+    ln -sf "$default_node/installation/bin/node" "$HOME/.local/bin/node"
   fi
 fi

--- a/home-manager/programs/fnm/default.nix
+++ b/home-manager/programs/fnm/default.nix
@@ -6,17 +6,23 @@
 }:
 let
   homeDir = config.home.homeDirectory;
+  fnmDir =
+    if pkgs.stdenv.isDarwin then
+      "${homeDir}/Library/Application Support/fnm"
+    else
+      "${homeDir}/.local/share/fnm";
   # Node versions to pre-install (first one is default)
   nodeVersions = [
-    "22"
-    "20"
+    "24.14.0"
+    "22.21.1"
+    "20.19.0"
   ];
   defaultVersion = builtins.head nodeVersions;
 in
 {
   home.packages = with pkgs; [ fnm ];
 
-  xdg.configFile."fish/conf.d/fnm.fish".text = builtins.toString ''
+  programs.fish.interactiveShellInit = lib.mkAfter ''
     fnm env --use-on-cd --shell fish | source
   '';
 
@@ -25,7 +31,7 @@ in
     export PATH="${pkgs.fnm}/bin:$PATH"
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" \
       "${pkgs.fnm}/bin/fnm" \
-      "${homeDir}/.local/share/fnm" \
+      "${fnmDir}" \
       "${defaultVersion}" \
       ${lib.concatMapStringsSep " " (version: "\"${version}\"") (builtins.tail nodeVersions)}
   '';

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -96,6 +96,7 @@
       export FNM_LOGLEVEL="info"
       export FNM_NODE_DIST_MIRROR="https://nodejs.org/dist"
       export FNM_VERSION_FILE_STRATEGY="local"
+      eval "$(fnm env --use-on-cd --shell zsh)"
 
       # Worktrunk shell init
       if command -v wt >/dev/null 2>&1; then

--- a/spec/activate_fnm_spec.sh
+++ b/spec/activate_fnm_spec.sh
@@ -17,6 +17,13 @@ End
 End
 
 Describe 'node version management'
+It 'pins the managed Node versions'
+When run cat "$PWD/home-manager/programs/fnm/default.nix"
+The output should include '"24.14.0"'
+The output should include '"22.21.1"'
+The output should include '"20.19.0"'
+End
+
 It 'accepts fnm binary path as argument'
 When run bash -c "grep 'FNM_BIN' '$SCRIPT'"
 The output should include 'FNM_BIN="$1"'
@@ -46,12 +53,22 @@ It 'creates stable symlink for systemd'
 When run bash -c "grep 'ln -sf' '$SCRIPT'"
 The output should include '.local/bin/node'
 End
+
+It 'links the stable Node binary to the configured default version'
+When run bash -c "grep 'node-versions/v\${DEFAULT_VERSION}' '$SCRIPT'"
+The output should include 'DEFAULT_VERSION'
+End
 End
 
 Describe 'activation wrapper quoting'
 It 'quotes the fnm directory path'
 When run cat "$PWD/home-manager/programs/fnm/default.nix"
-The output should include '"${homeDir}/.local/share/fnm"'
+The output should include '"${fnmDir}"'
+End
+
+It 'uses the macOS fnm directory on Darwin'
+When run cat "$PWD/home-manager/programs/fnm/default.nix"
+The output should include 'Library/Application Support/fnm'
 End
 End
 End


### PR DESCRIPTION
## Summary

Pins the managed Node versions and makes 24.14.0 the global default. Home Manager now uses the same fnm directory as macOS shells, keeps the stable non-interactive node symlink aligned with that default, and lets Fish and Zsh reselect a repository version after PATH setup.

## Contract diagram

```mermaid
flowchart LR
  A[Home Manager activation] --> B[fnm default 24.14.0]
  B --> C[stable local node symlink]
  B --> D[Fish and Zsh repository selection]
  C --> E[non-interactive commands]
  D --> F[interactive project shells]
```

## Before / after

| Surface | Before | After |
| --- | --- | --- |
| Managed default | Node 22 range | Pinned Node 24.14.0 |
| macOS activation | Updated a legacy fnm directory | Uses the active macOS fnm directory |
| Local node path | Always linked to Node 22 | Linked to the configured default |
| Fish and Zsh | PATH could mask the selected project Node | fnm selection runs after PATH setup |

## Breaking and irreversible changes

- **Behavioral:** Default Node changes from 22 to 24.14.0; reverting restores the previous default.
- **Compile-time:** None.
- **Durable state and rollback:** Home Manager updates fnm aliases and the `~/.local/bin/node` symlink. Reverting and switching restores the previous managed default; no migration or ops step is needed.

## Deliberate boundaries

- Does not run a macOS update or bypass its authentication prompt.
- Does not change project-specific `.nvmrc` files.

## Verification

- `make nix-format-check`
- `shellspec spec/activate_fnm_spec.sh` — 12 examples, 0 failures
- `make shell-test` — 1,943 ShellSpec examples and 449 Fish tests, 0 failures
- `make build`
- `make switch` — blocked before activation by a macOS Tahoe update authentication prompt


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins managed Node versions under `Home Manager` and sets Node 24.14.0 as the global default via `fnm`. Aligns macOS and shell behavior so non-interactive and interactive sessions use the same default and project versions.

- **Refactors**
  - Pin managed Node versions to 24.14.0 (default), 22.21.1, 20.19.0.
  - Use macOS `fnm` dir at `~/Library/Application Support/fnm`; Linux stays at `~/.local/share/fnm`.
  - Home activation passes the platform `fnm` dir and default to the activation script.

- **Bug Fixes**
  - Stable `~/.local/bin/node` symlink now targets the configured default, not a hardcoded v22.
  - Run `fnm env --use-on-cd` after PATH setup in Fish and Zsh so project Node versions are respected.

<sup>Written for commit e66a33ff777884d05a3026ef88fd0e5eae3e4faf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

