### PR TITLE
fix(activation): unblock OpenCode and Claude setup

### DIFF
--- a/config/claude/activate.sh
+++ b/config/claude/activate.sh
@@ -6,7 +6,7 @@ SETTINGS_JSON="$1"
 
 mkdir -p ~/.claude
 _TMP=$(mktemp)
-jq --arg host "$(hostname)" '
+jq --arg host "${HOSTNAME:-unknown}" '
   . * (.hostOverrides[$host] // {})
   | del(.hostOverrides)
 ' "$SETTINGS_JSON" >"$_TMP"

--- a/config/opencode/activate.sh
+++ b/config/opencode/activate.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 OPENCODE_BIN="${1:-opencode}"
 JQ_BIN="${2:-jq}"
+BUN_BIN="${3:-bun}"
 CACHE_ROOT="${XDG_CACHE_HOME:-${HOME}/.cache}/opencode/packages"
 
 if [[ ! -x $OPENCODE_BIN ]]; then
@@ -12,6 +13,11 @@ fi
 
 if [[ ! -x $JQ_BIN ]]; then
   echo "ERROR: jq executable not found: ${JQ_BIN}" >&2
+  exit 1
+fi
+
+if [[ ! -x $BUN_BIN ]]; then
+  echo "ERROR: Bun executable not found: ${BUN_BIN}" >&2
   exit 1
 fi
 
@@ -44,7 +50,7 @@ fi
 
 install_plugin() {
   local plugin_spec="$1"
-  local package_name cache_spec plugin_manifest
+  local package_name cache_spec plugin_root plugin_manifest
 
   case "$plugin_spec" in
   @*/*@*)
@@ -65,17 +71,23 @@ install_plugin() {
     ;;
   esac
 
-  plugin_manifest="${CACHE_ROOT}/${cache_spec}/node_modules/${package_name}/package.json"
+  plugin_root="${CACHE_ROOT}/${cache_spec}"
+  plugin_manifest="${plugin_root}/node_modules/${package_name}/package.json"
 
   if [[ -f $plugin_manifest ]]; then
     echo "OpenCode plugin already ready: ${plugin_spec}"
     return
   fi
 
-  "$OPENCODE_BIN" plugin "$plugin_spec" --global
+  mkdir -p "$plugin_root"
+  "$BUN_BIN" add \
+    --cwd "$plugin_root" \
+    --exact \
+    --minimum-release-age 0 \
+    "$plugin_spec"
 
   if [[ ! -f $plugin_manifest ]]; then
-    echo "ERROR: OpenCode did not materialize ${plugin_spec} at ${plugin_manifest}" >&2
+    echo "ERROR: Bun did not materialize OpenCode plugin ${plugin_spec} at ${plugin_manifest}" >&2
     exit 1
   fi
 

--- a/config/opencode/default.nix
+++ b/config/opencode/default.nix
@@ -30,6 +30,6 @@
   };
 
   home.activation.installOpenCodePlugins = config.lib.dag.entryAfter [ "writeBoundary" ] ''
-    $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${pkgs.opencode}/bin/opencode" "${pkgs.jq}/bin/jq"
+    $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${pkgs.opencode}/bin/opencode" "${pkgs.jq}/bin/jq" "${pkgs.bun}/bin/bun"
   '';
 }

--- a/spec/activate_config_spec.sh
+++ b/spec/activate_config_spec.sh
@@ -274,6 +274,12 @@ It 'copies settings.json'
 When run bash -c "grep 'SETTINGS_JSON' '$SCRIPT'"
 The output should include 'SETTINGS_JSON'
 End
+
+It 'uses the Bash hostname without requiring the hostname executable'
+When run bash -c "grep 'HOSTNAME:-unknown' '$SCRIPT' && ! grep -q '\$(hostname)' '$SCRIPT'"
+The status should be success
+The output should include 'HOSTNAME:-unknown'
+End
 End
 
 Describe 'config/dcg/activate.sh'

--- a/spec/activate_opencode_spec.sh
+++ b/spec/activate_opencode_spec.sh
@@ -13,6 +13,7 @@ PLUGIN_SPECS=(
 setup() {
   TEMP_HOME=$(mktemp -d)
   FAKE_OPENCODE="$TEMP_HOME/opencode"
+  FAKE_BUN="$TEMP_HOME/bun"
   printf '%s\n' \
     '#!/usr/bin/env bash' \
     'set -euo pipefail' \
@@ -24,14 +25,20 @@ setup() {
     '  fi' \
     '  printf '\''{"plugin":["cc-safety-net","opencode-atuin-history","opencode-claude-hooks","opencode-runtime-fallback@0.2.3","file:///tmp/local-plugin.ts"]}\n'\''' \
     '  exit 0' \
-    'fi' \
-    'printf "%s\n" "$*" >>"$HOME/opencode-invocations"' \
-    'plugin_spec="$2"' \
-    'case "$plugin_spec" in *@*) plugin_package="${plugin_spec%@*}"; cache_spec="$plugin_spec" ;; *) plugin_package="$plugin_spec"; cache_spec="${plugin_spec}@latest" ;; esac' \
-    'manifest="$HOME/.cache/opencode/packages/$cache_spec/node_modules/$plugin_package/package.json"' \
-    'mkdir -p "$(dirname "$manifest")"' \
-    ': >"$manifest"' >"$FAKE_OPENCODE"
+    'fi' >"$FAKE_OPENCODE"
   chmod +x "$FAKE_OPENCODE"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'set -euo pipefail' \
+    'printf "%s\n" "$*" >>"$HOME/bun-invocations"' \
+    'plugin_root="$3"' \
+    'plugin_spec="$7"' \
+    '[[ ${FAIL_BUN_PLUGIN:-} != "$plugin_spec" ]] || exit 1' \
+    'case "$plugin_spec" in @*/*@*) plugin_package="${plugin_spec%@*}" ;; @*/*) plugin_package="$plugin_spec" ;; *@*) plugin_package="${plugin_spec%@*}" ;; *) plugin_package="$plugin_spec" ;; esac' \
+    'manifest="$plugin_root/node_modules/$plugin_package/package.json"' \
+    'mkdir -p "$(dirname "$manifest")"' \
+    ': >"$manifest"' >"$FAKE_BUN"
+  chmod +x "$FAKE_BUN"
 }
 
 cleanup() {
@@ -42,7 +49,7 @@ BeforeEach 'setup'
 AfterEach 'cleanup'
 
 It 'materializes every declared npm plugin'
-When run env HOME="$TEMP_HOME" bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)"
+When run env HOME="$TEMP_HOME" bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)" "$FAKE_BUN"
 The status should be success
 The output should include 'OpenCode plugin ready: cc-safety-net'
 The output should include 'OpenCode plugin ready: opencode-atuin-history'
@@ -52,10 +59,10 @@ The file "$TEMP_HOME/.cache/opencode/packages/cc-safety-net@latest/node_modules/
 The file "$TEMP_HOME/.cache/opencode/packages/opencode-atuin-history@latest/node_modules/opencode-atuin-history/package.json" should be exist
 The file "$TEMP_HOME/.cache/opencode/packages/opencode-claude-hooks@latest/node_modules/opencode-claude-hooks/package.json" should be exist
 The file "$TEMP_HOME/.cache/opencode/packages/opencode-runtime-fallback@0.2.3/node_modules/opencode-runtime-fallback/package.json" should be exist
-The contents of file "$TEMP_HOME/opencode-invocations" should include 'plugin cc-safety-net --global'
-The contents of file "$TEMP_HOME/opencode-invocations" should include 'plugin opencode-atuin-history --global'
-The contents of file "$TEMP_HOME/opencode-invocations" should include 'plugin opencode-claude-hooks --global'
-The contents of file "$TEMP_HOME/opencode-invocations" should include 'plugin opencode-runtime-fallback@0.2.3 --global'
+The contents of file "$TEMP_HOME/bun-invocations" should include '--exact --minimum-release-age 0 cc-safety-net'
+The contents of file "$TEMP_HOME/bun-invocations" should include '--exact --minimum-release-age 0 opencode-atuin-history'
+The contents of file "$TEMP_HOME/bun-invocations" should include '--exact --minimum-release-age 0 opencode-claude-hooks'
+The contents of file "$TEMP_HOME/bun-invocations" should include '--exact --minimum-release-age 0 opencode-runtime-fallback@0.2.3'
 End
 
 It 'skips installation when every configured plugin is already ready'
@@ -74,31 +81,38 @@ for plugin_spec in "${PLUGIN_SPECS[@]}"; do
   mkdir -p "$(dirname "$manifest")"
   : >"$manifest"
 done
-When run env HOME="$TEMP_HOME" bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)"
+When run env HOME="$TEMP_HOME" bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)" "$FAKE_BUN"
 The status should be success
 The output should include 'OpenCode plugin already ready: cc-safety-net'
 The output should include 'OpenCode plugin already ready: opencode-runtime-fallback@0.2.3'
-The file "$TEMP_HOME/opencode-invocations" should not be exist
+The file "$TEMP_HOME/bun-invocations" should not be exist
 End
 
 It 'does not pass local file plugins to the package installer'
-When run env HOME="$TEMP_HOME" bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)"
+When run env HOME="$TEMP_HOME" bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)" "$FAKE_BUN"
 The status should be success
 The output should include 'OpenCode plugin ready: cc-safety-net'
-The contents of file "$TEMP_HOME/opencode-invocations" should not include 'local-plugin.ts'
+The contents of file "$TEMP_HOME/bun-invocations" should not include 'local-plugin.ts'
 End
 
 It 'succeeds when there are no npm plugins to materialize'
-When run env HOME="$TEMP_HOME" NO_NPM_PLUGINS=1 bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)"
+When run env HOME="$TEMP_HOME" NO_NPM_PLUGINS=1 bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)" "$FAKE_BUN"
 The status should be success
 The output should equal ''
-The file "$TEMP_HOME/opencode-invocations" should not be exist
+The file "$TEMP_HOME/bun-invocations" should not be exist
 End
 
 It 'fails closed when effective config cannot be resolved'
-When run env HOME="$TEMP_HOME" FAIL_DEBUG=1 bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)"
+When run env HOME="$TEMP_HOME" FAIL_DEBUG=1 bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)" "$FAKE_BUN"
 The status should be failure
 The stderr should include 'failed to resolve effective OpenCode config'
-The file "$TEMP_HOME/opencode-invocations" should not be exist
+The file "$TEMP_HOME/bun-invocations" should not be exist
+End
+
+It 'fails closed when Bun cannot materialize a configured plugin'
+When run env HOME="$TEMP_HOME" FAIL_BUN_PLUGIN=opencode-atuin-history bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)" "$FAKE_BUN"
+The status should be failure
+The output should include 'OpenCode plugin ready: cc-safety-net'
+The file "$TEMP_HOME/.cache/opencode/packages/opencode-atuin-history@latest/node_modules/opencode-atuin-history/package.json" should not be exist
 End
 End


### PR DESCRIPTION
## Summary

- install every configured npm OpenCode plugin with packaged Bun and a scoped minimum-release-age override
- preserve generic config discovery, exact versions, idempotency, and fail-closed activation behavior
- remove the Claude activation dependency on the external hostname executable

## Root cause

Matic applies a seven-day Bun minimum release age. opencode-atuin-history 0.2.0 was newer than that policy, but OpenCode surfaced the blocked install as Unsupported engine. An isolated Matic check confirmed that Bun installs the same package when minimum-release-age is overridden only for this activation command.

## Validation

- make format
- make nix-format-check
- focused ShellCheck for the changed activation scripts and specs
- focused ShellSpec: 62 examples, 0 failures
- make shell-test: 2061 ShellSpec examples and 454 Fish tests, 0 failures
- make build: Galactica Darwin configuration built successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks OpenCode plugin activation and Claude setup by installing npm plugins with `bun` (exact versions, minimum-release-age 0) and switching Claude host overrides to Bash `$HOSTNAME`. Preserves config discovery, idempotency, and fail-closed behavior.

- **Bug Fixes**
  - OpenCode: install each declared npm plugin via `bun add --exact --minimum-release-age 0`, materialize under `~/.cache/opencode/packages`, and skip `file://` plugins.
  - Claude: replace `$(hostname)` with `${HOSTNAME:-unknown}` to remove the external hostname dependency.

- **Dependencies**
  - `bun` is now required for OpenCode plugin installation and is passed in from `default.nix` (`${pkgs.bun}/bin/bun`).

<sup>Written for commit 6eea58944b66a47ab34dec72e7db4f2502cc562f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

