### PR TITLE
feat: add commandcode provider to cliproxyapi config

### DIFF
--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -546,7 +546,7 @@ openai-compatibility:
     base-url: "https://api.commandcode.ai/provider/v1"
     support-prompt-cache-key: true
     api-key-entries:
-      - api-key: "__COMMAND_CODE_API_KEY__"
+      - api-key: "__COMMANDCODE_API_KEY__"
     models:
       - name: "deepseek-v4-pro"
         alias: "deepseek-v4-pro"

--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -541,6 +541,17 @@ openai-compatibility:
         alias: "deepseek-v4-pro"
       - name: "deepseek-v4-flash"
         alias: "deepseek-v4-flash"
+  - name: "commandcode"
+    priority: 150
+    base-url: "https://api.commandcode.ai/provider/v1"
+    support-prompt-cache-key: true
+    api-key-entries:
+      - api-key: "__COMMAND_CODE_API_KEY__"
+    models:
+      - name: "deepseek-v4-pro"
+        alias: "deepseek-v4-pro"
+      - name: "deepseek-v4-flash"
+        alias: "deepseek-v4-flash"
   - name: "openai"
     base-url: "https://api.openai.com/v1"
     api-key-entries:

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -541,6 +541,17 @@ openai-compatibility:
         alias: "__DEEPSEEK_PRO__"
       - name: "__DEEPSEEK_FLASH__"
         alias: "__DEEPSEEK_FLASH__"
+  - name: "commandcode"
+    priority: 150
+    base-url: "https://api.commandcode.ai/provider/v1"
+    support-prompt-cache-key: true
+    api-key-entries:
+      - api-key: "__COMMAND_CODE_API_KEY__"
+    models:
+      - name: "__DEEPSEEK_PRO__"
+        alias: "__DEEPSEEK_PRO__"
+      - name: "__DEEPSEEK_FLASH__"
+        alias: "__DEEPSEEK_FLASH__"
   - name: "openai"
     base-url: "https://api.openai.com/v1"
     api-key-entries:

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -546,7 +546,7 @@ openai-compatibility:
     base-url: "https://api.commandcode.ai/provider/v1"
     support-prompt-cache-key: true
     api-key-entries:
-      - api-key: "__COMMAND_CODE_API_KEY__"
+      - api-key: "__COMMANDCODE_API_KEY__"
     models:
       - name: "__DEEPSEEK_PRO__"
         alias: "__DEEPSEEK_PRO__"

--- a/home-manager/services/cliproxyapi/README.md
+++ b/home-manager/services/cliproxyapi/README.md
@@ -113,6 +113,7 @@ QWEN_API_KEY="sk-..."
 ALIYUN_TOKEN_PLAN_API_KEY="sk-sp-..."
 VERBOO_API_KEY="..."
 SURPLUS_API_KEY="..."
+COMMANDCODE_API_KEY="..."
 ```
 
 For more than one OpenCode Go account behind the same upstream endpoint, set a

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -90,6 +90,7 @@ if [ -f "$TEMPLATE" ]; then
     -e "s|__ALIYUN_TOKEN_PLAN_API_KEY__|${ALIYUN_TOKEN_PLAN_API_KEY:-}|g" \
     -e "s|__VERBOO_API_KEY__|${VERBOO_API_KEY:-}|g" \
     -e "s|__SURPLUS_API_KEY__|${SURPLUS_API_KEY:-}|g" \
+    -e "s|__COMMANDCODE_API_KEY__|${COMMANDCODE_API_KEY:-}|g" \
     -e "s|__AMP_UPSTREAM_API_KEY__|${AMP_UPSTREAM_API_KEY:-}|g" \
     >"$CONFIG"
 

--- a/spec/cliproxyapi_spec.sh
+++ b/spec/cliproxyapi_spec.sh
@@ -283,6 +283,25 @@ The status should be success
 End
 End
 
+Describe 'Command Code provider'
+It 'hydrates the dedicated environment key into the runtime config'
+When run bash -c "grep 's|__COMMANDCODE_API_KEY__|.*COMMANDCODE_API_KEY' '$SCRIPT'"
+The output should include '__COMMANDCODE_API_KEY__'
+The output should include 'COMMANDCODE_API_KEY'
+The status should be success
+End
+
+It 'declares the OpenAI-compatible DeepSeek fallback upstream'
+When run bash -c "sed -n '/name: \"commandcode\"/,/name: \"openai\"/p' '$PWD/config/cliproxyapi/config.template.yaml'"
+The output should include 'priority: 150'
+The output should include 'base-url: "https://api.commandcode.ai/provider/v1"'
+The output should include 'api-key: "__COMMANDCODE_API_KEY__"'
+The output should include 'name: "deepseek-v4-pro"'
+The output should include 'name: "deepseek-v4-flash"'
+The status should be success
+End
+End
+
 Describe 'Surplus Intelligence marketplace provider'
 It 'hydrates the dedicated environment key into the runtime config'
 When run bash -c "grep 's|__SURPLUS_API_KEY__|.*SURPLUS_API_KEY' '$SCRIPT'"


### PR DESCRIPTION
Add commandcode openai-compat provider (priority 150) to both cliproxyapi config templates, wire COMMANDCODE_API_KEY substitution in start.sh, and document the new env var in the service README.

- config/cliproxyapi/config.template.yaml: commandcode provider block (priority 150, deepseek-v4-pro/flash)
- config/cliproxyapi/config.tpl.yaml: same
- home-manager/services/cliproxyapi/scripts/start.sh: __COMMANDCODE_API_KEY__ substitution
- home-manager/services/cliproxyapi/README.md: env var doc

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new OpenAI-compatible commandcode provider to cliproxyapi to route DeepSeek models with prompt-cache support. Previously there was no commandcode provider; now it can be selected with priority 150 and reads COMMANDCODE_API_KEY from the environment.

- Adds the provider block to both config templates (base URL https://api.commandcode.ai/provider/v1, prompt-cache enabled, models deepseek-v4-pro and deepseek-v4-flash).
- Aligns placeholder usage: templates now use __COMMANDCODE_API_KEY__ to match start.sh substitution; README documents COMMANDCODE_API_KEY.
- Adds spec coverage for the substitution and provider block.
- Action: Set COMMANDCODE_API_KEY in the environment to enable Commandcode routing.

<sup>Written for commit b829e1acbfa5d1347443ade559c041b71249598e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

