### PR TITLE
perf(hermes): optimize config for reliability, cost, security

### DIFF
--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -163,7 +163,7 @@ auxiliary:
     timeout: 30
     extra_body: {}
 display:
-  compact: false
+  compact: true
   personality: kawaii
   resume_display: full
   busy_input_mode: interrupt
@@ -231,7 +231,7 @@ human_delay:
   min_ms: 800
   max_ms: 2500
 context:
-  engine: compressor
+  engine: summary
 memory:
   memory_enabled: true
   user_profile_enabled: true
@@ -239,8 +239,8 @@ memory:
   user_char_limit: 1375
   provider: ''
 delegation:
-  model: ''
-  provider: ''
+  model: cliproxy/deepseek-v4-flash
+  provider: cliproxy
   base_url: ''
   api_key: ''
   inherit_mcp_toolsets: true
@@ -278,7 +278,7 @@ mattermost:
 approvals:
   mode: manual
   timeout: 60
-  cron_mode: deny
+  cron_mode: allow
 command_allowlist: []
 quick_commands: {}
 hooks: {}
@@ -286,11 +286,11 @@ hooks_auto_accept: false
 personalities: {}
 security:
   allow_private_urls: false
-  redact_secrets: false
+  redact_secrets: true
   tirith_enabled: true
   tirith_path: tirith
   tirith_timeout: 5
-  tirith_fail_open: true
+  tirith_fail_open: false
   website_blocklist:
     enabled: false
     domains: []
@@ -319,7 +319,7 @@ sessions:
 onboarding:
   seen: {}
 updates:
-  pre_update_backup: false
+  pre_update_backup: true
   backup_keep: 5
 _config_version: 22
 custom_providers:

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -163,7 +163,7 @@ auxiliary:
     timeout: 30
     extra_body: {}
 display:
-  compact: false
+  compact: true
   personality: kawaii
   resume_display: full
   busy_input_mode: interrupt
@@ -231,7 +231,7 @@ human_delay:
   min_ms: 800
   max_ms: 2500
 context:
-  engine: compressor
+  engine: summary
 memory:
   memory_enabled: true
   user_profile_enabled: true
@@ -239,8 +239,8 @@ memory:
   user_char_limit: 1375
   provider: ''
 delegation:
-  model: ''
-  provider: ''
+  model: cliproxy/__DEEPSEEK_FLASH__
+  provider: cliproxy
   base_url: ''
   api_key: ''
   inherit_mcp_toolsets: true
@@ -278,7 +278,7 @@ mattermost:
 approvals:
   mode: manual
   timeout: 60
-  cron_mode: deny
+  cron_mode: allow
 command_allowlist: []
 quick_commands: {}
 hooks: {}
@@ -286,11 +286,11 @@ hooks_auto_accept: false
 personalities: {}
 security:
   allow_private_urls: false
-  redact_secrets: false
+  redact_secrets: true
   tirith_enabled: true
   tirith_path: tirith
   tirith_timeout: 5
-  tirith_fail_open: true
+  tirith_fail_open: false
   website_blocklist:
     enabled: false
     domains: []
@@ -319,7 +319,7 @@ sessions:
 onboarding:
   seen: {}
 updates:
-  pre_update_backup: false
+  pre_update_backup: true
   backup_keep: 5
 _config_version: 22
 custom_providers:


### PR DESCRIPTION
## Changes

7 config optimizations for production Hermes:

| Setting | Before | After | Why |
|---|---|---|---|
| approvals.cron_mode | deny | allow | Cron jobs need tool approvals |
| context.engine | compressor | summary | Cheaper for long sessions |
| delegation.model | '' | cliproxy/deepseek-v4-flash | Cheaper subagents |
| delegation.provider | '' | cliproxy | Provider for subagents |
| display.compact | false | true | Shorter messages on Telegram |
| security.redact_secrets | false | true | Prevent API key leaks in logs |
| security.tirith_fail_open | true | false | Block suspicious commands by default |
| updates.pre_update_backup | false | true | Backup before Hermes updates |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize Hermes production config for lower cost, safer defaults, and smoother ops. Switches context engine and subagent settings, tightens security, enables cron approvals, compact display, and pre-update backups; applies the same changes to `config.tpl.yaml`.

- **Refactors**
  - Cost: Switch `context.engine` to summary; delegate to `cliproxy/deepseek-v4-flash` via `cliproxy`.
  - Security: Enable secret redaction; set `tirith_fail_open` to false to block suspicious commands.
  - Reliability: Enable `updates.pre_update_backup`.
  - Approvals: Allow cron jobs to request tool approvals.
  - UX: Enable compact display for shorter messages.
  - Parity: Mirror these settings in `config.tpl.yaml`.

<sup>Written for commit 6ceb316df1e367f99bc662b8d92c39ba75507731. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

