### PR TITLE
fix(openclaw,hermes): repair model routing for fallback and default models

### DIFF
--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -1,5 +1,5 @@
 model:
-  default: cliproxy/deepseek-v4-flash
+  default: deepseek-v4-flash
   provider: cliproxy
   base_url: https://cliproxy.shunkakinoki.com/v1
   api_key: __CLIPROXY_API_KEY__
@@ -242,7 +242,7 @@ memory:
   user_char_limit: 1375
   provider: ''
 delegation:
-  model: cliproxy/deepseek-v4-flash
+  model: deepseek-v4-flash
   provider: cliproxy
   base_url: ''
   api_key: ''

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -1,5 +1,5 @@
 model:
-  default: cliproxy/__DEEPSEEK_FLASH__
+  default: __DEEPSEEK_FLASH__
   provider: cliproxy
   base_url: https://cliproxy.shunkakinoki.com/v1
   api_key: __CLIPROXY_API_KEY__
@@ -242,7 +242,7 @@ memory:
   user_char_limit: 1375
   provider: ''
 delegation:
-  model: cliproxy/__DEEPSEEK_FLASH__
+  model: __DEEPSEEK_FLASH__
   provider: cliproxy
   base_url: ''
   api_key: ''

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -138,6 +138,23 @@
           {
             "id": "glm-4.7",
             "name": "GLM 4.7",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 200000,
+            "maxTokens": 32000
+          },
+          {
+            "id": "gemma-4-31b-it",
+            "name": "Gemma 4 31b It",
             "reasoning": false,
             "input": [
               "text",

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -138,6 +138,23 @@
           {
             "id": "__GLM__",
             "name": "__GLM_PRETTY__",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 200000,
+            "maxTokens": 32000
+          },
+          {
+            "id": "__GEMMA__",
+            "name": "__GEMMA_PRETTY__",
             "reasoning": false,
             "input": [
               "text",

--- a/spec/hermes_hydrate_spec.sh
+++ b/spec/hermes_hydrate_spec.sh
@@ -168,7 +168,7 @@ End
 Describe 'declarative model routing'
 It 'uses the OpenClaw primary and CLIProxy-only fallback chain'
 When run bash -c "sed -n '1,22p' '$PWD/config/hermes/config.template.yaml'"
-The output should include 'default: cliproxy/deepseek-v4-flash'
+The output should include 'default: deepseek-v4-flash'
 The output should include 'provider: cliproxy'
 The output should include 'model: gemma-4-31b-it'
 The output should include 'model: glm-4.7'

--- a/spec/openclaw_hydrate_spec.sh
+++ b/spec/openclaw_hydrate_spec.sh
@@ -16,6 +16,8 @@ template_uses_cliproxy_flash_default() {
     } and
     (.models.providers.cliproxy.models | any(.id == "deepseek-v4-pro")) and
     (.models.providers.cliproxy.models | any(.id == "deepseek-v4-flash")) and
+    (.models.providers.cliproxy.models | any(.id == "gemma-4-31b-it")) and
+    (.models.providers.cliproxy.models | any(.id == "glm-4.7")) and
     (.models.providers.cliproxy.models | all(
       if (.id == "deepseek-v4-pro" or .id == "deepseek-v4-flash")
       then .compat.supportsPromptCacheKey == true


### PR DESCRIPTION
## Summary
- **OpenClaw**: Add `gemma-4-31b-it` to model catalog (was referenced in fallback chain but missing from `models.providers.cliproxy.models`), and set `glm-4.7` reasoning to `true` (Hermes proves it works with 435 reasoning tokens)
- **Hermes**: Strip `cliproxy/` prefix from `model.default` and `delegation.model` - fallback models were unprefixed and routed correctly through CLIProxy; the prefixed default caused CLIProxy to reject requests since no backend has prefix `cliproxy`
- Spec assertions added for both Gemma and GLM in OpenClaw catalog, and Hermes default model assertion updated

## Test plan
- [x] `shellspec spec/openclaw_hydrate_spec.sh` - 23 examples, 0 failures
- [x] `shellspec spec/hermes_hydrate_spec.sh` - 25 examples, 0 failures
- [x] `make llm-update` regenerates both template configs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs model routing in Hermes and OpenClaw so CLIProxy requests succeed and the fallback chain is valid. Previously Hermes used a prefixed default model id (`cliproxy/deepseek-v4-flash`) that CLIProxy rejected; now it uses the unprefixed id with provider `cliproxy`. OpenClaw now includes the missing `gemma-4-31b-it` and marks `glm-4.7` as reasoning-capable.

- Changes
  - Hermes config: Remove `cliproxy/` prefix from `model.default` and `delegation.model`; keep `provider: cliproxy` for correct routing.
  - OpenClaw catalog: Add `gemma-4-31b-it`; set `glm-4.7` `reasoning: true` and define inputs, context window, max tokens, and cost fields.
  - Specs: Update hydrate specs to assert the new defaults and catalog entries.

- Migration
  - If you override Hermes `model.default` or `delegation.model`, remove the `cliproxy/` prefix from model IDs.

<sup>Written for commit 789d9eba0ce8e96dda13d373c4f96ec134ba33ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

