### PR TITLE
fix(t3): unbreak remote SSH server on Linux hosts, manage t3 via package.json

### DIFF
--- a/config/npm/npmrc
+++ b/config/npm/npmrc
@@ -2,3 +2,5 @@ minimum-release-age=10080
 ignore-scripts=true
 save-exact=true
 engine-strict=true
+audit=false
+fund=false


### PR DESCRIPTION
## Problem

Follow-up to #2301. Four distinct faults stacked, each masking the next, breaking the T3 remote SSH server on matic and kyber.

### 1. `omit=optional` (fixed in #2301)
`ffi-rs` ships its native binary as an optionalDependency, so it was never installed.

### 2. Startup timeout poisoning the npx cache
The same `MODULE_NOT_FOUND` persisted after #2301 -- it was a symptom, not the cause:

```
1440 http fetch POST 200 .../security/advisories/bulk 4675ms
1443 error process terminated
1444 error signal SIGTERM
1445 silly unfinished npm timer reify
```

Every tarball was a cache hit; the only slow step was the blocking audit POST. The client SIGTERMs npm mid-`reify` when its readiness deadline expires, leaving a partial tree. Every later attempt reuses that dir, turning a transient timeout into permanent failure.

### 3. `ignore-scripts=true` vs node-pty
`node-pty@1.1.0` ships prebuilds for darwin and win32 only -- **no linux-x64**. Linux compiles via its `install` script, which `ignore-scripts=true` suppresses. npm has no per-package allowlist, and `npm rebuild` honors the flag too.

### 4. nix/system glibc mismatch on kyber
Building node-pty produced a file that existed but could not load:

```
/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.42' not found
```

kyber is Ubuntu with nix layered on, so `~/.nix-profile/bin` shadows the system compiler. node-gyp linked against nix glibc 2.42 while the runtime node uses the system loader and Ubuntu's glibc 2.39. matic is NixOS and self-consistent, which is why only kyber was affected. **Presence of `pty.node` is not proof it works** -- every check must be an actual `require()`.

## Fix

**`audit=false` / `fund=false`** in `config/npm/npmrc` -- removes a variable-latency blocking call from the startup critical path.

**New `t3-warm` service** (Linux only), timer at boot+2min then every 30min:
1. Resolve the tag to an exact version, then `npx --yes t3@<version> --version`. npx keys its cache dir on the literal spec string, so warming `t3@nightly` warms a directory the client never reads.
2. `npm rebuild --ignore-scripts=false node-pty` in any npx cache dir *and* `~/.t3/runtime/versions/*/` missing `pty.node`, with the system toolchain pinned off NixOS.

**`t3` managed in `package.json`** plus `repair_node_pty_native_binding()` in the npm-globals installer:
- Gates on `require()`, not file presence, so a nix-built binary is detected as broken.
- Drives `node-gyp` directly: npm rejects t3's bun nested-override syntax (`"@clerk/clerk-js>@base-org/account"`) as an invalid package name, so `npm rebuild` cannot run inside a bun-installed t3.
- Searches one nesting level -- t3 keeps its own `t3/node_modules/node-pty`.
- `node-pty` is deliberately **not** in `trustedDependencies`: letting bun build it unattended on kyber would produce a file that exists but cannot load, masking the repair.

## Measurements

`npx --yes t3@nightly --version`:

| host | cold before | cold after | warm |
|---|---|---|---|
| matic | ~6.1s | 5.4s | 1.7s |
| kyber | ~15.2s | 13.6s | 2.7s |

## Verification

All on real hosts, verified by loading the module and binding the port -- not by file existence:

- `t3code.service` on kyber: active, listening on 127.0.0.1:3773, 0 errors
- Globally installed `t3` serves in 3s with 0 errors
- `repair_node_pty_native_binding()` run against kyber's broken tree: correctly skips `@lydell/node-pty` and the loadable top-level copy, repairs and verifies t3's nested copy, exit 0
- `shellcheck`, `nixfmt --check`, `make shell-inline-check` clean
- `shellspec`: 1985 examples, 1 failure -- `activate_paperclip_openclaw_spec.sh:117` (hermes), confirmed pre-existing on a clean tree

## Out-of-band changes on kyber, NOT captured here

kyber's system packages are not nix-managed, so a rebuild will not reproduce these:

- `loginctl enable-linger ubuntu` -- prerequisite for `t3 service install`
- `apt-get install g++` -- system had `gcc` but no `g++`, so node-gyp fell back to nix's

## Notes

- `~/.npmrc` was edited in place on both hosts as a stopgap. `force = true` means this must land before the next activation or those edits revert.
- matic has no `t3code.service`; it works only because a server from an earlier session is still listening.
- `minimum-release-age=10080` still warns on every npm call. It is a pnpm key npm ignores; left alone since pnpm reads the same file.