### PR TITLE
feat(hermes): enable webhook platform

### DIFF
--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -327,3 +327,9 @@ custom_providers:
     base_url: https://cliproxy.shunkakinoki.com/v1
     api_key: __CLIPROXY_API_KEY__
     api_mode: chat_completions
+platforms:
+  webhook:
+    enabled: true
+    extra:
+      port: 8644
+      secret: __WEBHOOK_SECRET__

--- a/config/hermes/hydrate.sh
+++ b/config/hermes/hydrate.sh
@@ -63,6 +63,7 @@ fi
 TELEGRAM_TOKEN="${HERMES_TELEGRAM_TOKEN:-${TELEGRAM_TOKEN:-$(read_secret "${SECRETS_DIR}/telegram-token")}}"
 GATEWAY_TOKEN="${HERMES_GATEWAY_TOKEN:-${GATEWAY_TOKEN:-$(read_secret "${SECRETS_DIR}/gateway-token")}}"
 WHATSAPP_ALLOW_FROM="${WHATSAPP_ALLOW_FROM:-$(read_secret "${SECRETS_DIR}/whatsapp-allow-from")}"
+WEBHOOK_SECRET="${WEBHOOK_SECRET:-$(read_secret "${SECRETS_DIR}/webhook-secret")}"
 
 if [ -z "${GATEWAY_TOKEN}" ]; then
   echo "Warning: HERMES_GATEWAY_TOKEN not set, skipping Hermes hydration" >&2
@@ -72,6 +73,7 @@ fi
 # Hydrate config.yaml
 @sed@ \
   -e "s|__CLIPROXY_API_KEY__|${CLIPROXY_API_KEY}|g" \
+  -e "s|__WEBHOOK_SECRET__|${WEBHOOK_SECRET}|g" \
   "$CONFIG_TEMPLATE" >"${STATE_DIR}/config.yaml"
 chmod 600 "${STATE_DIR}/config.yaml"
 

--- a/config/hermes/hydrate.sh
+++ b/config/hermes/hydrate.sh
@@ -63,7 +63,7 @@ fi
 TELEGRAM_TOKEN="${HERMES_TELEGRAM_TOKEN:-${TELEGRAM_TOKEN:-$(read_secret "${SECRETS_DIR}/telegram-token")}}"
 GATEWAY_TOKEN="${HERMES_GATEWAY_TOKEN:-${GATEWAY_TOKEN:-$(read_secret "${SECRETS_DIR}/gateway-token")}}"
 WHATSAPP_ALLOW_FROM="${WHATSAPP_ALLOW_FROM:-$(read_secret "${SECRETS_DIR}/whatsapp-allow-from")}"
-WEBHOOK_SECRET="${WEBHOOK_SECRET:-$(read_secret "${SECRETS_DIR}/webhook-secret")}"
+WEBHOOK_SECRET="${HERMES_WEBHOOK_SECRET:-$(read_secret "${SECRETS_DIR}/webhook-secret")}"
 
 if [ -z "${GATEWAY_TOKEN}" ]; then
   echo "Warning: HERMES_GATEWAY_TOKEN not set, skipping Hermes hydration" >&2


### PR DESCRIPTION
Enable webhook platform

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the Hermes webhook platform with a configurable port and secret to support incoming webhook integrations. Config is hydrated from `HERMES_WEBHOOK_SECRET` or a local secret during setup.

- **New Features**
  - Adds `platforms.webhook` to `config/hermes/config.template.yaml` (enabled, port `8644`, secret placeholder).
  - Updates `config/hermes/hydrate.sh` to read `HERMES_WEBHOOK_SECRET` and inject it into the generated config.

- **Migration**
  - Set `HERMES_WEBHOOK_SECRET` or add the secret at `~/.config/hermes/webhook-secret` before hydration.
  - Open/expose port `8644` if running behind a firewall or proxy.

<sup>Written for commit 4629c58ed5e0f05248d35a75ba70474ef11ae8e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

