### PR TITLE
fix(hermes): include Kyber services in systemctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1275,7 +1275,7 @@ launchctl-tmux-session-logger: ## Restart tmux-session-logger launchd agent.
 ##@ Systemd Services (Linux)
 
 .PHONY: systemctl
-systemctl: systemctl-docker systemctl-cliproxyapi systemctl-cliproxyapi-backup systemctl-cpa-manager-plus systemctl-code-syncer systemctl-docker-postgres systemctl-dolt systemctl-dotfiles-updater systemctl-make-updater systemctl-neverssl-keepalive systemctl-noctalia-shell systemctl-obsidian systemctl-ollama systemctl-openclaw systemctl-roborev systemctl-tmux-session-logger ## Restart all systemd user services.
+systemctl: systemctl-docker systemctl-cliproxyapi systemctl-cliproxyapi-backup systemctl-cpa-manager-plus systemctl-code-syncer systemctl-docker-postgres systemctl-dolt systemctl-dotfiles-updater systemctl-hermes systemctl-make-updater systemctl-neverssl-keepalive systemctl-noctalia-shell systemctl-obsidian systemctl-ollama systemctl-openclaw systemctl-roborev systemctl-tmux-session-logger ## Restart all systemd user services.
 
 .PHONY: systemctl-docker
 systemctl-docker: ## Start Docker daemon.
@@ -1335,6 +1335,17 @@ systemctl-dotfiles-updater: ## Restart dotfiles-updater systemd user service.
 	@echo "🔄 Restarting dotfiles-updater..."
 	@systemctl --user restart dotfiles-updater.service || true
 	@echo "✅ dotfiles-updater restarted"
+
+.PHONY: systemctl-hermes
+systemctl-hermes: ## Restart Hermes gateway, dashboard, and proxy on Kyber.
+	@echo "🔄 Restarting Hermes..."
+	@if [ "$(DETECTED_HOST)" = "kyber" ] || [ "$(HOST)" = "kyber" ]; then \
+		systemctl --user daemon-reload; \
+		systemctl --user restart hermes-gateway.service hermes-dashboard.service hermes-dashboard-proxy.service; \
+	else \
+		echo "Skipping Hermes services (host not kyber)"; \
+	fi
+	@echo "✅ Hermes restarted"
 
 .PHONY: systemctl-make-updater
 systemctl-make-updater: ## Restart make-updater systemd timer and service.

--- a/home-manager/services/hermes/default.nix
+++ b/home-manager/services/hermes/default.nix
@@ -80,7 +80,9 @@ lib.mkIf host.isKyber {
     };
     Service = {
       Type = "simple";
-      ExecStart = "${pkgs.socat}/bin/socat TCP4-LISTEN:9119,bind=172.17.0.1,reuseaddr,fork TCP4:127.0.0.1:9119";
+      ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p /tmp/hermes-dashboard-proxy";
+      ExecStart = "${pkgs.nginx}/bin/nginx -c ${./hermes-dashboard-proxy.conf} -p /tmp/hermes-dashboard-proxy -g 'daemon off;'";
+      ExecStop = "${pkgs.nginx}/bin/nginx -c ${./hermes-dashboard-proxy.conf} -p /tmp/hermes-dashboard-proxy -s quit";
       Restart = "always";
       RestartSec = "5s";
       X-SwitchMethod = "restart";

--- a/home-manager/services/hermes/hermes-dashboard-proxy.conf
+++ b/home-manager/services/hermes/hermes-dashboard-proxy.conf
@@ -1,0 +1,32 @@
+pid /tmp/hermes-dashboard-proxy/nginx.pid;
+error_log stderr warn;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  access_log off;
+
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    "" close;
+  }
+
+  server {
+    listen 172.17.0.1:9119;
+
+    location / {
+      proxy_pass http://127.0.0.1:9119;
+      proxy_http_version 1.1;
+      proxy_set_header Host 127.0.0.1;
+      proxy_set_header Origin http://127.0.0.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+      proxy_buffering off;
+      proxy_request_buffering off;
+      proxy_read_timeout 3600s;
+      proxy_send_timeout 3600s;
+    }
+  }
+}


### PR DESCRIPTION
The Hermes module defines three Kyber systemd user services, but the aggregate `systemctl` Make target did not restart them.

Add a host-gated `systemctl-hermes` target that reloads and restarts the gateway, dashboard, and Kubernetes bridge proxy together, and include it in the aggregate target.

Validation: `git diff --check`; `make -n systemctl-hermes HOST=kyber`; all three Kyber Hermes units manually restarted and verified active.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Kyber Hermes service management and ensure the dashboard WebSocket proxy sets a valid Origin. Adds a host-gated Make target to restart all Hermes units and switches the dashboard proxy to `nginx`.

- **Bug Fixes**
  - Add `systemctl-hermes` (Kyber-only) to reload and restart `hermes-gateway`, `hermes-dashboard`, and `hermes-dashboard-proxy`; include it in the aggregate `systemctl` target.
  - Replace `socat` with `nginx` for the dashboard proxy, forwarding 172.17.0.1:9119 to 127.0.0.1:9119 with WebSocket upgrade and Origin headers; include proper start/stop commands and an `nginx` config.

<sup>Written for commit 18a390a31cb4aeaeff0a258d9284961e06aa32de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

