### PR TITLE
perf(openclaw): Cap skills catalog in cached prefix

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -347,6 +347,12 @@
     "native": "auto",
     "nativeSkills": "auto"
   },
+  "skills": {
+    "limits": {
+      "maxSkillsInPrompt": 20,
+      "maxSkillsPromptChars": 4000
+    }
+  },
   "channels": {
     "telegram": {
       "enabled": true,

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -347,6 +347,12 @@
     "native": "auto",
     "nativeSkills": "auto"
   },
+  "skills": {
+    "limits": {
+      "maxSkillsInPrompt": 20,
+      "maxSkillsPromptChars": 4000
+    }
+  },
   "channels": {
     "telegram": {
       "enabled": true,

--- a/spec/openclaw_hydrate_spec.sh
+++ b/spec/openclaw_hydrate_spec.sh
@@ -271,6 +271,13 @@ The output should include 'hook:github:{{repository.full_name}}'
 The output should not include '{{delivery}}'
 The status should be success
 End
+
+It 'caps the skills catalog injected above the cache boundary'
+When run bash -c "jq -c '.skills.limits' '$PWD/config/openclaw/openclaw.tpl.json' '$PWD/config/openclaw/openclaw.template.json'"
+The output should include '"maxSkillsInPrompt":20'
+The output should include '"maxSkillsPromptChars":4000'
+The status should be success
+End
 End
 
 Describe 'execution'


### PR DESCRIPTION
The cached OpenClaw skills list is now capped at 20 skills / 4000 chars (defaults were 150 / 18000). Skill install or update churn no longer rewrites the whole prefix above the cache boundary.

Agents still load SKILL.md on demand. Does not change CLIProxy hop order.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>