### PR TITLE
chore(hermes): respond to all telegram messages

### DIFF
--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -276,6 +276,7 @@ discord:
 whatsapp: {}
 telegram:
   channel_prompts: {}
+  require_mention: false
 slack:
   channel_prompts: {}
 mattermost:

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -276,6 +276,7 @@ discord:
 whatsapp: {}
 telegram:
   channel_prompts: {}
+  require_mention: false
 slack:
   channel_prompts: {}
 mattermost:


### PR DESCRIPTION
Sets `require_mention: false` in the Hermes Telegram config so the agent responds to all messages in group threads (e.g. the みうら thread), not just when mentioned.\n\n- config/hermes/config.tpl.yaml\n- config/hermes/config.template.yaml

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hermes Telegram agent now responds to all group messages. Previously it replied only when mentioned; setting `telegram.require_mention: false` changes behavior to reply to every message in Telegram groups, which may increase noise and token usage.

- Affects Telegram only; Slack, Discord, and others are unchanged.
- Regenerate the Hermes config from templates and redeploy to apply. Revert by setting `telegram.require_mention: true` if noise becomes an issue.

<sup>Written for commit 739532f1e32e17b2e5b3b3c717b5344356443bff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

