### PR TITLE
fix(cliproxy): align Surplus fallback priority with Verboo (150)

### DIFF
--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -549,7 +549,7 @@ openai-compatibility:
       - name: "gpt-image-2"
         alias: "gpt-image-2"
   - name: "surplus"
-    priority: 50
+    priority: 150
     base-url: "https://api.surplusintelligence.ai/v1"
     support-prompt-cache-key: true
     api-key-entries:

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -549,7 +549,7 @@ openai-compatibility:
       - name: "__GPT_IMAGE__"
         alias: "__GPT_IMAGE__"
   - name: "surplus"
-    priority: 50
+    priority: 150
     base-url: "https://api.surplusintelligence.ai/v1"
     support-prompt-cache-key: true
     api-key-entries:

--- a/spec/cliproxyapi_spec.sh
+++ b/spec/cliproxyapi_spec.sh
@@ -293,7 +293,7 @@ End
 
 It 'declares the OpenAI-compatible last-resort fallback upstream'
 When run bash -c "sed -n '/name: \"surplus\"/,/name: \"openai\"/p' '$PWD/config/cliproxyapi/config.template.yaml'"
-The output should include 'priority: 50'
+The output should include 'priority: 150'
 The output should include 'base-url: "https://api.surplusintelligence.ai/v1"'
 The output should include 'api-key: "__SURPLUS_API_KEY__"'
 The output should include 'name: "deepseek-v4-pro"'
@@ -352,7 +352,7 @@ End
 
 It 'preserves the OpenCode then Aliyun then Verboo then OpenRouter then Surplus hop'
 When run bash -c "awk '/name: \"surplus\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'; awk '/name: \"openrouter\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'; awk '/name: \"verboo\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'; awk '/name: \"aliyun\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'; awk '/name: \"opencode\"/{p=1} p&&/priority:/{print; exit}' '$PWD/config/cliproxyapi/config.template.yaml'"
-The output should include 'priority: 50'
+The output should include 'priority: 150'
 The output should include 'priority: 100'
 The output should include 'priority: 150'
 The output should include 'priority: 200'

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -272,7 +272,7 @@ The status should be success
 End
 
 It 'orders DeepSeek providers as OpenCode then Aliyun then Verboo then OpenRouter then Surplus'
-When run bash -c "grep -A 2 'name: \"opencode\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 300' && grep -A 2 'name: \"aliyun\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 200' && grep -A 2 'name: \"verboo\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 150' && grep -A 2 'name: \"openrouter\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 100' && grep -A 2 'name: \"surplus\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 50'"
+When run bash -c "grep -A 2 'name: \"opencode\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 300' && grep -A 2 'name: \"aliyun\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 200' && grep -A 2 'name: \"verboo\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 150' && grep -A 2 'name: \"openrouter\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 100' && grep -A 2 'name: \"surplus\"' config/cliproxyapi/config.template.yaml | grep -q 'priority: 150'"
 The status should be success
 End
 


### PR DESCRIPTION
## Changes
- Raise Surplus Intelligence provider priority from 50 → 150, matching Verboo's fallback tier
- Hop order: OpenCode(300) → Aliyun(200) → Verboo(150) → Surplus(150) → OpenRouter(100)

## Why
#2400 merged with `priority: 50` before the 150 update was pushed; this aligns Surplus with the Verboo fallback tier per request.

## Testing
- `shellspec spec/cliproxyapi_spec.sh spec/llm_update_spec.sh` → 120 examples, 0 failures