### PR TITLE
fix: map aarch64-darwin hostname to galactica in palace exporter

### DIFF
--- a/home-manager/services/mempalace-exporter/export.sh
+++ b/home-manager/services/mempalace-exporter/export.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 _raw=$(hostname 2>/dev/null || echo "unknown")
 case "$_raw" in
-galactica*) HOST_NAME="galactica" ;;
+galactica* | aarch64-darwin*) HOST_NAME="galactica" ;;
 matic*) HOST_NAME="matic" ;;
 kyber*) HOST_NAME="kyber" ;;
 *) HOST_NAME="$_raw" ;;


### PR DESCRIPTION
Maps the actual macOS hostname `aarch64-darwin` to the canonical name `galactica` in the mempalace-exporter service.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Map macOS hostnames matching "aarch64-darwin*" to the canonical "galactica" in `mempalace-exporter` to align host labeling. Previously these hosts emitted "aarch64-darwin*", now they emit "galactica".

- Updates export.sh case pattern to treat "galactica* | aarch64-darwin*" as "galactica".
- Side effect: time series labeled "aarch64-darwin*" will stop updating; data continues under "galactica". Update any dashboards/alerts that filter on the old label.
- Takes effect on next deploy/restart of the exporter. No config changes required.

<sup>Written for commit 6e8c69e5813c908605fd40d91586c87194c1c0b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

