### PR TITLE
feat(dock): add T3 Code next to Orca

### DIFF
--- a/nix-darwin/config/dock.nix
+++ b/nix-darwin/config/dock.nix
@@ -29,6 +29,7 @@
       "/Applications/Conductor.app"
       "/Applications/OpenClaw.app"
       "/Applications/Orca.app"
+      "/Applications/T3 Code (Nightly).app"
       "/Applications/Beekeeper Studio.app"
       "/Applications/Google Chrome.app"
       "/Applications/Docker.app"


### PR DESCRIPTION
## Summary
- add the Homebrew-installed T3 Code bundle to the macOS Dock
- place it immediately to the right of Orca

## Validation
- `nixfmt --check nix-darwin/config/dock.nix`
- `git diff --check`
- verified `/Applications/T3 Code (Nightly).app` exists and is adjacent to `/Applications/Orca.app`
- `make nix-format-check` was attempted but interrupted after the Nix cache endpoint returned HTTP 503; the direct formatter check passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add T3 Code (Nightly) to the macOS Dock, placed immediately to the right of Orca. Updates the `nix-darwin` Dock configuration to include `/Applications/T3 Code (Nightly).app`.

<sup>Written for commit 15a7326891c94f7ebea05e3726bc2b21e038f1a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

