### PR TITLE
fix(tailscale): satisfy CI inline-script and nixfmt checks

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -32,7 +32,7 @@ jobs:
         run: make shell-check-dev
   shell-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -41,7 +41,7 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run ShellSpec
-        run: nix shell nixpkgs#shellspec --command shellspec
+        run: nix shell nixpkgs#shellspec --command shellspec --format documentation --jobs 1
   shell-check:
     if: always()
     needs:

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -32,7 +32,7 @@ jobs:
         run: make shell-check-dev
   shell-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -40,8 +40,8 @@ jobs:
         uses: cachix/install-nix-action@v31
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run ShellSpec Tests (Dev Shell)
-        run: make shell-test-dev
+      - name: Run ShellSpec
+        run: nix shell nixpkgs#shellspec --command shellspec
   shell-check:
     if: always()
     needs:

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run ShellSpec
-        run: nix shell nixpkgs#shellspec --command shellspec --format documentation --jobs 1
+        run: nix shell nixpkgs#shellspec nixpkgs#ripgrep --command shellspec --format documentation --jobs 1
   shell-check:
     if: always()
     needs:

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -32,7 +32,7 @@ jobs:
         run: make shell-check-dev
   shell-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 90
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/config/k3s/default.nix
+++ b/config/k3s/default.nix
@@ -6,7 +6,12 @@
   ...
 }:
 let
-  inherit (inputs.host) isGalactica isK3sServer isKyber k3s;
+  inherit (inputs.host)
+    isGalactica
+    isK3sServer
+    isKyber
+    k3s
+    ;
   clusterName = if isK3sServer then k3s.clusterName else "kyber";
   kubeconfig =
     if isGalactica then

--- a/home-manager/modules/tailscale/default.nix
+++ b/home-manager/modules/tailscale/default.nix
@@ -38,10 +38,6 @@ let
     WantedBy=multi-user.target
   '';
 
-  tailscaleUpScript = pkgs.writeShellScript "tailscale-up" ''
-    exec ${pkgs.bash}/bin/bash ${./activate-up.sh} ${cfg.tailscaled.package}/bin/tailscale ${lib.escapeShellArgs cfg.extraUpArgs}
-  '';
-
   tailscaleUpServiceFile = pkgs.writeText "tailscale-up.service" ''
     [Unit]
     Description=Apply Tailscale node flags
@@ -52,7 +48,7 @@ let
     [Service]
     Type=oneshot
     RemainAfterExit=yes
-    ExecStart=${tailscaleUpScript}
+    ExecStart=${pkgs.bash}/bin/bash ${./activate-up.sh} ${cfg.tailscaled.package}/bin/tailscale ${lib.escapeShellArgs cfg.extraUpArgs}
 
     [Install]
     WantedBy=multi-user.target

--- a/spec/activate_tailscale_spec.sh
+++ b/spec/activate_tailscale_spec.sh
@@ -102,6 +102,20 @@ End
 End
 End
 
+Describe 'home-manager/modules/tailscale/default.nix'
+MODULE="$PWD/home-manager/modules/tailscale/default.nix"
+
+It 'delegates tailscale-up to the external activate script'
+When run bash -c "grep 'activate-up.sh' '$MODULE' && grep 'bin/bash' '$MODULE'"
+The output should include 'activate-up.sh'
+End
+
+It 'does not wrap tailscale-up in an inline writeShellScript'
+When run bash -c "grep -E 'writeShellScript[[:space:]]+\"tailscale-up\"' '$MODULE' || true"
+The output should equal ''
+End
+End
+
 Describe 'home-manager/modules/tailscale/activate-up.sh'
 SCRIPT="$PWD/home-manager/modules/tailscale/activate-up.sh"
 

--- a/spec/make_build_host_resolution_spec.sh
+++ b/spec/make_build_host_resolution_spec.sh
@@ -4,7 +4,7 @@
 Describe 'Makefile nix-build host resolution'
 
 setup() {
-  mock_bin_setup nix sleep
+  mock_bin_setup nix sleep nixos-rebuild
 }
 
 cleanup() {
@@ -53,7 +53,6 @@ It 'builds andor through its named Home Manager configuration'
 When run bash -c 'make build HOST=andor OS=Linux ARCH=x86_64 NIX_SYSTEM=x86_64-linux NIX_CONFIG_TYPE=homeConfigurations NIX_EXEC=nix NIX_ENV=ok NIX_FLAGS= NIX_USER_TRUSTED=yes 2>/dev/null; cat "$MOCK_LOG"'
 The status should be success
 The output should include '.#homeConfigurations.andor.activationPackage'
-End
 End
 
 It 'detects matic from Framework 13 AMD AI 300 DMI data when the hostname is generic'


### PR DESCRIPTION
#2410 was admin-merged with red checks. This is the follow-through.

- `shell-inline-check` failed because `tailscale-up` used `pkgs.writeShellScript "..." ''`. ExecStart now calls `activate-up.sh` the same way the rest of the repo does.
- `nix-format` / `nix-flake` / `nix-test` failed because treefmt wants the k3s `inherit (inputs.host)` list wrapped.

Local: `check-nix-inline-scripts.sh` clean, `nixfmt --check` on the two Nix files, `shellspec` 174 examples 0 failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Tailscale “up” CI-safe without changing runtime behavior. Previously `ExecStart` used an inline `writeShellScript`; it now invokes `activate-up.sh` directly, and CI runs `shellspec` in a clean shell to avoid hangs.

- Updates `ExecStart` in `home-manager/modules/tailscale/default.nix` to call `activate-up.sh` with `bash` and Tailscale args.
- Adds `shellspec` checks to forbid inline `writeShellScript` and verify delegation to `activate-up.sh`.
- Runs `shellspec` via `nix shell` with `nixpkgs#shellspec` and `nixpkgs#ripgrep` and documentation output; raises the CI timeout to 45 minutes.
- Mocks `nixos-rebuild` and keeps host-resolution specs under the nix mock to prevent real system switches in CI.
- Wraps the `inherit (inputs.host)` list in `config/k3s/default.nix` to satisfy `nixfmt`/`treefmt`.

<sup>Written for commit 6230bcda8d443accd33d087621fb8565884f8f77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

