### PR TITLE
perf(llm): enable OpenCode prompt cache keys

### DIFF
--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -21,7 +21,8 @@
       "name": "CLIProxyAPI (remote)",
       "options": {
         "baseURL": "https://cliproxy.shunkakinoki.com/v1",
-        "apiKey": "{env:CLIPROXY_API_KEY}"
+        "apiKey": "{env:CLIPROXY_API_KEY}",
+        "setCacheKey": true
       },
       "models": {
         "claude-opus-5": {
@@ -76,7 +77,8 @@
       "name": "CLIProxyAPI (local)",
       "options": {
         "baseURL": "http://localhost:8317/v1",
-        "apiKey": "{env:CLIPROXY_API_KEY}"
+        "apiKey": "{env:CLIPROXY_API_KEY}",
+        "setCacheKey": true
       },
       "models": {
         "claude-opus-5": {

--- a/config/opencode/opencode.tpl.jsonc
+++ b/config/opencode/opencode.tpl.jsonc
@@ -21,7 +21,8 @@
       "name": "CLIProxyAPI (remote)",
       "options": {
         "baseURL": "https://cliproxy.shunkakinoki.com/v1",
-        "apiKey": "{env:CLIPROXY_API_KEY}"
+        "apiKey": "{env:CLIPROXY_API_KEY}",
+        "setCacheKey": true
       },
       "models": {
         "__CLAUDE_OPUS__": {
@@ -76,7 +77,8 @@
       "name": "CLIProxyAPI (local)",
       "options": {
         "baseURL": "http://localhost:8317/v1",
-        "apiKey": "{env:CLIPROXY_API_KEY}"
+        "apiKey": "{env:CLIPROXY_API_KEY}",
+        "setCacheKey": true
       },
       "models": {
         "__CLAUDE_OPUS__": {

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -108,6 +108,11 @@ When run bash -c "grep '\"model\": \"shunkakinoki/deepseek-v4-flash\"' config/op
 The output should include 'shunkakinoki/deepseek-v4-flash'
 End
 
+It 'enables stable prompt cache keys for both CLIProxy providers'
+When run bash -c "sed -n '/\"shunkakinoki\"/,/\"cliproxyapi\"/p' config/opencode/opencode.jsonc | grep -q '\"setCacheKey\": true' && sed -n '/\"cliproxyapi\"/,/\"lmstudio\"/p' config/opencode/opencode.jsonc | grep -q '\"setCacheKey\": true'"
+The status should be success
+End
+
 It 'keeps the explicitly pinned Z-AI small model'
 When run bash -c "grep '\"small_model\": \"shunkakinoki/z-ai/glm-4.7\"' config/opencode/opencode.jsonc"
 The output should include 'shunkakinoki/z-ai/glm-4.7'


### PR DESCRIPTION
## Summary

- enable OpenCode `setCacheKey` for both remote and local CLIProxy providers
- regenerate the checked-in OpenCode config
- add regression coverage for both provider blocks

## Validation

- `shellspec spec/llm_update_spec.sh` — 80 examples, 0 failures
- `git diff --check`
- `make build` reached Nix evaluation but was stopped after sustained shared `/nix/var/nix/db/db.sqlite` contention; no configuration error was reported


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable stable prompt cache keys in OpenCode for both remote and local `CLIProxyAPI` providers to improve cache hits and reduce latency. Regenerated the checked-in config and added a regression spec to ensure `setCacheKey` stays enabled.

<sup>Written for commit 4b84c2adc19299e3bfe827563beb73974ede821a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

