### PR TITLE
fix(openclaw): restore Kyber fallback and shell CI

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -261,9 +261,11 @@
       "model": {
         "primary": "cliproxy/deepseek-v4-flash",
         "fallbacks": [
+          "cliproxy/gpt-5.6-sol",
+          "cliproxy/claude-sonnet-5",
+          "cliproxy/free",
           "cliproxy/gemma-4-31b-it",
-          "cliproxy/glm-4.7",
-          "cliproxy/free"
+          "cliproxy/glm-4.7"
         ]
       },
       "workspace": "__HOME__/.openclaw/workspace",

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -261,9 +261,11 @@
       "model": {
         "primary": "cliproxy/__DEEPSEEK_FLASH__",
         "fallbacks": [
+          "cliproxy/__GPT__",
+          "cliproxy/__CLAUDE_SONNET__",
+          "cliproxy/free",
           "cliproxy/__GEMMA__",
-          "cliproxy/__GLM__",
-          "cliproxy/free"
+          "cliproxy/__GLM__"
         ]
       },
       "workspace": "__HOME__/.openclaw/workspace",

--- a/home-manager/services/mempalace-exporter/export.sh
+++ b/home-manager/services/mempalace-exporter/export.sh
@@ -24,7 +24,7 @@ WIKI_SYNC="$HOME/.mempalace/wiki-sync"
 }
 
 PALACE_PATH=$("$MEMPALACE_PYTHON" -c "import json; print(json.load(open('$CONFIG_FILE'))['palace_path'])")
-MEMPALACE_SITE=$(find "$MEMPALACE_BIN/lib" -type d -path '*/python*/site-packages' -print -quit)
+MEMPALACE_SITE=$("$MEMPALACE_PYTHON" -c 'import sysconfig; print(sysconfig.get_path("purelib"))')
 
 if [ -d "$WIKI_SYNC/.git" ]; then
   git -C "$WIKI_SYNC" fetch origin main

--- a/home-manager/services/mempalace-exporter/export.sh
+++ b/home-manager/services/mempalace-exporter/export.sh
@@ -3,10 +3,10 @@ set -euo pipefail
 
 _raw=$(hostname 2>/dev/null || echo "unknown")
 case "$_raw" in
-  galactica*) HOST_NAME="galactica" ;;
-  matic*)     HOST_NAME="matic" ;;
-  kyber*)     HOST_NAME="kyber" ;;
-  *)          HOST_NAME="$_raw" ;;
+galactica*) HOST_NAME="galactica" ;;
+matic*) HOST_NAME="matic" ;;
+kyber*) HOST_NAME="kyber" ;;
+*) HOST_NAME="$_raw" ;;
 esac
 
 MEMPALACE_BIN="$HOME/.local/share/uv/tools/mempalace"
@@ -14,11 +14,17 @@ MEMPALACE_PYTHON="$MEMPALACE_BIN/bin/python"
 CONFIG_FILE="$HOME/.mempalace/config.json"
 WIKI_SYNC="$HOME/.mempalace/wiki-sync"
 
-[ -x "$MEMPALACE_PYTHON" ] || { echo "mempalace not installed, skipping"; exit 0; }
-[ -f "$CONFIG_FILE" ]      || { echo "no mempalace config, skipping"; exit 0; }
+[ -x "$MEMPALACE_PYTHON" ] || {
+  echo "mempalace not installed, skipping"
+  exit 0
+}
+[ -f "$CONFIG_FILE" ] || {
+  echo "no mempalace config, skipping"
+  exit 0
+}
 
 PALACE_PATH=$("$MEMPALACE_PYTHON" -c "import json; print(json.load(open('$CONFIG_FILE'))['palace_path'])")
-MEMPALACE_SITE=$(ls -d "$MEMPALACE_BIN/lib/"python*/site-packages 2>/dev/null | tail -1)
+MEMPALACE_SITE=$(find "$MEMPALACE_BIN/lib" -type d -path '*/python*/site-packages' -print -quit)
 
 if [ -d "$WIKI_SYNC/.git" ]; then
   git -C "$WIKI_SYNC" fetch origin main

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -562,6 +562,7 @@ home-manager/services/dotfiles-updater/update.sh
 home-manager/services/gas-town/start.sh
 home-manager/services/k3s/activate.sh
 home-manager/services/make-updater/update.sh
+home-manager/services/mempalace-exporter/export.sh
 home-manager/services/neverssl-keepalive/keepalive.sh
 home-manager/services/night-shift/apply-night-shift.sh
 home-manager/services/t3-connect/connect.sh

--- a/spec/mempalace_exporter_spec.sh
+++ b/spec/mempalace_exporter_spec.sh
@@ -11,10 +11,10 @@ The status should be success
 The output should include 'set -euo pipefail'
 End
 
-It 'locates the installed Python package without parsing ls output'
-When run grep -F 'find "$MEMPALACE_BIN/lib"' "$SCRIPT"
+It 'resolves the installed package from the selected Python interpreter'
+When run grep -F 'sysconfig.get_path("purelib")' "$SCRIPT"
 The status should be success
-The output should include "-path '*/python*/site-packages' -print -quit"
+The output should include 'MEMPALACE_PYTHON'
 End
 
 It 'exits successfully when mempalace is not installed'
@@ -23,6 +23,65 @@ When run env HOME="$TEMP_HOME" bash "$SCRIPT"
 The status should be success
 The output should include 'mempalace not installed, skipping'
 rm -rf "$TEMP_HOME"
+End
+
+Describe 'Python package selection'
+setup_exporter_fixture() {
+  TEMP_HOME=$(mktemp -d)
+  tool_dir="$TEMP_HOME/.local/share/uv/tools/mempalace"
+  mkdir -p \
+    "$TEMP_HOME/.mempalace" \
+    "$TEMP_HOME/bin" \
+    "$tool_dir/bin" \
+    "$tool_dir/lib/python3.11/site-packages" \
+    "$tool_dir/lib/python3.12/site-packages"
+  printf '{}\n' >"$TEMP_HOME/.mempalace/config.json"
+
+  cat >"$tool_dir/bin/python" <<'PYTHON'
+#!/usr/bin/env bash
+code="${*: -1}"
+case "$code" in
+*json.load*)
+  printf '%s\n' '/tmp/palace'
+  ;;
+*sysconfig.get_path*)
+  printf '%s\n' "$HOME/.local/share/uv/tools/mempalace/lib/python3.12/site-packages"
+  ;;
+*export_palace*)
+  printf '%s\n' "$code" >"$HOME/export-code"
+  ;;
+esac
+PYTHON
+  chmod +x "$tool_dir/bin/python"
+
+  cat >"$TEMP_HOME/bin/git" <<'GIT'
+#!/usr/bin/env bash
+if [[ $1 == clone ]]; then
+  destination="${*: -1}"
+  mkdir -p "$destination/.git"
+fi
+if [[ $* == *'diff --cached --quiet'* ]]; then
+  exit 0
+fi
+GIT
+  chmod +x "$TEMP_HOME/bin/git"
+}
+
+cleanup_exporter_fixture() {
+  rm -rf "$TEMP_HOME"
+}
+
+Before 'setup_exporter_fixture'
+After 'cleanup_exporter_fixture'
+
+It 'uses the selected interpreter site-packages when multiple versions exist'
+When run env HOME="$TEMP_HOME" PATH="$TEMP_HOME/bin:$PATH" bash "$SCRIPT"
+The status should be success
+The output should include 'No palace changes'
+The file "$TEMP_HOME/export-code" should be exist
+The contents of file "$TEMP_HOME/export-code" should include 'lib/python3.12/site-packages'
+The contents of file "$TEMP_HOME/export-code" should not include 'lib/python3.11/site-packages'
+End
 End
 
 It 'declares both launchd and systemd schedules'

--- a/spec/mempalace_exporter_spec.sh
+++ b/spec/mempalace_exporter_spec.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+
+Describe 'home-manager/services/mempalace-exporter/export.sh'
+SCRIPT="$PWD/home-manager/services/mempalace-exporter/export.sh"
+MODULE="$PWD/home-manager/services/mempalace-exporter/default.nix"
+
+It 'uses strict Bash mode'
+When run bash -c "head -3 '$SCRIPT'"
+The status should be success
+The output should include 'set -euo pipefail'
+End
+
+It 'locates the installed Python package without parsing ls output'
+When run grep -F 'find "$MEMPALACE_BIN/lib"' "$SCRIPT"
+The status should be success
+The output should include "-path '*/python*/site-packages' -print -quit"
+End
+
+It 'exits successfully when mempalace is not installed'
+TEMP_HOME=$(mktemp -d)
+When run env HOME="$TEMP_HOME" bash "$SCRIPT"
+The status should be success
+The output should include 'mempalace not installed, skipping'
+rm -rf "$TEMP_HOME"
+End
+
+It 'declares both launchd and systemd schedules'
+When run cat "$MODULE"
+The status should be success
+The output should include 'launchd.agents.mempalace-exporter'
+The output should include 'systemd.user.timers.mempalace-exporter'
+End
+End

--- a/spec/openclaw_hydrate_spec.sh
+++ b/spec/openclaw_hydrate_spec.sh
@@ -9,11 +9,15 @@ template_uses_cliproxy_flash_default() {
     .agents.defaults.model == {
       "primary": "cliproxy/deepseek-v4-flash",
       "fallbacks": [
+        "cliproxy/gpt-5.6-sol",
+        "cliproxy/claude-sonnet-5",
+        "cliproxy/free",
         "cliproxy/gemma-4-31b-it",
-        "cliproxy/glm-4.7",
-        "cliproxy/free"
+        "cliproxy/glm-4.7"
       ]
     } and
+    (.models.providers.cliproxy.models | any(.id == "gpt-5.6-sol")) and
+    (.models.providers.cliproxy.models | any(.id == "claude-sonnet-5")) and
     (.models.providers.cliproxy.models | any(.id == "deepseek-v4-pro")) and
     (.models.providers.cliproxy.models | any(.id == "deepseek-v4-flash")) and
     (.models.providers.cliproxy.models | any(.id == "gemma-4-31b-it")) and

--- a/spec/openclaw_hydrate_spec.sh
+++ b/spec/openclaw_hydrate_spec.sh
@@ -22,6 +22,7 @@ template_uses_cliproxy_flash_default() {
     (.models.providers.cliproxy.models | any(.id == "deepseek-v4-flash")) and
     (.models.providers.cliproxy.models | any(.id == "gemma-4-31b-it")) and
     (.models.providers.cliproxy.models | any(.id == "glm-4.7")) and
+    (.models.providers.cliproxy.models | any(.id == "free")) and
     (.models.providers.cliproxy.models | all(
       if (.id == "deepseek-v4-pro" or .id == "deepseek-v4-flash")
       then .compat.supportsPromptCacheKey == true


### PR DESCRIPTION
## Summary

- add Kyber-proven GPT and Claude Sonnet routes ahead of volatile/exhausted OpenClaw fallbacks
- replace the mempalace exporter ls pipeline rejected by ShellCheck
- add exporter coverage and focused service tests

## Live diagnosis

- DeepSeek and Minimax: monthly allowance exhausted
- Gemma/OpenRouter: daily key cap reached
- GLM: insufficient balance
- free route: reached correctly but intermittently timed out
- gpt-5.6-sol and claude-sonnet-5: direct Kyber canaries succeeded

## Validation

- shellcheck
- focused ShellSpec: 134 examples
- full ShellSpec: 2079 examples
- Fish: 454 tests
- nix-format-check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `openclaw` live fallbacks and unblocks shell CI. Old order was `cliproxy/gemma-4-31b-it` → `cliproxy/glm-4.7` → `cliproxy/free`; new order is `cliproxy/gpt-5.6-sol` → `cliproxy/claude-sonnet-5` → `cliproxy/free` → `cliproxy/gemma-4-31b-it` → `cliproxy/glm-4.7`, improving reliability when non‑Kyber providers are throttled.

- Updates `openclaw.template.json` and `openclaw.tpl.json` with Kyber routes and new ordering; extends hydrate spec to assert the presence and order of `gpt-5.6-sol`, `claude-sonnet-5`, and `free`.
- Resolves `mempalace-exporter` site-packages via the selected interpreter using Python `sysconfig` (replaces the `ls | tail` heuristic); expands guard clauses for `shellcheck`; adds exporter tests for strict mode, no‑install path, interpreter binding across multiple Python versions, and launchd/systemd timers; includes the script in coverage.

- Rollout: Regenerate `openclaw` config from templates and set Kyber credentials; no other migration required.

<sup>Written for commit 79b01c98b1b290b0031a67886a258249d5d5326b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

