### PR TITLE
fix(hermes): restore terminal free fallback

### DIFF
--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -14,6 +14,8 @@ fallback_providers:
     model: gemma-4-31b-it
   - provider: cliproxy
     model: glm-4.7
+  - provider: cliproxy
+    model: free
 moa:
   default_preset: default
   presets:

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -14,6 +14,8 @@ fallback_providers:
     model: __GEMMA__
   - provider: cliproxy
     model: __GLM__
+  - provider: cliproxy
+    model: free
 moa:
   default_preset: default
   presets:

--- a/spec/hermes_hydrate_spec.sh
+++ b/spec/hermes_hydrate_spec.sh
@@ -166,18 +166,18 @@ End
 End
 
 Describe 'declarative model routing'
-It 'uses the Flash, Gemma, GLM fallback convention'
-When run bash -c "sed -n '1,18p' '$PWD/config/hermes/config.template.yaml'"
+It 'uses the Flash, Gemma, GLM, free fallback convention'
+When run bash -c "sed -n '1,20p' '$PWD/config/hermes/config.template.yaml'"
 The output should include 'default: deepseek-v4-flash'
 The output should include 'provider: cliproxy'
 The output should include 'model: gemma-4-31b-it'
 The output should include 'model: glm-4.7'
-The output should not include 'model: free'
+The output should include 'model: free'
 End
 
-It 'declares exactly two Hermes fallback models'
+It 'declares exactly three Hermes fallback models'
 When run bash -c "sed -n '/^fallback_providers:/,/^[^ ]/p' '$PWD/config/hermes/config.template.yaml' | grep -c '^    model:'"
-The output should equal '2'
+The output should equal '3'
 End
 
 It 'opts both CLIProxy config schemas into stable prompt cache keys'


### PR DESCRIPTION
## Summary
- Restore `free` (OpenRouter free router) as the terminal fallback in Hermes's `fallback_providers` chain
- #2370 removed `free` from both OpenClaw and Hermes to unify the convention, but #2371 only restored it for OpenClaw -- Hermes was missed
- Without `free`, Hermes hard-fails when Flash + Gemma + GLM are all down

## Test plan
- [x] `shellspec spec/hermes_hydrate_spec.sh` passes (26 examples, 0 failures)
- [x] Fallback count updated from 2 to 3

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the terminal `free` fallback in Hermes so requests don’t hard-fail when Flash, Gemma, and GLM are down. Previously the chain ended at GLM and errored; now it ends with `cliproxy` `free`.

- Add `provider: cliproxy` with `model: free` to `fallback_providers` in `config/hermes/config.template.yaml` and `config/hermes/config.tpl.yaml`.
- Update `spec/hermes_hydrate_spec.sh` to expect three fallbacks and include `free`.
- Rollout: if your deployment generates Hermes config from these templates, rehydrate to pick up the added fallback.

<sup>Written for commit 4cf6d1794d5959637a2b6222825d8cace44b2fc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

