### PR TITLE
fix(hermes): preserve dashboard WebSocket origin

### DIFF
--- a/home-manager/services/hermes/default.nix
+++ b/home-manager/services/hermes/default.nix
@@ -80,7 +80,9 @@ lib.mkIf host.isKyber {
     };
     Service = {
       Type = "simple";
-      ExecStart = "${pkgs.socat}/bin/socat TCP4-LISTEN:9119,bind=172.17.0.1,reuseaddr,fork TCP4:127.0.0.1:9119";
+      ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p /tmp/hermes-dashboard-proxy";
+      ExecStart = "${pkgs.nginx}/bin/nginx -c ${./hermes-dashboard-proxy.conf} -p /tmp/hermes-dashboard-proxy -g 'daemon off;'";
+      ExecStop = "${pkgs.nginx}/bin/nginx -c ${./hermes-dashboard-proxy.conf} -p /tmp/hermes-dashboard-proxy -s quit";
       Restart = "always";
       RestartSec = "5s";
       X-SwitchMethod = "restart";

--- a/home-manager/services/hermes/hermes-dashboard-proxy.conf
+++ b/home-manager/services/hermes/hermes-dashboard-proxy.conf
@@ -1,0 +1,32 @@
+pid /tmp/hermes-dashboard-proxy/nginx.pid;
+error_log stderr warn;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  access_log off;
+
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    "" close;
+  }
+
+  server {
+    listen 172.17.0.1:9119;
+
+    location / {
+      proxy_pass http://127.0.0.1:9119;
+      proxy_http_version 1.1;
+      proxy_set_header Host 127.0.0.1;
+      proxy_set_header Origin http://127.0.0.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+      proxy_buffering off;
+      proxy_request_buffering off;
+      proxy_read_timeout 3600s;
+      proxy_send_timeout 3600s;
+    }
+  }
+}


### PR DESCRIPTION
Hermes serves the dashboard on loopback and rejects browser WebSocket upgrades when the public Origin is forwarded unchanged.

This replaces the raw socat bridge with a checked-in NGINX proxy config that preserves Upgrade/Connection, rewrites the upstream Host and Origin to loopback, and keeps the existing loopback-only Hermes security boundary.

Validation: nix-instantiate --parse home-manager/services/hermes/default.nix; git diff --check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rejected dashboard WebSocket upgrades by replacing the `socat` bridge with an `nginx` reverse proxy that preserves Upgrade headers and rewrites Host/Origin to loopback. Keeps the loopback-only security boundary.

- **Bug Fixes**
  - Swapped `socat` for a checked-in `nginx` config listening on 172.17.0.1:9119 and proxying to 127.0.0.1:9119.
  - Rewrites Host/Origin to 127.0.0.1 and forwards Upgrade/Connection for WebSocket support.
  - Disables proxy buffering and sets long read/send timeouts for stable connections.
  - Adds service hooks: create runtime dir, run `nginx` in foreground, graceful stop.

<sup>Written for commit df17d184a0cf534dbb9923b5a368ddcb06abd0f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

