### PR TITLE
fix(openclaw): prefer independent free fallback

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -53,15 +53,24 @@ because the upstream ID differs from the canonical one:
 | `__GPT_IMAGE_OPENROUTER__` | `openai/gpt-5.4-image-2` | OpenRouter, aliased back to `gpt-image-2` |
 | `__DEEPSEEK_FLASH_0731__` | `deepseek-v4-flash-0731` | Aliyun, aliased back to `deepseek-v4-flash` |
 
-## The shared fallback chain
+## Fallback chains
 
-Harnesses that support runtime fallback use one chain, in this order:
+Fallback-capable harnesses share this base chain:
 
 ```
 deepseek-v4-flash  (primary)
   -> gemma-4-31b-it
   -> glm-4.7
-  -> free           (OpenRouter free router, last resort)
+```
+
+OpenClaw prioritizes the independently routed OpenRouter free pool before the
+shared model fallbacks so quota exhaustion does not interrupt messaging:
+
+```
+deepseek-v4-flash  (primary)
+  -> free           (OpenRouter free router)
+  -> gemma-4-31b-it
+  -> glm-4.7
 ```
 
 Rules:
@@ -81,9 +90,9 @@ Rules:
 
 | Harness | Default | Fallback chain | Config |
 | --- | --- | --- | --- |
-| OpenCode | `shunkakinoki/deepseek-v4-flash` | shared chain, `shunkakinoki/` prefix | [opencode-fallback.tpl.jsonc](config/opencode/opencode-fallback.tpl.jsonc) |
-| OpenClaw | `cliproxy/deepseek-v4-flash` | shared chain, `cliproxy/` prefix | [openclaw.tpl.json](config/openclaw/openclaw.tpl.json) |
-| Hermes | `cliproxy/deepseek-v4-flash` | shared chain via `fallback_providers` | [config.tpl.yaml](config/hermes/config.tpl.yaml) |
+| OpenCode | `shunkakinoki/deepseek-v4-flash` | shared base chain, `shunkakinoki/` prefix | [opencode-fallback.tpl.jsonc](config/opencode/opencode-fallback.tpl.jsonc) |
+| OpenClaw | `cliproxy/deepseek-v4-flash` | service-continuity chain, `cliproxy/` prefix | [openclaw.tpl.json](config/openclaw/openclaw.tpl.json) |
+| Hermes | `cliproxy/deepseek-v4-flash` | shared base chain via `fallback_providers` | [config.tpl.yaml](config/hermes/config.tpl.yaml) |
 
 OpenCode fallback is driven by the `opencode-runtime-fallback@0.2.3` plugin:
 

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -261,9 +261,9 @@
       "model": {
         "primary": "cliproxy/deepseek-v4-flash",
         "fallbacks": [
+          "cliproxy/free",
           "cliproxy/gemma-4-31b-it",
-          "cliproxy/glm-4.7",
-          "cliproxy/free"
+          "cliproxy/glm-4.7"
         ]
       },
       "workspace": "__HOME__/.openclaw/workspace",

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -261,9 +261,9 @@
       "model": {
         "primary": "cliproxy/__DEEPSEEK_FLASH__",
         "fallbacks": [
+          "cliproxy/free",
           "cliproxy/__GEMMA__",
-          "cliproxy/__GLM__",
-          "cliproxy/free"
+          "cliproxy/__GLM__"
         ]
       },
       "workspace": "__HOME__/.openclaw/workspace",

--- a/spec/openclaw_hydrate_spec.sh
+++ b/spec/openclaw_hydrate_spec.sh
@@ -19,7 +19,6 @@ template_uses_cliproxy_flash_default() {
     (.models.providers.cliproxy.models | any(.id == "gemma-4-31b-it")) and
     (.models.providers.cliproxy.models | any(.id == "glm-4.7")) and
     (.models.providers.cliproxy.models | any(.id == "free")) and
-    (.agents.defaults.model.fallbacks[0] == "cliproxy/free") and
     (.models.providers.cliproxy.models | all(
       if (.id == "deepseek-v4-pro" or .id == "deepseek-v4-flash")
       then .compat.supportsPromptCacheKey == true

--- a/spec/openclaw_hydrate_spec.sh
+++ b/spec/openclaw_hydrate_spec.sh
@@ -9,9 +9,9 @@ template_uses_cliproxy_flash_default() {
     .agents.defaults.model == {
       "primary": "cliproxy/deepseek-v4-flash",
       "fallbacks": [
+        "cliproxy/free",
         "cliproxy/gemma-4-31b-it",
-        "cliproxy/glm-4.7",
-        "cliproxy/free"
+        "cliproxy/glm-4.7"
       ]
     } and
     (.models.providers.cliproxy.models | any(.id == "deepseek-v4-pro")) and
@@ -19,7 +19,7 @@ template_uses_cliproxy_flash_default() {
     (.models.providers.cliproxy.models | any(.id == "gemma-4-31b-it")) and
     (.models.providers.cliproxy.models | any(.id == "glm-4.7")) and
     (.models.providers.cliproxy.models | any(.id == "free")) and
-    (.agents.defaults.model.fallbacks[-1] == "cliproxy/free") and
+    (.agents.defaults.model.fallbacks[0] == "cliproxy/free") and
     (.models.providers.cliproxy.models | all(
       if (.id == "deepseek-v4-pro" or .id == "deepseek-v4-flash")
       then .compat.supportsPromptCacheKey == true


### PR DESCRIPTION
## Summary

- move `cliproxy/free` ahead of Gemma and GLM in the OpenClaw fallback chain
- preserve DeepSeek V4 Flash as the primary model
- lock the generated and source template order with hydration coverage

## Root cause

CLIProxy correctly failed over `deepseek-v4-flash` across OpenCode, Aliyun Token Plan, and OpenRouter, but every Flash provider was quota-blocked. OpenClaw then probed quota-blocked Gemma and GLM routes before the independently healthy `free` route, delaying or preventing user-facing recovery.

## Verification

- `shellspec spec/cliproxyapi_spec.sh spec/llm_update_spec.sh spec/openclaw_hydrate_spec.sh` (135 examples, 0 failures)
- `make shell-check`
- `make llm-update` followed by a clean generated-config diff
- live Kyber OpenClaw probe: Flash, Gemma, and GLM unavailable; `cliproxy/free` returned `OK`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefers `cliproxy/free` as the first fallback in OpenClaw while keeping `cliproxy/deepseek-v4-flash` primary, reducing recovery time when Flash and shared-model providers are quota-blocked.

- Old behavior: fallbacks were Gemma → GLM → Free. New behavior: Free → Gemma → GLM. Side effect: sessions now fail over to `cliproxy/free` first during outages.
- Updates `config/openclaw/openclaw.template.json` and `config/openclaw/openclaw.tpl.json`; `spec/openclaw_hydrate_spec.sh` asserts `cliproxy/free` is the first fallback.
- Aligns `MODELS.md` to document the shared base chain vs OpenClaw’s service-continuity chain and show the new order.
- No migration required; generated config order remains stable.

<sup>Written for commit 17cda35f29be78d41b2339cda04357c57d5ed46d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

