### PR TITLE
fix(ci): repair Nix checks

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -10,10 +10,8 @@ on:
       name:
         type: string
         description: Run name
-
 permissions:
   contents: read
-
 jobs:
   pullfrog:
     runs-on: ubuntu-latest
@@ -34,34 +32,33 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GOOGLE_GENERATIVE_AI_API_KEY:
-            ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           MOONSHOT_API_KEY: ${{ secrets.MOONSHOT_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          
-          # for Amazon Bedrock (https://docs.pullfrog.com/bedrock)
-          # AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
-          # AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          # AWS_REGION: us-east-1
-          # BEDROCK_MODEL_ID: <bedrock-model-id>
-          
-          # for Google Vertex AI (https://docs.pullfrog.com/vertex)
-          # VERTEX_SERVICE_ACCOUNT_JSON: >-
-          #   ${{ secrets.VERTEX_SERVICE_ACCOUNT_JSON }}
-          # GOOGLE_CLOUD_PROJECT: my-project
-          # VERTEX_LOCATION: global
-          # VERTEX_MODEL_ID: <vertex-model-id>
 
-          # for any OpenAI-compatible endpoint — LiteLLM, Cloudflare AI Gateway,
-          # self-hosted vLLM (https://docs.pullfrog.com/openai-compatible)
-          # OPENAI_COMPATIBLE_BASE_URL: https://litellm.example.com/v1
-          # OPENAI_COMPATIBLE_API_KEY: ${{ secrets.OPENAI_COMPATIBLE_API_KEY }}
-          # OPENAI_COMPATIBLE_MODEL: <model-id>
-          # both limits are required — set them to the real limits of that model
-          # OPENAI_COMPATIBLE_CONTEXT: "128000"
-          # OPENAI_COMPATIBLE_MAX_OUTPUT: "16384"
+# for Amazon Bedrock (https://docs.pullfrog.com/bedrock)
+# AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+# AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+# AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+# AWS_REGION: us-east-1
+# BEDROCK_MODEL_ID: <bedrock-model-id>
+
+# for Google Vertex AI (https://docs.pullfrog.com/vertex)
+# VERTEX_SERVICE_ACCOUNT_JSON: >-
+#   ${{ secrets.VERTEX_SERVICE_ACCOUNT_JSON }}
+# GOOGLE_CLOUD_PROJECT: my-project
+# VERTEX_LOCATION: global
+# VERTEX_MODEL_ID: <vertex-model-id>
+
+# for any OpenAI-compatible endpoint — LiteLLM, Cloudflare AI Gateway,
+# self-hosted vLLM (https://docs.pullfrog.com/openai-compatible)
+# OPENAI_COMPATIBLE_BASE_URL: https://litellm.example.com/v1
+# OPENAI_COMPATIBLE_API_KEY: ${{ secrets.OPENAI_COMPATIBLE_API_KEY }}
+# OPENAI_COMPATIBLE_MODEL: <model-id>
+# both limits are required — set them to the real limits of that model
+# OPENAI_COMPATIBLE_CONTEXT: "128000"
+# OPENAI_COMPATIBLE_MAX_OUTPUT: "16384"

--- a/home-manager/services/mempalace-exporter/export.sh
+++ b/home-manager/services/mempalace-exporter/export.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [ -f /etc/hostname ]; then
-  _raw=$(tr -d '[:space:]' < /etc/hostname)
+  _raw=$(tr -d '[:space:]' </etc/hostname)
 else
   _raw=$(hostname 2>/dev/null || echo "unknown")
 fi

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -71,7 +71,7 @@
           # https://github.com/numtide/llm-agents.nix
           let
             pnpmDepsHashes = {
-              x86_64-linux = "sha256-sV9aynsvHXopeCkZ0Myjj+FrkySXAooh7SVSNsuL56c=";
+              x86_64-linux = "sha256-i/K5bj7CS7PGIX5hfayxAJ7ngNib92w3SDKGXTVWccA=";
             };
             hash = pnpmDepsHashes.${prev.stdenv.hostPlatform.system} or null;
             t3code = prev.llm-agents.t3code.overrideAttrs (old: {


### PR DESCRIPTION
## Summary
- refresh the x86_64 Linux t3code pnpm fixed-output hash from the failing CI derivation
- apply the repository formatter output required by the Nix format gate

## Validation
- `nix derivation show --impure .#nixosConfigurations.matic.pkgs.llm-agents.t3code.pnpmDeps` resolves the updated hash
- `make nix-format-check`
- `shellcheck home-manager/services/mempalace-exporter/export.sh`
- workflow YAML parses with Ruby

`make flake-check` is still running locally; the protected-branch GitHub Actions run is the authoritative end-to-end validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs failing Nix CI by updating the fixed-output `pnpmDeps` hash for `llm-agents.t3code` and aligning repository/CI formatting so format gates and YAML parsing pass. Previously CI failed on hash mismatch and format checks; now checks should pass with no runtime behavior changes.

- overlays/default.nix: refresh `x86_64-linux` `pnpmDeps` SHA256 from the CI derivation.
- .github/workflows/pullfrog.yml: normalize env formatting and unindent commented examples to satisfy YAML parsing; no workflow behavior change.
- home-manager/services/mempalace-exporter/export.sh: minor redirection tweak to satisfy `shellcheck`; no functional change.
- Validate with `nix derivation show --impure .#nixosConfigurations.matic.pkgs.llm-agents.t3code.pnpmDeps`, `make nix-format-check`, and `shellcheck` on the script; the protected Actions run is the end-to-end check.

<sup>Written for commit 937ab708788c71745a6afdbfed7a2e1affd96093. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

