### PR TITLE
fix(openclaw): bump compatible Node runtime

### DIFF
--- a/home-manager/programs/fnm/default.nix
+++ b/home-manager/programs/fnm/default.nix
@@ -13,7 +13,7 @@ let
       "${homeDir}/.local/share/fnm";
   # Node versions to pre-install (first one is default)
   nodeVersions = [
-    "24.14.0"
+    "24.15.0"
     "22.21.1"
     "20.19.0"
   ];

--- a/spec/activate_fnm_spec.sh
+++ b/spec/activate_fnm_spec.sh
@@ -17,9 +17,9 @@ End
 End
 
 Describe 'node version management'
-It 'pins the managed Node versions'
+It 'pins an OpenClaw-compatible default Node version'
 When run cat "$PWD/home-manager/programs/fnm/default.nix"
-The output should include '"24.14.0"'
+The output should include '"24.15.0"'
 The output should include '"22.21.1"'
 The output should include '"20.19.0"'
 End


### PR DESCRIPTION
## Summary

- bump the managed default Node runtime from 24.14.0 to 24.15.0
- update the FNM regression assertion to document OpenClaw compatibility

## Root cause

OpenClaw 2026.7.1-2 requires Node >=24.15.0 in the Node 24 line. Kyber had switched its stable service symlink to the declaratively pinned Node 24.14.0, so the gateway exited immediately and the dependent k3s proxy failed.

## Validation

- `shellspec spec/activate_fnm_spec.sh` (12 examples, 0 failures)
- Nix parse and formatting checks passed
- focused ShellCheck passed
- full `make test` was interrupted during flake evaluation at the requester’s direction to bypass remaining gates and create the PR immediately

Tracked by `shunkakinokisoftware-b4yi`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump the managed default Node runtime from 24.14.0 to 24.15.0 to meet OpenClaw 2026.7.1-2 and prevent gateway/k3s startup failures. Update the FNM spec to assert the new default and document compatibility; satisfies `shunkakinokisoftware-b4yi`.

<sup>Written for commit 1a0474fa5b18cdfec0a91d078929063bbf7bb56c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

