### PR TITLE
fix(claude): use host-portable $HOME paths in notification hook docs

### DIFF
--- a/config/claude/NOTIFICATIONS.md
+++ b/config/claude/NOTIFICATIONS.md
@@ -152,7 +152,7 @@ The hooks configuration (local settings override global settings):
           },
           {
             "type": "command",
-            "command": "/Users/shunkakinoki/dotfiles/config/claude/pushover.sh"
+            "command": "$HOME/dotfiles/config/claude/pushover.sh"
           }
         ]
       }
@@ -166,7 +166,7 @@ The hooks configuration (local settings override global settings):
           },
           {
             "type": "command",
-            "command": "/Users/shunkakinoki/dotfiles/config/claude/pushover.sh"
+            "command": "$HOME/dotfiles/config/claude/pushover.sh"
           }
         ]
       }
@@ -176,7 +176,7 @@ The hooks configuration (local settings override global settings):
         "hooks": [
           {
             "type": "command",
-            "command": "/Users/shunkakinoki/dotfiles/config/claude/pushover.sh"
+            "command": "$HOME/dotfiles/config/claude/pushover.sh"
           }
         ]
       }
@@ -186,7 +186,7 @@ The hooks configuration (local settings override global settings):
         "hooks": [
           {
             "type": "command",
-            "command": "/Users/shunkakinoki/dotfiles/config/claude/pushover.sh"
+            "command": "$HOME/dotfiles/config/claude/pushover.sh"
           }
         ]
       }
@@ -196,7 +196,7 @@ The hooks configuration (local settings override global settings):
         "hooks": [
           {
             "type": "command",
-            "command": "/Users/shunkakinoki/dotfiles/config/claude/pushover.sh"
+            "command": "$HOME/dotfiles/config/claude/pushover.sh"
           }
         ]
       }
@@ -265,7 +265,7 @@ To enable additional notifications like `SessionStart` or `SessionEnd`:
     "hooks": [
       {
         "type": "command",
-        "command": "/Users/shunkakinoki/dotfiles/config/claude/pushover.sh"
+        "command": "$HOME/dotfiles/config/claude/pushover.sh"
       }
     ]
   }


### PR DESCRIPTION
## What

NOTIFICATIONS.md documented Claude Code notification hooks with absolute macOS paths (e.g. `/Users/shunkakinoki/dotfiles/config/claude/pushover.sh`). On a non-mac host (kyber/Linux, HOME=/home/ubuntu) those paths don't exist, so the documented config is broken there.

## Why

Same bug class surfaced live on kyber: a Claude `PreToolUse` dcg hook in `~/.claude/settings.json` had leaked `/Users/shunkakinoki/.local/bin/dcg` (correct only on macOS), so the destructive-command guard was silently not enforcing on kyber. The live config has been fixed to the portable `dcg`/PATH-resolved form; this PR keeps the repo's docs from teaching the leaking pattern going forward.

## Change

- `config/claude/NOTIFICATIONS.md`: `/Users/shunkakinoki/dotfiles/...` -> `$HOME/dotfiles/...` (6 occurrences). Host-portable, expands correctly on macOS and Linux.

No behavior change on macOS hosts; fixes documentation for any non-mac host.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uses `$HOME` in Claude notification hook docs to replace macOS-only absolute paths, so examples work on macOS and Linux. Previously examples used `/Users/...`; now they use `$HOME/...`, avoiding broken configs on non-mac hosts.

**Review / Migration**
- Updates six examples in `config/claude/NOTIFICATIONS.md` from `/Users/shunkakinoki/dotfiles/...` to `$HOME/dotfiles/...`.
- Documentation-only change; no runtime impact.
- If you copied the old path into `~/.claude/settings.json`, replace it with `$HOME/dotfiles/config/claude/pushover.sh`.

<sup>Written for commit 3013d22e5608dc6c65fa03e60e28174170d60744. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

