### PR TITLE
chore: upgrade

### DIFF
--- a/config/ccs/agy.settings.template.json
+++ b/config/ccs/agy.settings.template.json
@@ -6,8 +6,5 @@
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-5",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-opus-5",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-5"
-  },
-  "permissions": {
-    "allow": ["read_file(*)", "command(*)"]
   }
 }


### PR DESCRIPTION
Automated upgrade

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the permissions allowlist from `config/ccs/agy.settings.template.json` to align with the upgraded config schema. Previously the template explicitly allowed `read_file(*)` and `command(*)`; now it sets no explicit permissions, so behavior follows runtime defaults.

- Migration: If your deployment requires read_file or command capabilities, define them in your environment-specific settings using the current schema or re-add the allowlist locally.

<sup>Written for commit 98362a2c418c447c6daed80bcfe099ba37f94d1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

