### PR TITLE
fix(llm): unify Flash fallback convention

### DIFF
--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -14,8 +14,6 @@ fallback_providers:
     model: gemma-4-31b-it
   - provider: cliproxy
     model: glm-4.7
-  - provider: cliproxy
-    model: free
 moa:
   default_preset: default
   presets:

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -14,8 +14,6 @@ fallback_providers:
     model: __GEMMA__
   - provider: cliproxy
     model: __GLM__
-  - provider: cliproxy
-    model: free
 moa:
   default_preset: default
   presets:

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -261,9 +261,6 @@
       "model": {
         "primary": "cliproxy/deepseek-v4-flash",
         "fallbacks": [
-          "cliproxy/gpt-5.6-sol",
-          "cliproxy/claude-sonnet-5",
-          "cliproxy/free",
           "cliproxy/gemma-4-31b-it",
           "cliproxy/glm-4.7"
         ]

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -261,9 +261,6 @@
       "model": {
         "primary": "cliproxy/__DEEPSEEK_FLASH__",
         "fallbacks": [
-          "cliproxy/__GPT__",
-          "cliproxy/__CLAUDE_SONNET__",
-          "cliproxy/free",
           "cliproxy/__GEMMA__",
           "cliproxy/__GLM__"
         ]

--- a/config/opencode/opencode-fallback.jsonc
+++ b/config/opencode/opencode-fallback.jsonc
@@ -8,7 +8,6 @@
   "notify_on_fallback": true,
   "fallback_models": [
     "shunkakinoki/gemma-4-31b-it",
-    "shunkakinoki/glm-4.7",
-    "shunkakinoki/free"
+    "shunkakinoki/glm-4.7"
   ]
 }

--- a/config/opencode/opencode-fallback.tpl.jsonc
+++ b/config/opencode/opencode-fallback.tpl.jsonc
@@ -8,7 +8,6 @@
   "notify_on_fallback": true,
   "fallback_models": [
     "shunkakinoki/__GEMMA__",
-    "shunkakinoki/__GLM__",
-    "shunkakinoki/free"
+    "shunkakinoki/__GLM__"
   ]
 }

--- a/spec/hermes_hydrate_spec.sh
+++ b/spec/hermes_hydrate_spec.sh
@@ -166,13 +166,18 @@ End
 End
 
 Describe 'declarative model routing'
-It 'uses the OpenClaw primary and CLIProxy-only fallback chain'
-When run bash -c "sed -n '1,22p' '$PWD/config/hermes/config.template.yaml'"
+It 'uses the Flash, Gemma, GLM fallback convention'
+When run bash -c "sed -n '1,18p' '$PWD/config/hermes/config.template.yaml'"
 The output should include 'default: deepseek-v4-flash'
 The output should include 'provider: cliproxy'
 The output should include 'model: gemma-4-31b-it'
 The output should include 'model: glm-4.7'
-The output should include 'model: free'
+The output should not include 'model: free'
+End
+
+It 'declares exactly two Hermes fallback models'
+When run bash -c "sed -n '/^fallback_providers:/,/^[^ ]/p' '$PWD/config/hermes/config.template.yaml' | grep -c '^    model:'"
+The output should equal '2'
 End
 
 It 'opts both CLIProxy config schemas into stable prompt cache keys'

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -171,8 +171,8 @@ When run bash -c "grep -q '\"opencode-runtime-fallback@0.2.3\"' config/opencode/
 The status should be success
 End
 
-It 'generates a separate OpenCode fallback chain'
-When run bash -c "jq -e '.retry_on_errors == [401,404,429,500,502,503,504] and .retryable_error_patterns == [\"unknown provider for model\"] and .max_fallback_attempts == 5 and .fallback_models == [\"shunkakinoki/gemma-4-31b-it\",\"shunkakinoki/glm-4.7\",\"shunkakinoki/free\"]' config/opencode/opencode-fallback.jsonc >/dev/null"
+It 'generates the Flash, Gemma, GLM OpenCode fallback convention'
+When run bash -c "jq -e '.model == null and .retry_on_errors == [401,404,429,500,502,503,504] and .retryable_error_patterns == [\"unknown provider for model\"] and .max_fallback_attempts == 5 and .fallback_models == [\"shunkakinoki/gemma-4-31b-it\",\"shunkakinoki/glm-4.7\"]' config/opencode/opencode-fallback.jsonc >/dev/null"
 The status should be success
 End
 

--- a/spec/openclaw_hydrate_spec.sh
+++ b/spec/openclaw_hydrate_spec.sh
@@ -9,20 +9,14 @@ template_uses_cliproxy_flash_default() {
     .agents.defaults.model == {
       "primary": "cliproxy/deepseek-v4-flash",
       "fallbacks": [
-        "cliproxy/gpt-5.6-sol",
-        "cliproxy/claude-sonnet-5",
-        "cliproxy/free",
         "cliproxy/gemma-4-31b-it",
         "cliproxy/glm-4.7"
       ]
     } and
-    (.models.providers.cliproxy.models | any(.id == "gpt-5.6-sol")) and
-    (.models.providers.cliproxy.models | any(.id == "claude-sonnet-5")) and
     (.models.providers.cliproxy.models | any(.id == "deepseek-v4-pro")) and
     (.models.providers.cliproxy.models | any(.id == "deepseek-v4-flash")) and
     (.models.providers.cliproxy.models | any(.id == "gemma-4-31b-it")) and
     (.models.providers.cliproxy.models | any(.id == "glm-4.7")) and
-    (.models.providers.cliproxy.models | any(.id == "free")) and
     (.models.providers.cliproxy.models | all(
       if (.id == "deepseek-v4-pro" or .id == "deepseek-v4-flash")
       then .compat.supportsPromptCacheKey == true


### PR DESCRIPTION
## Summary

- restore OpenClaw to DeepSeek Flash with Gemma then GLM fallbacks
- apply the same default fallback convention to Hermes and OpenCode
- keep GPT, Claude, free, and other models registered for explicit selection while removing them from these automatic chains
- regenerate derived configs and strengthen exact-chain regression coverage

## Validation

- focused ShellSpec: 137 examples, 0 failures
- ShellCheck
- Nix format check
- exact generated OpenClaw, Hermes, and OpenCode assertions

## Rollout

Admin-merge, then build and switch Kyber and verify the generated configs and services.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies default LLM fallbacks to the Flash, Gemma, GLM convention across OpenClaw, Hermes, and OpenCode. Previously, OpenClaw fell back to GPT, Claude, free, Gemma, then GLM and Hermes also included free; now defaults use DeepSeek Flash with fallbacks Gemma then GLM only, so GPT, Claude, and free are no longer used automatically.

**Review and rollout**
- OpenClaw: removes GPT, Claude, and free from the default fallback list; keeps Gemma → GLM.
- Hermes: removes free; asserts exactly two fallbacks (Gemma → GLM).
- OpenCode: fallback list is Gemma → GLM; excludes free; Flash remains the primary elsewhere.
- Tests: update specs to assert the exact chain and absence of free; regenerate derived configs.
- Migration: if you relied on implicit GPT/Claude/free fallbacks, explicitly select those models in your configs or presets.
- Rollout: merge, rebuild, switch Kyber, and verify generated configs and services.

<sup>Written for commit a48873dc25de60b517bdc64f154da6656eb8077d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

