### PR TITLE
fix(hermes): use supported Node runtime for dashboard chat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1275,7 +1275,7 @@ launchctl-tmux-session-logger: ## Restart tmux-session-logger launchd agent.
 ##@ Systemd Services (Linux)
 
 .PHONY: systemctl
-systemctl: systemctl-docker systemctl-cliproxyapi systemctl-cliproxyapi-backup systemctl-cpa-manager-plus systemctl-code-syncer systemctl-docker-postgres systemctl-dolt systemctl-dotfiles-updater systemctl-make-updater systemctl-neverssl-keepalive systemctl-noctalia-shell systemctl-obsidian systemctl-ollama systemctl-openclaw systemctl-roborev systemctl-tmux-session-logger ## Restart all systemd user services.
+systemctl: systemctl-docker systemctl-cliproxyapi systemctl-cliproxyapi-backup systemctl-cpa-manager-plus systemctl-code-syncer systemctl-docker-postgres systemctl-dolt systemctl-dotfiles-updater systemctl-hermes systemctl-make-updater systemctl-neverssl-keepalive systemctl-noctalia-shell systemctl-obsidian systemctl-ollama systemctl-openclaw systemctl-roborev systemctl-tmux-session-logger ## Restart all systemd user services.
 
 .PHONY: systemctl-docker
 systemctl-docker: ## Start Docker daemon.
@@ -1335,6 +1335,17 @@ systemctl-dotfiles-updater: ## Restart dotfiles-updater systemd user service.
 	@echo "🔄 Restarting dotfiles-updater..."
 	@systemctl --user restart dotfiles-updater.service || true
 	@echo "✅ dotfiles-updater restarted"
+
+.PHONY: systemctl-hermes
+systemctl-hermes: ## Restart Hermes gateway, dashboard, and proxy on Kyber.
+	@echo "🔄 Restarting Hermes..."
+	@if [ "$(DETECTED_HOST)" = "kyber" ] || [ "$(HOST)" = "kyber" ]; then \
+		systemctl --user daemon-reload; \
+		systemctl --user restart hermes-gateway.service hermes-dashboard.service hermes-dashboard-proxy.service; \
+	else \
+		echo "Skipping Hermes services (host not kyber)"; \
+	fi
+	@echo "✅ Hermes restarted"
 
 .PHONY: systemctl-make-updater
 systemctl-make-updater: ## Restart make-updater systemd timer and service.

--- a/home-manager/services/hermes/default.nix
+++ b/home-manager/services/hermes/default.nix
@@ -61,7 +61,9 @@ lib.mkIf host.isKyber {
       X-SwitchMethod = "restart";
       Environment = [
         "HOME=${homeDir}"
-        "PATH=${homeDir}/.local/bin:${homeDir}/.nix-profile/bin:/usr/local/bin:/usr/bin:/bin"
+        "PATH=${hermesNode}/bin:${homeDir}/.local/bin:${homeDir}/.nix-profile/bin:/usr/local/bin:/usr/bin:/bin"
+        "NPM_CONFIG_INCLUDE=optional"
+        "NPM_CONFIG_IGNORE_SCRIPTS=false"
       ];
       WorkingDirectory = "${homeDir}/.hermes";
       StandardOutput = "append:/tmp/hermes/hermes-dashboard.log";

--- a/home-manager/services/hermes/default.nix
+++ b/home-manager/services/hermes/default.nix
@@ -80,7 +80,9 @@ lib.mkIf host.isKyber {
     };
     Service = {
       Type = "simple";
-      ExecStart = "${pkgs.socat}/bin/socat TCP4-LISTEN:9119,bind=172.17.0.1,reuseaddr,fork TCP4:127.0.0.1:9119";
+      ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p /tmp/hermes-dashboard-proxy";
+      ExecStart = "${pkgs.nginx}/bin/nginx -c ${./hermes-dashboard-proxy.conf} -p /tmp/hermes-dashboard-proxy -g 'daemon off;'";
+      ExecStop = "${pkgs.nginx}/bin/nginx -c ${./hermes-dashboard-proxy.conf} -p /tmp/hermes-dashboard-proxy -s quit";
       Restart = "always";
       RestartSec = "5s";
       X-SwitchMethod = "restart";

--- a/home-manager/services/hermes/hermes-dashboard-proxy.conf
+++ b/home-manager/services/hermes/hermes-dashboard-proxy.conf
@@ -1,0 +1,32 @@
+pid /tmp/hermes-dashboard-proxy/nginx.pid;
+error_log stderr warn;
+
+events {
+  worker_connections 1024;
+}
+
+http {
+  access_log off;
+
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    "" close;
+  }
+
+  server {
+    listen 172.17.0.1:9119;
+
+    location / {
+      proxy_pass http://127.0.0.1:9119;
+      proxy_http_version 1.1;
+      proxy_set_header Host 127.0.0.1;
+      proxy_set_header Origin http://127.0.0.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+      proxy_buffering off;
+      proxy_request_buffering off;
+      proxy_read_timeout 3600s;
+      proxy_send_timeout 3600s;
+    }
+  }
+}


### PR DESCRIPTION
Hermes dashboard PTY connections were accepted but the TUI exited during npm bootstrap because the dashboard service inherited Node 24/npm 11.13 from the profile instead of the Hermes-supported Node 22/npm 10.9.8.

This adds the declared Hermes Node 22 runtime to the dashboard PATH and carries the same optional-dependency npm environment as the gateway. The existing systemctl aggregation change is already merged in the preceding PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the Hermes dashboard to Node 22/npm 10 and adds an Nginx WebSocket proxy to fix dashboard chat/PTY startup issues. Also adds a Make target to restart Hermes services on Kyber.

- **Bug Fixes**
  - Use the Hermes Node 22 runtime in the dashboard PATH and align npm env to prevent TUI exit during npm bootstrap.
  - Replace `socat` with an Nginx proxy for 172.17.0.1:9119 → 127.0.0.1:9119, preserving Host/Origin and WebSocket Upgrade headers.
  - Add `systemctl-hermes` and include it in the `systemctl` aggregate target to restart gateway, dashboard, and proxy on Kyber.

<sup>Written for commit 9ff97830a1a7315cc229e9bf8ff0ebc939f0eb8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

