### PR TITLE
feat(openclaw): enable models.pricing and gateway.terminal

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -7,6 +7,9 @@
   },
   "models": {
     "mode": "merge",
+    "pricing": {
+      "enabled": true
+    },
     "providers": {
       "cliproxy": {
         "baseUrl": "https://cliproxy.shunkakinoki.com/v1",
@@ -376,6 +379,9 @@
   "gateway": {
     "mode": "local",
     "bind": "loopback",
+    "terminal": {
+      "enabled": true
+    },
     "tailscale": {
       "mode": "serve",
       "resetOnExit": false

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -7,6 +7,9 @@
   },
   "models": {
     "mode": "merge",
+    "pricing": {
+      "enabled": true
+    },
     "providers": {
       "cliproxy": {
         "baseUrl": "https://cliproxy.shunkakinoki.com/v1",
@@ -376,6 +379,9 @@
   "gateway": {
     "mode": "local",
     "bind": "loopback",
+    "terminal": {
+      "enabled": true
+    },
     "tailscale": {
       "mode": "serve",
       "resetOnExit": false


### PR DESCRIPTION
## What

- **`models.pricing.enabled: true`** — background token cost tracking across all providers
- **`gateway.terminal.enabled: true`** — operator terminal tab in the Control UI

## Why

- 10+ models across multiple providers, currently all priced at $0 in config — real spend visibility
- Terminal in Control UI useful for debugging from phone/tablet

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable token spend tracking and the operator terminal in the Control UI. Sets `models.pricing.enabled: true` and `gateway.terminal.enabled: true` in `config/openclaw` templates.

<sup>Written for commit 3f1abebe2f307edcc2e352002dc8c2067d62b3db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

