### PR TITLE
fix(roborev): bypass maintainer PR throttle

### DIFF
--- a/config/roborev/config.template.toml
+++ b/config/roborev/config.template.toml
@@ -2,6 +2,9 @@
 enabled = true
 # Poll frequently so new pushes reach the daemon promptly.
 poll_interval = "1m"
+# Review maintainer pushes immediately so restacked heads do not wait behind
+# the default per-PR throttle.
+throttle_bypass_users = ["shunkakinoki"]
 # Never cancel a running CI review just to post an early result.
 batch_timeout = "0"
 repos = ["__ROBOREV_REPOS__"]

--- a/spec/roborev_hydrate_spec.sh
+++ b/spec/roborev_hydrate_spec.sh
@@ -47,6 +47,11 @@ When run bash -c "grep -E 'poll_interval = \"1m\"|batch_timeout = \"0\"' '$PWD/c
 The output should include 'poll_interval = "1m"'
 The output should include 'batch_timeout = "0"'
 End
+
+It 'reviews maintainer pushes without the per-PR cooldown'
+When run grep -F 'throttle_bypass_users = ["shunkakinoki"]' "$PWD/config/roborev/config.template.toml"
+The output should include 'throttle_bypass_users = ["shunkakinoki"]'
+End
 End
 
 Describe 'hydration'


### PR DESCRIPTION
## Summary

- bypass RoboRev's per-PR cooldown for pushes authored by `shunkakinoki`
- keep the default throttle unchanged for every other author
- cover the declarative Kyber configuration with a ShellSpec regression test

## Review flow

```mermaid
sequenceDiagram
    participant Maintainer
    participant GitHub
    participant KyberPoller
    participant ReviewPanel
    Maintainer->>GitHub: Push new PR head
    KyberPoller->>GitHub: Poll exact head
    KyberPoller->>ReviewPanel: Bypass per PR throttle
    ReviewPanel-->>GitHub: Upsert current head review
```

| Scenario | Before | After |
| --- | --- | --- |
| Maintainer restacks a PR | The new head can wait behind the prior head's one-hour throttle window | The new head becomes eligible for review immediately |
| Another author pushes | Default per-PR throttle applies | Unchanged |

## Compatibility and durability

- Behavioral: maintainer pushes can schedule one review per new head, increasing review volume during rapid restacks.
- Compile-time: no API or type contract changes.
- Durable state: configuration only; no schema or persisted-state migration. Reverting and activating the prior configuration restores the default throttle behavior.

## Boundaries

- does not disable throttling globally
- does not change RoboRev's single-panel comment behavior
- does not activate the configuration on Kyber as part of this source PR
- no rendered UI changes

## Verification

- `shellspec spec/roborev_hydrate_spec.sh` — 13 examples, 0 failures
- `shellspec` — 1951 examples, 0 failures
- `make shell-check`
- `make shell-inline-check`
- `nix-instantiate --parse config/roborev/default.nix`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bypass the per-PR cooldown for maintainer pushes by `shunkakinoki` so restacked heads are reviewed immediately. Other authors still use the default throttle.

- **Bug Fixes**
  - Set `throttle_bypass_users = ["shunkakinoki"]` in `config/roborev/config.template.toml`.
  - Added ShellSpec regression test in `spec/roborev_hydrate_spec.sh` to pin the config.

<sup>Written for commit 4170f47ab7edb710d414628011f6887b34f89e4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

