### PR TITLE
feat: add mempalace-exporter service

### DIFF
--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -22,6 +22,7 @@ let
   k3s = ./k3s;
   keydApplicationMapper = ./keyd-application-mapper;
   makeUpdater = import ./make-updater { inherit pkgs; };
+  mempalaceExporter = import ./mempalace-exporter { inherit pkgs; };
   moshiHook = ./moshi-hook;
   neversslKeepalive = import ./neverssl-keepalive { inherit pkgs; };
   nightShift = import ./night-shift { inherit pkgs; };
@@ -53,6 +54,7 @@ in
   k3s
   keydApplicationMapper
   makeUpdater
+  mempalaceExporter
   moshiHook
   neversslKeepalive
   nightShift

--- a/home-manager/services/mempalace-exporter/default.nix
+++ b/home-manager/services/mempalace-exporter/default.nix
@@ -1,0 +1,53 @@
+{ pkgs, ... }:
+let
+  inherit (pkgs) lib;
+  path = lib.makeBinPath [
+    pkgs.bash
+    pkgs.coreutils
+    pkgs.git
+  ];
+in
+{
+  launchd.agents.mempalace-exporter = lib.mkIf pkgs.stdenv.isDarwin {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "${pkgs.bash}/bin/bash"
+        "${./export.sh}"
+      ];
+      Environment = {
+        PATH = "${path}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
+      };
+      StartInterval = 21600;
+      StandardOutPath = "/tmp/mempalace-exporter.log";
+      StandardErrorPath = "/tmp/mempalace-exporter.error.log";
+    };
+  };
+
+  systemd.user.services.mempalace-exporter = lib.mkIf pkgs.stdenv.isLinux {
+    Unit = {
+      Description = "MemPalace palace export to wiki";
+      X-SwitchMethod = "keep-old";
+    };
+    Service = {
+      Type = "oneshot";
+      Environment = [ "PATH=${path}" ];
+      Nice = 19;
+      IOSchedulingPriority = 7;
+      ExecStart = "${pkgs.bash}/bin/bash ${./export.sh}";
+    };
+  };
+
+  systemd.user.timers.mempalace-exporter = lib.mkIf pkgs.stdenv.isLinux {
+    Unit = {
+      Description = "Timer for MemPalace palace exporter";
+    };
+    Timer = {
+      OnCalendar = "*-*-* 00/6:00:00";
+      Persistent = true;
+    };
+    Install = {
+      WantedBy = [ "timers.target" ];
+    };
+  };
+}

--- a/home-manager/services/mempalace-exporter/export.sh
+++ b/home-manager/services/mempalace-exporter/export.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+_raw=$(hostname 2>/dev/null || echo "unknown")
+case "$_raw" in
+  galactica*) HOST_NAME="galactica" ;;
+  matic*)     HOST_NAME="matic" ;;
+  kyber*)     HOST_NAME="kyber" ;;
+  *)          HOST_NAME="$_raw" ;;
+esac
+
+MEMPALACE_BIN="$HOME/.local/share/uv/tools/mempalace"
+MEMPALACE_PYTHON="$MEMPALACE_BIN/bin/python"
+CONFIG_FILE="$HOME/.mempalace/config.json"
+WIKI_SYNC="$HOME/.mempalace/wiki-sync"
+
+[ -x "$MEMPALACE_PYTHON" ] || { echo "mempalace not installed, skipping"; exit 0; }
+[ -f "$CONFIG_FILE" ]      || { echo "no mempalace config, skipping"; exit 0; }
+
+PALACE_PATH=$("$MEMPALACE_PYTHON" -c "import json; print(json.load(open('$CONFIG_FILE'))['palace_path'])")
+MEMPALACE_SITE=$(ls -d "$MEMPALACE_BIN/lib/"python*/site-packages 2>/dev/null | tail -1)
+
+if [ -d "$WIKI_SYNC/.git" ]; then
+  git -C "$WIKI_SYNC" fetch origin main
+  git -C "$WIKI_SYNC" rebase origin/main || git -C "$WIKI_SYNC" rebase --abort
+else
+  mkdir -p "$HOME/.mempalace"
+  git clone "https://github.com/shunkakinoki/wiki.git" "$WIKI_SYNC"
+fi
+
+"$MEMPALACE_PYTHON" -c "
+import sys
+sys.path.insert(0, '$MEMPALACE_SITE')
+from mempalace.exporter import export_palace
+export_palace(palace_path='$PALACE_PATH', output_dir='$WIKI_SYNC/palace/$HOST_NAME')
+"
+
+cd "$WIKI_SYNC"
+git add "palace/$HOST_NAME/"
+if git diff --cached --quiet; then
+  echo "No palace changes for $HOST_NAME, skipping"
+  exit 0
+fi
+git commit -m "chore: update mempalace palace export ($HOST_NAME)"
+git pull --rebase origin main || true
+git push origin main


### PR DESCRIPTION
## Summary
- Adds `home-manager/services/mempalace-exporter/` with launchd (Darwin) and systemd (Linux) timer
- Exports palace project wings (excluding sessions) to `palace/<hostname>/` in `shunkakinoki/wiki`
- Runs every 6 hours on all hosts (galactica, matic, kyber)

## Test plan
- [ ] `make switch` picks up new launchd agent on galactica
- [ ] `/tmp/mempalace-exporter.log` shows successful export after first run
- [ ] `shunkakinoki/wiki` gets updated `palace/<hostname>/` commits every 6h

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `mempalace-exporter` Home Manager service to export MemPalace palace data (excluding sessions) to `shunkakinoki/wiki` per host. Previously no automated export; now a `launchd`/`systemd` timer runs every 6 hours and pushes changes to `main`, introducing periodic background Git activity and macOS logs in `/tmp`.

**Details for review**
- Adds `home-manager/services/mempalace-exporter` and wires it into `home-manager/services/default.nix`; `launchd` agent on Darwin, `systemd` user service + timer on Linux (`*-*-* 00/6:00:00`, oneshot).
- `export.sh` reads `$HOME/.mempalace/config.json` `palace_path`, runs `mempalace.exporter.export_palace`, writes to `palace/<host>` in a local checkout of `shunkakinoki/wiki`, commits only on change, rebases, and pushes to `main`.
- Host folder is normalized to `galactica`, `matic`, or `kyber`; otherwise uses the raw hostname.

**Rollout**
- Required: Install `mempalace` via `uv` at `$HOME/.local/share/uv/tools/mempalace` and create `$HOME/.mempalace/config.json` with `palace_path`; otherwise the job skips.
- Required: Configure Git credentials with push access to `shunkakinoki/wiki` on each host.
- Apply with `home-manager switch` (or `make switch` on macOS). Verify `/tmp/mempalace-exporter.log` on macOS, or `systemctl --user list-timers` on Linux.

<sup>Written for commit 21bf87a6fd3339682b7bd556c33f88e09aae69da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

