### PR TITLE
perf(openclaw): Key GitHub hooks by repository

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -398,7 +398,7 @@
         "agentId": "main",
         "wakeMode": "now",
         "name": "GitHub",
-        "sessionKey": "hook:github:{{delivery}}",
+        "sessionKey": "hook:github:{{repository.full_name}}",
         "messageTemplate": "GitHub {{headers.x-github-event}} event on {{repository.full_name}}:\n\nAction: {{action}}\nSender: {{sender.login}}\n\n{{pull_request.title}}{{issue.title}}\n\n{{pull_request.html_url}}{{issue.html_url}}"
       }
     ]

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -398,7 +398,7 @@
         "agentId": "main",
         "wakeMode": "now",
         "name": "GitHub",
-        "sessionKey": "hook:github:{{delivery}}",
+        "sessionKey": "hook:github:{{repository.full_name}}",
         "messageTemplate": "GitHub {{headers.x-github-event}} event on {{repository.full_name}}:\n\nAction: {{action}}\nSender: {{sender.login}}\n\n{{pull_request.title}}{{issue.title}}\n\n{{pull_request.html_url}}{{issue.html_url}}"
       }
     ]

--- a/spec/openclaw_hydrate_spec.sh
+++ b/spec/openclaw_hydrate_spec.sh
@@ -264,6 +264,13 @@ It 'keeps the compiled wiki digest out of the cached system prefix'
 When run bash -c "jq -e '.plugins.entries[\"memory-wiki\"].config.context.includeCompiledDigestPrompt == false' '$PWD/config/openclaw/openclaw.tpl.json' '$PWD/config/openclaw/openclaw.template.json' >/dev/null"
 The status should be success
 End
+
+It 'reuses one GitHub hook session per repository'
+When run bash -c "jq -r '.hooks.mappings[] | select(.match.path == \"github\") | .sessionKey' '$PWD/config/openclaw/openclaw.tpl.json' '$PWD/config/openclaw/openclaw.template.json'"
+The output should include 'hook:github:{{repository.full_name}}'
+The output should not include '{{delivery}}'
+The status should be success
+End
 End
 
 Describe 'execution'


### PR DESCRIPTION
GitHub hook runs now share `hook:github:{{repository.full_name}}` instead of a new session per `{{delivery}}`. Events on the same repo reuse the same prefix cache.

Isolated cron runs stay per-run in OpenClaw runtime state; they are not in these templates. Does not change CLIProxy hop order.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>