### PR TITLE
feat(cliproxy): add Surplus Intelligence marketplace fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,8 @@ CLIPROXY_MANAGEMENT_PASSWORD=your-management-key-here
 ALIYUN_TOKEN_PLAN_API_KEY=sk-sp-your-token-plan-key-here
 # Verboo Code key for the DeepSeek CLIProxyAPI fallback upstream.
 VERBOO_API_KEY=your-verboo-api-key-here
+# Surplus Intelligence marketplace key for the low-priority CLIProxyAPI fallback upstream (inf_…).
+SURPLUS_API_KEY=your-surplus-api-key-here
 # Stable login key for the CPA Manager Plus analytics panel.
 # Generate one locally, for example: printf 'cpamp_%s\n' "$(openssl rand -hex 32)"
 CPA_MANAGER_ADMIN_KEY=cpamp_your-long-random-admin-key-here

--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -548,6 +548,17 @@ openai-compatibility:
     models:
       - name: "gpt-image-2"
         alias: "gpt-image-2"
+  - name: "surplus"
+    priority: 50
+    base-url: "https://api.surplusintelligence.ai/v1"
+    support-prompt-cache-key: true
+    api-key-entries:
+      - api-key: "__SURPLUS_API_KEY__"
+    models:
+      - name: "deepseek-v4-pro"
+        alias: "deepseek-v4-pro"
+      - name: "deepseek-v4-flash"
+        alias: "deepseek-v4-flash"
 
 # Official OpenAI compatibility provider reference
 # OpenAI compatibility providers

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -548,6 +548,17 @@ openai-compatibility:
     models:
       - name: "__GPT_IMAGE__"
         alias: "__GPT_IMAGE__"
+  - name: "surplus"
+    priority: 50
+    base-url: "https://api.surplusintelligence.ai/v1"
+    support-prompt-cache-key: true
+    api-key-entries:
+      - api-key: "__SURPLUS_API_KEY__"
+    models:
+      - name: "__DEEPSEEK_PRO__"
+        alias: "__DEEPSEEK_PRO__"
+      - name: "__DEEPSEEK_FLASH__"
+        alias: "__DEEPSEEK_FLASH__"
 
 # Official OpenAI compatibility provider reference
 # OpenAI compatibility providers

--- a/home-manager/services/cliproxyapi/README.md
+++ b/home-manager/services/cliproxyapi/README.md
@@ -112,6 +112,7 @@ OPENAI_API_KEY="sk-..."
 QWEN_API_KEY="sk-..."
 ALIYUN_TOKEN_PLAN_API_KEY="sk-sp-..."
 VERBOO_API_KEY="..."
+SURPLUS_API_KEY="..."
 ```
 
 For more than one OpenCode Go account behind the same upstream endpoint, set a

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -89,6 +89,7 @@ if [ -f "$TEMPLATE" ]; then
     -e "s|__QWEN_API_KEY__|${QWEN_API_KEY:-${DASHSCOPE_API_KEY:-}}|g" \
     -e "s|__ALIYUN_TOKEN_PLAN_API_KEY__|${ALIYUN_TOKEN_PLAN_API_KEY:-}|g" \
     -e "s|__VERBOO_API_KEY__|${VERBOO_API_KEY:-}|g" \
+    -e "s|__SURPLUS_API_KEY__|${SURPLUS_API_KEY:-}|g" \
     -e "s|__AMP_UPSTREAM_API_KEY__|${AMP_UPSTREAM_API_KEY:-}|g" \
     >"$CONFIG"
 

--- a/spec/cliproxyapi_spec.sh
+++ b/spec/cliproxyapi_spec.sh
@@ -17,6 +17,7 @@ openai_api_key: __OPENAI_API_KEY__
 qwen_api_key: __QWEN_API_KEY__
 aliyun_token_plan_api_key: __ALIYUN_TOKEN_PLAN_API_KEY__
 verboo_api_key: __VERBOO_API_KEY__
+surplus_api_key: __SURPLUS_API_KEY__
 management_password: __CLIPROXY_MANAGEMENT_PASSWORD__
 YAML
 
@@ -27,6 +28,7 @@ OPENAI_API_KEY=test_openai_key
 QWEN_API_KEY=test_qwen_key
 ALIYUN_TOKEN_PLAN_API_KEY=test_token_plan_key
 VERBOO_API_KEY=test_verboo_key
+SURPLUS_API_KEY=test_surplus_key
 CLIPROXY_MANAGEMENT_PASSWORD=test_mgmt_password
 ENV
 }
@@ -72,6 +74,7 @@ OPENAI_API_KEY="test_openai_key"
 QWEN_API_KEY="test_qwen_key"
 ALIYUN_TOKEN_PLAN_API_KEY="test_token_plan_key"
 VERBOO_API_KEY="test_verboo_key"
+SURPLUS_API_KEY="test_surplus_key"
 CLIPROXY_MANAGEMENT_PASSWORD="test_pass"
 
 if [ -f "$TEMPLATE" ]; then
@@ -80,6 +83,7 @@ if [ -f "$TEMPLATE" ]; then
     -e "s|__QWEN_API_KEY__|${QWEN_API_KEY:-}|g" \
     -e "s|__ALIYUN_TOKEN_PLAN_API_KEY__|${ALIYUN_TOKEN_PLAN_API_KEY:-}|g" \
     -e "s|__VERBOO_API_KEY__|${VERBOO_API_KEY:-}|g" \
+    -e "s|__SURPLUS_API_KEY__|${SURPLUS_API_KEY:-}|g" \
     -e "s|__CLIPROXY_MANAGEMENT_PASSWORD__|${CLIPROXY_MANAGEMENT_PASSWORD:-}|g" \
     "$TEMPLATE" >"$CONFIG"
 fi
@@ -93,6 +97,7 @@ The output should include 'openai_api_key: test_openai_key'
 The output should include 'qwen_api_key: test_qwen_key'
 The output should include 'aliyun_token_plan_api_key: test_token_plan_key'
 The output should include 'verboo_api_key: test_verboo_key'
+The output should include 'surplus_api_key: test_surplus_key'
 The output should include 'management_password: test_pass'
 The status should be success
 End
@@ -278,6 +283,25 @@ The status should be success
 End
 End
 
+Describe 'Surplus Intelligence marketplace provider'
+It 'hydrates the dedicated environment key into the runtime config'
+When run bash -c "grep 's|__SURPLUS_API_KEY__|.*SURPLUS_API_KEY' '$SCRIPT'"
+The output should include '__SURPLUS_API_KEY__'
+The output should include 'SURPLUS_API_KEY'
+The status should be success
+End
+
+It 'declares the OpenAI-compatible last-resort fallback upstream'
+When run bash -c "sed -n '/name: \"surplus\"/,/name: \"openai\"/p' '$PWD/config/cliproxyapi/config.template.yaml'"
+The output should include 'priority: 50'
+The output should include 'base-url: "https://api.surplusintelligence.ai/v1"'
+The output should include 'api-key: "__SURPLUS_API_KEY__"'
+The output should include 'name: "deepseek-v4-pro"'
+The output should include 'name: "deepseek-v4-flash"'
+The status should be success
+End
+End
+
 Describe 'Docker image handling'
 It 'supports a locally built canary image without pulling over it'
 When run bash -c "sed -n '/CLIPROXYAPI_IMAGE/,/\"\$docker_image\" \&/p' '$SCRIPT'"
@@ -326,8 +350,9 @@ The output should include 'alias: "free"'
 The status should be success
 End
 
-It 'preserves the OpenCode then Aliyun then Verboo then OpenRouter hop'
-When run bash -c "awk '/name: \"openrouter\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'; awk '/name: \"verboo\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'; awk '/name: \"aliyun\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'; awk '/name: \"opencode\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'"
+It 'preserves the OpenCode then Aliyun then Verboo then OpenRouter then Surplus hop'
+When run bash -c "awk '/name: \"surplus\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'; awk '/name: \"openrouter\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'; awk '/name: \"verboo\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'; awk '/name: \"aliyun\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'; awk '/name: \"opencode\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'"
+The output should include 'priority: 50'
 The output should include 'priority: 100'
 The output should include 'priority: 150'
 The output should include 'priority: 200'

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -271,8 +271,8 @@ When run bash -c "section=\$(sed -n '/name: \"aliyun\"/,/name: \"opencode\"/p' c
 The status should be success
 End
 
-It 'orders DeepSeek providers as OpenCode then Aliyun then Verboo then OpenRouter'
-When run bash -c "grep -A 2 'name: \"opencode\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 300' && grep -A 2 'name: \"aliyun\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 200' && grep -A 2 'name: \"verboo\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 150' && grep -A 2 'name: \"openrouter\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 100'"
+It 'orders DeepSeek providers as OpenCode then Aliyun then Verboo then OpenRouter then Surplus'
+When run bash -c "grep -A 2 'name: \"opencode\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 300' && grep -A 2 'name: \"aliyun\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 200' && grep -A 2 'name: \"verboo\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 150' && grep -A 2 'name: \"openrouter\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 100' && grep -A 2 'name: \"surplus\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 50'"
 The status should be success
 End
 


### PR DESCRIPTION
## Changes
- Add Surplus Intelligence (`https://api.surplusintelligence.ai/v1`) as the lowest-priority OpenAI-compatible fallback upstream
- `priority: 50` — below OpenRouter (100), so it's the last-resort hop: OpenCode(300) → Aliyun(200) → Verboo(150) → OpenRouter(100) → **Surplus(50)**
- Routes DeepSeek v4 pro/flash to the cheapest marketplace seller when higher-priority providers fail
- Add `SURPLUS_API_KEY` (inf_…) env placeholder + `start.sh` substitution

## Technical Details
- Mirrors the Verboo provider pattern (aff2b75b) across all 7 files
- Marketplace key format: `inf_...` (from [buyer quickstart](https://www.surplusintelligence.ai/docs/getting-started/buyer-quickstart))

## Testing
- `shellspec spec/cliproxyapi_spec.sh spec/llm_update_spec.sh` → 120 examples, 0 failures
- New specs cover key hydration + provider declaration + hop order

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Surplus Intelligence as the lowest-priority OpenAI-compatible fallback for CLIProxyAPI. Previously the chain ended at OpenRouter; now DeepSeek v4 requests continue to Surplus (priority 50) when higher-priority providers fail, improving resiliency and cost control.

- Preserves hop order: OpenCode (300) → Aliyun (200) → Verboo (150) → OpenRouter (100) → Surplus (50).
- Routes `deepseek-v4-pro` and `deepseek-v4-flash` via Surplus marketplace to the cheapest seller on failure of earlier hops.
- Mirrors the Verboo provider pattern in `config.template.yaml` and `config.tpl.yaml`; supports prompt cache key.
- Specs updated to cover key hydration, provider declaration, and hop order; all tests passing.

**Rollout**
- Set `SURPLUS_API_KEY` to an `inf_...` marketplace key in all environments. Without this key, the Surplus fallback will fail when reached.

<sup>Written for commit adbb09ae6c9741e7a901f7110e4122b8d9a247f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

