### PR TITLE
fix(ci): only run overlay upgrades in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -422,11 +422,13 @@ llm-update: ## Regenerate tool configs from models.json.
 	@echo "✅ LLM configs updated"
 
 .PHONY: overlays-update
-overlays-update: ## Upgrade all custom overlays to latest versions.
-	@echo "🔄 Upgrading custom overlays..."
-	@if [ "$$IN_DOCKER" = "true" ]; then \
+overlays-update: ## Upgrade all custom overlays to latest versions (CI only).
+	@if [ "$$CI" != "true" ]; then \
+		echo "⏭️ Skipping overlay upgrade outside CI"; \
+	elif [ "$$IN_DOCKER" = "true" ]; then \
 		echo "⏭️ Skipping overlay upgrade in Docker"; \
 	else \
+		echo "🔄 Upgrading custom overlays..."; \
 		./scripts/upgrade-overlays.sh all; \
 	fi
 


### PR DESCRIPTION
## Summary
- Gate `overlays-update` Makefile target to only run when `CI=true`
- Prevents `upgrade-overlays.sh` from running on local machines during `make upgrade`
- Docker skip is preserved as a secondary guard

## Test plan
- [ ] `make upgrade` locally skips overlay upgrade
- [ ] CI upgrade workflow still runs overlay upgrades

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restrict the `overlays-update` Makefile target to run only when `CI=true`, preventing accidental local overlay upgrades. Local `make upgrade` now skips overlays, and the `IN_DOCKER` guard still blocks runs inside containers.

<sup>Written for commit 1a91a67b45731c15b111909e24cb8dbf0c8855d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

