### PR TITLE
fix(neovim): fetch Treesitter parser revisions reliably

### DIFF
--- a/home-manager/programs/neovim/lua/config/plugins.lua
+++ b/home-manager/programs/neovim/lua/config/plugins.lua
@@ -71,7 +71,11 @@ vim.pack.add({
 		src = "https://github.com/nvim-treesitter/nvim-treesitter",
 		version = "main",
 	},
-	{ src = "https://github.com/romus204/tree-sitter-manager.nvim" },
+	{
+		-- Raw commit installs fail on Git 2.49+ until upstream PR #199 lands.
+		src = "https://github.com/shunkakinoki/tree-sitter-manager.nvim",
+		version = "fix/revision-sha-fetch",
+	},
 	{ src = "https://github.com/lukas-reineke/indent-blankline.nvim" },
 	{ src = "https://github.com/wansmer/treesj" },
 	{ src = "https://github.com/windwp/nvim-autopairs" },

--- a/home-manager/programs/neovim/nvim-pack-lock.json
+++ b/home-manager/programs/neovim/nvim-pack-lock.json
@@ -222,6 +222,11 @@
       "rev": "9a88eae817ef395952e08650b3283726786fb5fb",
       "src": "https://github.com/akinsho/toggleterm.nvim"
     },
+    "tree-sitter-manager.nvim": {
+      "rev": "6e5f2e7e13e7367fe7c4f83340d25832a7842fe6",
+      "src": "https://github.com/shunkakinoki/tree-sitter-manager.nvim",
+      "version": "'fix/revision-sha-fetch'"
+    },
     "treesj": {
       "rev": "4770492244ccecdc9b01e0e81fa8f2f6b4a23841",
       "src": "https://github.com/wansmer/treesj"

--- a/home-manager/programs/neovim/tests/treesitter_spec.lua
+++ b/home-manager/programs/neovim/tests/treesitter_spec.lua
@@ -2,6 +2,19 @@
 -- Tests treesitter configuration
 
 describe("treesitter", function()
+	describe("manager revision installer", function()
+		it("pins the raw commit fetch fix", function()
+			local source = debug.getinfo(1, "S").source:sub(2)
+			local nvim_dir = vim.fn.fnamemodify(source, ":p:h:h")
+			local lockfile = table.concat(vim.fn.readfile(nvim_dir .. "/nvim-pack-lock.json"), "\n")
+			local manager = vim.json.decode(lockfile).plugins["tree-sitter-manager.nvim"]
+
+			assert.are.equal("6e5f2e7e13e7367fe7c4f83340d25832a7842fe6", manager.rev)
+			assert.are.equal("https://github.com/shunkakinoki/tree-sitter-manager.nvim", manager.src)
+			assert.are.equal("'fix/revision-sha-fetch'", manager.version)
+		end)
+	end)
+
 	describe("configured parsers", function()
 		local configured = require("config.treesitter_parsers")
 		local available = require("nvim-treesitter").get_available()


### PR DESCRIPTION
## Summary

- pin `tree-sitter-manager.nvim` to the raw-commit fetch fix from upstream PR #199
- add the previously missing vim.pack lock entry for the manager
- cover the pinned source, branch, and exact revision in the Neovim suite

## Root cause

Kyber uses Git 2.54. The manager selects `git clone --revision=<sha>` on Git 2.49+, but GitHub does not resolve these non-tip parser commit IDs as advertised remote revisions. The same SHA succeeds through `git fetch --depth=1 origin <sha>`.

## Validation

- upstream `make test_git` (8 cases, 0 failures)
- `make neovim-test`
- isolated Neovim/Git 2.54 install of JSON revision `001c28d7a29832b06b0e831ec77845553c89b56d`
- `stylua --check` for changed Lua files
- `jq empty home-manager/programs/neovim/nvim-pack-lock.json`

## Upstream

- https://github.com/romus204/tree-sitter-manager.nvim/pull/199

Closes `shunkakinokisoftware-4gjj`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unreliable Treesitter parser revision installs on Git 2.49+ by pinning `tree-sitter-manager.nvim` to a fetch-by-SHA branch and locking its exact revision. Meets the issue requirement for reliable parser installs across environments (closes `shunkakinokisoftware-4gjj`).

- **Bug Fixes**
  - Pin `tree-sitter-manager.nvim` to `shunkakinoki/tree-sitter-manager.nvim` at `fix/revision-sha-fetch` to use `git fetch --depth=1 origin <sha>` instead of `git clone --revision=<sha>`.
  - Add the missing lockfile entry with exact `rev`, `src`, and `version`.
  - Add tests to assert the pinned source, branch, and revision.

- **Validation**
  - Upstream `make test_git` passes (8 cases).
  - `make neovim-test` passes; verified JSON parser SHA install on Git 2.54.
  - Formatting and lock checks: `stylua --check`, `jq` on nvim-pack-lock.json.

<sup>Written for commit 801ce5be07bb2825c99d3d4e5eaa60f6c9b71688. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

