### PR TITLE
fix: enable mempalace hook daemon mode

### DIFF
--- a/config/mempalace/config.json
+++ b/config/mempalace/config.json
@@ -1,3 +1,6 @@
 {
-  "palace_path": "__HOME_DIR__/ghq/github.com/shunkakinoki/wiki"
+  "palace_path": "__HOME_DIR__/ghq/github.com/shunkakinoki/wiki",
+  "hooks": {
+    "daemon": true
+  }
 }


### PR DESCRIPTION
## Summary
- Enable `hooks.daemon` in the MemPalace config so Stop-hook auto-mine jobs are submitted to the opt-in daemon (single worker queue per palace) instead of each session spawning its own detached, unsupervised subprocess.

## Why
On matic/kyber (swarm hosts running many concurrent claude/codex sessions), every session independently spawned its own background `mempalace mine` process against the same shared palace SQLite/Chroma DB, since daemon mode was never enabled. This caused stale lock buildup and FTS5 index corruption on one host, and was the root cause of a runaway mempalace mine process (888% CPU, 3.5GB RAM).

## Test plan
- [x] Applied equivalent config directly on mac, matic, kyber and confirmed `mempalace daemon status` reports running on all three
- [x] Repaired mac's corrupted FTS5 index; `PRAGMA integrity_check` now returns `ok`
- [x] Swept stale `mine_pids` lock files on all three hosts (0 remain)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables MemPalace hook daemon mode so stop-hook auto-mine jobs run through a single per‑palace worker instead of per‑session background processes. Old behavior spawned a `mempalace mine` process per session against the shared palace DB; new behavior queues jobs to the daemon. Side effect: mining will not run if the daemon is down.

**Review and rollout**
- Change: set `"hooks": { "daemon": true }` in `config/mempalace/config.json`.
- Required: start the daemon for the palace on each host and verify it stays up (`mempalace daemon start` / `mempalace daemon status`).

<sup>Written for commit d1bb90615c8a44facf1b90ebd0b5ada80de3b134. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

