### PR TITLE
fix(activation): run cleanups before checkLinkTargets and find tailscale off PATH

### DIFF
--- a/home-manager/activation/ensure-tailscale-serve.sh
+++ b/home-manager/activation/ensure-tailscale-serve.sh
@@ -18,36 +18,65 @@ HTTPS_PORT="${1:?https port required}"
 LOCAL_PORT="${2:?local port required}"
 TARGET="http://127.0.0.1:${LOCAL_PORT}"
 
-if ! command -v tailscale >/dev/null 2>&1; then
-  echo "tailscale not on PATH; skipping serve setup for :${HTTPS_PORT}" >&2
+# Home Manager activation runs with a minimal PATH, so `command -v` alone finds
+# nothing. Search where each host actually keeps it, and prefer the installed
+# CLI over a nix one so it always matches the running daemon.
+TS=""
+for candidate in \
+  "$(command -v tailscale 2>/dev/null || true)" \
+  "${HOME}/.nix-profile/bin/tailscale" \
+  "/etc/profiles/per-user/$(id -un)/bin/tailscale" \
+  /run/current-system/sw/bin/tailscale \
+  /usr/bin/tailscale \
+  /usr/local/bin/tailscale; do
+  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+    TS="$candidate"
+    break
+  fi
+done
+
+if [ -z "$TS" ]; then
+  echo "tailscale not found; skipping serve setup for :${HTTPS_PORT}" >&2
   exit 0
 fi
 
 # Not logged in / daemon down: leave the config alone rather than erroring the
 # whole activation.
-if ! tailscale status >/dev/null 2>&1; then
+if ! "$TS" status >/dev/null 2>&1; then
   echo "tailscale not running; skipping serve setup for :${HTTPS_PORT}" >&2
   exit 0
 fi
 
-if tailscale serve status 2>/dev/null | grep -qF "${TARGET}"; then
+if "$TS" serve status 2>/dev/null | grep -qF "${TARGET}"; then
   exit 0
 fi
 
+# Same minimal-PATH problem as above: fall back to absolute paths.
 SUDO_CMD=""
 if [ "$(id -u)" -ne 0 ]; then
-  if command -v sudo >/dev/null 2>&1; then
-    SUDO_CMD="sudo"
-  elif [ -x /run/wrappers/bin/sudo ]; then
-    SUDO_CMD="/run/wrappers/bin/sudo"
-  elif command -v doas >/dev/null 2>&1; then
-    SUDO_CMD="doas"
-  fi
+  for candidate in \
+    "$(command -v sudo 2>/dev/null || true)" \
+    /run/wrappers/bin/sudo \
+    /usr/bin/sudo \
+    "$(command -v doas 2>/dev/null || true)" \
+    /usr/bin/doas; do
+    if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+      SUDO_CMD="$candidate"
+      break
+    fi
+  done
+fi
+
+# `tailscale serve` needs root unless the user is a tailscale operator. Skipping
+# beats aborting the whole switch over an endpoint that can be set up later.
+if [ -z "$SUDO_CMD" ] && [ "$(id -u)" -ne 0 ]; then
+  echo "no sudo/doas available; skipping serve setup for :${HTTPS_PORT}" >&2
+  exit 0
 fi
 
 echo "Publishing ${TARGET} over Tailscale Serve on :${HTTPS_PORT}..."
 if [ -n "$SUDO_CMD" ]; then
-  "$SUDO_CMD" tailscale serve --bg --https="${HTTPS_PORT}" "${TARGET}"
+  "$SUDO_CMD" "$TS" serve --bg --https="${HTTPS_PORT}" "${TARGET}"
 else
-  tailscale serve --bg --https="${HTTPS_PORT}" "${TARGET}"
+  "$TS" serve --bg --https="${HTTPS_PORT}" "${TARGET}"
 fi

--- a/home-manager/programs/cass/default.nix
+++ b/home-manager/programs/cass/default.nix
@@ -9,9 +9,9 @@
   # until semantic indexing can complete reliably for this archive.
   home.sessionVariables.CASS_SEARCH_MODE = "lexical";
 
-  # Clean up the hydrate.sh output before linkGeneration so it doesn't
+  # Clean up the hydrate.sh output before checkLinkTargets so it does not
   # block the next nix-switch.
-  home.activation.cassSourcesCleanup = config.lib.dag.entryBefore [ "linkGeneration" ] ''
+  home.activation.cassSourcesCleanup = config.lib.dag.entryBefore [ "checkLinkTargets" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-cleanup-sources.sh}" \
       "${config.home.homeDirectory}/.config/cass/sources.toml"
   '';

--- a/home-manager/services/hermes/default.nix
+++ b/home-manager/services/hermes/default.nix
@@ -13,7 +13,7 @@ in
 lib.mkIf host.isKyber {
   # Clean up writable copies that Hermes activate.sh creates (replacing Nix-managed
   # symlinks) so they don't block the next nix-switch's linkGeneration.
-  home.activation.hermesCleanup = config.lib.dag.entryBefore [ "linkGeneration" ] ''
+  home.activation.hermesCleanup = config.lib.dag.entryBefore [ "checkLinkTargets" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-cleanup-units.sh}" \
       "${homeDir}/.config/systemd/user" \
       hermes-gateway.service \

--- a/spec/activation_cleanup_spec.sh
+++ b/spec/activation_cleanup_spec.sh
@@ -75,6 +75,19 @@ It 'neither nix file inlines a bash -c block'
 When run bash -c "cat '$PWD/home-manager/programs/cass/default.nix' '$PWD/home-manager/services/hermes/default.nix'"
 The output should not include 'bin/bash -c'
 End
+
+# Home Manager aborts in checkLinkTargets ("would be clobbered"), which runs
+# before linkGeneration. Anchoring the cleanup to linkGeneration is too late --
+# it only appeared to work when sibling DAG ordering happened to be favourable.
+It 'runs the cass cleanup before checkLinkTargets'
+When run bash -c "grep -A1 'cassSourcesCleanup' '$PWD/home-manager/programs/cass/default.nix' | head -1"
+The output should include 'entryBefore [ "checkLinkTargets" ]'
+End
+
+It 'runs the hermes cleanup before checkLinkTargets'
+When run bash -c "grep -A1 'hermesCleanup' '$PWD/home-manager/services/hermes/default.nix' | head -1"
+The output should include 'entryBefore [ "checkLinkTargets" ]'
+End
 End
 
 End

--- a/spec/tailscale_serve_spec.sh
+++ b/spec/tailscale_serve_spec.sh
@@ -48,6 +48,20 @@ The output should include 'skipping serve setup'
 The status should be success
 End
 
+# Activation runs with a minimal PATH, so a bare `command -v tailscale` finds
+# nothing and the step silently never ran on either host.
+It 'finds tailscale outside PATH'
+When run bash -c "cat '$SCRIPT'"
+The output should include '.nix-profile/bin/tailscale'
+The output should include '/run/current-system/sw/bin/tailscale'
+End
+
+# serve needs root; aborting the switch over it would be worse than skipping.
+It 'skips rather than failing when no sudo is available'
+When run bash -c "cat '$SCRIPT'"
+The output should include 'no sudo/doas available'
+End
+
 It 'skips when the daemon is not running'
 When run bash -c "$(declare -f mock_daemon_down); mock_daemon_down; bash '$SCRIPT' 443 3773 2>&1"
 The output should include 'skipping serve setup'


### PR DESCRIPTION
## 1. `nix-switch` was failing on kyber

```
Existing file '/home/ubuntu/.config/systemd/user/hermes-gateway.service' would be clobbered
make: *** [Makefile:734: nix-switch] Error 1
```

The hermes cleanup exists to prevent exactly this, but it never ran. Activation order on kyber:

```
Activating cassSourcesCleanup
Activating checkFilesChanged
Activating checkLinkTargets      <- aborts here
```

Both cleanups were anchored `entryBefore [ "linkGeneration" ]`, but the clobber check happens in **`checkLinkTargets`**, which runs earlier. `cassSourcesCleanup` only appeared to work because sibling DAG ordering happened to place it early -- it was luck, not correctness, and `hermesCleanup` did not get it.

Both now anchor `entryBefore [ "checkLinkTargets" ]`, with specs asserting the anchor so it cannot silently regress.

This bug predates the extraction in #2322 -- #2323 introduced the anchors and the extraction preserved them faithfully.

## 2. The tailnet HTTPS activation never ran

On kyber's switch:

```
Activating tailscaleServeT3
tailscale not on PATH; skipping serve setup for :8443
```

Home Manager activation runs with a minimal PATH, and neither host keeps tailscale on it:

| host | tailscale |
|---|---|
| matic | `/run/current-system/sw/bin/tailscale` |
| kyber | `~/.nix-profile/bin/tailscale` |

The graceful skip kept the switch green while the step silently did nothing -- the endpoints only worked because I had configured them by hand earlier. The script now searches known locations, preferring the installed CLI so it always matches the running daemon, and applies the same fallback to `sudo`/`doas`.

Verified on both hosts with `PATH=/nonexistent`: tailscale is found.

## 3. Do not abort a switch over serve setup

Testing the above surfaced a real hazard: with no resolvable `sudo`, the script ran `tailscale serve` unprivileged, failed, and would have aborted the entire switch. It now skips with a message instead -- an HTTPS endpoint can be set up later; a broken activation cannot.

## Verification

- kyber `make nix-switch` completes after clearing the stale writable units
- `PATH=/nonexistent` on both hosts: tailscale resolved, no false "not found"
- `shellcheck`, `nixfmt --check`, `make shell-inline-check` clean
- `shellspec`: **2028 examples, 0 failures**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix activation order and Tailscale Serve setup to prevent nix-switch aborts and ensure HTTPS endpoints are configured reliably. Cleanups run before link checks, and the script now finds `tailscale` off PATH and skips safely when privilege is unavailable.

- **Bug Fixes**
  - Run `cassSourcesCleanup` and `hermesCleanup` before `checkLinkTargets` to avoid “would be clobbered” failures; add specs to lock this ordering.
  - Update serve script to locate `tailscale` in common paths (prefers installed CLI), resolve `sudo`/`doas`, and skip when the daemon isn’t running or no privilege is available, avoiding activation aborts.

<sup>Written for commit 283eb2895dd759fa6567606ccbf650a184fb5468. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

