### PR TITLE
feat(fish): add all machines command helper

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -181,6 +181,7 @@
       pixelh = "_pixelh_function";
       pixeh = "_pixeh_function";
       sag = "_ssh_add_github";
+      all = "_all_function";
       lmu = "_llm_update_function";
       slb = "_sync_local_binaries_function";
       shortcuts = "_fish_shortcuts";
@@ -244,6 +245,7 @@
       })
       [
         "__tmux_bootstrap_default_session"
+        "_all_function"
         "_brew_update_function"
         "_caf_function"
         "_caam_exec_function"

--- a/home-manager/programs/fish/functions/_all_function.fish
+++ b/home-manager/programs/fish/functions/_all_function.fish
@@ -1,0 +1,34 @@
+function _all_function --description "Run a Fish command once on local, Kyber, and Matic"
+  if test (count $argv) -eq 0
+    echo "Usage: all <command> [arguments...]" >&2
+    return 2
+  end
+
+  # Escape each argument before joining it into the Fish source passed to every
+  # target. This keeps arguments containing spaces or shell metacharacters intact.
+  set -l command (string join ' ' (string escape -- $argv))
+  set -l failed 0
+
+  echo "==> local"
+  command fish -lc "$command"
+  or begin
+    echo "==> local failed" >&2
+    set failed 1
+  end
+
+  echo "==> kyber"
+  command ssh kyber fish -lc "$command"
+  or begin
+    echo "==> kyber failed" >&2
+    set failed 1
+  end
+
+  echo "==> matic"
+  command tailscale ssh shunkakinoki@matic fish -lc "$command"
+  or begin
+    echo "==> matic failed" >&2
+    set failed 1
+  end
+
+  return $failed
+end

--- a/spec/fish/_all_function_test.fish
+++ b/spec/fish/_all_function_test.fish
@@ -1,0 +1,31 @@
+set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_all_function.fish
+
+set log (mktemp)
+set mock_bin (mktemp -d)
+set -gx ALL_FUNCTION_LOG $log
+set -gx PATH $mock_bin $PATH
+
+for command in fish ssh tailscale
+  printf '%s\n' '#!/bin/sh' "printf '$command %s\\n' \"\$*\" >>\"\$ALL_FUNCTION_LOG\"" >$mock_bin/$command
+  chmod +x $mock_bin/$command
+end
+
+_all_function echo "hello world"
+
+@test "runs the command locally through Fish" \
+  (string match -q -- "fish -lc echo 'hello world'" (cat $log); echo $status) -eq 0
+@test "runs the command on Kyber through OpenSSH" \
+  (string match -q -- "ssh kyber fish -lc echo 'hello world'" (cat $log); echo $status) -eq 0
+@test "runs the command on Matic through Tailscale SSH" \
+  (string match -q -- "tailscale ssh shunkakinoki@matic fish -lc echo 'hello world'" (cat $log); echo $status) -eq 0
+
+printf '%s\n' '#!/bin/sh' 'printf "ssh %s\n" "$*" >>"$ALL_FUNCTION_LOG"' 'exit 1' >$mock_bin/ssh
+chmod +x $mock_bin/ssh
+
+@test "returns failure when a target fails" (_all_function true >/dev/null 2>/dev/null; echo $status) -eq 1
+
+@test "requires a command" (_all_function >/dev/null 2>/dev/null; echo $status) -eq 2
+
+rm -rf $mock_bin
+rm -f $log


### PR DESCRIPTION
## Summary
- add the `all` Fish abbreviation to run a command on local, Kyber, and Matic
- preserve escaped arguments and report per-host failures
- cover local and remote dispatch plus failure handling

## Validation
- `make fish-test`
- `make nix-format-check`
- `nix eval` for the Kyber and Matic Fish abbreviation

`make shell-test` is still running in the local terminal; its result will be followed up separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the `all` Fish abbreviation to run one command across local, Kyber, and Matic. Preserves argument escaping and exits nonzero if any host fails.

- **New Features**
  - Introduces `_all_function` bound to `all`.
  - Runs via local `fish -lc`, `ssh kyber`, and `tailscale ssh shunkakinoki@matic`.
  - Escapes args safely; prints per-host failures.
  - Exit codes: 1 if any target fails, 2 if no command provided. Tests cover dispatch and failures.

<sup>Written for commit 38c8964aabfc5291c81229a03c40049cd9355c55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

