### PR TITLE
fix(cliproxyapi): route DeepSeek by priority

### DIFF
--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -82,12 +82,11 @@ ws-auth: false
 # OpenAI compatibility providers
 openai-compatibility:
   - name: "openrouter"
+    priority: 100
     base-url: "https://openrouter.ai/api/v1"
     api-key-entries:
       - api-key: "__OPENROUTER_API_KEY__"
     models:
-      - name: "openrouter/free"
-        alias: "free"
       - name: "openai/gpt-5.4-image-2"
         alias: "gpt-image-2"
       - name: "@preset/glm-4-7"
@@ -105,8 +104,6 @@ openai-compatibility:
     models:
       - name: "glm-4.7"
         alias: "glm-4.7"
-      - name: "glm-4.7"
-        alias: "@preset/glm-4-7"
   - name: "kimi"
     base-url: "https://api.moonshot.cn/v1"
     api-key-entries:
@@ -122,44 +119,20 @@ openai-compatibility:
       - name: "qwen3.6-plus"
         alias: "qwen3.6-plus"
   - name: "aliyun"
+    priority: 200
     prefix: "aliyun"
     base-url: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
     api-key-entries:
       - api-key: "__ALIYUN_TOKEN_PLAN_API_KEY__"
     models:
-      - name: "qwen3.8-max"
-        alias: "qwen3.8-max"
-      - name: "qwen3.7-max"
-        alias: "qwen3.7-max"
-      - name: "qwen3.7-plus"
-        alias: "qwen3.7-plus"
       - name: "qwen3.6-plus"
         alias: "qwen3.6-plus"
-      - name: "qwen3.6-flash"
-        alias: "qwen3.6-flash"
       - name: "deepseek-v4-pro"
         alias: "deepseek-v4-pro"
-      - name: "deepseek-v4-flash"
-        alias: "deepseek-v4-flash"
       - name: "deepseek-v4-flash-0731"
-        alias: "deepseek-v4-flash-0731"
-      - name: "deepseek-v3.2"
-        alias: "deepseek-v3.2"
-      - name: "kimi-k2.7-code"
-        alias: "kimi-k2.7-code"
-      - name: "kimi-k2.6"
-        alias: "kimi-k2.6"
-      - name: "kimi-k2.5"
-        alias: "kimi-k2.5"
-      - name: "glm-5.2"
-        alias: "glm-5.2"
-      - name: "glm-5.1"
-        alias: "glm-5.1"
-      - name: "glm-5"
-        alias: "glm-5"
-      - name: "MiniMax-M2.5"
-        alias: "MiniMax-M2.5"
+        alias: "deepseek-v4-flash"
   - name: "opencode"
+    priority: 300
     base-url: "https://opencode.ai/zen/go/v1"
     api-key-entries:
       - api-key: "__OPENCODE_API_KEY__"

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -82,12 +82,11 @@ ws-auth: false
 # OpenAI compatibility providers
 openai-compatibility:
   - name: "openrouter"
+    priority: 100
     base-url: "https://openrouter.ai/api/v1"
     api-key-entries:
       - api-key: "__OPENROUTER_API_KEY__"
     models:
-      - name: "openrouter/free"
-        alias: "free"
       - name: "__GPT_IMAGE_OPENROUTER__"
         alias: "__GPT_IMAGE__"
       - name: "@preset/__GLM_NONDOT__"
@@ -105,8 +104,6 @@ openai-compatibility:
     models:
       - name: "__GLM__"
         alias: "__GLM__"
-      - name: "__GLM__"
-        alias: "@preset/__GLM_NONDOT__"
   - name: "kimi"
     base-url: "https://api.moonshot.cn/v1"
     api-key-entries:
@@ -122,44 +119,20 @@ openai-compatibility:
       - name: "__QWEN__"
         alias: "__QWEN__"
   - name: "aliyun"
+    priority: 200
     prefix: "aliyun"
     base-url: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
     api-key-entries:
       - api-key: "__ALIYUN_TOKEN_PLAN_API_KEY__"
     models:
-      - name: "qwen3.8-max"
-        alias: "qwen3.8-max"
-      - name: "qwen3.7-max"
-        alias: "qwen3.7-max"
-      - name: "qwen3.7-plus"
-        alias: "qwen3.7-plus"
-      - name: "qwen3.6-plus"
-        alias: "qwen3.6-plus"
-      - name: "qwen3.6-flash"
-        alias: "qwen3.6-flash"
-      - name: "deepseek-v4-pro"
-        alias: "deepseek-v4-pro"
-      - name: "deepseek-v4-flash"
-        alias: "deepseek-v4-flash"
-      - name: "deepseek-v4-flash-0731"
-        alias: "deepseek-v4-flash-0731"
-      - name: "deepseek-v3.2"
-        alias: "deepseek-v3.2"
-      - name: "kimi-k2.7-code"
-        alias: "kimi-k2.7-code"
-      - name: "kimi-k2.6"
-        alias: "kimi-k2.6"
-      - name: "kimi-k2.5"
-        alias: "kimi-k2.5"
-      - name: "glm-5.2"
-        alias: "glm-5.2"
-      - name: "glm-5.1"
-        alias: "glm-5.1"
-      - name: "glm-5"
-        alias: "glm-5"
-      - name: "MiniMax-M2.5"
-        alias: "MiniMax-M2.5"
+      - name: "__QWEN__"
+        alias: "__QWEN__"
+      - name: "__DEEPSEEK_PRO__"
+        alias: "__DEEPSEEK_PRO__"
+      - name: "__DEEPSEEK_FLASH_0731__"
+        alias: "__DEEPSEEK_FLASH__"
   - name: "opencode"
+    priority: 300
     base-url: "https://opencode.ai/zen/go/v1"
     api-key-entries:
       - api-key: "__OPENCODE_API_KEY__"

--- a/scripts/llm-update.sh
+++ b/scripts/llm-update.sh
@@ -81,6 +81,7 @@ done <<<"$model_rows"
 # Provider-specific upstream slugs that intentionally differ from the canonical
 # alias stored in models.json.
 add_model_override "gpt-image" "openrouter" "openai/gpt-5.4-image-2"
+add_model_override "deepseek-flash" "0731" "deepseek-v4-flash-0731"
 
 # Template → output pairs
 declare -A TEMPLATES=(

--- a/spec/cliproxyapi_spec.sh
+++ b/spec/cliproxyapi_spec.sh
@@ -231,14 +231,25 @@ End
 End
 
 Describe 'Alibaba Cloud Token Plan provider'
+It 'hydrates the dedicated environment key into the runtime config'
+When run bash -c "grep 's|__ALIYUN_TOKEN_PLAN_API_KEY__|.*ALIYUN_TOKEN_PLAN_API_KEY' '$SCRIPT'"
+The output should include '__ALIYUN_TOKEN_PLAN_API_KEY__'
+The output should include 'ALIYUN_TOKEN_PLAN_API_KEY'
+The status should be success
+End
+
 It 'declares a dedicated prefixed upstream and secret placeholder'
 When run bash -c "sed -n '/name: \"aliyun\"/,/name: \"opencode\"/p' '$PWD/config/cliproxyapi/config.template.yaml'"
 The output should include 'prefix: "aliyun"'
 The output should include 'base-url: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"'
 The output should include 'api-key: "__ALIYUN_TOKEN_PLAN_API_KEY__"'
-The output should include 'name: "qwen3.8-max"'
+The output should include 'priority: 200'
+The output should include 'name: "qwen3.6-plus"'
 The output should include 'name: "deepseek-v4-pro"'
-The output should include 'name: "glm-5.2"'
+The output should include 'name: "deepseek-v4-flash-0731"'
+The output should include 'alias: "deepseek-v4-flash"'
+The output should not include 'name: "qwen3.8-max"'
+The output should not include 'name: "glm-5.2"'
 The status should be success
 End
 End

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -122,6 +122,21 @@ It 'routes DeepSeek presets through OpenRouter with OpenCode Go fallbacks in Cli
 When run bash -c "sed -n '/name: \"openrouter\"/,/name: \"z-ai\"/p' config/cliproxyapi/config.template.yaml | grep -q 'name: \"@preset/deepseek-v4-pro\"' && sed -n '/name: \"openrouter\"/,/name: \"z-ai\"/p' config/cliproxyapi/config.template.yaml | grep -q 'name: \"@preset/deepseek-v4-flash\"' && sed -n '/name: \"opencode\"/,/name: \"openai\"/p' config/cliproxyapi/config.template.yaml | grep -q 'name: \"deepseek-v4-pro\"' && sed -n '/name: \"opencode\"/,/name: \"openai\"/p' config/cliproxyapi/config.template.yaml | grep -q 'name: \"deepseek-v4-flash\"'"
 The status should be success
 End
+
+It 'hydrates the versioned Aliyun DeepSeek model behind the canonical alias'
+When run bash -c "section=\$(sed -n '/name: \"aliyun\"/,/name: \"opencode\"/p' config/cliproxyapi/config.template.yaml); printf '%s\n' \"\$section\" | grep -q 'name: \"deepseek-v4-flash-0731\"' && printf '%s\n' \"\$section\" | grep -q 'alias: \"deepseek-v4-flash\"'"
+The status should be success
+End
+
+It 'orders DeepSeek providers as OpenCode then Aliyun then OpenRouter'
+When run bash -c "grep -A 2 'name: \"opencode\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 300' && grep -A 2 'name: \"aliyun\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 200' && grep -A 2 'name: \"openrouter\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 100'"
+The status should be success
+End
+
+It 'only exposes CLIProxy model aliases selected in models.json'
+When run bash -c "allowed=\$(jq -r '.[]' models.json); while IFS= read -r alias; do printf '%s\n' \"\$allowed\" | grep -Fxq \"\$alias\" || { echo \"unexpected alias: \$alias\"; exit 1; }; done < <(sed -n 's/^[[:space:]]*alias: \"\\(.*\\)\"/\\1/p' config/cliproxyapi/config.template.yaml)"
+The status should be success
+End
 End
 
 Describe 'Codex subagent defaults'
@@ -190,6 +205,8 @@ When run bash -c "grep 'add_model_override' '$SCRIPT'"
 The output should include 'add_model_override'
 The output should include 'gpt-image'
 The output should include 'openrouter'
+The output should include 'deepseek-flash'
+The output should include '0731'
 End
 End
 


### PR DESCRIPTION
## Summary
- route `deepseek-v4-flash` to Aliyun's exact `deepseek-v4-flash-0731` upstream model
- enforce OpenCode → Aliyun → OpenRouter with explicit `fill-first` priorities
- remove CLIProxy aliases not selected by `models.json` and add a ShellSpec allowlist guard
- keep model generation declarative with `__DEEPSEEK_FLASH_0731__` and verify env-key hydration

## Validation
- `shellspec spec/llm_update_spec.sh spec/cliproxyapi_spec.sh` (83 examples, 0 failures)
- `make shell-test` (exit 0; FishTape 454/454)
- `shellcheck scripts/llm-update.sh spec/llm_update_spec.sh spec/cliproxyapi_spec.sh`
- YAML parse, Nix parse, and `git diff --check`
- live direct curl confirmed `deepseek-v4-flash-0731` returns HTTP 200 from Aliyun

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces priority routing for DeepSeek in CLIProxy: OpenCode → Aliyun → OpenRouter, and pins `deepseek-v4-flash` to Aliyun’s versioned `deepseek-v4-flash-0731`. Cleans up unused aliases and adds tests to ensure only allowed models are exposed.

- **Bug Fixes**
  - Set explicit provider priorities: OpenCode (300) → Aliyun (200) → OpenRouter (100) with fill-first behavior.
  - Route `deepseek-v4-flash` to Aliyun `deepseek-v4-flash-0731`; added override in `scripts/llm-update.sh`.
  - Removed unselected CLIProxy aliases and added a ShellSpec allowlist gate tied to `models.json`.
  - Added tests for Aliyun env key hydration, DeepSeek alias mapping, and priority ordering.

<sup>Written for commit 10808fddd67c2e572a7b588b46f3c186e84c7ddc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

