### PR TITLE
fix(bun): add 30s test timeout to prevent hung processes

### DIFF
--- a/config/bun/bunfig.toml
+++ b/config/bun/bunfig.toml
@@ -1,5 +1,5 @@
 [test]
-timeout = 30000
+timeout = 300000
 
 [install]
 # Supply-chain hygiene: only install packages published at least 7 days ago.

--- a/config/bun/bunfig.toml
+++ b/config/bun/bunfig.toml
@@ -1,3 +1,6 @@
+[test]
+timeout = 30000
+
 [install]
 # Supply-chain hygiene: only install packages published at least 7 days ago.
 minimumReleaseAge = 604800


### PR DESCRIPTION
Adds a global `[test]` timeout to `config/bun/bunfig.toml` so runaway `bun test` processes are killed after 30s per test rather than hanging indefinitely.

Found a `bun test` process that had been running since Aug 04 at 99.5% CPU (7127 min of CPU time) before being manually killed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a global 300s test timeout in Bun to stop hung tests and runaway CPU usage. Configures `[test] timeout = 300000` in `config/bun/bunfig.toml` so each test is killed after 5 minutes.

<sup>Written for commit 8765e654f2599fea8eb495bf60534a8122125b9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

