### PR TITLE
fix: declutter writable activation artifacts before nix linkGeneration

### DIFF
--- a/home-manager/programs/cass/default.nix
+++ b/home-manager/programs/cass/default.nix
@@ -4,6 +4,16 @@
   ...
 }:
 {
+  # Clean up the hydrate.sh output before linkGeneration so it doesn't
+  # block the next nix-switch.
+  home.activation.cassSourcesCleanup = config.lib.dag.entryBefore [ "linkGeneration" ] ''
+    $DRY_RUN_CMD ${pkgs.bash}/bin/bash -c '
+      if [ -f "${config.home.homeDirectory}/.config/cass/sources.toml" ]; then
+        rm -f "${config.home.homeDirectory}/.config/cass/sources.toml"
+      fi
+    '
+  '';
+
   # sources.toml is hydrated at activation so each machine can drop itself from
   # the peer list using its runtime hostname.
   home.activation.hydrateCassSources = config.lib.dag.entryAfter [ "writeBoundary" ] ''

--- a/home-manager/services/hermes/default.nix
+++ b/home-manager/services/hermes/default.nix
@@ -11,6 +11,19 @@ let
   hermesNode = pkgs.nodejs_22;
 in
 lib.mkIf host.isKyber {
+  # Clean up writable copies that Hermes activate.sh creates (replacing Nix-managed
+  # symlinks) so they don't block the next nix-switch's linkGeneration.
+  home.activation.hermesCleanup = config.lib.dag.entryBefore [ "linkGeneration" ] ''
+    $DRY_RUN_CMD ${pkgs.bash}/bin/bash -c '
+      for f in hermes-gateway.service hermes-dashboard.service hermes-dashboard-proxy.service; do
+        unit="${homeDir}/.config/systemd/user/$f"
+        if [ -f "$unit" ] && [ ! -L "$unit" ]; then
+          rm -f "$unit"
+        fi
+      done
+    '
+  '';
+
   home.activation.hermesSetup = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${homeDir}" "${hermesNode}/bin/npm"
   '';


### PR DESCRIPTION
## What

Two pre-`linkGeneration` home-manager activation hooks that remove writable files left by Hermes `activate.sh` and Cass `hydrate.sh` before the next switch expects clean symlinks.

## Why

- Hermes `activate.sh` replaces Nix-managed systemd unit symlinks with writable copies so Hermes can auto-refresh them
- Cass `hydrate.sh` writes `sources.toml` to `~/.config/cass/`
- Both happen after `writeBoundary`, so on the *next* `nix-switch`, home-manager's `linkGeneration` finds regular files instead of symlinks and refuses to clobber them

## Files changed

- `home-manager/services/hermes/default.nix` — cleanup before `linkGeneration` for `hermes-gateway.service`, `hermes-dashboard.service`, `hermes-dashboard-proxy.service`
- `home-manager/programs/cass/default.nix` — cleanup before `linkGeneration` for `sources.toml`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clean up writable activation artifacts before `home-manager` `linkGeneration` so the next `nix-switch` can safely recreate symlinks and avoid clobber errors. Adds pre-`linkGeneration` hooks for Hermes and Cass.

- **Bug Fixes**
  - Hermes: delete non-symlink user units before `linkGeneration` (`hermes-gateway.service`, `hermes-dashboard.service`, `hermes-dashboard-proxy.service`).
  - Cass: delete `~/.config/cass/sources.toml` before `linkGeneration`.

<sup>Written for commit b3ce01fd7f0a06b5355f1e6e73131d1f3e0b9187. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

