### PR TITLE
fix(ci): update MoA test for flash model, cancel stale upgrade runs

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -40,6 +40,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
           SKIP_HOME_MANAGER_SWITCH: "true"
+      - name: Cancel stale runs on upgrade branch
+        if: github.event_name != 'pull_request'
+        run: |
+          gh run list --branch chore/upgrade --status queued --json databaseId -q '.[].databaseId' | xargs -rn1 gh run cancel || true
+          gh run list --branch chore/upgrade --status in_progress --json databaseId -q '.[].databaseId' | xargs -rn1 gh run cancel || true
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
       - name: Create Pull Request
         if: github.event_name != 'pull_request'
         id: cpr

--- a/spec/hermes_hydrate_spec.sh
+++ b/spec/hermes_hydrate_spec.sh
@@ -196,9 +196,8 @@ End
 It 'hydrates the default Mixture-of-Agents models from the canonical model list'
 When run bash -c "sed -n '/^moa:/,/^credential_pool_strategies:/p' '$PWD/config/hermes/config.template.yaml'"
 The output should include 'provider: cliproxy'
-The output should include 'model: deepseek-v4-pro'
-The output should include 'model: minimax-m3'
 The output should include 'model: deepseek-v4-flash'
+The output should include 'model: minimax-m3'
 The output should not include 'opus'
 End
 End


### PR DESCRIPTION
## Summary
- Update shell test to match MoA config after 724c5872 switched reference model from deepseek-v4-pro to deepseek-v4-flash
- Add stale run cancellation step to upgrade workflow to prevent orphaned queued/in-progress runs from blocking auto-merge on chore/upgrade

## Test plan
- [ ] Shell CI passes (hermes_hydrate_spec.sh:196)
- [ ] Upgrade workflow still creates PR and enables auto-merge on cron

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the MoA shell test to expect `deepseek-v4-flash` and keep `minimax-m3` to match the current config. Added a CI step to cancel stale `chore/upgrade` runs so auto-merge isn’t blocked.

- **Bug Fixes**
  - Updated `spec/hermes_hydrate_spec.sh` to assert `deepseek-v4-flash` (replacing `deepseek-v4-pro`) and keep `minimax-m3`; still excludes `opus`.
  - In `.github/workflows/upgrade.yml`, cancel queued and in-progress runs on `chore/upgrade` using `gh run cancel` with `PAT_TOKEN` to prevent blocked auto-merge.

<sup>Written for commit 1dc3fd3b72c095628362e0a4673c993187ffd042. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

