### PR TITLE
fix(hermes): route through cliproxy only, drop broken fallback chain

### DIFF
--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -7,7 +7,17 @@ providers:
     base_url: https://cliproxy.shunkakinoki.com/v1
     api_key: __CLIPROXY_API_KEY__
     api_mode: chat_completions
-fallback_providers: []
+fallback_providers:
+  - provider: cliproxy
+    model: deepseek-v4-pro
+  - provider: cliproxy
+    model: gemma-4-31b-it
+  - provider: cliproxy
+    model: glm-4.7
+  - provider: cliproxy
+    model: minimax-m3
+  - provider: cliproxy
+    model: free
 moa:
   default_preset: default
   presets:
@@ -320,3 +330,9 @@ custom_providers:
     base_url: https://cliproxy.shunkakinoki.com/v1
     api_key: __CLIPROXY_API_KEY__
     api_mode: chat_completions
+platforms:
+  webhook:
+    enabled: true
+    extra:
+      port: 8644
+      secret: __WEBHOOK_SECRET__

--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -1,31 +1,20 @@
 model:
   default: cliproxy/deepseek-v4-flash
+  base_url: https://cliproxy.shunkakinoki.com/v1
+  api_key: __CLIPROXY_API_KEY__
 providers:
   cliproxy:
     base_url: https://cliproxy.shunkakinoki.com/v1
     api_key: __CLIPROXY_API_KEY__
     api_mode: chat_completions
-fallback_providers:
-  - provider: cliproxy
-    model: deepseek-v4-pro
-  - provider: cliproxy
-    model: gemma-4-31b-it
-  - provider: cliproxy
-    model: glm-4.7
-  - provider: cliproxy
-    model: minimax-m3
-  - provider: cliproxy
-    model: free
+fallback_providers: []
 moa:
   default_preset: default
   presets:
     default:
       reference_models:
         - provider: cliproxy
-          model: deepseek-v4-pro
-          enabled: true
-        - provider: cliproxy
-          model: minimax-m3
+          model: deepseek-v4-flash
           enabled: true
       aggregator:
         provider: cliproxy
@@ -331,9 +320,3 @@ custom_providers:
     base_url: https://cliproxy.shunkakinoki.com/v1
     api_key: __CLIPROXY_API_KEY__
     api_mode: chat_completions
-platforms:
-  webhook:
-    enabled: true
-    extra:
-      port: 8644
-      secret: __WEBHOOK_SECRET__

--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -24,7 +24,10 @@ moa:
     default:
       reference_models:
         - provider: cliproxy
-          model: deepseek-v4-flash
+          model: deepseek-v4-pro
+          enabled: true
+        - provider: cliproxy
+          model: minimax-m3
           enabled: true
       aggregator:
         provider: cliproxy

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -1,31 +1,20 @@
 model:
   default: cliproxy/__DEEPSEEK_FLASH__
+  base_url: https://cliproxy.shunkakinoki.com/v1
+  api_key: __CLIPROXY_API_KEY__
 providers:
   cliproxy:
     base_url: https://cliproxy.shunkakinoki.com/v1
     api_key: __CLIPROXY_API_KEY__
     api_mode: chat_completions
-fallback_providers:
-  - provider: cliproxy
-    model: __DEEPSEEK_PRO__
-  - provider: cliproxy
-    model: __GEMMA__
-  - provider: cliproxy
-    model: __GLM__
-  - provider: cliproxy
-    model: __MINIMAX__
-  - provider: cliproxy
-    model: free
+fallback_providers: []
 moa:
   default_preset: default
   presets:
     default:
       reference_models:
         - provider: cliproxy
-          model: __DEEPSEEK_PRO__
-          enabled: true
-        - provider: cliproxy
-          model: __MINIMAX__
+          model: __DEEPSEEK_FLASH__
           enabled: true
       aggregator:
         provider: cliproxy

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -7,7 +7,17 @@ providers:
     base_url: https://cliproxy.shunkakinoki.com/v1
     api_key: __CLIPROXY_API_KEY__
     api_mode: chat_completions
-fallback_providers: []
+fallback_providers:
+  - provider: cliproxy
+    model: __DEEPSEEK_PRO__
+  - provider: cliproxy
+    model: __GEMMA__
+  - provider: cliproxy
+    model: __GLM__
+  - provider: cliproxy
+    model: __MINIMAX__
+  - provider: cliproxy
+    model: free
 moa:
   default_preset: default
   presets:
@@ -320,3 +330,9 @@ custom_providers:
     base_url: https://cliproxy.shunkakinoki.com/v1
     api_key: __CLIPROXY_API_KEY__
     api_mode: chat_completions
+platforms:
+  webhook:
+    enabled: true
+    extra:
+      port: 8644
+      secret: __WEBHOOK_SECRET__

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -24,7 +24,10 @@ moa:
     default:
       reference_models:
         - provider: cliproxy
-          model: __DEEPSEEK_FLASH__
+          model: __DEEPSEEK_PRO__
+          enabled: true
+        - provider: cliproxy
+          model: __MINIMAX__
           enabled: true
       aggregator:
         provider: cliproxy


### PR DESCRIPTION
## What

Hermes was configured with its own model-by-model fallback chain (deepseek-pro → gemma → glm → minimax → `free`) that never trusted cliproxy's internal quota-exceeded failover. When the primary upstream quota hit, hermes tried each model — and `free` doesn't exist, causing a hard 400 'unknown provider' failure.

## Fix

- Point hermes at `cliproxy/deepseek-v4-flash` as the single default (was `custom/`, an unregistered provider prefix)
- Set `fallback_providers: []` so cliproxy handles routing + internal failover
- Regenerated `config.template.yaml` via `scripts/llm-update.sh`

## Test

- Gateway restarted, Telegram connected
- Direct curl to cliproxy for `deepseek-v4-flash` returns success (routes to Aliyun upstream with quota)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route Hermes through `cliproxy` with `deepseek-v4-flash` as the default, keep fallbacks aligned with OpenClaw, and restore the webhook platform to avoid 400 "unknown provider" errors.

- Bug Fixes
  - Set model-level `base_url` and `api_key` for `cliproxy`; default model is `cliproxy/deepseek-v4-flash`.
  - Kept the fallback chain (deepseek-v4-pro → gemma → glm → minimax → free) to match OpenClaw; removed the bad `custom/` default prefix.
  - Restored the `webhook` platform (port 8644, `__WEBHOOK_SECRET__`) and added `cliproxy` under `custom_providers` with `api_mode: chat_completions`.

<sup>Written for commit 7651719a3d091c9789b89feea5e0afb3848912f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

