### PR TITLE
feat(openclaw): enable web search tool

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -306,6 +306,13 @@
       "mode": "interrupt"
     }
   },
+  "tools": {
+    "web": {
+      "search": {
+        "enabled": true
+      }
+    }
+  },
   "commands": {
     "native": "auto",
     "nativeSkills": "auto"

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -306,6 +306,13 @@
       "mode": "interrupt"
     }
   },
+  "tools": {
+    "web": {
+      "search": {
+        "enabled": true
+      }
+    }
+  },
   "commands": {
     "native": "auto",
     "nativeSkills": "auto"


### PR DESCRIPTION
Enables `tools.web.search.enabled: true` so the agent can search the web. The provider auto-detects from available API keys.\n\nApplied to both:\n- `config/openclaw/openclaw.template.json`\n- `config/openclaw/openclaw.tpl.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enabled the web search tool by setting `tools.web.search.enabled` to `true`, letting the agent search the web when API keys are available. Applied to `config/openclaw/openclaw.template.json` and `config/openclaw/openclaw.tpl.json`; the provider auto-detects keys.

<sup>Written for commit 40196e6facbd630e278dfd009801dc64659ef0a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

