### PR TITLE
fix(k3s): restore isKyber inherit broken by andor generalization

### DIFF
--- a/config/k3s/default.nix
+++ b/config/k3s/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 let
-  inherit (inputs.host) isGalactica isK3sServer k3s;
+  inherit (inputs.host) isGalactica isK3sServer isKyber k3s;
   clusterName = if isK3sServer then k3s.clusterName else "kyber";
   kubeconfig =
     if isGalactica then


### PR DESCRIPTION
## Changes
- Add `isKyber` back to the `inherit (inputs.host)` in `config/k3s/default.nix`

## Why
The #2129 merge generalized the k3s let-binding to `isK3sServer` but kept the kyber-only service files (containerd.mount, journald limits, host-health, smartd) gated on `isKyber`, which was dropped from the inherit. This makes **every kyber home-manager eval fail** with `undefined variable 'isKyber'` — blocking activation on kyber (including cliproxy template refresh).

## Testing
- `nix-instantiate --parse config/k3s/default.nix` → OK