### PR TITLE
fix(opencode): install plugins into config root for runtime resolution

### DIFF
--- a/config/opencode/activate.sh
+++ b/config/opencode/activate.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 OPENCODE_BIN="${1:-opencode}"
 JQ_BIN="${2:-jq}"
 BUN_BIN="${3:-bun}"
-CACHE_ROOT="${XDG_CACHE_HOME:-${HOME}/.cache}/opencode/packages"
+CONFIG_ROOT="${XDG_CONFIG_HOME:-${HOME}/.config}/opencode"
 
 if [[ ! -x $OPENCODE_BIN ]]; then
   echo "ERROR: OpenCode executable not found: ${OPENCODE_BIN}" >&2
@@ -50,38 +50,32 @@ fi
 
 install_plugin() {
   local plugin_spec="$1"
-  local package_name cache_spec plugin_root plugin_manifest
+  local package_name plugin_manifest
 
   case "$plugin_spec" in
   @*/*@*)
     package_name="${plugin_spec%@*}"
-    cache_spec="$plugin_spec"
     ;;
   @*/*)
     package_name="$plugin_spec"
-    cache_spec="${plugin_spec}@latest"
     ;;
   *@*)
     package_name="${plugin_spec%@*}"
-    cache_spec="$plugin_spec"
     ;;
   *)
     package_name="$plugin_spec"
-    cache_spec="${plugin_spec}@latest"
     ;;
   esac
 
-  plugin_root="${CACHE_ROOT}/${cache_spec}"
-  plugin_manifest="${plugin_root}/node_modules/${package_name}/package.json"
+  plugin_manifest="${CONFIG_ROOT}/node_modules/${package_name}/package.json"
 
   if [[ -f $plugin_manifest ]]; then
     echo "OpenCode plugin already ready: ${plugin_spec}"
     return
   fi
 
-  mkdir -p "$plugin_root"
   "$BUN_BIN" add \
-    --cwd "$plugin_root" \
+    --cwd "$CONFIG_ROOT" \
     --exact \
     --minimum-release-age 0 \
     "$plugin_spec"

--- a/spec/activate_opencode_spec.sh
+++ b/spec/activate_opencode_spec.sh
@@ -39,6 +39,7 @@ setup() {
     'mkdir -p "$(dirname "$manifest")"' \
     ': >"$manifest"' >"$FAKE_BUN"
   chmod +x "$FAKE_BUN"
+  mkdir -p "$TEMP_HOME/.config/opencode"
 }
 
 cleanup() {
@@ -49,16 +50,16 @@ BeforeEach 'setup'
 AfterEach 'cleanup'
 
 It 'materializes every declared npm plugin'
-When run env HOME="$TEMP_HOME" bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)" "$FAKE_BUN"
+When run env HOME="$TEMP_HOME" XDG_CONFIG_HOME="$TEMP_HOME/.config" bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)" "$FAKE_BUN"
 The status should be success
 The output should include 'OpenCode plugin ready: cc-safety-net'
 The output should include 'OpenCode plugin ready: opencode-atuin-history'
 The output should include 'OpenCode plugin ready: opencode-claude-hooks'
 The output should include 'OpenCode plugin ready: opencode-runtime-fallback@0.2.3'
-The file "$TEMP_HOME/.cache/opencode/packages/cc-safety-net@latest/node_modules/cc-safety-net/package.json" should be exist
-The file "$TEMP_HOME/.cache/opencode/packages/opencode-atuin-history@latest/node_modules/opencode-atuin-history/package.json" should be exist
-The file "$TEMP_HOME/.cache/opencode/packages/opencode-claude-hooks@latest/node_modules/opencode-claude-hooks/package.json" should be exist
-The file "$TEMP_HOME/.cache/opencode/packages/opencode-runtime-fallback@0.2.3/node_modules/opencode-runtime-fallback/package.json" should be exist
+The file "$TEMP_HOME/.config/opencode/node_modules/cc-safety-net/package.json" should be exist
+The file "$TEMP_HOME/.config/opencode/node_modules/opencode-atuin-history/package.json" should be exist
+The file "$TEMP_HOME/.config/opencode/node_modules/opencode-claude-hooks/package.json" should be exist
+The file "$TEMP_HOME/.config/opencode/node_modules/opencode-runtime-fallback/package.json" should be exist
 The contents of file "$TEMP_HOME/bun-invocations" should include '--exact --minimum-release-age 0 cc-safety-net'
 The contents of file "$TEMP_HOME/bun-invocations" should include '--exact --minimum-release-age 0 opencode-atuin-history'
 The contents of file "$TEMP_HOME/bun-invocations" should include '--exact --minimum-release-age 0 opencode-claude-hooks'
@@ -70,18 +71,16 @@ for plugin_spec in "${PLUGIN_SPECS[@]}"; do
   case "$plugin_spec" in
   *@*)
     plugin_package="${plugin_spec%@*}"
-    cache_spec="$plugin_spec"
     ;;
   *)
     plugin_package="$plugin_spec"
-    cache_spec="${plugin_spec}@latest"
     ;;
   esac
-  manifest="$TEMP_HOME/.cache/opencode/packages/$cache_spec/node_modules/$plugin_package/package.json"
+  manifest="$TEMP_HOME/.config/opencode/node_modules/$plugin_package/package.json"
   mkdir -p "$(dirname "$manifest")"
   : >"$manifest"
 done
-When run env HOME="$TEMP_HOME" bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)" "$FAKE_BUN"
+When run env HOME="$TEMP_HOME" XDG_CONFIG_HOME="$TEMP_HOME/.config" bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)" "$FAKE_BUN"
 The status should be success
 The output should include 'OpenCode plugin already ready: cc-safety-net'
 The output should include 'OpenCode plugin already ready: opencode-runtime-fallback@0.2.3'
@@ -89,30 +88,30 @@ The file "$TEMP_HOME/bun-invocations" should not be exist
 End
 
 It 'does not pass local file plugins to the package installer'
-When run env HOME="$TEMP_HOME" bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)" "$FAKE_BUN"
+When run env HOME="$TEMP_HOME" XDG_CONFIG_HOME="$TEMP_HOME/.config" bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)" "$FAKE_BUN"
 The status should be success
 The output should include 'OpenCode plugin ready: cc-safety-net'
 The contents of file "$TEMP_HOME/bun-invocations" should not include 'local-plugin.ts'
 End
 
 It 'succeeds when there are no npm plugins to materialize'
-When run env HOME="$TEMP_HOME" NO_NPM_PLUGINS=1 bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)" "$FAKE_BUN"
+When run env HOME="$TEMP_HOME" XDG_CONFIG_HOME="$TEMP_HOME/.config" NO_NPM_PLUGINS=1 bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)" "$FAKE_BUN"
 The status should be success
 The output should equal ''
 The file "$TEMP_HOME/bun-invocations" should not be exist
 End
 
 It 'fails closed when effective config cannot be resolved'
-When run env HOME="$TEMP_HOME" FAIL_DEBUG=1 bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)" "$FAKE_BUN"
+When run env HOME="$TEMP_HOME" XDG_CONFIG_HOME="$TEMP_HOME/.config" FAIL_DEBUG=1 bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)" "$FAKE_BUN"
 The status should be failure
 The stderr should include 'failed to resolve effective OpenCode config'
 The file "$TEMP_HOME/bun-invocations" should not be exist
 End
 
 It 'fails closed when Bun cannot materialize a configured plugin'
-When run env HOME="$TEMP_HOME" FAIL_BUN_PLUGIN=opencode-atuin-history bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)" "$FAKE_BUN"
+When run env HOME="$TEMP_HOME" XDG_CONFIG_HOME="$TEMP_HOME/.config" FAIL_BUN_PLUGIN=opencode-atuin-history bash "$SCRIPT" "$FAKE_OPENCODE" "$(command -v jq)" "$FAKE_BUN"
 The status should be failure
 The output should include 'OpenCode plugin ready: cc-safety-net'
-The file "$TEMP_HOME/.cache/opencode/packages/opencode-atuin-history@latest/node_modules/opencode-atuin-history/package.json" should not be exist
+The file "$TEMP_HOME/.config/opencode/node_modules/opencode-atuin-history/package.json" should not be exist
 End
 End


### PR DESCRIPTION
## Summary

- `activate.sh` installed npm plugins into `~/.cache/opencode/packages/<spec>/` but opencode resolves imports from `~/.config/opencode/node_modules/` -- all npm plugins (runtime-fallback, cc-safety-net, atuin-history, claude-hooks) were silently never loaded at runtime
- Changed install target to `~/.config/opencode/` so `bun add --cwd` puts modules where opencode's resolver finds them
- Updated spec to use correct paths and override `XDG_CONFIG_HOME` in test env

## Test plan

- [x] `shellspec spec/activate_opencode_spec.sh` -- 6/6 pass
- [ ] After `home-manager switch`, verify `opencode debug info` lists plugins AND logs show plugin activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix plugin install path so `opencode` loads npm plugins at runtime. Plugins now install under ~/.config/opencode/node_modules, restoring `cc-safety-net`, `opencode-atuin-history`, `opencode-claude-hooks`, and `opencode-runtime-fallback`.

- **Bug Fixes**
  - Install to `${XDG_CONFIG_HOME:-~/.config}/opencode` and run `bun add --cwd` there.
  - Drop cache-based layout and manifest checks.
  - Update specs to set `XDG_CONFIG_HOME` and expect manifests in config `node_modules`.

- **Migration**
  - No action needed; next activation installs plugins to the config root.
  - Optional: delete `~/.cache/opencode/packages` to clean up.

<sup>Written for commit ec562eae86489d60a7be07d7785de7639f847f6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

