### PR TITLE
fix(networking): Use DHCP-provided DNS on macOS

### DIFF
--- a/nix-darwin/config/networking.nix
+++ b/nix-darwin/config/networking.nix
@@ -8,10 +8,6 @@
       enable = false;
       enableStealthMode = false;
     };
-    dns = [
-      "1.1.1.1"
-      "8.8.8.8"
-    ];
     knownNetworkServices = [
       "Wi-Fi"
       "Ethernet Adaptor"
@@ -21,7 +17,7 @@
 
   # Split DNS: route only Tailscale domains through Tailscale's DNS proxy.
   # Keep Tailscale from installing its transient DNS proxy as the global
-  # resolver; regular internet DNS stays on the Wi-Fi service below.
+  # resolver; regular internet DNS comes from the active network via DHCP.
   environment.etc = {
     "resolver/ts.net".text = ''
       nameserver 100.100.100.100


### PR DESCRIPTION
## Summary

- remove the global Cloudflare and Google DNS override on macOS
- use the active network's DHCP-provided resolver for regular internet DNS
- preserve the scoped `ts.net` resolver and `--accept-dns=false` Tailscale behavior

This lets captive portals use their local DNS during sign-in without changing tailnet name resolution.

## Validation

- `nix fmt -- nix-darwin/config/networking.nix`
- `nix-instantiate --parse nix-darwin/config/networking.nix`
- `make build`
- live Wi-Fi reports no statically configured DNS servers

## Known unrelated issue

`make nix-format-check` currently rewrites two CLIProxy YAML templates before failing its no-change guard. Those side effects were restored and are tracked separately as `shunkakinokisoftware-4ojx`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On macOS, stop forcing global public DNS and use the active network’s DHCP resolver instead (fixes `shunkakinokisoftware-1e1q`). Tailscale split DNS remains scoped to `ts.net` and `--accept-dns=false` behavior is unchanged.

<sup>Written for commit 62aa2c3f2b2e63358eb29588b516334d37f7e837. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

