### PR TITLE
chore(tokscale): cap submit scan with timeout to prevent flaky hang

### DIFF
--- a/home-manager/services/tokscale/submit.sh
+++ b/home-manager/services/tokscale/submit.sh
@@ -17,4 +17,11 @@ fi
 
 # stdin from /dev/null keeps submit non-interactive (skips the "star the repo"
 # prompt seen on a TTY).
-exec bun "$TOKSCALE_BIN" submit </dev/null
+#
+# Wrap with `timeout`: the scan intermittently hangs on Kyber (100+ parked
+# threads, ~0% CPU, no progress - e.g. walking the 34k+ entry
+# ~/.config/Code/logs tree). A hard cap makes a wedged submit self-terminate
+# instead of pinning the oneshot thread until the next tick. 240s covers a cold
+# scan of all active clients (codex 2.1G, opencode 1.2G DB); adjust if the 3h
+# cadence drifts.
+timeout 240 bun "$TOKSCALE_BIN" submit </dev/null


### PR DESCRIPTION
## Summary
Wraps `tokscale submit` in `timeout 240` so a wedged scan self-terminates instead of parking 100+ threads on futex until the next 3h tick. On Kyber the scan intermittently hangs (0.3% CPU, no progress) while walking pathological trees like `~/.config/Code/logs` (34k+ entries). Prior to this, a stuck oneshot run pinned the systemd thread indefinitely; two observed within 24h.

240s covers a cold scan of all active clients (codex 2.1G, opencode 1.2G DB) based on the successful prior runs.

## Test plan
- `shellspec spec/tokscale_spec.sh`: 19 examples, 0 failures (incl. exit-status propagation test)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the `tokscale submit` scan at 240s to prevent rare hangs that pinned the oneshot service until the next 3h tick. Previously a wedged scan could stall at ~0% CPU; now it self-terminates on timeout.

- Change: replace `exec bun "$TOKSCALE_BIN" submit </dev/null` with `timeout 240 bun "$TOKSCALE_BIN" submit </dev/null` in `home-manager/services/tokscale/submit.sh`.
- Side effects: scans exceeding 240s receive SIGTERM (then SIGKILL) and exit with code 124; otherwise exit codes propagate from `bun`.
- Rollout: watch logs for 124 timeouts on large trees; increase the cap if cold scans approach the limit.

<sup>Written for commit 9eeb50b5e0aab4d1f3d9c89faceabc8a94802399. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

