### PR TITLE
fix(packages): remove t3code from nix packages

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -137,7 +137,6 @@ with pkgs;
 ++ lib.optionals (!isRunner) [
   pkgs.llm-agents.antigravity-cli
   pkgs.llm-agents.prime-agent
-  pkgs.llm-agents.t3code
   vector
 ]
 ++ lib.optionals stdenv.isDarwin [


### PR DESCRIPTION
## Summary
- Remove `pkgs.llm-agents.t3code` from nix packages - already managed via `package.json`
- Also unloaded and removed stale `cass-watcher` launchd plist that was causing infinite CPU drain (the nix config already removed the service but home-manager didn't clean up the plist)

## Test plan
- [x] Verified `cass search` works standalone in clean environment (<220ms responses)
- [x] Confirmed `cass-watcher` no longer respawns after `launchctl unload` + plist removal

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `pkgs.llm-agents.t3code` from Nix packages since it’s already installed via `package.json`, avoiding duplicate installs. Also cleaned up a stale `cass-watcher` launchd plist so it stops respawning and burning CPU.

<sup>Written for commit 1b0fc6e86df94ee0516312629ea963424d0748d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

