### PR TITLE
fix(hermes): replace read-only Nix systemd unit symlinks with writable copies

### DIFF
--- a/home-manager/services/hermes/activate.sh
+++ b/home-manager/services/hermes/activate.sh
@@ -13,6 +13,24 @@ mkdir -p "$HOME_DIR/.hermes/skills"
 mkdir -p "$HOME_DIR/.hermes/cron"
 chmod 700 "$HOME_DIR/.hermes"
 
+# Replace Nix-managed read-only systemd unit symlinks with writable copies
+# so Hermes can auto-refresh them without PermissionError.
+SYSTEMD_USER_DIR="$HOME_DIR/.config/systemd/user"
+for unit in hermes-gateway.service hermes-dashboard.service hermes-dashboard-proxy.service; do
+  unit_path="$SYSTEMD_USER_DIR/$unit"
+  if [ -L "$unit_path" ]; then
+    # Read the target file content, then replace symlink with writable copy
+    content="$(cat "$unit_path" 2>/dev/null || true)"
+    if [ -n "$content" ]; then
+      rm -f "$unit_path"
+      printf '%s\n' "$content" > "$unit_path"
+      chmod 644 "$unit_path"
+      echo "Replaced symlink $unit with writable copy"
+    fi
+  fi
+done
+systemctl --user daemon-reload 2>/dev/null || true
+
 # Install hermes gateway runtime deps from pyproject.toml dependency group
 HERMES_VENV="$HOME_DIR/ghq/github.com/NousResearch/hermes-agent/.venv"
 if [ -d "$HERMES_VENV" ]; then


### PR DESCRIPTION
Hermes gateway crashes with PermissionError every time it tries to auto-refresh its systemd unit file, because the unit is a Nix-managed read-only symlink into /nix/store/.

This fix adds a post-activation step in activate.sh that:
1. Detects Nix-managed symlinks for all three hermes services
2. Replaces each symlink with a writable copy of the unit file content
3. Runs systemctl --user daemon-reload to pick up the changes

This runs on every Nix switch, so the unit files stay current while remaining writable for Hermes' auto-refresh.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop Hermes gateway crashes by replacing Nix-managed read-only systemd unit symlinks with writable copies during activation, then reloading the user daemon. This keeps unit files current and writable for Hermes’ auto-refresh.

- **Bug Fixes**
  - In `activate.sh`, detect symlinked units for `hermes-gateway.service`, `hermes-dashboard.service`, and `hermes-dashboard-proxy.service` and replace each with a writable copy (644) of its content.
  - Run `systemctl --user daemon-reload` to pick up changes.
  - Executes on every Nix switch so units remain up to date and editable.

<sup>Written for commit fa881d0abc890d401323dd68f37f34b27bbbd6de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

