### PR TITLE
fix(cliproxyapi): recover OpenRouter fallbacks

### DIFF
--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -97,6 +97,8 @@ openai-compatibility:
         alias: "deepseek-v4-flash"
       - name: "@preset/deepseek-v4-pro"
         alias: "deepseek-v4-pro"
+      - name: "openrouter/free"
+        alias: "free"
   - name: "z-ai"
     base-url: "https://api.z.ai/api/coding/paas/v4"
     api-key-entries:

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -97,6 +97,8 @@ openai-compatibility:
         alias: "__DEEPSEEK_FLASH__"
       - name: "@preset/__DEEPSEEK_PRO_NONDOT__"
         alias: "__DEEPSEEK_PRO__"
+      - name: "openrouter/free"
+        alias: "free"
   - name: "z-ai"
     base-url: "https://api.z.ai/api/coding/paas/v4"
     api-key-entries:

--- a/config/omp/activate.sh
+++ b/config/omp/activate.sh
@@ -6,9 +6,9 @@ CONFIG_YML="$1"
 
 BUN_GLOBAL_EXTENSION="${BUN_INSTALL:-$HOME/.bun}/install/global/node_modules/@oh-my-pi/swarm-extension"
 LOCAL_EXTENSION="$HOME/dotfiles/node_modules/@oh-my-pi/swarm-extension"
-if [[ -d "$BUN_GLOBAL_EXTENSION" ]]; then
+if [[ -d $BUN_GLOBAL_EXTENSION ]]; then
   SWARM_EXTENSION="$BUN_GLOBAL_EXTENSION"
-elif [[ -d "$LOCAL_EXTENSION" ]]; then
+elif [[ -d $LOCAL_EXTENSION ]]; then
   SWARM_EXTENSION="$LOCAL_EXTENSION"
 else
   echo "ERROR: @oh-my-pi/swarm-extension is not installed" >&2

--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -173,6 +173,9 @@ in
         "docker.service"
       ];
       Wants = [ "docker.service" ];
+      X-Restart-Triggers = [
+        "${config.home.file.".cli-proxy-api/config.template.yaml".source}"
+      ];
     };
     Service = {
       Type = "simple";

--- a/spec/cliproxyapi_spec.sh
+++ b/spec/cliproxyapi_spec.sh
@@ -254,6 +254,22 @@ The status should be success
 End
 End
 
+Describe 'OpenRouter fallback routing'
+It 'maps the free router to OpenClaw canonical model alias'
+When run bash -c "sed -n '/name: \"openrouter\"/,/name: \"z-ai\"/p' '$PWD/config/cliproxyapi/config.template.yaml'"
+The output should include 'name: "openrouter/free"'
+The output should include 'alias: "free"'
+The status should be success
+End
+
+It 'restarts the Linux service when the managed template changes'
+When run bash -c "sed -n '/systemd.user.services.cliproxyapi =/,/systemd.user.paths.cliproxyapi-backup =/p' '$PWD/home-manager/services/cliproxyapi/default.nix'"
+The output should include 'X-Restart-Triggers'
+The output should include 'config.home.file.".cli-proxy-api/config.template.yaml".source'
+The status should be success
+End
+End
+
 Describe 'OpenCode API key pool'
 setup_opencode_pool() {
   TEMP_POOL=$(mktemp -d)

--- a/spec/hermes_hydrate_spec.sh
+++ b/spec/hermes_hydrate_spec.sh
@@ -167,7 +167,7 @@ End
 
 Describe 'declarative model routing'
 It 'uses the OpenClaw primary and CLIProxy-only fallback chain'
-When run bash -c "sed -n '1,18p' '$PWD/config/hermes/config.template.yaml'"
+When run bash -c "sed -n '1,22p' '$PWD/config/hermes/config.template.yaml'"
 The output should include 'default: cliproxy/deepseek-v4-flash'
 The output should include 'provider: cliproxy'
 The output should include 'model: deepseek-v4-pro'

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -138,6 +138,11 @@ When run bash -c "sed -n '/name: \"openrouter\"/,/name: \"z-ai\"/p' config/clipr
 The status should be success
 End
 
+It 'maps the OpenRouter free router to the canonical alias'
+When run bash -c "section=\$(sed -n '/name: \"openrouter\"/,/name: \"z-ai\"/p' config/cliproxyapi/config.template.yaml); printf '%s\n' \"\$section\" | grep -q 'name: \"openrouter/free\"' && printf '%s\n' \"\$section\" | grep -q 'alias: \"free\"'"
+The status should be success
+End
+
 It 'hydrates the versioned Aliyun DeepSeek model behind the canonical alias'
 When run bash -c "section=\$(sed -n '/name: \"aliyun\"/,/name: \"opencode\"/p' config/cliproxyapi/config.template.yaml); printf '%s\n' \"\$section\" | grep -q 'name: \"deepseek-v4-flash-0731\"' && printf '%s\n' \"\$section\" | grep -q 'alias: \"deepseek-v4-flash\"'"
 The status should be success
@@ -148,8 +153,8 @@ When run bash -c "grep -A 2 'name: \"opencode\"' config/cliproxyapi/config.templ
 The status should be success
 End
 
-It 'only exposes CLIProxy model aliases selected in models.json'
-When run bash -c "allowed=\$(jq -r '.[]' models.json); while IFS= read -r alias; do printf '%s\n' \"\$allowed\" | grep -Fxq \"\$alias\" || { echo \"unexpected alias: \$alias\"; exit 1; }; done < <(sed -n 's/^[[:space:]]*alias: \"\\(.*\\)\"/\\1/p' config/cliproxyapi/config.template.yaml)"
+It 'only exposes selected model aliases plus the reserved free router alias'
+When run bash -c "allowed=\$(jq -r '.[]' models.json); while IFS= read -r alias; do [ \"\$alias\" = free ] || printf '%s\n' \"\$allowed\" | grep -Fxq \"\$alias\" || { echo \"unexpected alias: \$alias\"; exit 1; }; done < <(sed -n 's/^[[:space:]]*alias: \"\\(.*\\)\"/\\1/p' config/cliproxyapi/config.template.yaml)"
 The status should be success
 End
 End


### PR DESCRIPTION
## Summary

- map OpenRouter's free router to the `free` CLIProxy alias used by OpenClaw
- restart the Kyber CLIProxy user service when its managed template changes, clearing stale provider suspensions and rendering current configuration
- cover the free route, restart trigger, generated alias policy, and full Hermes fallback assertion

## Validation

- `make shell-test` — 2,043 ShellSpec examples and 454 Fish checks passed
- focused CLIProxy/LLM/Hermes suite — 117 examples passed
- `make nix-format-check`
- `nix-instantiate --parse home-manager/services/cliproxyapi/default.nix`
- evaluated `homeConfigurations.kyber` restart trigger to the managed template store path
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores OpenRouter fallback behavior by mapping `openrouter/free` to the canonical `free` alias and restarting the `cliproxyapi` user service when the managed template changes. Also applies minor formatting in `config/omp/activate.sh`; this fixes Hermes fallback and clears stale provider suspensions after config updates.

- **Bug Fixes**
  - Map `openrouter/free` to the `free` CLIProxy alias used by `OpenClaw`.
  - Add systemd `X-Restart-Triggers` for `config.template.yaml` to restart the `cliproxyapi` user service on changes.
  - Extend tests to cover the free route mapping, alias policy (allow `free` plus selected aliases), and the full Hermes fallback chain.

<sup>Written for commit de4b11d956f0e168a09f47f23cdd3bd3874fabfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

