### PR TITLE
fix(codex): remove duplicate agent thread setting

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -75,7 +75,6 @@ workspace_owner_usage_nudge = true
 
 [agents]
 enabled = true
-max_threads = 300
 max_concurrent_threads_per_session = 300
 default_subagent_model = "gpt-5.6-luna"
 default_subagent_reasoning_effort = "max"

--- a/config/codex/config.tpl.toml
+++ b/config/codex/config.tpl.toml
@@ -75,7 +75,6 @@ workspace_owner_usage_nudge = true
 
 [agents]
 enabled = true
-max_threads = 300
 max_concurrent_threads_per_session = 300
 default_subagent_model = "__GPT_LUNA__"
 default_subagent_reasoning_effort = "max"

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -141,8 +141,8 @@ When run bash -c "sed -n '/^\[agents\]/,/^\[/p' config/codex/config.toml | grep 
 The output should include 'enabled = true'
 End
 
-It 'allows 300 concurrent subagent threads per session'
-When run bash -c "sed -n '/^\[agents\]/,/^\[/p' config/codex/config.toml | grep -q 'max_threads = 300' && sed -n '/^\[agents\]/,/^\[/p' config/codex/config.toml | grep -q 'max_concurrent_threads_per_session = 300'"
+It 'uses only the canonical per-session concurrency setting'
+When run bash -c "for file in config/codex/config.tpl.toml config/codex/config.toml; do agents=\$(sed -n '/^\[agents\]/,/^\[/p' \"\$file\"); test \"\$(printf '%s\n' \"\$agents\" | grep -Ec '^(max_threads|max_concurrent_threads_per_session) = ')\" -eq 1 && printf '%s\n' \"\$agents\" | grep -qx 'max_concurrent_threads_per_session = 300' || exit 1; done"
 The status should be success
 End
 


### PR DESCRIPTION
## Summary

- remove the legacy `agents.max_threads` alias from the Codex template and generated config
- keep `agents.max_concurrent_threads_per_session = 300` as the single canonical concurrency setting
- guard both template and generated config against duplicate concurrency keys

## Root cause

Codex maps `max_threads` to `max_concurrent_threads_per_session`. Defining both names in the same `[agents]` table makes the settings updater deserialize the same field twice.

## Validation

- `shellspec spec/llm_update_spec.sh` (68 examples)
- `shellspec spec/activate_config_spec.sh` (55 examples)
- `make shell-check`
- `git diff --check`

Bead: `shunkakinokisoftware-dzle`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the legacy agents.max_threads from the Codex config and template to eliminate duplicate concurrency settings. Keep max_concurrent_threads_per_session = 300 as the single canonical setting, and add a spec to ensure only this key exists in both files.

<sup>Written for commit dc5c40f74c50d38263e3bd725ccf7f0b94734bf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

