### PR TITLE
fix(mempalace-exporter): replace rebase with merge/ff-only for git sync

### DIFF
--- a/home-manager/services/mempalace-exporter/export.sh
+++ b/home-manager/services/mempalace-exporter/export.sh
@@ -32,7 +32,8 @@ MEMPALACE_SITE=$("$MEMPALACE_PYTHON" -c 'import sysconfig; print(sysconfig.get_p
 
 if [ -d "$WIKI_SYNC/.git" ]; then
   git -C "$WIKI_SYNC" fetch origin main
-  git -C "$WIKI_SYNC" rebase origin/main || git -C "$WIKI_SYNC" rebase --abort
+  git -C "$WIKI_SYNC" checkout -f main 2>/dev/null || git -C "$WIKI_SYNC" checkout -f -b main origin/main
+  git -C "$WIKI_SYNC" merge --ff-only origin/main || git -C "$WIKI_SYNC" reset --mixed origin/main
 else
   mkdir -p "$HOME/.mempalace"
   git clone "https://github.com/shunkakinoki/wiki.git" "$WIKI_SYNC"
@@ -52,5 +53,5 @@ if git diff --cached --quiet; then
   exit 0
 fi
 git commit -m "chore: update mempalace palace export ($HOST_NAME)"
-git pull --rebase origin main || true
+git merge --ff-only origin/main 2>/dev/null || true
 git push origin main


### PR DESCRIPTION
Avoids rebase conflicts when origin diverges (e.g. cleanup PRs deleting stale palace dirs). Checkout -f main to escape any detached HEAD state, then ff-only merge or reset --mixed as fallback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches mempalace-exporter git sync from rebase to fast-forward merge with a reset fallback to avoid conflicts when origin diverges. Previously we rebased against origin/main and used pull --rebase; now we force-checkout main, fast-forward merge origin/main or reset --mixed to origin/main, then attempt a fast-forward merge again before push.

- Ensures we operate on main (no detached HEAD) by checking out or creating main.
- Discards divergent local commits at sync time; working tree changes remain unstaged.
- Keeps history linear and avoids rebase conflicts; push behavior is unchanged (non-fast-forward states surface via rejected pushes).

<sup>Written for commit abd9ebf4b37d09a3a534ed72ccecf1889aaeb823. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

