### PR TITLE
feat(galactica): enable OpenSSH over Tailscale

### DIFF
--- a/named-hosts/galactica/default.nix
+++ b/named-hosts/galactica/default.nix
@@ -21,6 +21,11 @@ inputs.nix-darwin.lib.darwinSystem {
       };
       age.identityPaths = [ "/Users/${username}/.ssh/id_ed25519" ];
       age.secrets = builtins.mapAttrs (_: value: { inherit (value) file; }) (import ./secrets.nix);
+
+      # The standalone macOS Tailscale app cannot host Tailscale SSH. Enable
+      # Apple's SSH server so Galactica remains reachable over its tailnet IP.
+      services.openssh.enable = true;
+
       home-manager.users.${username} =
         { pkgs, ... }:
         {

--- a/spec/galactica_openssh_spec.sh
+++ b/spec/galactica_openssh_spec.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'named-hosts/galactica/default.nix OpenSSH'
+CONFIG="$PWD/named-hosts/galactica/default.nix"
+
+It 'enables the built-in OpenSSH server for tailnet access'
+When run bash -c "grep -F 'services.openssh.enable = true;' '$CONFIG'"
+The output should include 'services.openssh.enable = true;'
+End
+
+End


### PR DESCRIPTION
## Summary

- enable Apple's built-in OpenSSH server declaratively on Galactica
- retain the supported Tailscale Standalone macOS client and its exit-node support
- add regression coverage for the host setting

## Validation

- `make test` (2,095 ShellSpec examples, 454 Fish tests, 8 Python tests, Neovim, and 12 Darwin flake checks)
- `make build`
- `make switch`
- `com.openssh.sshd` enabled in launchd
- port 22 reachable on Galactica's Tailscale IP (`100.69.230.112`)
- remote Kyber handshake returned `SSH-2.0-OpenSSH_10.3` and Galactica's ED25519 host key

## Context

The Standalone macOS Tailscale app cannot act as a Tailscale SSH server. This enables standard OpenSSH over the encrypted tailnet without migrating to the CLI-only `tailscaled` variant or losing exit-node client support.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables macOS OpenSSH on Galactica to allow SSH over Tailscale without migrating to `tailscaled` or losing exit-node client support. Previously Galactica could not host Tailscale SSH; now the built-in server is enabled and reachable on the tailnet IP.

**Review notes**
- Set `services.openssh.enable = true;` in `named-hosts/galactica/default.nix`.
- Added `spec/galactica_openssh_spec.sh` to assert the OpenSSH setting.
- SSH now listens on port 22 over the tailnet IP; Tailscale Standalone client behavior is unchanged.

<sup>Written for commit 3119bbc9a559978332c09604d90bcbf321aa9561. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

