### PR TITLE
fix(opencode): materialize configured plugins on activation

### DIFF
--- a/config/opencode/activate.sh
+++ b/config/opencode/activate.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OPENCODE_BIN="${1:-opencode}"
+JQ_BIN="${2:-jq}"
+CACHE_ROOT="${XDG_CACHE_HOME:-${HOME}/.cache}/opencode/packages"
+
+if [[ ! -x $OPENCODE_BIN ]]; then
+  echo "ERROR: OpenCode executable not found: ${OPENCODE_BIN}" >&2
+  exit 1
+fi
+
+if [[ ! -x $JQ_BIN ]]; then
+  echo "ERROR: jq executable not found: ${JQ_BIN}" >&2
+  exit 1
+fi
+
+if ! effective_config="$($OPENCODE_BIN debug config)"; then
+  echo "ERROR: failed to resolve effective OpenCode config" >&2
+  exit 1
+fi
+
+if ! plugin_spec_lines="$({
+  printf '%s\n' "$effective_config" | "$JQ_BIN" -r '
+    .plugin[]? |
+    select(type == "string") |
+    select(
+      (startswith("file://") or
+       startswith("./") or
+       startswith("../") or
+       startswith("/") or
+       startswith("-")) | not
+    )
+  '
+})"; then
+  echo "ERROR: failed to read npm plugins from effective OpenCode config" >&2
+  exit 1
+fi
+
+plugin_specs=()
+if [[ -n $plugin_spec_lines ]]; then
+  mapfile -t plugin_specs <<<"$plugin_spec_lines"
+fi
+
+install_plugin() {
+  local plugin_spec="$1"
+  local package_name cache_spec plugin_manifest
+
+  case "$plugin_spec" in
+  @*/*@*)
+    package_name="${plugin_spec%@*}"
+    cache_spec="$plugin_spec"
+    ;;
+  @*/*)
+    package_name="$plugin_spec"
+    cache_spec="${plugin_spec}@latest"
+    ;;
+  *@*)
+    package_name="${plugin_spec%@*}"
+    cache_spec="$plugin_spec"
+    ;;
+  *)
+    package_name="$plugin_spec"
+    cache_spec="${plugin_spec}@latest"
+    ;;
+  esac
+
+  plugin_manifest="${CACHE_ROOT}/${cache_spec}/node_modules/${package_name}/package.json"
+
+  if [[ -f $plugin_manifest ]]; then
+    echo "OpenCode plugin already ready: ${plugin_spec}"
+    return
+  fi
+
+  "$OPENCODE_BIN" plugin "$plugin_spec" --global
+
+  if [[ ! -f $plugin_manifest ]]; then
+    echo "ERROR: OpenCode did not materialize ${plugin_spec} at ${plugin_manifest}" >&2
+    exit 1
+  fi
+
+  echo "OpenCode plugin ready: ${plugin_spec}"
+}
+
+for plugin_spec in "${plugin_specs[@]}"; do
+  install_plugin "$plugin_spec"
+done

--- a/config/opencode/default.nix
+++ b/config/opencode/default.nix
@@ -1,4 +1,9 @@
-_: {
+{
+  config,
+  pkgs,
+  ...
+}:
+{
   home.file.".config/opencode/opencode.jsonc" = {
     source = ./opencode.jsonc;
     force = true;
@@ -23,4 +28,8 @@ _: {
     source = ./moshi-hooks.ts;
     force = true;
   };
+
+  home.activation.installOpenCodePlugins = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${pkgs.opencode}/bin/opencode" "${pkgs.jq}/bin/jq"
+  '';
 }

--- a/config/opencode/opencode-fallback.jsonc
+++ b/config/opencode/opencode-fallback.jsonc
@@ -1,6 +1,7 @@
 {
   "enabled": true,
   "retry_on_errors": [401, 404, 429, 500, 502, 503, 504],
+  "retryable_error_patterns": ["unknown provider for model"],
   "max_fallback_attempts": 5,
   "cooldown_seconds": 60,
   "timeout_seconds": 30,

--- a/config/opencode/opencode-fallback.tpl.jsonc
+++ b/config/opencode/opencode-fallback.tpl.jsonc
@@ -1,6 +1,7 @@
 {
   "enabled": true,
   "retry_on_errors": [401, 404, 429, 500, 502, 503, 504],
+  "retryable_error_patterns": ["unknown provider for model"],
   "max_fallback_attempts": 5,
   "cooldown_seconds": 60,
   "timeout_seconds": 30,

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "model": "shunkakinoki/deepseek-v4-flash",
-  "small_model": "shunkakinoki/z-ai/glm-4.7",
+  "small_model": "shunkakinoki/glm-4.7",
   "autoupdate": true,
   "agent": {
     "code-reviewer": {

--- a/config/opencode/opencode.tpl.jsonc
+++ b/config/opencode/opencode.tpl.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "model": "shunkakinoki/__DEEPSEEK_FLASH__",
-  "small_model": "shunkakinoki/z-ai/__GLM__",
+  "small_model": "shunkakinoki/__GLM__",
   "autoupdate": true,
   "agent": {
     "code-reviewer": {

--- a/spec/activate_opencode_spec.sh
+++ b/spec/activate_opencode_spec.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329,SC2034,SC2016
+
+Describe 'config/opencode/activate.sh'
+SCRIPT="$PWD/config/opencode/activate.sh"
+PLUGIN_SPECS=(
+  'cc-safety-net'
+  'opencode-atuin-history'
+  'opencode-claude-hooks'
+  'opencode-runtime-fallback@0.2.3'
+)
+
+setup() {
+  TEMP_HOME=$(mktemp -d)
+  FAKE_OPENCODE="$TEMP_HOME/opencode"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'set -euo pipefail' \
+    'if [[ $1 == debug && $2 == config ]]; then' \
+    '  [[ ${FAIL_DEBUG:-0} != 1 ]] || exit 1' \
+    '  if [[ ${NO_NPM_PLUGINS:-0} == 1 ]]; then' \
+    '    printf '\''{"plugin":["file:///tmp/local-plugin.ts"]}\n'\''' \
+    '    exit 0' \
+    '  fi' \
+    '  printf '\''{"plugin":["cc-safety-net","opencode-atuin-history","opencode-claude-hooks","opencode-runtime-fallback@0.2.3","file:///tmp/local-plugin.ts"]}\n'\''' \
+    '  exit 0' \
+    'fi' \
+    'printf "%s\n" "$*" >>"$HOME/opencode-invocations"' \
+    'plugin_spec="$2"' \
+    'case "$plugin_spec" in *@*) plugin_package="${plugin_spec%@*}"; cache_spec="$plugin_spec" ;; *) plugin_package="$plugin_spec"; cache_spec="${plugin_spec}@latest" ;; esac' \
+    'manifest="$HOME/.cache/opencode/packages/$cache_spec/node_modules/$plugin_package/package.json"' \
+    'mkdir -p "$(dirname "$manifest")"' \
+    ': >"$manifest"' >"$FAKE_OPENCODE"
+  chmod +x "$FAKE_OPENCODE"
+}
+
+cleanup() {
+  rm -rf "$TEMP_HOME"
+}
+
+BeforeEach 'setup'
+AfterEach 'cleanup'
+
+It 'materializes every declared npm plugin'
+When run env HOME="$TEMP_HOME" bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)"
+The status should be success
+The output should include 'OpenCode plugin ready: cc-safety-net'
+The output should include 'OpenCode plugin ready: opencode-atuin-history'
+The output should include 'OpenCode plugin ready: opencode-claude-hooks'
+The output should include 'OpenCode plugin ready: opencode-runtime-fallback@0.2.3'
+The file "$TEMP_HOME/.cache/opencode/packages/cc-safety-net@latest/node_modules/cc-safety-net/package.json" should be exist
+The file "$TEMP_HOME/.cache/opencode/packages/opencode-atuin-history@latest/node_modules/opencode-atuin-history/package.json" should be exist
+The file "$TEMP_HOME/.cache/opencode/packages/opencode-claude-hooks@latest/node_modules/opencode-claude-hooks/package.json" should be exist
+The file "$TEMP_HOME/.cache/opencode/packages/opencode-runtime-fallback@0.2.3/node_modules/opencode-runtime-fallback/package.json" should be exist
+The contents of file "$TEMP_HOME/opencode-invocations" should include 'plugin cc-safety-net --global'
+The contents of file "$TEMP_HOME/opencode-invocations" should include 'plugin opencode-atuin-history --global'
+The contents of file "$TEMP_HOME/opencode-invocations" should include 'plugin opencode-claude-hooks --global'
+The contents of file "$TEMP_HOME/opencode-invocations" should include 'plugin opencode-runtime-fallback@0.2.3 --global'
+End
+
+It 'skips installation when every configured plugin is already ready'
+for plugin_spec in "${PLUGIN_SPECS[@]}"; do
+  case "$plugin_spec" in
+  *@*)
+    plugin_package="${plugin_spec%@*}"
+    cache_spec="$plugin_spec"
+    ;;
+  *)
+    plugin_package="$plugin_spec"
+    cache_spec="${plugin_spec}@latest"
+    ;;
+  esac
+  manifest="$TEMP_HOME/.cache/opencode/packages/$cache_spec/node_modules/$plugin_package/package.json"
+  mkdir -p "$(dirname "$manifest")"
+  : >"$manifest"
+done
+When run env HOME="$TEMP_HOME" bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)"
+The status should be success
+The output should include 'OpenCode plugin already ready: cc-safety-net'
+The output should include 'OpenCode plugin already ready: opencode-runtime-fallback@0.2.3'
+The file "$TEMP_HOME/opencode-invocations" should not be exist
+End
+
+It 'does not pass local file plugins to the package installer'
+When run env HOME="$TEMP_HOME" bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)"
+The status should be success
+The output should include 'OpenCode plugin ready: cc-safety-net'
+The contents of file "$TEMP_HOME/opencode-invocations" should not include 'local-plugin.ts'
+End
+
+It 'succeeds when there are no npm plugins to materialize'
+When run env HOME="$TEMP_HOME" NO_NPM_PLUGINS=1 bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)"
+The status should be success
+The output should equal ''
+The file "$TEMP_HOME/opencode-invocations" should not be exist
+End
+
+It 'fails closed when effective config cannot be resolved'
+When run env HOME="$TEMP_HOME" FAIL_DEBUG=1 bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)"
+The status should be failure
+The stderr should include 'failed to resolve effective OpenCode config'
+The file "$TEMP_HOME/opencode-invocations" should not be exist
+End
+End

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -497,6 +497,7 @@ config/noctalia/quit-all-apps.sh
 config/obsidian/activate.sh
 config/omp/activate.sh
 config/openclaw/hydrate.sh
+config/opencode/activate.sh
 config/roborev/hydrate.sh
 config/serena/activate.sh
 home-manager/activation/deploy-agenix-secret.sh

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -113,9 +113,9 @@ When run bash -c "sed -n '/\"shunkakinoki\"/,/\"cliproxyapi\"/p' config/opencode
 The status should be success
 End
 
-It 'keeps the explicitly pinned Z-AI small model'
-When run bash -c "grep '\"small_model\": \"shunkakinoki/z-ai/glm-4.7\"' config/opencode/opencode.jsonc"
-The output should include 'shunkakinoki/z-ai/glm-4.7'
+It 'uses the CLIProxy provider-fallback GLM alias for the small model'
+When run bash -c "grep '\"small_model\": \"shunkakinoki/glm-4.7\"' config/opencode/opencode.jsonc"
+The output should include 'shunkakinoki/glm-4.7'
 End
 
 It 'pins the audited OpenCode runtime fallback plugin release'
@@ -124,7 +124,7 @@ The status should be success
 End
 
 It 'generates a separate OpenCode fallback chain'
-When run bash -c "jq -e '.retry_on_errors == [401,404,429,500,502,503,504] and .max_fallback_attempts == 5 and .fallback_models == [\"shunkakinoki/deepseek-v4-pro\",\"shunkakinoki/gemma-4-31b-it\",\"shunkakinoki/glm-4.7\",\"shunkakinoki/minimax-m3\",\"shunkakinoki/free\"]' config/opencode/opencode-fallback.jsonc >/dev/null"
+When run bash -c "jq -e '.retry_on_errors == [401,404,429,500,502,503,504] and .retryable_error_patterns == [\"unknown provider for model\"] and .max_fallback_attempts == 5 and .fallback_models == [\"shunkakinoki/deepseek-v4-pro\",\"shunkakinoki/gemma-4-31b-it\",\"shunkakinoki/glm-4.7\",\"shunkakinoki/minimax-m3\",\"shunkakinoki/free\"]' config/opencode/opencode-fallback.jsonc >/dev/null"
 The status should be success
 End
 


### PR DESCRIPTION
## Summary

- materialize every npm plugin discovered from the effective OpenCode config during Home Manager activation
- keep plugin names and versions out of the activation installer; bare specs resolve unpinned while configured versions remain exact
- route the GLM small model through the CLIProxy alias and retry the CLIProxy `unknown provider for model` response
- cover installation, idempotency, local-plugin filtering, empty plugin lists, and config failures

## Validation

- `make format`
- `make nix-format-check`
- `shellcheck config/opencode/activate.sh spec/activate_opencode_spec.sh spec/llm_update_spec.sh`
- `shellspec spec/activate_opencode_spec.sh spec/llm_update_spec.sh spec/coverage_spec.sh` (192 examples, 0 failures on rebased head)
- `make shell-test` (2,056 ShellSpec examples and 454 Fish tests)
- `make build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install all configured OpenCode npm plugins during Home Manager activation to prevent missing-plugin errors. Also switch the small model to the `shunkakinoki/glm-4.7` alias and retry on CLIProxy “unknown provider for model” errors.

- **Bug Fixes**
  - Add activation script to materialize each non-local npm plugin from the effective config; idempotent via cache checks, installs pinned versions when specified and `@latest` otherwise.
  - Wire the script into `home.activation.installOpenCodePlugins` in `default.nix`.
  - Treat “unknown provider for model” as retryable in the fallback config.
  - Change `small_model` to `shunkakinoki/glm-4.7` (CLIProxy alias).
  - Add ShellSpec tests for install path, idempotency, local-plugin filtering, empty lists, and config failures.

<sup>Written for commit 53f4edf016028cb3be3a85a27be6cb642f1fe4c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

