### PR TITLE
fix(npm): drop omit=optional so native optional deps install

### DIFF
--- a/config/npm/npmrc
+++ b/config/npm/npmrc
@@ -1,5 +1,4 @@
 minimum-release-age=10080
 ignore-scripts=true
 save-exact=true
-omit=optional
 engine-strict=true


### PR DESCRIPTION
## Problem

`config/npm/npmrc` (deployed to `~/.npmrc` via `config/npm/default.nix`) set `omit=optional`.

Packages that ship platform-specific native binaries do so as **optionalDependencies**. With `omit=optional`, npm/npx skips them and `require()` throws at runtime.

Observed on matic and kyber - the T3 remote SSH server failed to boot:

```
Error: Cannot find module '@yuuang/ffi-rs-linux-x64-gnu'
Require stack:
- ~/.npm/_npx/15e95c9a02dfa35a/node_modules/ffi-rs/index.js
```

which surfaced client-side as `Remote T3 server did not become ready on 127.0.0.1:3773`.

This is not T3-specific - esbuild, swc, rollup, sharp, and lightningcss use the same optional-native-binary pattern.

## Fix

Remove `omit=optional`. The remaining hardening (`ignore-scripts`, `save-exact`, `engine-strict`) is unaffected.

## Recovery on existing hosts

Rebuild home-manager, then purge the cached bad installs:

```fish
rm -rf ~/.npm/_npx
```

Without this the already-materialized npx caches keep the broken tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove npm’s `omit=optional` so optional native binaries install. Fixes runtime module-not-found errors in FFI packages and lets the T3 remote SSH server boot reliably.

- **Bug Fixes**
  - Drop `omit=optional` from `config/npm/npmrc`; `ignore-scripts`, `save-exact`, and `engine-strict` remain.

- **Migration**
  - Rebuild home-manager to update `~/.npmrc`.
  - Purge npx cache: `rm -rf ~/.npm/_npx`.

<sup>Written for commit ffacac8a2d009f998f41d80d07027574271b5eab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

