### PR TITLE
fix(opencode): use deepseek flash for code-reviewer agent

### DIFF
--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -6,7 +6,7 @@
   "agent": {
     "code-reviewer": {
       "description": "Reviews code for best practices and potential issues",
-      "model": "anthropic/claude-sonnet-4-20250514",
+      "model": "shunkakinoki/deepseek-v4-flash",
       "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
       "tools": {
         // Disable file modification tools for review-only agent

--- a/config/opencode/opencode.tpl.jsonc
+++ b/config/opencode/opencode.tpl.jsonc
@@ -6,7 +6,7 @@
   "agent": {
     "code-reviewer": {
       "description": "Reviews code for best practices and potential issues",
-      "model": "anthropic/claude-sonnet-4-20250514",
+      "model": "shunkakinoki/__DEEPSEEK_FLASH__",
       "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
       "tools": {
         // Disable file modification tools for review-only agent


### PR DESCRIPTION
## Summary
- Switch code-reviewer agent model from `anthropic/claude-sonnet-4-20250514` to `shunkakinoki/deepseek-v4-flash`
- Template uses `__DEEPSEEK_FLASH__` placeholder for hydration via models.json
- Avoids Anthropic quota/auth errors that were triggering fallback on every code-review session

## Test plan
- [ ] Run opencode with code-reviewer agent and verify it uses deepseek-v4-flash
- [ ] Confirm fallback log no longer shows anthropic model failures for code-reviewer

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the code-reviewer agent to `shunkakinoki/deepseek-v4-flash` and introduce `__DEEPSEEK_FLASH__` in the template for hydration via `models.json`. This avoids Anthropic quota/auth failures that were triggering fallback during reviews.

<sup>Written for commit 090645bef672d4b36cc6ee6771fecacfa1a52e84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

