### PR TITLE
chore(hermes): authorize users in group via group_allowed_chats

### DIFF
--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -277,6 +277,7 @@ whatsapp: {}
 telegram:
   channel_prompts: {}
   require_mention: false
+  group_allowed_chats: '-1003813578232'
 slack:
   channel_prompts: {}
 mattermost:

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -277,6 +277,7 @@ whatsapp: {}
 telegram:
   channel_prompts: {}
   require_mention: false
+  group_allowed_chats: '-1003813578232'
 slack:
   channel_prompts: {}
 mattermost:


### PR DESCRIPTION
## Summary
Adds `telegram.group_allowed_chats: '-1003813578232'` to the Hermes config templates so every member of the みうら/Shun group chat is authorized (per gateway authz: authorizes all members of the listed chat regardless of sender). Fixes the "Unauthorized user: 8816096318" rejection that caused Hermes to only react (thumbs-up) instead of replying in that group.

Mirrors #2391 (same 2-template pattern). Requires gateway restart after hydration.

## Test plan
- YAML validated (`ruby -ryaml` load of both templates)
- Config hydrates on next nix-switch (kyber); gateway restart activates authz

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authorize all members of the みうら/Shun Telegram group in Hermes by adding `telegram.group_allowed_chats: '-1003813578232'` to both config templates. Previously, Hermes rejected messages from group members and only reacted; now it will reply in that chat. This change authorizes any member of that specific chat.

**Rollout**
- Hydrate config and deploy (e.g., run nix-switch), then restart the Hermes gateway.
- Confirm `-1003813578232` is the correct group ID.

<sup>Written for commit 46bbc177faa758193dc81ec8c7f6804eb264184f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

