### PR TITLE
fix(hermes): register cliproxy as a proper provider

### DIFF
--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -1,6 +1,10 @@
 model:
   default: cliproxy/deepseek-v4-flash
-providers: {}
+providers:
+  cliproxy:
+    base_url: https://cliproxy.shunkakinoki.com/v1
+    api_key: __CLIPROXY_API_KEY__
+    api_mode: chat_completions
 fallback_providers:
   - provider: cliproxy
     model: deepseek-v4-pro

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -1,6 +1,10 @@
 model:
   default: cliproxy/__DEEPSEEK_FLASH__
-providers: {}
+providers:
+  cliproxy:
+    base_url: https://cliproxy.shunkakinoki.com/v1
+    api_key: __CLIPROXY_API_KEY__
+    api_mode: chat_completions
 fallback_providers:
   - provider: cliproxy
     model: __DEEPSEEK_PRO__


### PR DESCRIPTION
## Problem

The Hermes config had `providers: {}` which means no inference providers registered. The `custom_providers` section at the bottom of the config doesn't register providers for model routing. Every request failed with:

```
Primary provider auth failed: No inference provider configured.
```

This caused every request to fall back from `deepseek-v4-flash` to `deepseek-v4-pro`, wasting tokens.

## Fix

Changed `providers: {}` to a proper cliproxy provider definition:

```yaml
providers:
  cliproxy:
    base_url: https://cliproxy.shunkakinoki.com/v1
    api_key: __CLIPROXY_API_KEY__
    api_mode: chat_completions
```

## After merge

Re-hydrate config and restart gateway. deepseek-v4-flash should work as the primary model.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers cliproxy as an inference provider in Hermes so the default deepseek-v4-flash model works without falling back to pro. Fixes “No inference provider configured” errors and stops token waste.

- **Bug Fixes**
  - Replaced `providers: {}` with a proper `cliproxy` provider (base_url, `__CLIPROXY_API_KEY__`, `api_mode: chat_completions`) in both Hermes config templates.
  - Primary model now authenticates via cliproxy; fallback to deepseek-v4-pro only if needed.

- **Migration**
  - Re-hydrate the Hermes config and restart the gateway.
  - Ensure `__CLIPROXY_API_KEY__` is set.

<sup>Written for commit 94b2b516e9e0b76316a32f0c028abd21c436fe18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

