### PR TITLE
perf(hermes): improve prompt cache hit rate

### DIFF
--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -98,7 +98,7 @@ compression:
   target_ratio: 0.2
   protect_last_n: 20
 prompt_caching:
-  cache_ttl: 5m
+  cache_ttl: 15m
 bedrock:
   region: ''
   discovery:
@@ -238,7 +238,7 @@ human_delay:
   min_ms: 800
   max_ms: 2500
 context:
-  engine: summary
+  engine: compressor
 memory:
   memory_enabled: true
   user_profile_enabled: true

--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -98,7 +98,7 @@ compression:
   target_ratio: 0.2
   protect_last_n: 20
 prompt_caching:
-  cache_ttl: 15m
+  cache_ttl: 30m
 bedrock:
   region: ''
   discovery:

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -98,7 +98,7 @@ compression:
   target_ratio: 0.2
   protect_last_n: 20
 prompt_caching:
-  cache_ttl: 5m
+  cache_ttl: 15m
 bedrock:
   region: ''
   discovery:
@@ -238,7 +238,7 @@ human_delay:
   min_ms: 800
   max_ms: 2500
 context:
-  engine: summary
+  engine: compressor
 memory:
   memory_enabled: true
   user_profile_enabled: true

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -98,7 +98,7 @@ compression:
   target_ratio: 0.2
   protect_last_n: 20
 prompt_caching:
-  cache_ttl: 15m
+  cache_ttl: 30m
 bedrock:
   region: ''
   discovery:


### PR DESCRIPTION
## Problem

Prompt cache hit rate is low, wasting tokens on every turn.

## Root Cause

Two cache-breakers in the config:

1. **context.engine: summary** — Summary mode injects new summary messages into the conversation prefix after compression. This changes the prefix, invalidating the prompt cache on every compression cycle. Reverted to **compressor** mode, which truncates old messages in-place without changing the prefix — cache-safe.

2. **prompt_caching.cache_ttl: 5m** — Provider-side cache TTL was at minimum. Cache expired every 5 minutes even in active conversations. Bumped to **15m** (3x longer).

## Changes

| Setting | Before | After | Why |
|---|---|---|---|
| context.engine | summary | compressor | Summary breaks cache prefix; compressor preserves it |
| prompt_caching.cache_ttl | 5m | 15m | 3x longer cache lifetime |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Hermes prompt cache hit rate by stabilizing the conversation prefix and extending provider cache lifetime to 30m. This reduces token spend and lowers latency in active chats.

- **Performance**
  - Set context.engine from summary to compressor to keep the prefix stable and cache-safe.
  - Increased prompt_caching.cache_ttl from 5m to 30m to keep active sessions warm longer.

<sup>Written for commit 113187dc3713b4a83e158257e9449f9f0590165d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

