### PR TITLE
feat(cliproxy): add Verboo DeepSeek fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ CLIPROXY_API_KEY=your-api-key-here
 CLIPROXY_MANAGEMENT_PASSWORD=your-management-key-here
 # Dedicated Alibaba Cloud Token Plan key for the aliyun CLIProxyAPI upstream.
 ALIYUN_TOKEN_PLAN_API_KEY=sk-sp-your-token-plan-key-here
+# Verboo Code key for the DeepSeek CLIProxyAPI fallback upstream.
+VERBOO_API_KEY=your-verboo-api-key-here
 # Stable login key for the CPA Manager Plus analytics panel.
 # Generate one locally, for example: printf 'cpamp_%s\n' "$(openssl rand -hex 32)"
 CPA_MANAGER_ADMIN_KEY=cpamp_your-long-random-admin-key-here

--- a/config/ccs/agy.settings.template.json
+++ b/config/ccs/agy.settings.template.json
@@ -8,6 +8,9 @@
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-5"
   },
   "permissions": {
-    "allow": ["read_file(*)", "command(*)"]
+    "allow": [
+      "read_file(*)",
+      "command(*)"
+    ]
   }
 }

--- a/config/ccs/agy.settings.tpl.json
+++ b/config/ccs/agy.settings.tpl.json
@@ -6,5 +6,11 @@
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "__CLAUDE_OPUS__",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "__CLAUDE_OPUS__",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "__CLAUDE_SONNET__"
+  },
+  "permissions": {
+    "allow": [
+      "read_file(*)",
+      "command(*)"
+    ]
   }
 }

--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -530,6 +530,17 @@ openai-compatibility:
         alias: "minimax-m3"
       - name: "kimi-k3"
         alias: "kimi-k3"
+  - name: "verboo"
+    priority: 150
+    base-url: "https://code.verboo.ai/router/v1"
+    support-prompt-cache-key: true
+    api-key-entries:
+      - api-key: "__VERBOO_API_KEY__"
+    models:
+      - name: "deepseek-v4-pro"
+        alias: "deepseek-v4-pro"
+      - name: "deepseek-v4-flash"
+        alias: "deepseek-v4-flash"
   - name: "openai"
     base-url: "https://api.openai.com/v1"
     api-key-entries:

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -530,6 +530,17 @@ openai-compatibility:
         alias: "__MINIMAX__"
       - name: "__KIMI__"
         alias: "__KIMI__"
+  - name: "verboo"
+    priority: 150
+    base-url: "https://code.verboo.ai/router/v1"
+    support-prompt-cache-key: true
+    api-key-entries:
+      - api-key: "__VERBOO_API_KEY__"
+    models:
+      - name: "__DEEPSEEK_PRO__"
+        alias: "__DEEPSEEK_PRO__"
+      - name: "__DEEPSEEK_FLASH__"
+        alias: "__DEEPSEEK_FLASH__"
   - name: "openai"
     base-url: "https://api.openai.com/v1"
     api-key-entries:

--- a/home-manager/services/cliproxyapi/README.md
+++ b/home-manager/services/cliproxyapi/README.md
@@ -111,6 +111,7 @@ OPENROUTER_API_KEY="sk-or-v1-..."
 OPENAI_API_KEY="sk-..."
 QWEN_API_KEY="sk-..."
 ALIYUN_TOKEN_PLAN_API_KEY="sk-sp-..."
+VERBOO_API_KEY="..."
 ```
 
 For more than one OpenCode Go account behind the same upstream endpoint, set a

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -88,6 +88,7 @@ if [ -f "$TEMPLATE" ]; then
     -e "s|__ZAI_API_KEY__|${ZAI_API_KEY:-}|g" \
     -e "s|__QWEN_API_KEY__|${QWEN_API_KEY:-${DASHSCOPE_API_KEY:-}}|g" \
     -e "s|__ALIYUN_TOKEN_PLAN_API_KEY__|${ALIYUN_TOKEN_PLAN_API_KEY:-}|g" \
+    -e "s|__VERBOO_API_KEY__|${VERBOO_API_KEY:-}|g" \
     -e "s|__AMP_UPSTREAM_API_KEY__|${AMP_UPSTREAM_API_KEY:-}|g" \
     >"$CONFIG"
 

--- a/spec/cliproxyapi_spec.sh
+++ b/spec/cliproxyapi_spec.sh
@@ -16,6 +16,7 @@ api_key: __OPENROUTER_API_KEY__
 openai_api_key: __OPENAI_API_KEY__
 qwen_api_key: __QWEN_API_KEY__
 aliyun_token_plan_api_key: __ALIYUN_TOKEN_PLAN_API_KEY__
+verboo_api_key: __VERBOO_API_KEY__
 management_password: __CLIPROXY_MANAGEMENT_PASSWORD__
 YAML
 
@@ -25,6 +26,7 @@ OPENROUTER_API_KEY=test_openrouter_key
 OPENAI_API_KEY=test_openai_key
 QWEN_API_KEY=test_qwen_key
 ALIYUN_TOKEN_PLAN_API_KEY=test_token_plan_key
+VERBOO_API_KEY=test_verboo_key
 CLIPROXY_MANAGEMENT_PASSWORD=test_mgmt_password
 ENV
 }
@@ -69,6 +71,7 @@ OPENROUTER_API_KEY="test_key"
 OPENAI_API_KEY="test_openai_key"
 QWEN_API_KEY="test_qwen_key"
 ALIYUN_TOKEN_PLAN_API_KEY="test_token_plan_key"
+VERBOO_API_KEY="test_verboo_key"
 CLIPROXY_MANAGEMENT_PASSWORD="test_pass"
 
 if [ -f "$TEMPLATE" ]; then
@@ -76,6 +79,7 @@ if [ -f "$TEMPLATE" ]; then
     -e "s|__OPENAI_API_KEY__|${OPENAI_API_KEY:-}|g" \
     -e "s|__QWEN_API_KEY__|${QWEN_API_KEY:-}|g" \
     -e "s|__ALIYUN_TOKEN_PLAN_API_KEY__|${ALIYUN_TOKEN_PLAN_API_KEY:-}|g" \
+    -e "s|__VERBOO_API_KEY__|${VERBOO_API_KEY:-}|g" \
     -e "s|__CLIPROXY_MANAGEMENT_PASSWORD__|${CLIPROXY_MANAGEMENT_PASSWORD:-}|g" \
     "$TEMPLATE" >"$CONFIG"
 fi
@@ -88,6 +92,7 @@ The output should include 'api_key: test_key'
 The output should include 'openai_api_key: test_openai_key'
 The output should include 'qwen_api_key: test_qwen_key'
 The output should include 'aliyun_token_plan_api_key: test_token_plan_key'
+The output should include 'verboo_api_key: test_verboo_key'
 The output should include 'management_password: test_pass'
 The status should be success
 End
@@ -254,6 +259,25 @@ The status should be success
 End
 End
 
+Describe 'Verboo DeepSeek provider'
+It 'hydrates the dedicated environment key into the runtime config'
+When run bash -c "grep 's|__VERBOO_API_KEY__|.*VERBOO_API_KEY' '$SCRIPT'"
+The output should include '__VERBOO_API_KEY__'
+The output should include 'VERBOO_API_KEY'
+The status should be success
+End
+
+It 'declares the OpenAI-compatible DeepSeek fallback upstream'
+When run bash -c "sed -n '/name: \"verboo\"/,/name: \"openai\"/p' '$PWD/config/cliproxyapi/config.template.yaml'"
+The output should include 'priority: 150'
+The output should include 'base-url: "https://code.verboo.ai/router/v1"'
+The output should include 'api-key: "__VERBOO_API_KEY__"'
+The output should include 'name: "deepseek-v4-pro"'
+The output should include 'name: "deepseek-v4-flash"'
+The status should be success
+End
+End
+
 Describe 'Docker image handling'
 It 'supports a locally built canary image without pulling over it'
 When run bash -c "sed -n '/CLIPROXYAPI_IMAGE/,/\"\$docker_image\" \&/p' '$SCRIPT'"
@@ -302,9 +326,10 @@ The output should include 'alias: "free"'
 The status should be success
 End
 
-It 'preserves the OpenCode then Aliyun then OpenRouter hop'
-When run bash -c "awk '/name: \"openrouter\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'; awk '/name: \"aliyun\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'; awk '/name: \"opencode\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'"
+It 'preserves the OpenCode then Aliyun then Verboo then OpenRouter hop'
+When run bash -c "awk '/name: \"openrouter\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'; awk '/name: \"verboo\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'; awk '/name: \"aliyun\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'; awk '/name: \"opencode\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'"
 The output should include 'priority: 100'
+The output should include 'priority: 150'
 The output should include 'priority: 200'
 The output should include 'priority: 300'
 The status should be success

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -150,6 +150,13 @@ The status should be success
 End
 End
 
+Describe 'generated AGY settings'
+It 'keeps explicit read and command permissions in both template and generated settings'
+When run bash -c "for settings in config/ccs/agy.settings.tpl.json config/ccs/agy.settings.template.json; do jq -e '.permissions.allow == [\"read_file(*)\", \"command(*)\"]' \"\$settings\" >/dev/null || exit 1; done"
+The status should be success
+End
+End
+
 Describe 'OpenCode runtime fallback'
 It 'keeps DeepSeek Flash as the explicit default model'
 When run bash -c "grep '\"model\": \"shunkakinoki/deepseek-v4-flash\"' config/opencode/opencode.jsonc"
@@ -264,8 +271,8 @@ When run bash -c "section=\$(sed -n '/name: \"aliyun\"/,/name: \"opencode\"/p' c
 The status should be success
 End
 
-It 'orders DeepSeek providers as OpenCode then Aliyun then OpenRouter'
-When run bash -c "grep -A 2 'name: \"opencode\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 300' && grep -A 2 'name: \"aliyun\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 200' && grep -A 2 'name: \"openrouter\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 100'"
+It 'orders DeepSeek providers as OpenCode then Aliyun then Verboo then OpenRouter'
+When run bash -c "grep -A 2 'name: \"opencode\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 300' && grep -A 2 'name: \"aliyun\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 200' && grep -A 2 'name: \"verboo\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 150' && grep -A 2 'name: \"openrouter\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 100'"
 The status should be success
 End
 


### PR DESCRIPTION
## Summary
- add Verboo Code as an OpenAI-compatible DeepSeek fallback after OpenCode and Aliyun
- hydrate VERBOO_API_KEY from the managed environment into CLIProxyAPI
- add the required read and command permissions to both AGY source and generated settings
- document the key and cover provider order, endpoint, aliases, hydration, and AGY permissions

## Validation
- make llm-update
- shellspec spec/llm_update_spec.sh (89 examples, 0 failures)
- shellspec spec/cliproxyapi_spec.sh spec/llm_update_spec.sh (118 examples, 0 failures before the AGY-only correction)
- shellcheck home-manager/services/cliproxyapi/scripts/start.sh
- Ruby YAML parse of config/cliproxyapi/config.template.yaml
- git diff --check