### PR TITLE
perf(hermes): switch MoA reference model from pro to flash

### DIFF
--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -26,7 +26,7 @@ moa:
     default:
       reference_models:
         - provider: cliproxy
-          model: deepseek-v4-pro
+          model: deepseek-v4-flash
           enabled: true
         - provider: cliproxy
           model: minimax-m3

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -26,10 +26,10 @@ moa:
     default:
       reference_models:
         - provider: cliproxy
-          model: __DEEPSEEK_PRO__
+          model: __DEEPSEEK_FLASH__
           enabled: true
         - provider: cliproxy
-          model: __MINIMAX__
+          model: minimax-m3
           enabled: true
       aggregator:
         provider: cliproxy


### PR DESCRIPTION
MoA was configured with deepseek-v4-pro as the reference model,
firing 307 cross-validation queries in 8 hours while the aggregator
is already flash.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the MoA reference model from `deepseek-v4-pro` to `deepseek-v4-flash` to match the flash aggregator and stop unintended pro cross-validation traffic. This cuts pro requests (307 in the last 8h), reduces cost/latency, and pins the minimax reference to `minimax-m3` in the template.

<sup>Written for commit 5187281d4c3e0595d4ca9fa50884e2608c092c16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

