### PR TITLE
Submit Tokscale usage at startup

### DIFF
--- a/home-manager/services/tokscale/default.nix
+++ b/home-manager/services/tokscale/default.nix
@@ -38,6 +38,7 @@ in
         Hour = hour;
         Minute = 0;
       }) calendarHours;
+      RunAtLoad = true;
       StandardOutPath = "/tmp/tokscale.log";
       StandardErrorPath = "/tmp/tokscale.error.log";
     };
@@ -66,6 +67,7 @@ in
   systemd.user.timers.tokscale = lib.mkIf pkgs.stdenv.isLinux {
     Unit.Description = "Submit local usage data to Tokscale every three hours";
     Timer = {
+      OnBootSec = "1min";
       OnCalendar = "*-*-* 0/3:00:00";
       Persistent = true;
       Unit = "tokscale.service";

--- a/spec/tokscale_spec.sh
+++ b/spec/tokscale_spec.sh
@@ -106,6 +106,11 @@ The output should include 'Hour = hour;'
 The output should include 'Minute = 0;'
 End
 
+It 'submits when the macOS user agent loads after startup'
+When run bash -c "grep -F 'RunAtLoad = true;' '$CONFIG'"
+The output should include 'RunAtLoad = true;'
+End
+
 It 'sets the macOS PATH through the launchd environment key'
 When run bash -c "grep -F 'EnvironmentVariables = {' '$CONFIG'"
 The output should include 'EnvironmentVariables'
@@ -142,6 +147,11 @@ The output should include 'systemd.user.timers.tokscale'
 The output should include 'OnCalendar = "*-*-* 0/3:00:00";'
 The output should include 'Persistent = true;'
 The output should include 'Unit = "tokscale.service";'
+End
+
+It 'submits shortly after Linux boot'
+When run bash -c "grep -F 'OnBootSec = \"1min\";' '$CONFIG'"
+The output should include 'OnBootSec = "1min";'
 End
 
 It 'enables the Linux timer without requiring cron'


### PR DESCRIPTION
## Summary
- submit Tokscale once when the managed user service starts
- retain the existing three-hour wall-clock schedule
- cover both launchd and systemd startup triggers

## Validation
- `make shell-test`
- `make nix-format-check`
- `make build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Submit Tokscale usage once at user service startup on macOS and Linux, while keeping the existing 3-hour schedule. This captures usage promptly after boot.

- **New Features**
  - macOS (launchd): RunAtLoad = true to submit at agent load.
  - Linux (systemd): OnBootSec = "1min" to submit shortly after boot.

<sup>Written for commit b16a82bea07b37bcd79154cff300134987e6b7ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

