### PR TITLE
fix(t3-connect): repair node-gyp builds and survive reboots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1275,7 +1275,54 @@ launchctl-tmux-session-logger: ## Restart tmux-session-logger launchd agent.
 ##@ Systemd Services (Linux)
 
 .PHONY: systemctl
-systemctl: systemctl-docker systemctl-cliproxyapi systemctl-cliproxyapi-backup systemctl-cpa-manager-plus systemctl-code-syncer systemctl-docker-postgres systemctl-dolt systemctl-dotfiles-updater systemctl-hermes systemctl-make-updater systemctl-neverssl-keepalive systemctl-noctalia-shell systemctl-obsidian systemctl-ollama systemctl-openclaw systemctl-roborev systemctl-tmux-session-logger ## Restart all systemd user services.
+systemctl: systemctl-docker systemctl-cliproxyapi systemctl-cliproxyapi-backup systemctl-cpa-manager-plus systemctl-code-syncer systemctl-docker-postgres systemctl-dolt systemctl-dotfiles-updater systemctl-hermes systemctl-make-updater systemctl-neverssl-keepalive systemctl-noctalia-shell systemctl-obsidian systemctl-ollama systemctl-openclaw systemctl-roborev systemctl-t3-connect systemctl-tmux-session-logger ## Restart all systemd user services.
+
+.PHONY: systemctl-t3-connect
+systemctl-t3-connect: t3-linger ## Restart the t3-connect timer and run it once.
+	@echo "🔄 Restarting t3-connect..."
+	@systemctl --user daemon-reload
+	@systemctl --user restart t3-connect.timer || true
+	@systemctl --user start t3-connect.service || true
+	@echo "✅ t3-connect restarted"
+
+.PHONY: t3-linger
+t3-linger: ## Enable systemd lingering so user timers survive reboot without a login session.
+	@set -eu; \
+	if [ "$(OS)" != "Linux" ]; then \
+		echo "⏭️ Lingering is Linux-only, skipped"; \
+		exit 0; \
+	fi; \
+	user="$$(id -un)"; \
+	if [ "$$(loginctl show-user "$$user" -p Linger --value 2>/dev/null || echo no)" = "yes" ]; then \
+		echo "✅ Lingering already enabled for $$user"; \
+		exit 0; \
+	fi; \
+	echo "🔧 Enabling lingering for $$user..."; \
+	loginctl enable-linger "$$user" 2>/dev/null \
+		|| $(SUDO) loginctl enable-linger "$$user" \
+		|| { echo "❌ Could not enable lingering for $$user"; exit 1; }; \
+	echo "✅ Lingering enabled for $$user"
+
+.PHONY: t3-service
+t3-service: t3-linger ## Install/repair the T3 background server so the client never cold-starts it.
+	@set -eu; \
+	if [ "$(OS)" != "Linux" ]; then \
+		echo "⏭️ T3 background service is Linux-only, skipped"; \
+		exit 0; \
+	fi; \
+	T3_BIN="$$(command -v t3 || true)"; \
+	if [ -z "$$T3_BIN" ]; then \
+		echo "❌ t3 is not installed (expected from package.json npm globals)"; \
+		exit 1; \
+	fi; \
+	echo "🔧 Installing T3 background service..."; \
+	"$$T3_BIN" service install || "$$T3_BIN" service update; \
+	systemctl --user daemon-reload; \
+	systemctl --user enable --now t3code.service || true; \
+	echo "🔧 Building native modules for the service runtime..."; \
+	$(MAKE) systemctl-t3-connect; \
+	systemctl --user restart t3code.service || true; \
+	"$$T3_BIN" service status || true
 
 .PHONY: systemctl-docker
 systemctl-docker: ## Start Docker daemon.

--- a/home-manager/services/t3-connect/default.nix
+++ b/home-manager/services/t3-connect/default.nix
@@ -10,14 +10,22 @@ in
     Service = {
       Type = "oneshot";
       Environment = [
+        # node-gyp's generated Makefile shells out to sed/grep/awk/which, so a
+        # minimal PATH fails the compile with `sed: command not found` rather
+        # than anything that names the real dependency.
         "PATH=${
           lib.makeBinPath [
             pkgs.bash
             pkgs.coreutils
+            pkgs.findutils
+            pkgs.gawk
             pkgs.gcc
+            pkgs.gnugrep
             pkgs.gnumake
+            pkgs.gnused
             pkgs.nodejs
             pkgs.python3
+            pkgs.which
           ]
         }"
       ];

--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -54,6 +54,9 @@ let
         ++ userExtraGroups;
         home = "/home/${username}";
         shell = pkgs.fish;
+        # Without lingering, systemd --user units only exist while a session is
+        # open, so timers like t3-connect never fire after an unattended reboot.
+        linger = true;
       }
       // lib.optionalAttrs (userInitialPassword != null) {
         initialPassword = userInitialPassword;

--- a/spec/t3_connect_spec.sh
+++ b/spec/t3_connect_spec.sh
@@ -84,6 +84,27 @@ The status should be success
 End
 End
 
+Describe 'systemd unit PATH'
+UNIT="$PWD/home-manager/services/t3-connect/default.nix"
+
+# node-gyp's generated Makefile shells out to these. Omitting them fails the
+# build with `sed: command not found`, which names none of the real cause.
+It 'includes the build tools node-gyp shells out to'
+When run bash -c "cat '$UNIT'"
+The output should include 'pkgs.gnused'
+The output should include 'pkgs.gnugrep'
+The output should include 'pkgs.gawk'
+The output should include 'pkgs.which'
+End
+
+It 'includes a compiler, make and python for node-gyp'
+When run bash -c "cat '$UNIT'"
+The output should include 'pkgs.gcc'
+The output should include 'pkgs.gnumake'
+The output should include 'pkgs.python3'
+End
+End
+
 Describe 'toolchain selection'
 It 'documents the nix/system glibc mismatch'
 When run bash -c "cat '$SCRIPT'"


### PR DESCRIPTION
## Context

Follow-up to #2314. After switching both hosts, two gaps surfaced that only a real activation could reveal.

## 1. `t3-connect.service` failed on kyber: `sed: command not found`

The unit PATH was `makeBinPath [bash coreutils gcc gnumake nodejs python3]`. node-gyp's generated Makefile shells out to `sed`, so the build died with an error naming none of the real cause:

```
npm error sh: line 1: sed: command not found
npm error make: *** [pty.target.mk:115: Release/obj.target/pty/src/unix/pty.o] Error 127
npm error gyp ERR! not ok
t3-connect.service: Failed with result 'exit-code'
```

matic passed only because its cache already had `pty.node` from an earlier manual run, so the compile path was skipped -- it would have failed identically on the next nightly.

A/B on kyber, same command, only PATH differing:

| PATH | result |
|---|---|
| unit PATH as-is | `sed: command not found`, gyp not ok |
| unit PATH + sed | `rebuilt dependencies successfully`, node-pty **loads** |

Fix: add `gnused`, `gnugrep`, `gawk`, `findutils`, `which` to the unit PATH.

## 2. Nothing survived a reboot

`systemd --user` units only exist while a session is open unless lingering is enabled. Neither host had it declared anywhere in the repo:

| host | Linger before |
|---|---|
| matic | **no** -- timer would never fire after an unattended reboot |
| kyber | yes, but set imperatively by hand; lost on reimage |

Fixes:

- `users.users.<username>.linger = true` in `hosts/nixos/default.nix` -- declarative for NixOS hosts.
- `make t3-linger` -- idempotent, tries unprivileged `loginctl enable-linger` first and falls back to sudo. For hosts like kyber whose system config is not nix-managed.
- `make t3-service` -- installs/repairs the T3 background server, enables the unit, builds native modules, restarts, prints status. This is the durable fix: with a server already listening on 3773 the client never cold-starts one, so there is no npx race and no login-shell PATH probe.
- `make systemctl-t3-connect`, wired into the existing `systemctl` aggregate so `make switch` picks it up.

## Verification

- A/B build test above run on kyber against a real broken tree; `node-pty LOADS OK` after
- `make -n` parses all three new targets; they appear in `make help`
- `nixfmt --check`, `nix-instantiate --parse`, `make shell-inline-check` clean
- `shellspec spec/t3_connect_spec.sh spec/coverage_spec.sh`: 115 examples, 0 failures

## Post-merge

Both hosts need another `make nix-switch`; matic additionally needs it to pick up lingering. kyber still carries two out-of-band system changes not reproducible from the repo: `apt-get install g++` and the original `loginctl enable-linger` (now covered by `make t3-linger`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `t3-connect` node-gyp builds by adding missing CLI tools to the service PATH, and makes the service survive reboots by enabling systemd lingering and adding Make targets to install/manage the background server.

- **Bug Fixes**
  - Add `gnused`, `gnugrep`, `gawk`, `findutils`, and `which` to the systemd unit PATH to unblock `node-gyp` builds (avoids "sed: command not found").
  - Tests assert the PATH includes required tools and build deps.

- **New Features**
  - Set `users.users.<name>.linger = true` on NixOS so user services/timers persist across reboots.
  - New Make targets:
    - `t3-linger` — enable lingering (tries unprivileged first, falls back to sudo).
    - `t3-service` — install/update the T3 background service, build native modules, restart, show status.
    - `systemctl-t3-connect` — reload/restart the timer/service; included in `systemctl` aggregate.

<sup>Written for commit 730448337f15dbb8d0064b8a69400af529d02a59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

