### PR TITLE
fix(hermes): route MoA models through CLIProxy

### DIFF
--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -12,6 +12,20 @@ fallback_providers:
     model: minimax-m3
   - provider: cliproxy
     model: free
+moa:
+  default_preset: default
+  presets:
+    default:
+      reference_models:
+        - provider: cliproxy
+          model: deepseek-v4-flash
+          enabled: true
+        - provider: cliproxy
+          model: minimax-m3
+          enabled: true
+      aggregator:
+        provider: cliproxy
+        model: deepseek-v4-flash
 credential_pool_strategies: {}
 toolsets:
   - hermes-cli

--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -18,7 +18,7 @@ moa:
     default:
       reference_models:
         - provider: cliproxy
-          model: deepseek-v4-flash
+          model: deepseek-v4-pro
           enabled: true
         - provider: cliproxy
           model: minimax-m3

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -12,6 +12,20 @@ fallback_providers:
     model: __MINIMAX__
   - provider: cliproxy
     model: free
+moa:
+  default_preset: default
+  presets:
+    default:
+      reference_models:
+        - provider: cliproxy
+          model: __DEEPSEEK_FLASH__
+          enabled: true
+        - provider: cliproxy
+          model: __MINIMAX__
+          enabled: true
+      aggregator:
+        provider: cliproxy
+        model: __DEEPSEEK_FLASH__
 credential_pool_strategies: {}
 toolsets:
   - hermes-cli

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -18,7 +18,7 @@ moa:
     default:
       reference_models:
         - provider: cliproxy
-          model: __DEEPSEEK_FLASH__
+          model: __DEEPSEEK_PRO__
           enabled: true
         - provider: cliproxy
           model: __MINIMAX__

--- a/spec/hermes_hydrate_spec.sh
+++ b/spec/hermes_hydrate_spec.sh
@@ -190,8 +190,9 @@ End
 It 'hydrates the default Mixture-of-Agents models from the canonical model list'
 When run bash -c "sed -n '/^moa:/,/^credential_pool_strategies:/p' '$PWD/config/hermes/config.template.yaml'"
 The output should include 'provider: cliproxy'
-The output should include 'model: deepseek-v4-flash'
+The output should include 'model: deepseek-v4-pro'
 The output should include 'model: minimax-m3'
+The output should include 'model: deepseek-v4-flash'
 The output should not include 'opus'
 End
 End

--- a/spec/hermes_hydrate_spec.sh
+++ b/spec/hermes_hydrate_spec.sh
@@ -181,6 +181,19 @@ It 'does not configure OpenRouter or Mixture-of-Agents presets'
 When run bash -c "! rg -q 'openrouter|@preset/' '$PWD/config/hermes/config.template.yaml'"
 The status should be success
 End
+
+It 'routes every default Mixture-of-Agents model through CLIProxy'
+When run bash -c "sed -n '/^moa:/,/^credential_pool_strategies:/p' '$PWD/config/hermes/config.template.yaml' | awk '/provider: / && \$NF != \"cliproxy\" {exit 1}'"
+The status should be success
+End
+
+It 'hydrates the default Mixture-of-Agents models from the canonical model list'
+When run bash -c "sed -n '/^moa:/,/^credential_pool_strategies:/p' '$PWD/config/hermes/config.template.yaml'"
+The output should include 'provider: cliproxy'
+The output should include 'model: deepseek-v4-flash'
+The output should include 'model: minimax-m3'
+The output should not include 'opus'
+End
 End
 
 Describe 'execution'


### PR DESCRIPTION
## Summary
- add a declarative default Hermes MoA preset to the managed config
- use only CLIProxy DeepSeek Flash and Minimax models
- use CLIProxy DeepSeek Flash as the aggregator and prevent Opus from returning

## Validation
- `shellspec spec/hermes_hydrate_spec.sh`
- `shellspec spec/llm_update_spec.sh`
- `bash -n config/hermes/hydrate.sh spec/hermes_hydrate_spec.sh scripts/llm-update.sh`
- `make shell-test` *(1,967 examples; one pre-existing failure in `spec/activate_paperclip_openclaw_spec.sh` expects the Hermes dashboard proxy to use socat, while the base config uses nginx)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route all Hermes MoA models through `cliproxy`, set `deepseek-v4-flash` as the default aggregator, and update the default preset to use `deepseek-v4-pro` and `minimax-m3` as references. Exclude `opus`.

- **Bug Fixes**
  - Hydrate spec enforces `cliproxy` routing and verifies the default preset hydrates `deepseek-v4-pro`, `minimax-m3`, and `deepseek-v4-flash` from the canonical list.

<sup>Written for commit 364626f72f0ebd6d96087cf53ac2a0acaaa0c0b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

