### PR TITLE
fix(roborev): expose Bun agents to daemon

### DIFF
--- a/home-manager/services/roborev/default.nix
+++ b/home-manager/services/roborev/default.nix
@@ -32,7 +32,7 @@ lib.mkIf enabled {
       EnvironmentVariables = {
         HOME = homeDir;
         ROBOREV_DATA_DIR = dataDir;
-        PATH = "${homeDir}/.local/bin:/etc/profiles/per-user/${config.home.username}/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
+        PATH = "${homeDir}/.local/bin:${homeDir}/.bun/bin:/etc/profiles/per-user/${config.home.username}/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
       };
       StandardOutPath = "/tmp/roborev.log";
       StandardErrorPath = "/tmp/roborev.error.log";
@@ -53,7 +53,7 @@ lib.mkIf enabled {
       Environment = [
         "HOME=${homeDir}"
         "ROBOREV_DATA_DIR=${dataDir}"
-        "PATH=${homeDir}/.local/bin:/etc/profiles/per-user/${config.home.username}/bin:${homeDir}/.nix-profile/bin:/usr/local/bin:/usr/bin:/bin"
+        "PATH=${homeDir}/.local/bin:${homeDir}/.bun/bin:/etc/profiles/per-user/${config.home.username}/bin:${homeDir}/.nix-profile/bin:/usr/local/bin:/usr/bin:/bin"
       ];
     };
     Install = {

--- a/spec/activate_roborev_spec.sh
+++ b/spec/activate_roborev_spec.sh
@@ -73,6 +73,11 @@ When run grep -F '/etc/profiles/per-user/${config.home.username}/bin' "$PWD/home
 The output should include '/etc/profiles/per-user/${config.home.username}/bin'
 End
 
+It 'includes Bun-installed agents in the daemon PATH'
+When run grep -F '${homeDir}/.bun/bin' "$PWD/home-manager/services/roborev/default.nix"
+The output should include '${homeDir}/.bun/bin'
+End
+
 It 'binds the daemon to the local host'
 When run grep -F '127.0.0.1:7373' "$PWD/home-manager/services/roborev/default.nix"
 The output should include '127.0.0.1:7373'

--- a/spec/activate_roborev_spec.sh
+++ b/spec/activate_roborev_spec.sh
@@ -73,9 +73,14 @@ When run grep -F '/etc/profiles/per-user/${config.home.username}/bin' "$PWD/home
 The output should include '/etc/profiles/per-user/${config.home.username}/bin'
 End
 
-It 'includes Bun-installed agents in the daemon PATH'
-When run grep -Fc '${homeDir}/.bun/bin' "$PWD/home-manager/services/roborev/default.nix"
-The output should equal '2'
+It 'includes Bun-installed agents in the launchd PATH'
+When run grep -F 'PATH = "${homeDir}/.local/bin:${homeDir}/.bun/bin:' "$PWD/home-manager/services/roborev/default.nix"
+The output should include '${homeDir}/.bun/bin'
+End
+
+It 'includes Bun-installed agents in the systemd PATH'
+When run grep -F '"PATH=${homeDir}/.local/bin:${homeDir}/.bun/bin:' "$PWD/home-manager/services/roborev/default.nix"
+The output should include '${homeDir}/.bun/bin'
 End
 
 It 'binds the daemon to the local host'

--- a/spec/activate_roborev_spec.sh
+++ b/spec/activate_roborev_spec.sh
@@ -74,8 +74,8 @@ The output should include '/etc/profiles/per-user/${config.home.username}/bin'
 End
 
 It 'includes Bun-installed agents in the daemon PATH'
-When run grep -F '${homeDir}/.bun/bin' "$PWD/home-manager/services/roborev/default.nix"
-The output should include '${homeDir}/.bun/bin'
+When run grep -Fc '${homeDir}/.bun/bin' "$PWD/home-manager/services/roborev/default.nix"
+The output should equal '2'
 End
 
 It 'binds the daemon to the local host'


### PR DESCRIPTION
## Summary

- add the Bun global binary directory to the declarative RoboRev service PATH
- make the installed Droid CLI discoverable by the Kyber systemd user service
- cover launchd and systemd service-path contracts independently in ShellSpec

Kyber already has Droid at `/home/ubuntu/.bun/bin/droid`, but the live `roborev.service` PATH omits `/home/ubuntu/.bun/bin`. RoboRev therefore marks Droid unavailable and resolves the panel member named `droid` to its configured Gemini backup.

Bead: `shunkakinokisoftware-vwlj`

## Before / after

| Layer | Before | After activation |
| --- | --- | --- |
| Kyber RoboRev PATH | Nix and local bins only | Includes `/home/ubuntu/.bun/bin` |
| Droid panel member | Resolves to Gemini backup | Resolves to the installed Droid CLI |
| Host configuration | Live unit differs from interactive shell capability | Declarative unit matches the installed runtime |

## Breaking and rollback

- Behavioral: RoboRev will use Droid instead of Gemini for the `droid` panel member when Droid is installed.
- Compile-time: none.
- Durable state: none.
- Rollback: revert the PATH entry and reactivate Home Manager.

## Deliberate boundaries

- This PR does not mutate the live Kyber unit manually; activation remains declarative after merge.
- It does not add Bun's internal `node_modules/.bin`: the stable Droid shim is in `~/.bun/bin`, and that exact future environment passed an authenticated probe.
- It does not change RoboRev's reviewer failure policy or Gemini quota classification; those are separate concerns.

## Verification

- `shellspec spec/activate_roborev_spec.sh` — 13 examples, 0 failures
- `make nix-format-check`
- `make nix-lint`
- `HOST=kyber HOSTNAME=kyber nix eval --json .#homeConfigurations.kyber.config.systemd.user.services.roborev.Service.Environment --impure --no-update-lock-file`
  - evaluated PATH contains `/home/ubuntu/.bun/bin`
- minimal Kyber `droid exec` under the future unit environment returned exactly `OK`, confirming current authentication
- `git diff --check`
