### PR TITLE
fix(cass): keep TUI on lexical search

### DIFF
--- a/home-manager/programs/cass/default.nix
+++ b/home-manager/programs/cass/default.nix
@@ -4,6 +4,11 @@
   ...
 }:
 {
+  # Hybrid is Cass's upstream default, but it starts semantic refinement even
+  # when only the lexical index is ready. Keep interactive search responsive
+  # until semantic indexing can complete reliably for this archive.
+  home.sessionVariables.CASS_SEARCH_MODE = "lexical";
+
   # Clean up the hydrate.sh output before linkGeneration so it doesn't
   # block the next nix-switch.
   home.activation.cassSourcesCleanup = config.lib.dag.entryBefore [ "linkGeneration" ] ''

--- a/home-manager/services/cass/default.nix
+++ b/home-manager/services/cass/default.nix
@@ -1,24 +1,11 @@
 { pkgs, ... }:
 let
   inherit (pkgs) lib;
-  cass = "$HOME/.local/bin/cass";
 in
 {
-  # Persistent watcher - incrementally indexes new sessions via filesystem notifications
-  launchd.agents.cass-watcher = lib.mkIf pkgs.stdenv.isDarwin {
-    enable = true;
-    config = {
-      ProgramArguments = [
-        "${pkgs.bash}/bin/bash"
-        "-c"
-        "${cass} index --watch"
-      ];
-      KeepAlive = true;
-      RunAtLoad = true;
-      StandardOutPath = "/tmp/cass-watcher.log";
-      StandardErrorPath = "/tmp/cass-watcher.error.log";
-    };
-  };
+  # Do not run `cass index --watch` persistently. On large archives it can
+  # wedge during startup, and launchd/systemd restart it indefinitely, which
+  # blocks the TUI's otherwise usable lexical search path.
 
   # Daily remote sync + analytics rebuild (runs at 4am)
   launchd.agents.cass-daily = lib.mkIf pkgs.stdenv.isDarwin {
@@ -36,22 +23,6 @@ in
       ];
       StandardOutPath = "/tmp/cass-daily.log";
       StandardErrorPath = "/tmp/cass-daily.error.log";
-    };
-  };
-
-  systemd.user.services.cass-watcher = lib.mkIf pkgs.stdenv.isLinux {
-    Unit = {
-      Description = "cass incremental session indexer (watch mode)";
-      After = [ "network.target" ];
-    };
-    Service = {
-      Type = "simple";
-      ExecStart = "${pkgs.bash}/bin/bash -c '${cass} index --watch'";
-      Restart = "always";
-      RestartSec = 10;
-    };
-    Install = {
-      WantedBy = [ "default.target" ];
     };
   };
 

--- a/spec/cass_indexer_spec.sh
+++ b/spec/cass_indexer_spec.sh
@@ -17,6 +17,11 @@ End
 End
 
 Describe 'cass commands'
+It 'does not start a persistent watch indexer'
+When run bash -c "! rg -F '\${cass} index --watch' home-manager/services/cass/default.nix"
+The status should be success
+End
+
 It 'runs sources sync'
 When run bash -c "cat '$SCRIPT'"
 The output should include 'sources sync'
@@ -38,6 +43,15 @@ The output should include '! -x'
 End
 End
 
+End
+
+Describe 'cass interactive defaults'
+PROGRAM="$PWD/home-manager/programs/cass/default.nix"
+
+It 'defaults search to lexical mode'
+When run bash -c "grep -F 'CASS_SEARCH_MODE = \"lexical\"' '$PROGRAM'"
+The output should include 'CASS_SEARCH_MODE = "lexical"'
+End
 End
 
 Describe 'cass/hydrate.sh'


### PR DESCRIPTION
## Summary
- default Cass shells to `CASS_SEARCH_MODE=lexical` so the TUI avoids semantic-startup stalls
- stop declaring persistent `cass index --watch` services that restart into the known large-archive wedge
- retain the daily remote-sync and analytics job
- cover both runtime defaults with focused ShellSpec assertions

## Validation
- `shellspec spec/cass_indexer_spec.sh` (13 examples, 0 failures)
- `nixfmt --check home-manager/services/cass/default.nix home-manager/programs/cass/default.nix`
- `CASS_SEARCH_MODE=lexical cass search workflow --mode lexical --json --fields minimal --limit 1` (hits returned)

## Note
The broad Nix format/build commands were blocked by concurrent Nix input fetches in the shared checkout; this PR was isolated into a clean worktree and the focused checks above pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default `CASS_SEARCH_MODE=lexical` and remove persistent `cass index --watch` services to keep the `cass` TUI responsive on large archives. Daily remote sync and analytics still run, with focused ShellSpec checks covering these defaults.

<sup>Written for commit 3a401de9b1ad1ebfa45c2ceef10af2908f31407c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

