### PR TITLE
fix(ccs): allow antigravity headless agent to read files and run commands

### DIFF
--- a/config/ccs/agy.settings.template.json
+++ b/config/ccs/agy.settings.template.json
@@ -6,5 +6,8 @@
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-5",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-opus-5",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-5"
+  },
+  "permissions": {
+    "allow": ["read_file(*)", "command(*)"]
   }
 }


### PR DESCRIPTION
## Summary
- Add `read_file(*)` and `command(*)` to `permissions.allow` in the agy settings template (config/ccs/agy.settings.template.json)
- RoboRev review jobs fail after 3 retries because the agy/antigravity agent running headless can't prompt for tool permissions, so read_file/command are auto-denied and no review output is produced

## Test plan
- [x] Verified live runtime config (~/.ccs/agy.settings.json) now carries permissions.allow
- [x] No new review job failures since the fix applied

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows the agy/antigravity headless agent to read files and run commands by default so RoboRev review jobs can complete. Previously, headless runs auto-denied `read_file` and `command`, causing reviews to fail after 3 retries; the template now whitelists `read_file(*)` and `command(*)` to avoid prompts.

**Rollout / Migration**
- Update `~/.ccs/agy.settings.json` to include: `"permissions": { "allow": ["read_file(*)", "command(*)"] }`, or regenerate it from the updated template.
- Commands and file reads run without interactive confirmation in headless mode; run the agent in a restricted environment if needed.

<sup>Written for commit a8c35b45bd9f36f541482f39453316290162dea3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

