### PR TITLE
config(openclaw): run dreaming sweep every 3 hours

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -433,7 +433,9 @@
       "memory-core": {
         "config": {
           "dreaming": {
-            "enabled": true
+            "enabled": true,
+            "frequency": "0 */3 * * *",
+            "timezone": "UTC"
           }
         }
       },

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -433,7 +433,9 @@
       "memory-core": {
         "config": {
           "dreaming": {
-            "enabled": true
+            "enabled": true,
+            "frequency": "0 */3 * * *",
+            "timezone": "UTC"
           }
         }
       },


### PR DESCRIPTION
Changes the OpenClaw dreaming cron frequency from the default once-daily (3 AM) to every 3 hours (`0 */3 * * *`) with UTC timezone, applied to both:
- `config/openclaw/openclaw.template.json`
- `config/openclaw/openclaw.tpl.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase OpenClaw dreaming sweep cadence to every 3 hours (cron: 0 */3 * * *, UTC) instead of once daily.

Updated both config templates: config/openclaw/openclaw.template.json and config/openclaw/openclaw.tpl.json (added frequency and timezone fields).

<sup>Written for commit 3bf403c59038e277e07801eddd4fcb47b0a371c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

