### PR TITLE
fix(hermes): set provider to openrouter to enable prompt caching

### DIFF
--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -98,7 +98,7 @@ compression:
   target_ratio: 0.2
   protect_last_n: 20
 prompt_caching:
-  cache_ttl: 5m
+  cache_ttl: 15m
 bedrock:
   region: ''
   discovery:
@@ -238,7 +238,7 @@ human_delay:
   min_ms: 800
   max_ms: 2500
 context:
-  engine: summary
+  engine: compressor
 memory:
   memory_enabled: true
   user_profile_enabled: true

--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -1,6 +1,6 @@
 model:
   default: cliproxy/deepseek-v4-flash
-  provider: cliproxy
+  provider: openrouter
   base_url: https://cliproxy.shunkakinoki.com/v1
   api_key: __CLIPROXY_API_KEY__
 providers:

--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -98,7 +98,7 @@ compression:
   target_ratio: 0.2
   protect_last_n: 20
 prompt_caching:
-  cache_ttl: 15m
+  cache_ttl: 30m
 bedrock:
   region: ''
   discovery:

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -98,7 +98,7 @@ compression:
   target_ratio: 0.2
   protect_last_n: 20
 prompt_caching:
-  cache_ttl: 5m
+  cache_ttl: 15m
 bedrock:
   region: ''
   discovery:
@@ -238,7 +238,7 @@ human_delay:
   min_ms: 800
   max_ms: 2500
 context:
-  engine: summary
+  engine: compressor
 memory:
   memory_enabled: true
   user_profile_enabled: true

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -1,6 +1,6 @@
 model:
   default: cliproxy/__DEEPSEEK_FLASH__
-  provider: cliproxy
+  provider: openrouter
   base_url: https://cliproxy.shunkakinoki.com/v1
   api_key: __CLIPROXY_API_KEY__
 providers:

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -98,7 +98,7 @@ compression:
   target_ratio: 0.2
   protect_last_n: 20
 prompt_caching:
-  cache_ttl: 15m
+  cache_ttl: 30m
 bedrock:
   region: ''
   discovery:


### PR DESCRIPTION
## Problem

`model.provider: cliproxy` returns `(False, False)` from Hermes'
`anthropic_prompt_cache_policy()`. Zero `cache_control` headers sent to
the API. Prompt cache hit rate is virtually 0% because cliproxy is
unrecognized as a caching-capable provider.

## Root Cause

The cache policy in `agent/agent_runtime_helpers.py` only enables
caching for recognized providers (OpenRouter, Anthropic, OpenCode,
Alibaba, MiniMax, Nous Portal). `cliproxy` is a transparent proxy
that routes to OpenRouter — but Hermes doesn't know that.

## Fix

Set `model.provider: openrouter` — the actual upstream provider.
Keep `base_url: https://cliproxy.shunkakinoki.com/v1` for routing.
This tells the cache policy the truth while preserving the cliproxy
proxy path.

## Known Gap

The cache policy still excludes DeepSeek models on OpenRouter (only
Claude/Kimi get cache markers). Upstream Hermes issue needed to add
DeepSeek to the OpenRouter cache policy branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Hermes prompt caching by setting `model.provider` to `openrouter` while still routing through the cliproxy `base_url`. This boosts cache hit rate and keeps prompts cache-safe.

- **Bug Fixes**
  - Set `model.provider: openrouter` (kept `base_url: https://cliproxy.shunkakinoki.com/v1`) so the cache policy sends cache headers.
  - Increased `prompt_caching.cache_ttl` from `5m` to `30m` for longer reuse.
  - Reverted `context.engine` from `summary` to `compressor` to avoid prompt mutations that break caching.

<sup>Written for commit 8cec5c046f7814f888ea42aee27375df4da741df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

