### PR TITLE
fix(hermes): mirror OpenClaw CLIProxy fallback chain

### DIFF
--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -1,7 +1,17 @@
 model:
-  default: cliproxy/minimax-m3
+  default: cliproxy/deepseek-v4-flash
 providers: {}
-fallback_providers: []
+fallback_providers:
+  - provider: cliproxy
+    model: deepseek-v4-pro
+  - provider: cliproxy
+    model: gemma-4-31b-it
+  - provider: cliproxy
+    model: glm-4.7
+  - provider: cliproxy
+    model: minimax-m3
+  - provider: cliproxy
+    model: free
 credential_pool_strategies: {}
 toolsets:
   - hermes-cli

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -1,7 +1,17 @@
 model:
-  default: cliproxy/__MINIMAX__
+  default: cliproxy/__DEEPSEEK_FLASH__
 providers: {}
-fallback_providers: []
+fallback_providers:
+  - provider: cliproxy
+    model: __DEEPSEEK_PRO__
+  - provider: cliproxy
+    model: __GEMMA__
+  - provider: cliproxy
+    model: __GLM__
+  - provider: cliproxy
+    model: __MINIMAX__
+  - provider: cliproxy
+    model: free
 credential_pool_strategies: {}
 toolsets:
   - hermes-cli

--- a/spec/hermes_hydrate_spec.sh
+++ b/spec/hermes_hydrate_spec.sh
@@ -165,6 +165,24 @@ The output should include 'STATE_DIR'
 End
 End
 
+Describe 'declarative model routing'
+It 'uses the OpenClaw primary and CLIProxy-only fallback chain'
+When run bash -c "sed -n '1,18p' '$PWD/config/hermes/config.template.yaml'"
+The output should include 'default: cliproxy/deepseek-v4-flash'
+The output should include 'provider: cliproxy'
+The output should include 'model: deepseek-v4-pro'
+The output should include 'model: gemma-4-31b-it'
+The output should include 'model: glm-4.7'
+The output should include 'model: minimax-m3'
+The output should include 'model: free'
+End
+
+It 'does not configure OpenRouter or Mixture-of-Agents presets'
+When run bash -c "! rg -q 'openrouter|@preset/' '$PWD/config/hermes/config.template.yaml'"
+The status should be success
+End
+End
+
 Describe 'execution'
 It 'reports config generation'
 When run bash -c "grep 'Generated hermes' '$SCRIPT'"


### PR DESCRIPTION
## Summary

- Set Hermes primary model to DeepSeek V4 Flash.
- Configure the ordered fallback chain: DeepSeek V4 Pro, Gemma, GLM, MiniMax, then Free.
- Route every Hermes entry through the `cliproxy` provider.
- Keep OpenRouter and Mixture-of-Agents preset routes out of Hermes configuration.

## Validation

- 22 Hermes hydration examples pass.
- ShellCheck, YAML parsing, and `git diff --check` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align Hermes with OpenClaw by mirroring the CLIProxy fallback chain. Default to `cliproxy/deepseek-v4-flash` and route all fallbacks through `cliproxy` while excluding OpenRouter and preset routes.

- **Bug Fixes**
  - Default model: `cliproxy/deepseek-v4-flash`.
  - Fallbacks (in order via `cliproxy`): deepseek-v4-pro → gemma-4-31b-it → glm-4.7 → minimax-m3 → free.
  - Route all Hermes traffic through `cliproxy`; no `openrouter` or `@preset/` entries.
  - Add spec to assert routing and exclusions; hydration examples pass.

<sup>Written for commit b54f96d4774dff478c02715c6d112ae5756731d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

