### PR TITLE
fix(mempalace-exporter): use /etc/hostname on Linux, fix kyber c2 hostname

### DIFF
--- a/home-manager/services/mempalace-exporter/export.sh
+++ b/home-manager/services/mempalace-exporter/export.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-_raw=$(hostname 2>/dev/null || echo "unknown")
+if [ -f /etc/hostname ]; then
+  _raw=$(tr -d '[:space:]' < /etc/hostname)
+else
+  _raw=$(hostname 2>/dev/null || echo "unknown")
+fi
 case "$_raw" in
 galactica* | aarch64-darwin*) HOST_NAME="galactica" ;;
 matic*) HOST_NAME="matic" ;;
-kyber*) HOST_NAME="kyber" ;;
+kyber* | c2-small-x86-chi-1*) HOST_NAME="kyber" ;;
 *) HOST_NAME="$_raw" ;;
 esac
 


### PR DESCRIPTION
## Summary
- Use `cat /etc/hostname` as primary hostname source on Linux (avoids needing `inetutils` in nix PATH)
- Add `c2-small-x86-chi-1*` case for kyber (actual cloud hostname doesn't match `kyber*`)

Both matic and kyber were committing to `palace/unknown/` instead of `palace/matic/` and `palace/kyber/`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hostname detection in `mempalace-exporter` so Linux hosts write to the correct palace path. Previously we used `hostname` and only matched `kyber*`, causing `matic` and some `kyber` nodes to commit to `palace/unknown/`. Now we prefer `/etc/hostname` and map `c2-small-x86-chi-1*` to `kyber`.

- Prefer `/etc/hostname` on Linux (trim whitespace); fall back to `hostname`.
- Map `kyber*` and `c2-small-x86-chi-1*` to `kyber`.
- No action required; exporter no longer needs `inetutils` in `PATH`. Verify Linux nodes now report `palace/matic/` and `palace/kyber/`.

<sup>Written for commit 180a2db1fd4d0f929e2a455ff8c9c0017b65c666. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

