### PR TITLE
fix(gemini): merge CCS permissions into antigravity-cli settings

### DIFF
--- a/config/gemini/activate-antigravity.sh
+++ b/config/gemini/activate-antigravity.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Merge managed permissions into antigravity-cli's settings.json.
+# The agy binary reads ~/.gemini/antigravity-cli/settings.json, but CCS
+# hydration writes permissions to ~/.ccs/agy.settings.json. This script
+# bridges the gap by merging the permissions block.
+# Usage: activate-antigravity.sh <jq_bin>
+set -euo pipefail
+
+JQ_BIN="$1"
+CCS_SETTINGS="${HOME}/.ccs/agy.settings.json"
+AGY_DIR="${HOME}/.gemini/antigravity-cli"
+AGY_SETTINGS="${AGY_DIR}/settings.json"
+
+if [ ! -f "$CCS_SETTINGS" ]; then
+  exit 0
+fi
+
+PERMS=$("$JQ_BIN" -c '.permissions // empty' "$CCS_SETTINGS" 2>/dev/null) || true
+if [ -z "$PERMS" ]; then
+  exit 0
+fi
+
+mkdir -p "$AGY_DIR"
+
+TEMP_SETTINGS=""
+cleanup() {
+  if [ -n "$TEMP_SETTINGS" ]; then
+    rm -f "$TEMP_SETTINGS"
+  fi
+}
+trap cleanup EXIT
+
+TEMP_SETTINGS="$(mktemp "$AGY_DIR/settings.json.XXXXXX")"
+
+if [ -f "$AGY_SETTINGS" ]; then
+  "$JQ_BIN" --argjson perms "$PERMS" '.permissions = $perms' "$AGY_SETTINGS" >"$TEMP_SETTINGS"
+else
+  "$JQ_BIN" -n --argjson perms "$PERMS" '{permissions: $perms}' >"$TEMP_SETTINGS"
+fi
+
+mv -f "$TEMP_SETTINGS" "$AGY_SETTINGS"
+TEMP_SETTINGS=""
+chmod 600 "$AGY_SETTINGS"

--- a/config/gemini/activate-antigravity.sh
+++ b/config/gemini/activate-antigravity.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016
 # Merge managed permissions into antigravity-cli's settings.json.
 # The agy binary reads ~/.gemini/antigravity-cli/settings.json, but CCS
 # hydration writes permissions to ~/.ccs/agy.settings.json. This script
@@ -15,7 +16,10 @@ if [ ! -f "$CCS_SETTINGS" ]; then
   exit 0
 fi
 
-PERMS=$("$JQ_BIN" -c '.permissions // empty' "$CCS_SETTINGS" 2>/dev/null) || true
+if ! PERMS=$("$JQ_BIN" -c '.permissions // empty' "$CCS_SETTINGS"); then
+  echo "Warning: CCS agy settings are malformed or unreadable: $CCS_SETTINGS" >&2
+  exit 1
+fi
 if [ -z "$PERMS" ]; then
   exit 0
 fi
@@ -33,7 +37,20 @@ trap cleanup EXIT
 TEMP_SETTINGS="$(mktemp "$AGY_DIR/settings.json.XXXXXX")"
 
 if [ -f "$AGY_SETTINGS" ]; then
-  "$JQ_BIN" --argjson perms "$PERMS" '.permissions = $perms' "$AGY_SETTINGS" >"$TEMP_SETTINGS"
+  "$JQ_BIN" --argjson perms "$PERMS" '
+    def union($left; $right):
+      reduce ($left + $right)[] as $item
+        ([]; if index($item) == null then . + [$item] else . end);
+    def merge_permissions($existing; $incoming):
+      ($existing * $incoming)
+      | if (($existing | has("allow")) or ($incoming | has("allow"))) then
+          .allow = union(($existing.allow // []); ($incoming.allow // []))
+        else
+          .
+        end;
+    (.permissions // {}) as $existing
+    | .permissions = merge_permissions($existing; $perms)
+  ' "$AGY_SETTINGS" >"$TEMP_SETTINGS"
 else
   "$JQ_BIN" -n --argjson perms "$PERMS" '{permissions: $perms}' >"$TEMP_SETTINGS"
 fi

--- a/config/gemini/default.nix
+++ b/config/gemini/default.nix
@@ -9,7 +9,9 @@
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${./settings.json}"
   '';
 
-  home.activation.antigravitySettings = config.lib.dag.entryAfter [ "writeBoundary" "hydrateCcsSettings" ] ''
-    $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-antigravity.sh}" "${pkgs.jq}/bin/jq" || true
-  '';
+  home.activation.antigravitySettings =
+    config.lib.dag.entryAfter [ "writeBoundary" "hydrateCcsSettings" ]
+      ''
+        $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-antigravity.sh}" "${pkgs.jq}/bin/jq"
+      '';
 }

--- a/config/gemini/default.nix
+++ b/config/gemini/default.nix
@@ -5,9 +5,11 @@
   ...
 }:
 {
-  # Use activation script to copy settings.json instead of symlinking
-  # This allows ruler and other tools to modify the file
   home.activation.geminiSettings = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${./settings.json}"
+  '';
+
+  home.activation.antigravitySettings = config.lib.dag.entryAfter [ "writeBoundary" "hydrateCcsSettings" ] ''
+    $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-antigravity.sh}" "${pkgs.jq}/bin/jq" || true
   '';
 }

--- a/spec/activate_antigravity_spec.sh
+++ b/spec/activate_antigravity_spec.sh
@@ -35,7 +35,12 @@ JSON
   cat >"$TEMP_HOME/.gemini/antigravity-cli/settings.json" <<'JSON'
 {
   "colorScheme": "tokyo night",
-  "trustedWorkspaces": ["/some/path"]
+  "trustedWorkspaces": ["/some/path"],
+  "permissions": {
+    "allow": ["command(*)", "project_read(*)"],
+    "deny": ["delete(*)"],
+    "scope": {"workspace": "trusted"}
+  }
 }
 JSON
 }
@@ -45,13 +50,17 @@ Before 'setup'
 After 'cleanup'
 
 It 'preserves existing fields and adds permissions'
-When run bash -c 'HOME="$1" bash "$2" jq && jq -r ".colorScheme, (.trustedWorkspaces | length), (.permissions.allow | length), .permissions.allow[0], .permissions.allow[1]" "$1/.gemini/antigravity-cli/settings.json"' _ "$TEMP_HOME" "$SCRIPT"
+When run bash -c 'HOME="$1" bash "$2" jq && jq -r ".colorScheme, (.trustedWorkspaces | length), (.permissions.allow | length), .permissions.allow[0], .permissions.allow[1], .permissions.allow[2], .permissions.deny[0], .permissions.scope.workspace" "$1/.gemini/antigravity-cli/settings.json" && (stat -c "%a" "$1/.gemini/antigravity-cli/settings.json" 2>/dev/null || stat -f "%OLp" "$1/.gemini/antigravity-cli/settings.json")' _ "$TEMP_HOME" "$SCRIPT"
 The status should be success
 The line 1 should eq 'tokyo night'
 The line 2 should eq '1'
-The line 3 should eq '2'
-The line 4 should eq 'read_file(*)'
-The line 5 should eq 'command(*)'
+The line 3 should eq '3'
+The line 4 should eq 'command(*)'
+The line 5 should eq 'project_read(*)'
+The line 6 should eq 'read_file(*)'
+The line 7 should eq 'delete(*)'
+The line 8 should eq 'trusted'
+The line 9 should eq '600'
 End
 End
 
@@ -77,6 +86,24 @@ When run bash -c 'HOME="$1" bash "$2" jq && jq -r "(.permissions.allow | length)
 The status should be success
 The line 1 should eq '1'
 The line 2 should eq 'read_file(*)'
+End
+End
+
+Describe 'fails when CCS settings are malformed'
+setup() {
+  TEMP_HOME=$(mktemp -d)
+  mkdir -p "$TEMP_HOME/.ccs"
+  printf '{"permissions":\n' >"$TEMP_HOME/.ccs/agy.settings.json"
+}
+cleanup() { rm -rf "$TEMP_HOME"; }
+
+Before 'setup'
+After 'cleanup'
+
+It 'reports malformed settings and fails'
+When run bash -c 'HOME="$1" bash "$2" jq' _ "$TEMP_HOME" "$SCRIPT"
+The status should be failure
+The stderr should include 'Warning: CCS agy settings are malformed or unreadable'
 End
 End
 

--- a/spec/activate_antigravity_spec.sh
+++ b/spec/activate_antigravity_spec.sh
@@ -1,0 +1,138 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2016,SC2329
+
+Describe 'config/gemini/activate-antigravity.sh'
+SCRIPT="$PWD/config/gemini/activate-antigravity.sh"
+
+It 'uses bash shebang'
+When run bash -c "head -1 '$SCRIPT'"
+The output should include '#!/usr/bin/env bash'
+End
+
+It 'references the CCS agy settings as source'
+When run grep 'ccs/agy.settings.json' "$SCRIPT"
+The output should include '.ccs/agy.settings.json'
+End
+
+It 'targets the antigravity-cli settings path'
+When run grep 'antigravity-cli' "$SCRIPT"
+The output should include '.gemini/antigravity-cli'
+End
+
+Describe 'merges permissions into existing settings'
+setup() {
+  TEMP_HOME=$(mktemp -d)
+  mkdir -p "$TEMP_HOME/.ccs"
+  cat >"$TEMP_HOME/.ccs/agy.settings.json" <<'JSON'
+{
+  "env": {"ANTHROPIC_BASE_URL": "https://example.com"},
+  "permissions": {
+    "allow": ["read_file(*)", "command(*)"]
+  }
+}
+JSON
+  mkdir -p "$TEMP_HOME/.gemini/antigravity-cli"
+  cat >"$TEMP_HOME/.gemini/antigravity-cli/settings.json" <<'JSON'
+{
+  "colorScheme": "tokyo night",
+  "trustedWorkspaces": ["/some/path"]
+}
+JSON
+}
+cleanup() { rm -rf "$TEMP_HOME"; }
+
+Before 'setup'
+After 'cleanup'
+
+It 'preserves existing fields and adds permissions'
+When run bash -c 'HOME="$1" bash "$2" jq && jq -r ".colorScheme, (.trustedWorkspaces | length), (.permissions.allow | length), .permissions.allow[0], .permissions.allow[1]" "$1/.gemini/antigravity-cli/settings.json"' _ "$TEMP_HOME" "$SCRIPT"
+The status should be success
+The line 1 should eq 'tokyo night'
+The line 2 should eq '1'
+The line 3 should eq '2'
+The line 4 should eq 'read_file(*)'
+The line 5 should eq 'command(*)'
+End
+End
+
+Describe 'creates settings when none exist'
+setup() {
+  TEMP_HOME=$(mktemp -d)
+  mkdir -p "$TEMP_HOME/.ccs"
+  cat >"$TEMP_HOME/.ccs/agy.settings.json" <<'JSON'
+{
+  "permissions": {
+    "allow": ["read_file(*)"]
+  }
+}
+JSON
+}
+cleanup() { rm -rf "$TEMP_HOME"; }
+
+Before 'setup'
+After 'cleanup'
+
+It 'creates the settings file with permissions'
+When run bash -c 'HOME="$1" bash "$2" jq && jq -r "(.permissions.allow | length), .permissions.allow[0]" "$1/.gemini/antigravity-cli/settings.json"' _ "$TEMP_HOME" "$SCRIPT"
+The status should be success
+The line 1 should eq '1'
+The line 2 should eq 'read_file(*)'
+End
+End
+
+Describe 'skips when CCS settings are missing'
+setup() {
+  TEMP_HOME=$(mktemp -d)
+}
+cleanup() { rm -rf "$TEMP_HOME"; }
+
+Before 'setup'
+After 'cleanup'
+
+It 'exits successfully without creating anything'
+When run bash -c 'HOME="$1" bash "$2" jq && test ! -f "$1/.gemini/antigravity-cli/settings.json" && echo "no file"' _ "$TEMP_HOME" "$SCRIPT"
+The status should be success
+The output should eq 'no file'
+End
+End
+
+Describe 'skips when CCS settings have no permissions'
+setup() {
+  TEMP_HOME=$(mktemp -d)
+  mkdir -p "$TEMP_HOME/.ccs"
+  cat >"$TEMP_HOME/.ccs/agy.settings.json" <<'JSON'
+{
+  "env": {"ANTHROPIC_BASE_URL": "https://example.com"}
+}
+JSON
+  mkdir -p "$TEMP_HOME/.gemini/antigravity-cli"
+  cat >"$TEMP_HOME/.gemini/antigravity-cli/settings.json" <<'JSON'
+{"colorScheme": "default"}
+JSON
+}
+cleanup() { rm -rf "$TEMP_HOME"; }
+
+Before 'setup'
+After 'cleanup'
+
+It 'does not modify the settings file'
+When run bash -c 'HOME="$1" bash "$2" jq && jq -r ".colorScheme, has(\"permissions\")" "$1/.gemini/antigravity-cli/settings.json"' _ "$TEMP_HOME" "$SCRIPT"
+The status should be success
+The line 1 should eq 'default'
+The line 2 should eq 'false'
+End
+End
+
+Describe 'config/gemini/default.nix antigravity activation'
+It 'declares the antigravitySettings activation entry'
+When run grep 'antigravitySettings' "$PWD/config/gemini/default.nix"
+The output should include 'antigravitySettings'
+End
+
+It 'runs after CCS hydration'
+When run grep 'hydrateCcsSettings' "$PWD/config/gemini/default.nix"
+The output should include 'hydrateCcsSettings'
+End
+End
+
+End

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -320,6 +320,10 @@ It 'has spec file for config/gemini/activate.sh'
 The path "spec/activate_config_spec.sh" should be exist
 End
 
+It 'has spec file for config/gemini/activate-antigravity.sh'
+The path "spec/activate_antigravity_spec.sh" should be exist
+End
+
 It 'has spec file for config/git-ai/activate.sh'
 The path "spec/activate_config_spec.sh" should be exist
 End
@@ -477,6 +481,7 @@ config/shared/hooks/roborev-agent.sh
 config/cursor/activate.sh
 config/cursor/hooks/notify.sh
 config/cursor/hooks/pushover.sh
+config/gemini/activate-antigravity.sh
 config/gemini/activate.sh
 config/git-ai/activate.sh
 config/grok/activate.sh


### PR DESCRIPTION
## Summary

- **Root cause**: The `agy` (antigravity) binary reads settings from `~/.gemini/antigravity-cli/settings.json`, but CCS hydration only writes `permissions.allow` to `~/.ccs/agy.settings.json` - a path `agy` never reads. In headless print mode (`--sandbox`), agy >= 1.1.3 soft-denies tools needing permission confirmation and exits 0 with no output, causing the RoboRev review worker to fail with "antigravity produced no review output; add read_file(*) to permissions.allow".
- **Fix**: Add an activation step (`config/gemini/activate-antigravity.sh`) that merges the `permissions` block from the CCS-hydrated settings into `~/.gemini/antigravity-cli/settings.json`, preserving user-owned fields (`colorScheme`, `trustedWorkspaces`). Wired into Nix activation via `config/gemini/default.nix`, ordered after `hydrateCcsSettings`.
- **The source templates were already correct** - `config/ccs/agy.settings.tpl.json` already had `read_file(*)` and `command(*)`. The gap was the missing bridge from the CCS output path to the agy native settings path.

## Files changed

| File | Change |
|------|--------|
| `config/gemini/activate-antigravity.sh` | New activation script: reads `~/.ccs/agy.settings.json`, merges `.permissions` into `~/.gemini/antigravity-cli/settings.json` via jq |
| `config/gemini/default.nix` | Add `antigravitySettings` activation entry, ordered after `hydrateCcsSettings` |
| `spec/activate_antigravity_spec.sh` | 9 new ShellSpec tests covering merge, create, skip-no-ccs, skip-no-permissions scenarios |
| `spec/coverage_spec.sh` | Register the new script in coverage tracking |

## Test plan

- [x] All 145 specs pass (`shellspec spec/roborev_*.sh spec/activate_roborev_spec.sh spec/activate_antigravity_spec.sh spec/coverage_spec.sh`)
- [ ] `make build && make switch` on kyber to hydrate and verify `~/.gemini/antigravity-cli/settings.json` contains `permissions.allow`
- [ ] `roborev check-agents` shows agy OK
- [ ] Trigger a review with `roborev review --agent gemini --wait` and confirm output is produced

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing `agy` permissions in headless RoboRev runs by merging CCS-hydrated `.permissions` into `~/.gemini/antigravity-cli/settings.json`. Previously `agy` soft-denied tools in `--sandbox` and returned no output; now activation ensures `permissions.allow` is present, deduplicated, and preserves user fields. Hardened to fail fast with a warning on malformed CCS settings.

- Adds `config/gemini/activate-antigravity.sh`: merges `.permissions` from `~/.ccs/agy.settings.json` into `~/.gemini/antigravity-cli/settings.json`; unions `permissions.allow` with de-duplication; creates the file if absent (chmod 600); no-op if CCS settings or `.permissions` are missing; emits a warning and exits non-zero on malformed CCS JSON.
- Wires `home.activation.antigravitySettings` in `config/gemini/default.nix` to run after `hydrateCcsSettings` using `jq`.
- Tests: new `spec/activate_antigravity_spec.sh` covering merge, create, skip, and malformed scenarios; `spec/coverage_spec.sh` updated.
- Migration: run `make build && make switch`; verify `~/.gemini/antigravity-cli/settings.json` contains `permissions.allow`; run `roborev check-agents` and a test review.

<sup>Written for commit def9c59d272bd4135d7a868b6bc0ba0dd350f0f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

