### PR TITLE
fix(hermes): add model.provider to prevent fallback to pro

### DIFF
--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -1,5 +1,6 @@
 model:
   default: cliproxy/deepseek-v4-flash
+  provider: cliproxy
   base_url: https://cliproxy.shunkakinoki.com/v1
   api_key: __CLIPROXY_API_KEY__
 providers:

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -1,5 +1,6 @@
 model:
   default: cliproxy/__DEEPSEEK_FLASH__
+  provider: cliproxy
   base_url: https://cliproxy.shunkakinoki.com/v1
   api_key: __CLIPROXY_API_KEY__
 providers:


### PR DESCRIPTION
## Root Cause

`model.default: cliproxy/deepseek-v4-flash` has a provider prefix, but `model.provider` was not set. Hermes auto-detection checks `model.provider` — not the prefix in `model.default` — so every request hit:

```
Primary provider auth failed: No inference provider configured.
Runtime provider supplied explicit model override: cliproxy/deepseek-v4-flash -> deepseek-v4-pro
```

## Fix

Added `provider: cliproxy` to the model section. This lets Hermes discover the provider without falling back.

## After merge

Re-hydrate config and restart gateway.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `model.provider: cliproxy` in Hermes config so `cliproxy/deepseek-v4-flash` is correctly selected without falling back to `deepseek-v4-pro`. Fixes auth errors from missing provider detection.

- **Migration**
  - Rehydrate config and restart the gateway.

<sup>Written for commit 15d274ddcc717ce18057c2ed90bfcbbd2d4aceec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

