### PR TITLE
feat(openclaw): enable inferred commitments

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -295,6 +295,9 @@
       }
     ]
   },
+  "commitments": {
+    "enabled": true
+  },
   "session": {
     "dmScope": "per-channel-peer"
   },

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -295,6 +295,9 @@
       }
     ]
   },
+  "commitments": {
+    "enabled": true
+  },
   "session": {
     "dmScope": "per-channel-peer"
   },


### PR DESCRIPTION
Enables `commitments.enabled: true` so OpenClaw can infer natural follow-ups from conversation and deliver check-ins through heartbeat.\n\nZero-config after the toggle — no cron, no hooks needed.\n\nApplied to both:\n- `config/openclaw/openclaw.template.json`\n- `config/openclaw/openclaw.tpl.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable inferred commitments in OpenClaw by setting `commitments.enabled: true` in both config templates. OpenClaw now infers follow-ups from conversations and sends check-ins via heartbeat with no extra setup (no cron, no hooks).

<sup>Written for commit cf2b776a46b06e385b07db6b185a727c3aa2b4a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

