### PR TITLE
fix(fish): preserve ssxe remote arguments

### DIFF
--- a/home-manager/programs/fish/functions/_ssxe_function.fish
+++ b/home-manager/programs/fish/functions/_ssxe_function.fish
@@ -7,6 +7,9 @@ function _ssxe_function --description "Run a Fish command once on local, Kyber, 
   # Escape each argument before joining it into the Fish source passed to every
   # target. This keeps arguments containing spaces or shell metacharacters intact.
   set -l command (string join ' ' (string escape -- $argv))
+  # SSH transports remote commands as a shell string. Escape the complete Fish
+  # source once more so its arguments remain part of Fish's -c script.
+  set -l remote_command "fish -lc "(string escape -- "$command")
   set -l failed 0
 
   echo "==> local"
@@ -17,14 +20,14 @@ function _ssxe_function --description "Run a Fish command once on local, Kyber, 
   end
 
   echo "==> kyber"
-  command ssh kyber fish -lc "$command"
+  command ssh kyber "$remote_command"
   or begin
     echo "==> kyber failed" >&2
     set failed 1
   end
 
   echo "==> matic"
-  command tailscale ssh shunkakinoki@matic fish -lc "$command"
+  command tailscale ssh shunkakinoki@matic "$remote_command"
   or begin
     echo "==> matic failed" >&2
     set failed 1

--- a/spec/fish/_ssxe_function_test.fish
+++ b/spec/fish/_ssxe_function_test.fish
@@ -16,9 +16,9 @@ _ssxe_function echo "hello world"
 @test "runs the command locally through Fish" \
   (string match -q -- "fish -lc echo 'hello world'" (cat $log); echo $status) -eq 0
 @test "runs the command on Kyber through OpenSSH" \
-  (string match -q -- "ssh kyber fish -lc echo 'hello world'" (cat $log); echo $status) -eq 0
+  (string match -q -- "ssh kyber fish -lc \"echo 'hello world'\"" (cat $log); echo $status) -eq 0
 @test "runs the command on Matic through Tailscale SSH" \
-  (string match -q -- "tailscale ssh shunkakinoki@matic fish -lc echo 'hello world'" (cat $log); echo $status) -eq 0
+  (string match -q -- "tailscale ssh shunkakinoki@matic fish -lc \"echo 'hello world'\"" (cat $log); echo $status) -eq 0
 
 printf '%s\n' '#!/bin/sh' 'printf "ssh %s\n" "$*" >>"$SSXE_FUNCTION_LOG"' 'exit 1' >$mock_bin/ssh
 chmod +x $mock_bin/ssh


### PR DESCRIPTION
## Summary
- preserve the complete Fish command as one escaped SSH command string
- cover Kyber and Matic remote command forwarding

## Verification
- `make fish-test` (454 passed)
- live `_ssxe_function printf "%s\n" submit` prints `submit` on local, Kyber, and Matic

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves full Fish command when run remotely by sending a single escaped shell string. Fixes broken arguments (spaces, metacharacters) on Kyber and Matic.

- **Bug Fixes**
  - Build a `remote_command` that escapes the entire Fish source and pass it to `ssh kyber` and `tailscale ssh shunkakinoki@matic`.
  - Update tests to expect `fish -lc "..."` on remote calls; `make fish-test` passes (454).

<sup>Written for commit 3c27d83470f6561f3ca0dbf7d4ea61985a42237c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

