### PR TITLE
chore: remove kawaii mode from config files

### DIFF
--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -168,7 +168,6 @@ auxiliary:
     extra_body: {}
 display:
   compact: true
-  personality: kawaii
   resume_display: full
   busy_input_mode: interrupt
   bell_on_complete: false

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -168,7 +168,6 @@ auxiliary:
     extra_body: {}
 display:
   compact: true
-  personality: kawaii
   resume_display: full
   busy_input_mode: interrupt
   bell_on_complete: false


### PR DESCRIPTION
Removed the kawaii personality setting from the Hermes configuration files:\n\n- config/hermes/config.tpl.yaml - removed personality: kawaii\n- config/hermes/config.template.yaml - removed personality: kawaii\n\nThe kawaii mode has been turned off in both config templates.