### PR TITLE
fix(omp): route DeepSeek Flash through local CLIProxy

### DIFF
--- a/config/omp/activate.sh
+++ b/config/omp/activate.sh
@@ -4,7 +4,19 @@
 set -euo pipefail
 CONFIG_YML="$1"
 
+BUN_GLOBAL_EXTENSION="${BUN_INSTALL:-$HOME/.bun}/install/global/node_modules/@oh-my-pi/swarm-extension"
+LOCAL_EXTENSION="$HOME/dotfiles/node_modules/@oh-my-pi/swarm-extension"
+if [[ -d "$BUN_GLOBAL_EXTENSION" ]]; then
+  SWARM_EXTENSION="$BUN_GLOBAL_EXTENSION"
+elif [[ -d "$LOCAL_EXTENSION" ]]; then
+  SWARM_EXTENSION="$LOCAL_EXTENSION"
+else
+  echo "ERROR: @oh-my-pi/swarm-extension is not installed" >&2
+  echo "Install it globally or run the dotfiles dependency bootstrap, then retry Home Manager activation." >&2
+  exit 1
+fi
+
 mkdir -p ~/.omp/agent ~/.omp/agent/extensions
 cp -f "$CONFIG_YML" ~/.omp/agent/config.yml
 chmod 644 ~/.omp/agent/config.yml
-ln -sfn "$HOME/dotfiles/node_modules/@oh-my-pi/swarm-extension" ~/.omp/agent/extensions/swarm-extension
+ln -sfn "$SWARM_EXTENSION" ~/.omp/agent/extensions/swarm-extension

--- a/config/omp/config.tpl.yml
+++ b/config/omp/config.tpl.yml
@@ -64,7 +64,7 @@ disabledExtensions: []
 #   slow:    openai-codex/__GPT_CODEX__:high
 modelRoles:
   # Default model role used as the fallback when no other role is selected.
-  default: "opencode-zen/__DEEPSEEK_FLASH__"
+  default: "cliproxyapi/__DEEPSEEK_FLASH__"
   # Smaller / dumber model for cheap lightweight work.
   smol: "openai-codex/__GPT_LUNA__"
   # Strongest model in the suite for hard tasks.

--- a/config/omp/config.yml
+++ b/config/omp/config.yml
@@ -64,7 +64,7 @@ disabledExtensions: []
 #   slow:    openai-codex/gpt-5.3-codex:high
 modelRoles:
   # Default model role used as the fallback when no other role is selected.
-  default: "opencode-zen/deepseek-v4-flash"
+  default: "cliproxyapi/deepseek-v4-flash"
   # Smaller / dumber model for cheap lightweight work.
   smol: "openai-codex/gpt-5.6-luna"
   # Strongest model in the suite for hard tasks.

--- a/config/omp/default.nix
+++ b/config/omp/default.nix
@@ -11,6 +11,11 @@
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${./config.yml}"
   '';
 
+  home.file.".omp/agent/models.yml" = {
+    source = ./models.yml;
+    force = true;
+  };
+
   home.file.".omp/agent/hooks/post/moshi-hooks.ts" = {
     source = ./moshi-hooks.ts;
     force = true;

--- a/config/omp/default.nix
+++ b/config/omp/default.nix
@@ -6,7 +6,7 @@
 }:
 {
   # Use activation script instead of home.file symlink.
-  # Keep only the tracked config.yml in dotfiles and leave runtime state untouched.
+  # Keep the generated config files in dotfiles and leave runtime state untouched.
   home.activation.ompConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${./config.yml}"
   '';

--- a/config/omp/models.tpl.yml
+++ b/config/omp/models.tpl.yml
@@ -4,8 +4,8 @@ providers:
     api: openai-completions
     auth: none
     models:
-      - id: deepseek-v4-flash
-        name: Deepseek V4 Flash (local CLIProxyAPI)
+      - id: __DEEPSEEK_FLASH__
+        name: __DEEPSEEK_FLASH_PRETTY__ (local CLIProxyAPI)
         reasoning: true
         input:
           - text

--- a/config/omp/models.yml
+++ b/config/omp/models.yml
@@ -1,0 +1,19 @@
+providers:
+  cliproxyapi:
+    baseUrl: http://127.0.0.1:8317/v1
+    api: openai-completions
+    auth: none
+    models:
+      - id: deepseek-v4-flash
+        name: DeepSeek V4 Flash (local CLIProxyAPI)
+        reasoning: true
+        input:
+          - text
+        supportsTools: true
+        contextWindow: 1000000
+        maxTokens: 384000
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0

--- a/scripts/llm-update.sh
+++ b/scripts/llm-update.sh
@@ -100,6 +100,7 @@ declare -A TEMPLATES=(
   ["config/factory/settings.tpl.json"]=config/factory/settings.json
   ["config/hermes/config.tpl.yaml"]=config/hermes/config.template.yaml
   ["config/omp/config.tpl.yml"]=config/omp/config.yml
+  ["config/omp/models.tpl.yml"]=config/omp/models.yml
   ["config/pi/models.tpl.json"]=config/pi/models.json
   ["config/pi/settings.tpl.json"]=config/pi/settings.json
   ["home-manager/programs/fish/functions/_coxe_function.tpl.fish"]=home-manager/programs/fish/functions/_coxe_function.fish

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -109,8 +109,13 @@ The status should be success
 End
 
 It 'generates the OMP Flash default role'
-When run bash -c "grep 'default: \"opencode-zen/deepseek-v4-flash\"' config/omp/config.yml"
-The output should include 'opencode-zen/deepseek-v4-flash'
+When run bash -c "grep 'default: \"cliproxyapi/deepseek-v4-flash\"' config/omp/config.yml"
+The output should include 'cliproxyapi/deepseek-v4-flash'
+End
+
+It 'configures the OMP local CLIProxyAPI DeepSeek Flash provider'
+When run bash -c "grep -q 'baseUrl: http://127.0.0.1:8317/v1' config/omp/models.yml && grep -q 'id: deepseek-v4-flash' config/omp/models.yml"
+The status should be success
 End
 
 It 'generates the DeepSeek Go routes in CliProxy'

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -72,6 +72,11 @@ The output should include '_ocxe_function.tpl.fish'
 The output should include '_pixe_function.tpl.fish'
 The output should include '_pixel_function.tpl.fish'
 End
+
+It 'includes OMP model registry in template mappings'
+When run bash -c "grep 'config/omp/models.tpl.yml' '$SCRIPT'"
+The output should include 'config/omp/models.tpl.yml'
+End
 End
 
 Describe 'generated fish wrapper outputs'
@@ -113,8 +118,13 @@ When run bash -c "grep 'default: \"cliproxyapi/deepseek-v4-flash\"' config/omp/c
 The output should include 'cliproxyapi/deepseek-v4-flash'
 End
 
-It 'configures the OMP local CLIProxyAPI DeepSeek Flash provider'
-When run bash -c "grep -q 'baseUrl: http://127.0.0.1:8317/v1' config/omp/models.yml && grep -q 'id: deepseek-v4-flash' config/omp/models.yml"
+It 'keeps the OMP model registry placeholder in the template'
+When run bash -c "grep 'id: __DEEPSEEK_FLASH__' config/omp/models.tpl.yml"
+The output should include '__DEEPSEEK_FLASH__'
+End
+
+It 'hydrates the OMP local CLIProxyAPI DeepSeek Flash provider'
+When run bash -c "grep -q 'baseUrl: http://127.0.0.1:8317/v1' config/omp/models.yml && grep -q 'id: deepseek-v4-flash' config/omp/models.yml && ! grep -q '__DEEPSEEK_FLASH__' config/omp/models.yml"
 The status should be success
 End
 


### PR DESCRIPTION
Routes OMP DeepSeek Flash through the local CLIProxyAPI provider. The OMP model registry now follows the repository hydration pattern: config/omp/models.tpl.yml uses models.json placeholders and scripts/llm-update.sh generates config/omp/models.yml. The swarm extension resolves from Bun's global install when project-local node_modules is absent. Validation: shellspec spec/activate_config_spec.sh spec/llm_update_spec.sh — 129 examples, 0 failures; Nix parse and shell syntax checks pass. Live Matic discovery lists cliproxyapi/deepseek-v4-flash. Upstream completion still requires OpenCode Flash opt-in and a valid CLIProxy backend credential.