### PR TITLE
fix(openclaw): restore terminal free fallback

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -262,7 +262,8 @@
         "primary": "cliproxy/deepseek-v4-flash",
         "fallbacks": [
           "cliproxy/gemma-4-31b-it",
-          "cliproxy/glm-4.7"
+          "cliproxy/glm-4.7",
+          "cliproxy/free"
         ]
       },
       "workspace": "__HOME__/.openclaw/workspace",

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -262,7 +262,8 @@
         "primary": "cliproxy/__DEEPSEEK_FLASH__",
         "fallbacks": [
           "cliproxy/__GEMMA__",
-          "cliproxy/__GLM__"
+          "cliproxy/__GLM__",
+          "cliproxy/free"
         ]
       },
       "workspace": "__HOME__/.openclaw/workspace",

--- a/spec/openclaw_hydrate_spec.sh
+++ b/spec/openclaw_hydrate_spec.sh
@@ -10,13 +10,16 @@ template_uses_cliproxy_flash_default() {
       "primary": "cliproxy/deepseek-v4-flash",
       "fallbacks": [
         "cliproxy/gemma-4-31b-it",
-        "cliproxy/glm-4.7"
+        "cliproxy/glm-4.7",
+        "cliproxy/free"
       ]
     } and
     (.models.providers.cliproxy.models | any(.id == "deepseek-v4-pro")) and
     (.models.providers.cliproxy.models | any(.id == "deepseek-v4-flash")) and
     (.models.providers.cliproxy.models | any(.id == "gemma-4-31b-it")) and
     (.models.providers.cliproxy.models | any(.id == "glm-4.7")) and
+    (.models.providers.cliproxy.models | any(.id == "free")) and
+    (.agents.defaults.model.fallbacks[-1] == "cliproxy/free") and
     (.models.providers.cliproxy.models | all(
       if (.id == "deepseek-v4-pro" or .id == "deepseek-v4-flash")
       then .compat.supportsPromptCacheKey == true


### PR DESCRIPTION
## Summary

- restore `cliproxy/free` as OpenClaw's final fallback after Gemma and GLM
- keep the canonical template and generated JSON in sync
- lock the free model's registration and terminal fallback position with regression coverage

## Diagnosis

Live Kyber probes isolated the failure to exhausted upstream DeepSeek allowances, not the CLIProxy free alias:

- direct OpenRouter DeepSeek presets: HTTP 403, daily key limit exceeded
- CLIProxy `deepseek-v4-flash` / `deepseek-v4-pro`: HTTP 429 from higher-priority OpenCode Go, monthly usage limit reached
- CLIProxy `free`: HTTP 200, resolved through OpenRouter's free router

PR #2370 removed the working `free` escape hatch from OpenClaw. This restores it as the final fallback without disguising the exhausted paid-provider limits.

## Validation

- `make llm-update`
- `shellspec spec/openclaw_hydrate_spec.sh spec/cliproxyapi_spec.sh spec/llm_update_spec.sh` (135 examples, 0 failures)
- `make nix-format-check`
- Nix parse and exact JSON routing assertions
- live Kyber CLIProxy free probe: HTTP 200

`make build` entered Nix evaluation but was cancelled after it remained queued behind an unrelated pre-existing `darwin-rebuild switch` running on the host for more than three hours. No build failure was emitted.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `cliproxy/free` as OpenClaw’s terminal fallback after `cliproxy/gemma-4-31b-it` and `cliproxy/glm-4.7` so requests continue when DeepSeek quotas are exhausted. Previously the chain ended at GLM and failed; now it falls back to the OpenRouter free route while preserving visibility into paid-provider limit errors.

- Adds `cliproxy/free` to the `fallbacks` array in `config/openclaw/openclaw.template.json` and `config/openclaw/openclaw.tpl.json`.
- Extends `spec/openclaw_hydrate_spec.sh` to assert the `free` model exists and that `cliproxy/free` is the final fallback, locking ordering with regression coverage.
- No migration required; templates stay in sync and regenerate through the existing hydrate/update flow.

<sup>Written for commit 749e6392ccb39ef1fdbd48d0feae0678f95dd26c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

