### PR TITLE
feat(packages): add prime-agent, t3code, t3code-desktop

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,31 +25,6 @@
         "type": "github"
       }
     },
-    "blueprint": {
-      "inputs": {
-        "nixpkgs": [
-          "llm-agents",
-          "nixpkgs"
-        ],
-        "systems": [
-          "llm-agents",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776249299,
-        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
-        "owner": "numtide",
-        "repo": "blueprint",
-        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "blueprint",
-        "type": "github"
-      }
-    },
     "bun2nix": {
       "inputs": {
         "flake-parts": "flake-parts_3",
@@ -96,11 +71,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782772816,
-        "narHash": "sha256-s9BuFv0mRuZx9C1MF8qPHRdcAK14ONi0A5m6E2wqOoM=",
+        "lastModified": 1784665499,
+        "narHash": "sha256-9BMxlTxCCDAeoNLtb1a/st7udtTIJep+wpUzquA29VU=",
         "owner": "nix-community",
         "repo": "bun2nix",
-        "rev": "5a39d717029e94163ac223aee8d5c9946cafed1c",
+        "rev": "0f2a1f0b6f42cebe3b149bf62d38754c5e0e9729",
         "type": "github"
       },
       "original": {
@@ -291,11 +266,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782949081,
-        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
         "type": "github"
       },
       "original": {
@@ -504,7 +479,6 @@
     },
     "llm-agents": {
       "inputs": {
-        "blueprint": "blueprint",
         "bun2nix": "bun2nix_2",
         "flake-parts": "flake-parts_4",
         "nixpkgs": [
@@ -514,11 +488,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1783416216,
-        "narHash": "sha256-vRBG4ldP7GisR3OAlvFk0GTjX2lrzrL+ZxSwUO69W6o=",
+        "lastModified": 1786432690,
+        "narHash": "sha256-ujFqZhEVqBJduStQdAHJG1JxbCqgREXWHPod5K9Lwro=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "23c2c2049b21ff57bc4c159ccb1e0eddb1d4238b",
+        "rev": "3e74f0043b38111e659173a141413a003a790972",
         "type": "github"
       },
       "original": {
@@ -981,11 +955,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780220602,
-        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "lastModified": 1785945821,
+        "narHash": "sha256-NLSyTCW4K4ofhNBllt3omPasm6QpralXH1DBZOc91Dw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "rev": "ae7910970dddc408fe6ab1c8e4b277bb21d72dc0",
         "type": "github"
       },
       "original": {

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -101,6 +101,7 @@ with pkgs;
   pingu
   pnpm
   postgresql_18
+  pkgs.llm-agents.prime-agent
   process-compose
   procs
   rclone
@@ -113,6 +114,7 @@ with pkgs;
   sops
   speedtest-cli
   sqlite
+  pkgs.llm-agents.t3code
   tealdeer
   termshark
   tig
@@ -244,6 +246,7 @@ with pkgs;
   slack
   slurp
   swappy
+  pkgs.llm-agents.t3code-desktop
   tectonic
   telegram-desktop
   totem

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -101,7 +101,6 @@ with pkgs;
   pingu
   pnpm
   postgresql_18
-  pkgs.llm-agents.prime-agent
   process-compose
   procs
   rclone
@@ -114,7 +113,6 @@ with pkgs;
   sops
   speedtest-cli
   sqlite
-  pkgs.llm-agents.t3code
   tealdeer
   termshark
   tig
@@ -138,6 +136,8 @@ with pkgs;
 # Heavy packages: skip on CI runners (disk pressure / LTO OOM on macos-latest).
 ++ lib.optionals (!isRunner) [
   pkgs.llm-agents.antigravity-cli
+  pkgs.llm-agents.prime-agent
+  pkgs.llm-agents.t3code
   vector
 ]
 ++ lib.optionals stdenv.isDarwin [

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -41,7 +41,7 @@
       '';
     });
   })
-  inputs.llm-agents.overlays.default
+  inputs.llm-agents.overlays.shared-nixpkgs
   (
     _: prev:
     {


### PR DESCRIPTION
## Summary
- Add `pkgs.llm-agents.prime-agent` and `pkgs.llm-agents.t3code` (CLI) to the cross-platform home-manager package list
- Add `pkgs.llm-agents.t3code-desktop` (GUI) to the Linux desktop package list, alongside `claude-desktop`

## Test plan
- [x] `nix flake check` (aarch64-darwin) passes
- [x] `nix fmt` produces no further diff on the changed file

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `pkgs.llm-agents.prime-agent` and `pkgs.llm-agents.t3code` to cross-platform Home Manager packages (skipped on CI runners), and `pkgs.llm-agents.t3code-desktop` to Linux desktop. Bump the `llm-agents.nix` input and switch overlay to `overlays.shared-nixpkgs` to fix attribute-missing eval errors and expose these packages.

<sup>Written for commit 76b7d1785a840ea50a722b5ed46a51d31a6b3f04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

