### PR TITLE
config(openclaw): run dreaming sweep every 3 hours

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -433,7 +433,9 @@
       "memory-core": {
         "config": {
           "dreaming": {
-            "enabled": true
+            "enabled": true,
+            "frequency": "0 */3 * * *",
+            "timezone": "UTC"
           }
         }
       },

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -433,7 +433,9 @@
       "memory-core": {
         "config": {
           "dreaming": {
-            "enabled": true
+            "enabled": true,
+            "frequency": "0 */3 * * *",
+            "timezone": "UTC"
           }
         }
       },

--- a/home-manager/services/hermes/default.nix
+++ b/home-manager/services/hermes/default.nix
@@ -80,7 +80,9 @@ lib.mkIf host.isKyber {
     };
     Service = {
       Type = "simple";
-      ExecStart = "${pkgs.socat}/bin/socat TCP4-LISTEN:9119,bind=172.17.0.1,reuseaddr,fork TCP4:127.0.0.1:9119";
+      ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p /tmp/hermes-dashboard-proxy";
+      ExecStart = "${pkgs.nginx}/bin/nginx -c ${./hermes-dashboard-proxy.conf} -p /tmp/hermes-dashboard-proxy -g 'daemon off;'";
+      ExecStop = "${pkgs.nginx}/bin/nginx -c ${./hermes-dashboard-proxy.conf} -p /tmp/hermes-dashboard-proxy -s quit";
       Restart = "always";
       RestartSec = "5s";
       X-SwitchMethod = "restart";

--- a/home-manager/services/hermes/hermes-dashboard-proxy.conf
+++ b/home-manager/services/hermes/hermes-dashboard-proxy.conf
@@ -1,0 +1,32 @@
+pid /tmp/hermes-dashboard-proxy/nginx.pid;
+error_log stderr warn;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  access_log off;
+
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    "" close;
+  }
+
+  server {
+    listen 172.17.0.1:9119;
+
+    location / {
+      proxy_pass http://127.0.0.1:9119;
+      proxy_http_version 1.1;
+      proxy_set_header Host 127.0.0.1;
+      proxy_set_header Origin http://127.0.0.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+      proxy_buffering off;
+      proxy_request_buffering off;
+      proxy_read_timeout 3600s;
+      proxy_send_timeout 3600s;
+    }
+  }
+}


### PR DESCRIPTION
Changes the OpenClaw dreaming cron frequency from the default once-daily (3 AM) to every 3 hours (`0 */3 * * *`) with UTC0 timezone, applied to both:
- `openclaw.template.json`
- `openclaw.tpl.json`

This gives the dreaming system more frequent opportunities to promote short-term memory into durable `MEMORY.md` entries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase OpenClaw dreaming to every 3 hours (UTC) to improve memory consolidation. Replace the Hermes dashboard proxy with `nginx` to fix WebSocket origin/upgrade issues.

- **Bug Fixes**
  - Replaced `socat` TCP proxy with an `nginx` reverse proxy (172.17.0.1:9119 -> 127.0.0.1:9119) with Upgrade and Origin headers handled.
  - Added `hermes-dashboard-proxy.conf` and updated the service to create a runtime dir, run `nginx` in the foreground, and stop cleanly.

<sup>Written for commit 8f1198e23e50a4339292e7c62d18f7dc4ca0e0eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

