### PR TITLE
perf(cliproxy): Stick sessions 8h and cache-key all hops

### DIFF
--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -184,7 +184,10 @@ routing:
   # still decides cold bindings, requests without a session, and post-failover rebinding.
   session-affinity: true # default: false
   # How long session-to-auth bindings are retained. Default: 1h
-  session-affinity-ttl: "1h"
+  # 8h covers the 0/8/16 UTC cron gap. Cold requests still hop
+  # OpenCode (300) -> Aliyun (200) -> OpenRouter (100). Failover
+  # still rebinds when the bound plan 429s.
+  session-affinity-ttl: "8h"
 # Codex provider behavior.
 codex:
   # When true, and routing.strategy is fill-first or routing.session-affinity is true,
@@ -503,6 +506,7 @@ openai-compatibility:
     priority: 200
     prefix: "aliyun"
     base-url: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
+    support-prompt-cache-key: true
     api-key-entries:
       - api-key: "__ALIYUN_TOKEN_PLAN_API_KEY__"
     models:
@@ -515,6 +519,7 @@ openai-compatibility:
   - name: "opencode"
     priority: 300
     base-url: "https://opencode.ai/zen/go/v1"
+    support-prompt-cache-key: true
     api-key-entries: __OPENCODE_API_KEY_ENTRIES__
     models:
       - name: "deepseek-v4-pro"

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -184,7 +184,10 @@ routing:
   # still decides cold bindings, requests without a session, and post-failover rebinding.
   session-affinity: true # default: false
   # How long session-to-auth bindings are retained. Default: 1h
-  session-affinity-ttl: "1h"
+  # 8h covers the 0/8/16 UTC cron gap. Cold requests still hop
+  # OpenCode (300) -> Aliyun (200) -> OpenRouter (100). Failover
+  # still rebinds when the bound plan 429s.
+  session-affinity-ttl: "8h"
 # Codex provider behavior.
 codex:
   # When true, and routing.strategy is fill-first or routing.session-affinity is true,
@@ -503,6 +506,7 @@ openai-compatibility:
     priority: 200
     prefix: "aliyun"
     base-url: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
+    support-prompt-cache-key: true
     api-key-entries:
       - api-key: "__ALIYUN_TOKEN_PLAN_API_KEY__"
     models:
@@ -515,6 +519,7 @@ openai-compatibility:
   - name: "opencode"
     priority: 300
     base-url: "https://opencode.ai/zen/go/v1"
+    support-prompt-cache-key: true
     api-key-entries: __OPENCODE_API_KEY_ENTRIES__
     models:
       - name: "__DEEPSEEK_PRO__"

--- a/spec/cliproxyapi_spec.sh
+++ b/spec/cliproxyapi_spec.sh
@@ -287,10 +287,11 @@ End
 
 Describe 'OpenRouter fallback routing'
 
-It 'keeps provider selection sticky for one hour per client session'
+It 'keeps provider selection sticky for eight hours per client session'
 When run bash -c "sed -n '/^routing:/,/^[a-z]/p' '$PWD/config/cliproxyapi/config.template.yaml'"
 The output should include 'session-affinity: true'
-The output should include 'session-affinity-ttl: "1h"'
+The output should include 'session-affinity-ttl: "8h"'
+The output should include 'strategy: "fill-first"'
 The status should be success
 End
 
@@ -301,8 +302,28 @@ The output should include 'alias: "free"'
 The status should be success
 End
 
-It 'preserves prompt cache keys for the OpenRouter provider'
-When run bash -c "sed -n '/name: \"openrouter\"/,/name: \"z-ai\"/p' '$PWD/config/cliproxyapi/config.template.yaml'"
+It 'preserves the OpenCode then Aliyun then OpenRouter hop'
+When run bash -c "awk '/name: \"openrouter\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'; awk '/name: \"aliyun\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'; awk '/name: \"opencode\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'"
+The output should include 'priority: 100'
+The output should include 'priority: 200'
+The output should include 'priority: 300'
+The status should be success
+End
+
+It 'preserves prompt cache keys for OpenRouter, Aliyun, and OpenCode'
+When run bash -c "sed -n '/name: \"openrouter\"/,/name: \"z-ai\"/p' '$PWD/config/cliproxyapi/config.template.yaml'; sed -n '/name: \"aliyun\"/,/name: \"opencode\"/p' '$PWD/config/cliproxyapi/config.template.yaml'; sed -n '/name: \"opencode\"/,/name: \"openai\"/p' '$PWD/config/cliproxyapi/config.template.yaml'"
+The output should include 'support-prompt-cache-key: true'
+The status should be success
+End
+
+It 'enables prompt cache keys on the Aliyun hop'
+When run bash -c "sed -n '/name: \"aliyun\"/,/name: \"opencode\"/p' '$PWD/config/cliproxyapi/config.template.yaml'"
+The output should include 'support-prompt-cache-key: true'
+The status should be success
+End
+
+It 'enables prompt cache keys on the OpenCode hop'
+When run bash -c "sed -n '/name: \"opencode\"/,/name: \"openai\"/p' '$PWD/config/cliproxyapi/config.template.yaml'"
 The output should include 'support-prompt-cache-key: true'
 The status should be success
 End


### PR DESCRIPTION
CLIProxy now sticks a session to whichever hop first served it for 8h, and every hop forwards `prompt_cache_key`.

The fill-first hop is unchanged: OpenCode 300, then Aliyun 200, then OpenRouter 100. Plan subscriptions are still tried first. Affinity only holds a binding after a successful fill; a 429 still fails over and rebinds.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>