### PR TITLE
perf(llm): improve DeepSeek cache affinity

### DIFF
--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -31,6 +31,8 @@ request-retry: 3
 # Routing strategy: "round-robin" (default) or "fill-first" (tries first matching provider)
 routing:
   strategy: "fill-first"
+  session-affinity: true
+  session-affinity-ttl: "1h"
 # Quota exceeded behavior
 quota-exceeded:
   switch-project: true # Whether to automatically switch to another project when a quota is exceeded

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -31,6 +31,8 @@ request-retry: 3
 # Routing strategy: "round-robin" (default) or "fill-first" (tries first matching provider)
 routing:
   strategy: "fill-first"
+  session-affinity: true
+  session-affinity-ttl: "1h"
 # Quota exceeded behavior
 quota-exceeded:
   switch-project: true # Whether to automatically switch to another project when a quota is exceeded

--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -1,6 +1,6 @@
 model:
   default: cliproxy/deepseek-v4-flash
-  provider: openrouter
+  provider: cliproxy
   base_url: https://cliproxy.shunkakinoki.com/v1
   api_key: __CLIPROXY_API_KEY__
 providers:
@@ -8,6 +8,7 @@ providers:
     base_url: https://cliproxy.shunkakinoki.com/v1
     api_key: __CLIPROXY_API_KEY__
     api_mode: chat_completions
+    supports_prompt_cache_key: true
 fallback_providers:
   - provider: cliproxy
     model: deepseek-v4-pro
@@ -334,6 +335,7 @@ custom_providers:
     base_url: https://cliproxy.shunkakinoki.com/v1
     api_key: __CLIPROXY_API_KEY__
     api_mode: chat_completions
+    supports_prompt_cache_key: true
 platforms:
   webhook:
     enabled: true

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -1,6 +1,6 @@
 model:
   default: cliproxy/__DEEPSEEK_FLASH__
-  provider: openrouter
+  provider: cliproxy
   base_url: https://cliproxy.shunkakinoki.com/v1
   api_key: __CLIPROXY_API_KEY__
 providers:
@@ -8,6 +8,7 @@ providers:
     base_url: https://cliproxy.shunkakinoki.com/v1
     api_key: __CLIPROXY_API_KEY__
     api_mode: chat_completions
+    supports_prompt_cache_key: true
 fallback_providers:
   - provider: cliproxy
     model: __DEEPSEEK_PRO__
@@ -334,6 +335,7 @@ custom_providers:
     base_url: https://cliproxy.shunkakinoki.com/v1
     api_key: __CLIPROXY_API_KEY__
     api_mode: chat_completions
+    supports_prompt_cache_key: true
 platforms:
   webhook:
     enabled: true

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -183,7 +183,10 @@
               "cacheWrite": 0
             },
             "contextWindow": 1000000,
-            "maxTokens": 384000
+            "maxTokens": 384000,
+            "compat": {
+              "supportsPromptCacheKey": true
+            }
           },
           {
             "id": "deepseek-v4-flash",
@@ -199,7 +202,10 @@
               "cacheWrite": 0
             },
             "contextWindow": 1000000,
-            "maxTokens": 384000
+            "maxTokens": 384000,
+            "compat": {
+              "supportsPromptCacheKey": true
+            }
           },
           {
             "id": "free",

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -183,7 +183,10 @@
               "cacheWrite": 0
             },
             "contextWindow": 1000000,
-            "maxTokens": 384000
+            "maxTokens": 384000,
+            "compat": {
+              "supportsPromptCacheKey": true
+            }
           },
           {
             "id": "__DEEPSEEK_FLASH__",
@@ -199,7 +202,10 @@
               "cacheWrite": 0
             },
             "contextWindow": 1000000,
-            "maxTokens": 384000
+            "maxTokens": 384000,
+            "compat": {
+              "supportsPromptCacheKey": true
+            }
           },
           {
             "id": "free",

--- a/spec/cliproxyapi_spec.sh
+++ b/spec/cliproxyapi_spec.sh
@@ -255,6 +255,13 @@ End
 End
 
 Describe 'OpenRouter fallback routing'
+It 'keeps provider selection sticky for one hour per client session'
+When run bash -c "sed -n '/^routing:/,/^[a-z]/p' '$PWD/config/cliproxyapi/config.template.yaml'"
+The output should include 'session-affinity: true'
+The output should include 'session-affinity-ttl: "1h"'
+The status should be success
+End
+
 It 'maps the free router to OpenClaw canonical model alias'
 When run bash -c "sed -n '/name: \"openrouter\"/,/name: \"z-ai\"/p' '$PWD/config/cliproxyapi/config.template.yaml'"
 The output should include 'name: "openrouter/free"'

--- a/spec/hermes_hydrate_spec.sh
+++ b/spec/hermes_hydrate_spec.sh
@@ -177,6 +177,12 @@ The output should include 'model: minimax-m3'
 The output should include 'model: free'
 End
 
+It 'opts both CLIProxy config schemas into stable prompt cache keys'
+When run rg -c '^    supports_prompt_cache_key: true$' "$PWD/config/hermes/config.template.yaml"
+The output should equal '2'
+The status should be success
+End
+
 It 'does not configure OpenRouter or Mixture-of-Agents presets'
 When run bash -c "! rg -q 'openrouter|@preset/' '$PWD/config/hermes/config.template.yaml'"
 The status should be success

--- a/spec/openclaw_hydrate_spec.sh
+++ b/spec/openclaw_hydrate_spec.sh
@@ -17,7 +17,13 @@ template_uses_cliproxy_flash_default() {
       ]
     } and
     (.models.providers.cliproxy.models | any(.id == "deepseek-v4-pro")) and
-    (.models.providers.cliproxy.models | any(.id == "deepseek-v4-flash"))
+    (.models.providers.cliproxy.models | any(.id == "deepseek-v4-flash")) and
+    (.models.providers.cliproxy.models | all(
+      if (.id == "deepseek-v4-pro" or .id == "deepseek-v4-flash")
+      then .compat.supportsPromptCacheKey == true
+      else .compat.supportsPromptCacheKey? != true
+      end
+    ))
   ' "$PWD/config/openclaw/openclaw.template.json" >/dev/null
 }
 


### PR DESCRIPTION
## Summary

- keep CLIProxy provider selection sticky per client session for one hour
- enable OpenClaw prompt cache keys for the DeepSeek Pro and Flash model entries only
- opt both Hermes CLIProxy config schemas into prompt cache keys and make CLIProxy the declared primary provider
- keep the CLIProxy container on the existing `:latest` update policy

Hermes support is proposed upstream in NousResearch/hermes-agent#83214.

## Testing

- `shellspec spec/llm_update_spec.sh spec/cliproxyapi_spec.sh spec/openclaw_hydrate_spec.sh spec/hermes_hydrate_spec.sh` (146 examples)
- JSON validation for both OpenClaw templates
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves DeepSeek cache hit rate and routing stability. Adds 1-hour session affinity in CLIProxy and enables prompt cache keys for DeepSeek Pro/Flash in OpenClaw and Hermes.

- New Features
  - Added session affinity in `config/cliproxyapi` (`session-affinity: true`, TTL `1h`) to keep the selected provider sticky per client session.
  - Enabled prompt cache keys only for DeepSeek Pro and Flash in `config/openclaw` (`"compat.supportsPromptCacheKey": true`).
  - Made CLIProxy the primary provider in Hermes and set `supports_prompt_cache_key: true` in both Hermes config schemas.
  - Updated specs to validate session affinity and cache-key settings.

<sup>Written for commit 2ae23e17db3db6a848c0dfc6d36f151e4a5c9e3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

