### PR TITLE
feat(gh): add signoff extension

### DIFF
--- a/home-manager/programs/gh/default.nix
+++ b/home-manager/programs/gh/default.nix
@@ -4,6 +4,7 @@
     enable = true;
     extensions = with pkgs; [
       gh-markdown-preview
+      gh-signoff
       gh-stack
     ];
     settings = {


### PR DESCRIPTION
## Summary
- Provision `gh-signoff` through Home Manager alongside the existing GitHub CLI extensions.
- This makes the local-CI signoff command available after normal Nix activation.

## Breaking and irreversible changes
- Behavioral: none.
- Compile-time: none.
- Durable state and rollback: none; reverting removes the managed extension.

## Deliberate boundaries
- Host activation is not performed by this PR.
- The PR changes only `home-manager/programs/gh/default.nix`.

## Verification
- `nixfmt --check home-manager/programs/gh/default.nix`
- `nix eval --json .#darwinConfigurations.galactica.config.home-manager.users.shunkakinoki.programs.gh.extensions` (includes `gh-signoff-0.2.1`)
- `make nix-format-check` is currently red on the clean PR head because it would reformat two pre-existing files outside this diff: `.github/workflows/pullfrog.yml` and `home-manager/services/mempalace-exporter/export.sh`.
- `make build` was attempted but the host Nix evaluation stalled without producing derivations; it was cancelled after confirming the focused evaluation.