### PR TITLE
fix(kyber): protect CLIProxy from host pressure

### DIFF
--- a/config/k3s/activate.sh
+++ b/config/k3s/activate.sh
@@ -33,10 +33,12 @@ ensure_authorized_key() {
 ensure_authorized_key "$GALACTICA_AUTHORIZED_KEY"
 
 K3S_CONFIG_SOURCE="$HOME/.config/k3s/config.yaml"
+RESOLV_CONFIG_SOURCE="$HOME/.config/k3s/resolv.conf"
+RESOLV_CONFIG_TARGET="/etc/rancher/k3s/resolv.conf"
 KUBELET_CONFIG_SOURCE="$HOME/.config/k3s/kubelet.conf.d/$KUBELET_CONFIG_NAME"
 KUBELET_CONFIG_TARGET="/var/lib/rancher/k3s/agent/etc/kubelet.conf.d/$KUBELET_CONFIG_NAME"
 
-if [ ! -f "$K3S_CONFIG_SOURCE" ] || [ ! -f "$KUBELET_CONFIG_SOURCE" ]; then
+if [ ! -f "$K3S_CONFIG_SOURCE" ] || [ ! -f "$RESOLV_CONFIG_SOURCE" ] || [ ! -f "$KUBELET_CONFIG_SOURCE" ]; then
   exit 0
 fi
 
@@ -59,6 +61,11 @@ $SUDO_CMD mkdir -p /etc/rancher/k3s "$(dirname "$KUBELET_CONFIG_TARGET")"
 K3S_CONFIG_CHANGED=0
 if ! $SUDO_CMD diff -q "$K3S_CONFIG_SOURCE" /etc/rancher/k3s/config.yaml >/dev/null 2>&1; then
   $SUDO_CMD cp "$K3S_CONFIG_SOURCE" /etc/rancher/k3s/config.yaml
+  K3S_CONFIG_CHANGED=1
+fi
+
+if ! $SUDO_CMD diff -q "$RESOLV_CONFIG_SOURCE" "$RESOLV_CONFIG_TARGET" >/dev/null 2>&1; then
+  $SUDO_CMD cp "$RESOLV_CONFIG_SOURCE" "$RESOLV_CONFIG_TARGET"
   K3S_CONFIG_CHANGED=1
 fi
 

--- a/config/k3s/default.nix
+++ b/config/k3s/default.nix
@@ -30,6 +30,7 @@ let
       "infra.shunkakinoki.software/cluster=${clusterName}"
       "infra.shunkakinoki.software/workload-profile=${k3s.workloadProfile}"
     ];
+    resolv-conf = "/etc/rancher/k3s/resolv.conf";
     tls-san = k3s.tlsSans;
   };
   # Authorize galactica on k3s servers so the client activation can scp the
@@ -77,6 +78,11 @@ in
 
   home.file.".config/k3s/kubelet.conf.d/${kubeletConfigName}" = lib.mkIf isK3sServer {
     source = ./kubelet.conf;
+    force = true;
+  };
+
+  home.file.".config/k3s/resolv.conf" = lib.mkIf isK3sServer {
+    source = ./resolv.conf;
     force = true;
   };
 

--- a/config/k3s/kubelet.conf
+++ b/config/k3s/kubelet.conf
@@ -7,11 +7,14 @@ serializeImagePulls: true
 # unpacking before kubelet reaches an eviction threshold.
 imageGCHighThresholdPercent: 70
 imageGCLowThresholdPercent: 60
-# Keep at least twenty percent free on both the root/control-plane filesystem
-# and the dedicated image filesystem. Kubelet remains the sole CRI collector.
+# Keep an absolute emergency reserve on the large root/control-plane filesystem.
+# A percentage reserve caused kubelet to evict the entire single-node cluster
+# while 193 GiB was still available. Keep the dedicated image filesystem at a
+# percentage threshold because it exclusively carries CRI state and image
+# unpacking. Kubelet remains the sole CRI collector.
 evictionHard:
   memory.available: "500Mi"
-  nodefs.available: "20%"
+  nodefs.available: "50Gi"
   imagefs.available: "20%"
   nodefs.inodesFree: "10%"
   imagefs.inodesFree: "10%"

--- a/config/k3s/kyber-host-health.sh
+++ b/config/k3s/kyber-host-health.sh
@@ -8,6 +8,7 @@ readonly D_STATE_THRESHOLD=3
 readonly D_STATE_SUSTAINED_SAMPLES=5
 readonly IO_SOME_AVG300_THRESHOLD=20
 readonly IO_FULL_AVG300_THRESHOLD=10
+readonly NODEFS_USAGE_THRESHOLD=75
 readonly IMAGEFS_USAGE_THRESHOLD=70
 readonly CRI_LATENCY_THRESHOLD_SECONDS=5
 readonly CRI_ERROR_THRESHOLD=5
@@ -68,6 +69,17 @@ check_d_state() {
     set_alert "d-state" "${d_state_count} processes have remained in uninterruptible sleep for ${samples} consecutive samples"
   elif [ "$samples" -eq 0 ]; then
     clear_alert "d-state"
+  fi
+}
+
+check_node_filesystem() {
+  local usage_percent
+
+  usage_percent="$(df --output=pcent / | tail -n 1 | tr -cd '0-9')"
+  if [ "$usage_percent" -ge "$NODEFS_USAGE_THRESHOLD" ]; then
+    set_alert "node-filesystem" "root nodefs usage is ${usage_percent}% (warning threshold ${NODEFS_USAGE_THRESHOLD}%, kubelet eviction threshold 80%)"
+  else
+    clear_alert "node-filesystem"
   fi
 }
 
@@ -143,6 +155,7 @@ check_cri() {
 
 check_io_pressure
 check_d_state
+check_node_filesystem
 check_image_filesystem
 check_cri
 check_dns

--- a/config/k3s/kyber-host-health.sh
+++ b/config/k3s/kyber-host-health.sh
@@ -8,12 +8,12 @@ readonly D_STATE_THRESHOLD=3
 readonly D_STATE_SUSTAINED_SAMPLES=5
 readonly IO_SOME_AVG300_THRESHOLD=20
 readonly IO_FULL_AVG300_THRESHOLD=10
-readonly NODEFS_USAGE_THRESHOLD=75
+readonly NODEFS_AVAILABLE_WARNING_GIB=200
+readonly NODEFS_AVAILABLE_WARNING_BYTES=$((NODEFS_AVAILABLE_WARNING_GIB * 1024 * 1024 * 1024))
+readonly NODEFS_KUBELET_RESERVE_GIB=50
 readonly IMAGEFS_USAGE_THRESHOLD=70
 readonly CRI_LATENCY_THRESHOLD_SECONDS=5
 readonly CRI_ERROR_THRESHOLD=5
-
-install -d --mode 0755 "$STATE_DIR"
 
 set_alert() {
   local key="$1"
@@ -73,11 +73,17 @@ check_d_state() {
 }
 
 check_node_filesystem() {
-  local usage_percent
+  local available_bytes available_gib
 
-  usage_percent="$(df --output=pcent / | tail -n 1 | tr -cd '0-9')"
-  if [ "$usage_percent" -ge "$NODEFS_USAGE_THRESHOLD" ]; then
-    set_alert "node-filesystem" "root nodefs usage is ${usage_percent}% (warning threshold ${NODEFS_USAGE_THRESHOLD}%, kubelet emergency reserve 50 GiB)"
+  if ! available_bytes="$(df --block-size=1 --output=avail / 2>/dev/null | tail -n 1 | tr -d '[:space:]')" ||
+    [[ ! $available_bytes =~ ^[0-9]+$ ]]; then
+    set_alert "node-filesystem" "unable to read available bytes on root nodefs"
+    return
+  fi
+
+  available_gib=$((available_bytes / 1024 / 1024 / 1024))
+  if [ "$available_bytes" -le "$NODEFS_AVAILABLE_WARNING_BYTES" ]; then
+    set_alert "node-filesystem" "root nodefs has ${available_gib} GiB available (warning threshold ${NODEFS_AVAILABLE_WARNING_GIB} GiB, kubelet emergency reserve ${NODEFS_KUBELET_RESERVE_GIB} GiB)"
   else
     clear_alert "node-filesystem"
   fi
@@ -153,9 +159,16 @@ check_cri() {
   fi
 }
 
-check_io_pressure
-check_d_state
-check_node_filesystem
-check_image_filesystem
-check_cri
-check_dns
+main() {
+  install -d --mode 0755 "$STATE_DIR"
+  check_io_pressure
+  check_d_state
+  check_node_filesystem
+  check_image_filesystem
+  check_cri
+  check_dns
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  main "$@"
+fi

--- a/config/k3s/kyber-host-health.sh
+++ b/config/k3s/kyber-host-health.sh
@@ -77,7 +77,7 @@ check_node_filesystem() {
 
   usage_percent="$(df --output=pcent / | tail -n 1 | tr -cd '0-9')"
   if [ "$usage_percent" -ge "$NODEFS_USAGE_THRESHOLD" ]; then
-    set_alert "node-filesystem" "root nodefs usage is ${usage_percent}% (warning threshold ${NODEFS_USAGE_THRESHOLD}%, kubelet eviction threshold 80%)"
+    set_alert "node-filesystem" "root nodefs usage is ${usage_percent}% (warning threshold ${NODEFS_USAGE_THRESHOLD}%, kubelet emergency reserve 50 GiB)"
   else
     clear_alert "node-filesystem"
   fi

--- a/config/k3s/kyber-host-health.timer
+++ b/config/k3s/kyber-host-health.timer
@@ -2,7 +2,7 @@
 Description=Run Kyber storage and CRI reliability checks
 
 [Timer]
-OnBootSec=5min
+OnActiveSec=1min
 OnUnitActiveSec=1min
 RandomizedDelaySec=15s
 Persistent=true

--- a/config/k3s/resolv.conf
+++ b/config/k3s/resolv.conf
@@ -1,0 +1,5 @@
+# Stable upstreams for pod DNS. K3s must not pass systemd-resolved's
+# 127.0.0.53 loopback stub into CoreDNS.
+nameserver 1.1.1.1
+nameserver 8.8.8.8
+options edns0 trust-ad

--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -192,6 +192,11 @@ in
         ]
       }:/usr/bin:/usr/sbin";
       ExecStart = "${dockerStartScript}";
+      # Prefer the public proxy within the managed service cgroup during
+      # concurrent local validation. Kyber also weights user@.service above
+      # abandoned interactive session scopes.
+      CPUWeight = 10000;
+      IOWeight = 10000;
       # Give the start wrapper's TERM trap time to flush usage + docker stop
       # the container cleanly before systemd escalates to SIGKILL.
       TimeoutStopSec = 45;

--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -192,11 +192,6 @@ in
         ]
       }:/usr/bin:/usr/sbin";
       ExecStart = "${dockerStartScript}";
-      # Prefer the public proxy within the managed service cgroup during
-      # concurrent local validation. Kyber also weights user@.service above
-      # abandoned interactive session scopes.
-      CPUWeight = 10000;
-      IOWeight = 10000;
       # Give the start wrapper's TERM trap time to flush usage + docker stop
       # the container cleanly before systemd escalates to SIGKILL.
       TimeoutStopSec = 45;

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -251,6 +251,8 @@ if [ "$(uname)" = "Linux" ] && command -v docker >/dev/null 2>&1; then
   docker run --rm \
     --name cliproxyapi \
     --network host \
+    --cpu-shares 262144 \
+    --blkio-weight 1000 \
     --ulimit nofile=65536:65536 \
     -v "$CONFIG:/CLIProxyAPI/config.yaml:ro" \
     -v "$CONFIG_DIR:/root/.cli-proxy-api" \

--- a/named-hosts/kyber/README.md
+++ b/named-hosts/kyber/README.md
@@ -243,12 +243,13 @@ kubelet clear `DiskPressure`. Durable controls now:
 
 - schedule host health from timer activation and every minute thereafter;
 - replace the oversized 20% nodefs threshold with an absolute 50 GiB emergency
-  reserve and warn at 75% usage, leaving roughly 180 GiB for attended cleanup;
+  reserve and warn at 200 GiB available for attended cleanup;
 - give pods a dedicated public upstream resolver file instead of the host's
   `127.0.0.53` systemd-resolved stub;
-- weight the managed user-service cgroup above interactive session scopes; and
-- give CLIProxy the highest CPU and I/O weight inside the managed service
-  cgroup.
+- weight the host system slice and managed user-service cgroup above interactive
+  session scopes; and
+- give CLIProxy maximum Docker CPU shares and block-I/O weight within the
+  protected system slice.
 
 During a recurrence, compare local `http://127.0.0.1:8317`, the public endpoint,
 node conditions, session cgroups, and the Cloudflare tunnel pods before

--- a/named-hosts/kyber/README.md
+++ b/named-hosts/kyber/README.md
@@ -186,8 +186,9 @@ cleaner:
   disks, including the containerd SSD, and runs short and long self-tests;
 - `kyber-host-health.timer` runs a read-only check every minute for five-minute
   I/O PSI, five consecutive samples of at least three D-state processes,
-  containerd image-filesystem usage/identity, CRI probe latency, recent CRI
-  lifecycle errors, and host DNS (Tailscale must not own `/etc/resolv.conf`).
+  root node-filesystem headroom, containerd image-filesystem usage/identity,
+  CRI probe latency, recent CRI lifecycle errors, and host DNS (Tailscale must
+  not own `/etc/resolv.conf`).
 
 Alerts are deduplicated until recovery. They are written to the journal at
 `daemon.alert` priority and broadcast to logged-in sessions with `wall`; a
@@ -212,6 +213,38 @@ because the upstream unit uses `KillMode=process`. If containerd itself is
 wedged, use the installed `k3s-killall.sh` once during an attended recovery,
 then start k3s again. The helper preserves cluster data but terminates every
 running workload, so it is not a timer or routine cleanup mechanism.
+
+## August 2026 CLIProxy and Kubernetes Pressure Outage
+
+On 2026-08-19, `cliproxy.shunkakinoki.com` timed out while
+`cliproxyapi.service` remained `active`. The proxy process and local `:8317`
+listener were healthy; the host was not. A 17-hour-old SSH/Herdr session was
+stuck in systemd's `closing` state with roughly 900-1,100 tasks. Concurrent
+type-aware Oxlint/tsgolint validation peaked near 99 GiB and consumed dozens of
+CPU cores. At the same time, root `nodefs` crossed the configured 20%-free
+kubelet threshold. Kubelet evicted the Cloudflare tunnel and ingress workloads,
+CRI and Kine calls timed out, and the public proxy lost its origin path.
+
+The incident escaped the existing checks because systemd tracked the live
+Docker client rather than end-to-end reachability, the host-health timer had no
+next trigger after activation, and storage monitoring covered the dedicated
+containerd filesystem but not root `nodefs`.
+
+Recovery stopped only the runaway validation process groups, preserved the
+Herdr/Codex session and dirty lanes, removed generated dependency data from
+clean temporary lanes, applied the existing 30-day Nix GC policy, and let
+kubelet clear `DiskPressure`. Durable controls now:
+
+- schedule host health from timer activation and every minute thereafter;
+- warn when root `nodefs` reaches 75%, before kubelet's 80% eviction boundary;
+- weight the managed user-service cgroup above interactive session scopes; and
+- give CLIProxy the highest CPU and I/O weight inside the managed service
+  cgroup.
+
+During a recurrence, compare local `http://127.0.0.1:8317`, the public endpoint,
+node conditions, session cgroups, and the Cloudflare tunnel pods before
+restarting CLIProxy. An `active` unit plus a fast local response indicates an
+origin-path or host-pressure incident, not a proxy daemon crash.
 
 ## SSH Key Management
 

--- a/named-hosts/kyber/README.md
+++ b/named-hosts/kyber/README.md
@@ -117,11 +117,14 @@ unrestricted local-path PVC must not be treated as a hard capacity quota.
 ## k3s Disk Headroom
 
 Host activation keeps the root ext4 reserved blocks at 1%. Kubelet serializes
-image pulls, begins image garbage collection at 70% usage, targets 60%, and
-evicts before either the root (`nodefs`) or containerd (`imagefs`) filesystem
-falls below 20% available space. Before containerd received a dedicated SSD,
-Ubuntu's default 5% reserve on the 916 GiB root volume hid about 46 GiB from
-kubelet and left too little usable headroom during overlapping rollouts.
+image pulls, begins image garbage collection at 70% usage, targets 60%, keeps a
+50 GiB emergency reserve on the root (`nodefs`), and keeps 20% available on the
+dedicated containerd (`imagefs`) filesystem. A percentage-based nodefs reserve
+is intentionally avoided: 20% of Kyber's 916 GiB root volume is roughly 183
+GiB, enough working headroom that eviction causes more harm than continued
+operation. Before containerd received a dedicated SSD, Ubuntu's default 5%
+reserve on the root volume hid about 46 GiB from kubelet and left too little
+usable headroom during overlapping rollouts.
 
 Kubelet owns image, container, and pod-sandbox garbage collection. Do not add a
 separate `crictl` cleanup timer: deleting CRI objects behind kubelet can race
@@ -222,8 +225,9 @@ listener were healthy; the host was not. A 17-hour-old SSH/Herdr session was
 stuck in systemd's `closing` state with roughly 900-1,100 tasks. Concurrent
 type-aware Oxlint/tsgolint validation peaked near 99 GiB and consumed dozens of
 CPU cores. At the same time, root `nodefs` crossed the configured 20%-free
-kubelet threshold. Kubelet evicted the Cloudflare tunnel and ingress workloads,
-CRI and Kine calls timed out, and the public proxy lost its origin path.
+kubelet threshold despite retaining roughly 193 GiB. Kubelet evicted the
+Cloudflare tunnel and ingress workloads, CRI and Kine calls timed out, and the
+public proxy lost its origin path.
 
 The incident escaped the existing checks because systemd tracked the live
 Docker client rather than end-to-end reachability, the host-health timer had no
@@ -236,7 +240,8 @@ clean temporary lanes, applied the existing 30-day Nix GC policy, and let
 kubelet clear `DiskPressure`. Durable controls now:
 
 - schedule host health from timer activation and every minute thereafter;
-- warn when root `nodefs` reaches 75%, before kubelet's 80% eviction boundary;
+- replace the oversized 20% nodefs threshold with an absolute 50 GiB emergency
+  reserve and warn at 75% usage, leaving roughly 180 GiB for attended cleanup;
 - weight the managed user-service cgroup above interactive session scopes; and
 - give CLIProxy the highest CPU and I/O weight inside the managed service
   cgroup.

--- a/named-hosts/kyber/README.md
+++ b/named-hosts/kyber/README.md
@@ -231,8 +231,10 @@ public proxy lost its origin path.
 
 The incident escaped the existing checks because systemd tracked the live
 Docker client rather than end-to-end reachability, the host-health timer had no
-next trigger after activation, and storage monitoring covered the dedicated
-containerd filesystem but not root `nodefs`.
+next trigger after activation, storage monitoring covered the dedicated
+containerd filesystem but not root `nodefs`, and K3s passed systemd-resolved's
+loopback stub into CoreDNS. After the cluster restarted, CoreDNS detected that
+forwarding loop and could not bring the Cloudflare tunnel back online.
 
 Recovery stopped only the runaway validation process groups, preserved the
 Herdr/Codex session and dirty lanes, removed generated dependency data from
@@ -242,6 +244,8 @@ kubelet clear `DiskPressure`. Durable controls now:
 - schedule host health from timer activation and every minute thereafter;
 - replace the oversized 20% nodefs threshold with an absolute 50 GiB emergency
   reserve and warn at 75% usage, leaving roughly 180 GiB for attended cleanup;
+- give pods a dedicated public upstream resolver file instead of the host's
+  `127.0.0.53` systemd-resolved stub;
 - weight the managed user-service cgroup above interactive session scopes; and
 - give CLIProxy the highest CPU and I/O weight inside the managed service
   cgroup.

--- a/named-hosts/kyber/activate-user-service-priority.sh
+++ b/named-hosts/kyber/activate-user-service-priority.sh
@@ -1,34 +1,42 @@
 #!/usr/bin/env bash
-# Keep managed user services responsive when an abandoned SSH session is busy.
+# Keep host and managed user services responsive when an SSH session is busy.
 set -euo pipefail
 
 USER_UID="$(id -u)"
-DROP_IN_DIR="/etc/systemd/system/user@${USER_UID}.service.d"
-DROP_IN_FILE="${DROP_IN_DIR}/10-kyber-managed-services.conf"
+readonly USER_UID
+readonly SYSTEM_DROP_IN_FILE="/etc/systemd/system/system.slice.d/10-kyber-managed-services.conf"
+readonly USER_DROP_IN_FILE="/etc/systemd/system/user@${USER_UID}.service.d/10-kyber-managed-services.conf"
 
-SUDO_CMD=""
+ROOT_CMD=()
 if command -v sudo >/dev/null 2>&1; then
-  SUDO_CMD="sudo"
+  ROOT_CMD=(sudo -n)
 elif [ -x /run/wrappers/bin/sudo ]; then
-  SUDO_CMD="/run/wrappers/bin/sudo"
+  ROOT_CMD=(/run/wrappers/bin/sudo -n)
 elif [ -x /usr/bin/sudo ]; then
-  SUDO_CMD="/usr/bin/sudo"
+  ROOT_CMD=(/usr/bin/sudo -n)
 elif command -v doas >/dev/null 2>&1; then
-  SUDO_CMD="doas"
+  ROOT_CMD=(doas -n)
 elif [ "$(id -u)" -ne 0 ]; then
   echo "Managed service priority requires root privileges." >&2
   exit 1
 fi
 
 run_root() {
-  if [ -n "$SUDO_CMD" ]; then
-    "$SUDO_CMD" "$@"
+  if [ "${#ROOT_CMD[@]}" -gt 0 ]; then
+    "${ROOT_CMD[@]}" "$@"
   else
     "$@"
   fi
 }
 
-CONTENT=$(
+SYSTEM_CONTENT=$(
+  cat <<'EOF'
+[Slice]
+CPUWeight=1000
+IOWeight=1000
+EOF
+)
+USER_CONTENT=$(
   cat <<'EOF'
 [Service]
 CPUWeight=1000
@@ -36,18 +44,44 @@ IOWeight=1000
 EOF
 )
 
-if ! { [ -f "$DROP_IN_FILE" ] && printf '%s\n' "$CONTENT" | cmp -s - "$DROP_IN_FILE"; }; then
-  echo "Installing managed service priority at $DROP_IN_FILE..."
-  run_root mkdir -p "$DROP_IN_DIR"
-  printf '%s\n' "$CONTENT" | run_root tee "$DROP_IN_FILE" >/dev/null
-  run_root chmod 0644 "$DROP_IN_FILE"
+changed=0
+install_drop_in() {
+  local drop_in_file="$1"
+  local content="$2"
+
+  if [ -f "$drop_in_file" ] && printf '%s\n' "$content" | cmp -s - "$drop_in_file"; then
+    return
+  fi
+
+  echo "Installing managed service priority at $drop_in_file..."
+  run_root mkdir -p "$(dirname "$drop_in_file")"
+  printf '%s\n' "$content" | run_root tee "$drop_in_file" >/dev/null
+  run_root chmod 0644 "$drop_in_file"
+  changed=1
+}
+
+apply_runtime_weights() {
+  local unit="$1"
+  local cpu_weight io_weight
+
+  cpu_weight="$(run_root systemctl show "$unit" --property CPUWeight --value)"
+  io_weight="$(run_root systemctl show "$unit" --property IOWeight --value)"
+  if [ "$cpu_weight" = 1000 ] && [ "$io_weight" = 1000 ]; then
+    return
+  fi
+
+  run_root systemctl set-property --runtime "$unit" CPUWeight=1000 IOWeight=1000
+}
+
+install_drop_in "$SYSTEM_DROP_IN_FILE" "$SYSTEM_CONTENT"
+install_drop_in "$USER_DROP_IN_FILE" "$USER_CONTENT"
+if [ "$changed" -eq 1 ]; then
   run_root systemctl daemon-reload
 fi
 
-# A user manager restart would interrupt every managed service. Apply the same
-# weights to the current manager cgroup without restarting it; the drop-in owns
-# the next boot/login.
-run_root systemctl set-property --runtime "user@${USER_UID}.service" \
-  CPUWeight=1000 IOWeight=1000
+# Restarts would interrupt managed services. Apply the weights to the running
+# slices only when needed; the drop-ins own subsequent boots and logins.
+apply_runtime_weights system.slice
+apply_runtime_weights "user@${USER_UID}.service"
 
-echo "Managed user services have priority over interactive session scopes."
+echo "Host and managed user services have priority over interactive sessions."

--- a/named-hosts/kyber/activate-user-service-priority.sh
+++ b/named-hosts/kyber/activate-user-service-priority.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Keep managed user services responsive when an abandoned SSH session is busy.
+set -euo pipefail
+
+USER_UID="$(id -u)"
+DROP_IN_DIR="/etc/systemd/system/user@${USER_UID}.service.d"
+DROP_IN_FILE="${DROP_IN_DIR}/10-kyber-managed-services.conf"
+
+SUDO_CMD=""
+if command -v sudo >/dev/null 2>&1; then
+  SUDO_CMD="sudo"
+elif [ -x /run/wrappers/bin/sudo ]; then
+  SUDO_CMD="/run/wrappers/bin/sudo"
+elif [ -x /usr/bin/sudo ]; then
+  SUDO_CMD="/usr/bin/sudo"
+elif command -v doas >/dev/null 2>&1; then
+  SUDO_CMD="doas"
+elif [ "$(id -u)" -ne 0 ]; then
+  echo "Managed service priority requires root privileges." >&2
+  exit 1
+fi
+
+run_root() {
+  if [ -n "$SUDO_CMD" ]; then
+    "$SUDO_CMD" "$@"
+  else
+    "$@"
+  fi
+}
+
+CONTENT=$(
+  cat <<'EOF'
+[Service]
+CPUWeight=1000
+IOWeight=1000
+EOF
+)
+
+if ! { [ -f "$DROP_IN_FILE" ] && printf '%s\n' "$CONTENT" | cmp -s - "$DROP_IN_FILE"; }; then
+  echo "Installing managed service priority at $DROP_IN_FILE..."
+  run_root mkdir -p "$DROP_IN_DIR"
+  printf '%s\n' "$CONTENT" | run_root tee "$DROP_IN_FILE" >/dev/null
+  run_root chmod 0644 "$DROP_IN_FILE"
+  run_root systemctl daemon-reload
+fi
+
+# A user manager restart would interrupt every managed service. Apply the same
+# weights to the current manager cgroup without restarting it; the drop-in owns
+# the next boot/login.
+run_root systemctl set-property --runtime "user@${USER_UID}.service" \
+  CPUWeight=1000 IOWeight=1000
+
+echo "Managed user services have priority over interactive session scopes."

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -139,6 +139,12 @@ home-manager.lib.homeManagerConfiguration {
           $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-ip-forwarding.sh}"
         '';
 
+        # Keep Home Manager services responsive when a disconnected SSH/Herdr
+        # session leaves CPU- or I/O-heavy validation processes behind.
+        home.activation.prioritizeManagedUserServices = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+          $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-user-service-priority.sh}"
+        '';
+
         # Publish the T3 server over tailnet HTTPS. openclaw already owns :443
         # here, and T3's discovery path must sit at the serve root, so T3 gets
         # its own HTTPS port: https://kyber.tail950b36.ts.net:8443

--- a/spec/activate_k3s_spec.sh
+++ b/spec/activate_k3s_spec.sh
@@ -44,6 +44,11 @@ When run bash -c "grep 'config.yaml' '$SCRIPT'"
 The output should include 'config.yaml'
 End
 
+It 'installs a non-loopback pod DNS resolver file'
+When run bash -c "grep -q 'RESOLV_CONFIG_TARGET=\"/etc/rancher/k3s/resolv.conf\"' '$SCRIPT' && grep -q 'RESOLV_CONFIG_SOURCE' '$SCRIPT'"
+The status should be success
+End
+
 It 'copies the kubelet configuration drop-in'
 When run bash -c "grep 'KUBELET_CONFIG_TARGET' '$SCRIPT'"
 The output should include 'kubelet.conf.d/$KUBELET_CONFIG_NAME'

--- a/spec/activate_kyber_spec.sh
+++ b/spec/activate_kyber_spec.sh
@@ -133,9 +133,9 @@ End
 Describe 'named-hosts/kyber/activate-user-service-priority.sh'
 SCRIPT="$PWD/named-hosts/kyber/activate-user-service-priority.sh"
 
-It 'installs a user manager systemd drop-in'
-When run grep '10-kyber-managed-services.conf' "$SCRIPT"
-The output should include '10-kyber-managed-services.conf'
+It 'installs system and user manager systemd drop-ins'
+When run bash -c "grep -q 'system.slice.d/10-kyber-managed-services.conf' '$SCRIPT' && grep -q 'user@.*service.d/10-kyber-managed-services.conf' '$SCRIPT'"
+The status should be success
 End
 
 It 'weights managed services above interactive session scopes'
@@ -146,6 +146,16 @@ End
 It 'applies the weights without restarting the user manager'
 When run grep 'set-property --runtime' "$SCRIPT"
 The output should include 'set-property --runtime'
+End
+
+It 'uses non-interactive privilege escalation'
+When run bash -c "grep -q 'ROOT_CMD=(sudo -n)' '$SCRIPT' && grep -q 'ROOT_CMD=(doas -n)' '$SCRIPT'"
+The status should be success
+End
+
+It 'skips redundant runtime property updates'
+When run bash -c "grep -q 'systemctl show' '$SCRIPT' && grep -q '\[ \"\$cpu_weight\" = 1000 \].*\[ \"\$io_weight\" = 1000 \]' '$SCRIPT'"
+The status should be success
 End
 End
 End

--- a/spec/activate_kyber_spec.sh
+++ b/spec/activate_kyber_spec.sh
@@ -104,6 +104,11 @@ When run bash -c "grep 'activate-sshd.sh' '$PWD/named-hosts/kyber/default.nix'"
 The output should include 'activate-sshd.sh'
 End
 
+It 'prioritizes managed services during activation'
+When run bash -c "grep 'activate-user-service-priority.sh' '$PWD/named-hosts/kyber/default.nix'"
+The output should include 'activate-user-service-priority.sh'
+End
+
 It 'keeps a long gpg-agent cache ttl'
 When run bash -c "grep 'defaultCacheTtl = 94608000' '$PWD/named-hosts/kyber/default.nix'"
 The output should include 'defaultCacheTtl = 94608000'
@@ -122,6 +127,25 @@ End
 It 'explicitly disables Tailscale DNS'
 When run bash -c "grep -F '\"--accept-dns=false\"' '$PWD/named-hosts/kyber/default.nix'"
 The output should include '--accept-dns=false'
+End
+End
+
+Describe 'named-hosts/kyber/activate-user-service-priority.sh'
+SCRIPT="$PWD/named-hosts/kyber/activate-user-service-priority.sh"
+
+It 'installs a user manager systemd drop-in'
+When run grep '10-kyber-managed-services.conf' "$SCRIPT"
+The output should include '10-kyber-managed-services.conf'
+End
+
+It 'weights managed services above interactive session scopes'
+When run bash -c "grep -q 'CPUWeight=1000' '$SCRIPT' && grep -q 'IOWeight=1000' '$SCRIPT'"
+The status should be success
+End
+
+It 'applies the weights without restarting the user manager'
+When run grep 'set-property --runtime' "$SCRIPT"
+The output should include 'set-property --runtime'
 End
 End
 End

--- a/spec/cliproxyapi_spec.sh
+++ b/spec/cliproxyapi_spec.sh
@@ -322,6 +322,11 @@ End
 End
 
 Describe 'Docker image handling'
+It 'prioritizes the Kyber proxy within the managed service cgroup'
+When run bash -c "grep -q 'CPUWeight = 10000' '$PWD/home-manager/services/cliproxyapi/default.nix' && grep -q 'IOWeight = 10000' '$PWD/home-manager/services/cliproxyapi/default.nix'"
+The status should be success
+End
+
 It 'supports a locally built canary image without pulling over it'
 When run bash -c "sed -n '/CLIPROXYAPI_IMAGE/,/\"\$docker_image\" \&/p' '$SCRIPT'"
 The output should include 'CLIPROXYAPI_IMAGE:-eceasy/cli-proxy-api:latest'

--- a/spec/cliproxyapi_spec.sh
+++ b/spec/cliproxyapi_spec.sh
@@ -322,8 +322,8 @@ End
 End
 
 Describe 'Docker image handling'
-It 'prioritizes the Kyber proxy within the managed service cgroup'
-When run bash -c "grep -q 'CPUWeight = 10000' '$PWD/home-manager/services/cliproxyapi/default.nix' && grep -q 'IOWeight = 10000' '$PWD/home-manager/services/cliproxyapi/default.nix'"
+It 'prioritizes the proxy container among Docker workloads'
+When run bash -c "grep -q -- '--cpu-shares 262144' '$SCRIPT' && grep -q -- '--blkio-weight 1000' '$SCRIPT'"
 The status should be success
 End
 

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -578,6 +578,7 @@ install.sh
 named-hosts/kyber/activate-backup-files.sh
 named-hosts/kyber/activate-ip-forwarding.sh
 named-hosts/kyber/activate-sshd.sh
+named-hosts/kyber/activate-user-service-priority.sh
 named-hosts/kyber/prepare-containerd-disk.sh
 named-hosts/kyber/rekey-galactica.sh
 named-hosts/kyber/setup.sh

--- a/spec/k3s_service_activate_spec.sh
+++ b/spec/k3s_service_activate_spec.sh
@@ -162,9 +162,63 @@ When run bash -c "grep -q '^OnActiveSec=1min$' '$PWD/config/k3s/kyber-host-healt
 The status should be success
 End
 
-It 'warns before root nodefs reaches the kubelet emergency reserve'
-When run bash -c "grep -q 'NODEFS_USAGE_THRESHOLD=75' '$PWD/config/k3s/kyber-host-health.sh' && grep -q 'kubelet emergency reserve 50 GiB' '$PWD/config/k3s/kyber-host-health.sh'"
+It 'warns at an absolute margin before the root nodefs emergency reserve'
+When run bash -c "grep -q 'NODEFS_AVAILABLE_WARNING_GIB=200' '$PWD/config/k3s/kyber-host-health.sh' && grep -q 'NODEFS_KUBELET_RESERVE_GIB=50' '$PWD/config/k3s/kyber-host-health.sh'"
 The status should be success
+End
+
+Describe 'root nodefs check behavior'
+HEALTH_CHECK="$PWD/config/k3s/kyber-host-health.sh"
+
+It 'clears the alert after available space recovers above 200 GiB'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  source "$HEALTH_CHECK"
+  df() { printf "Avail\n%s\n" "$((201 * 1024 * 1024 * 1024))"; }
+  set_alert() { printf "alert:%s:%s\n" "$1" "$2"; }
+  clear_alert() { printf "clear:%s\n" "$1"; }
+  check_node_filesystem
+'
+The output should equal 'clear:node-filesystem'
+The status should be success
+End
+
+It 'alerts at the 200 GiB warning threshold'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  source "$HEALTH_CHECK"
+  df() { printf "Avail\n%s\n" "$((200 * 1024 * 1024 * 1024))"; }
+  set_alert() { printf "alert:%s:%s\n" "$1" "$2"; }
+  clear_alert() { printf "clear:%s\n" "$1"; }
+  check_node_filesystem
+'
+The output should include 'alert:node-filesystem:root nodefs has 200 GiB available'
+The status should be success
+End
+
+It 'alerts without clearing on malformed available-space output'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  source "$HEALTH_CHECK"
+  df() { printf "Avail\nnot-a-number\n"; }
+  set_alert() { printf "alert:%s:%s\n" "$1" "$2"; }
+  clear_alert() { printf "clear:%s\n" "$1"; }
+  check_node_filesystem
+'
+The output should equal 'alert:node-filesystem:unable to read available bytes on root nodefs'
+The status should be success
+End
+
+It 'alerts without aborting when df fails'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  source "$HEALTH_CHECK"
+  df() { return 1; }
+  set_alert() { printf "alert:%s:%s\n" "$1" "$2"; }
+  clear_alert() { printf "clear:%s\n" "$1"; }
+  check_node_filesystem
+  printf "continued\n"
+'
+The output should equal 'alert:node-filesystem:unable to read available bytes on root nodefs
+continued'
+The status should be success
+End
 End
 
 It 'orders the k3s config hook after the mount hook'

--- a/spec/k3s_service_activate_spec.sh
+++ b/spec/k3s_service_activate_spec.sh
@@ -63,7 +63,7 @@ The status should be success
 End
 
 It 'preserves twenty percent on root and image filesystems'
-When run bash -c "grep -qxF '  nodefs.available: \"20%\"' '$KUBELET_CONFIG' && grep -qxF '  imagefs.available: \"20%\"' '$KUBELET_CONFIG'"
+When run bash -c "grep -qxF '  nodefs.available: \"50Gi\"' '$KUBELET_CONFIG' && grep -qxF '  imagefs.available: \"20%\"' '$KUBELET_CONFIG'"
 The status should be success
 End
 
@@ -153,8 +153,8 @@ When run bash -c "grep -q '^OnActiveSec=1min$' '$PWD/config/k3s/kyber-host-healt
 The status should be success
 End
 
-It 'warns before root nodefs reaches the kubelet eviction threshold'
-When run bash -c "grep -q 'NODEFS_USAGE_THRESHOLD=75' '$PWD/config/k3s/kyber-host-health.sh' && grep -q 'kubelet eviction threshold 80%' '$PWD/config/k3s/kyber-host-health.sh'"
+It 'warns before root nodefs reaches the kubelet emergency reserve'
+When run bash -c "grep -q 'NODEFS_USAGE_THRESHOLD=75' '$PWD/config/k3s/kyber-host-health.sh' && grep -q 'kubelet emergency reserve 50 GiB' '$PWD/config/k3s/kyber-host-health.sh'"
 The status should be success
 End
 

--- a/spec/k3s_service_activate_spec.sh
+++ b/spec/k3s_service_activate_spec.sh
@@ -62,13 +62,22 @@ When run bash -c "grep -qxF 'imageGCHighThresholdPercent: 70' '$KUBELET_CONFIG' 
 The status should be success
 End
 
-It 'preserves twenty percent on root and image filesystems'
+It 'keeps an absolute root reserve and twenty percent on imagefs'
 When run bash -c "grep -qxF '  nodefs.available: \"50Gi\"' '$KUBELET_CONFIG' && grep -qxF '  imagefs.available: \"20%\"' '$KUBELET_CONFIG'"
 The status should be success
 End
 
 It 'uses kubelet native container log rotation'
 When run bash -c "grep -qxF 'containerLogMaxSize: 10Mi' '$KUBELET_CONFIG' && grep -qxF 'containerLogMaxFiles: 3' '$KUBELET_CONFIG'"
+The status should be success
+End
+End
+
+Describe 'pod DNS policy'
+RESOLV_CONFIG="$PWD/config/k3s/resolv.conf"
+
+It 'uses a dedicated non-loopback resolver file'
+When run bash -c "grep -q 'resolv-conf = \"/etc/rancher/k3s/resolv.conf\"' '$PWD/config/k3s/default.nix' && grep -qxF 'nameserver 1.1.1.1' '$RESOLV_CONFIG' && ! grep -qxF 'nameserver 127.0.0.53' '$RESOLV_CONFIG'"
 The status should be success
 End
 End

--- a/spec/k3s_service_activate_spec.sh
+++ b/spec/k3s_service_activate_spec.sh
@@ -148,6 +148,16 @@ When run bash -c "grep -q '/etc/systemd/journald.conf.d/10-kyber-limits.conf' '$
 The status should be success
 End
 
+It 'schedules the host-health timer relative to activation'
+When run bash -c "grep -q '^OnActiveSec=1min$' '$PWD/config/k3s/kyber-host-health.timer' && grep -q '^OnUnitActiveSec=1min$' '$PWD/config/k3s/kyber-host-health.timer'"
+The status should be success
+End
+
+It 'warns before root nodefs reaches the kubelet eviction threshold'
+When run bash -c "grep -q 'NODEFS_USAGE_THRESHOLD=75' '$PWD/config/k3s/kyber-host-health.sh' && grep -q 'kubelet eviction threshold 80%' '$PWD/config/k3s/kyber-host-health.sh'"
+The status should be success
+End
+
 It 'orders the k3s config hook after the mount hook'
 When run grep 'entryAfter \[ "setupK3s" \]' "$SERVER_MODULE"
 The output should include 'entryAfter [ "setupK3s" ]'


### PR DESCRIPTION
## Summary

- repair the Kyber host-health timer and warn on root nodefs pressure before kubelet eviction
- persist CPU/IO preference for managed user services and CLIProxy
- document the August 2026 CLIProxy/public-origin outage and recovery sequence

## Root cause

CLIProxy stayed healthy on localhost, but an abandoned 17-hour SSH/Herdr session left roughly 900-1,100 validation tasks consuming CPU, memory, I/O, and temporary root-disk space. Root nodefs crossed Kyber's 20%-available kubelet threshold, which evicted the Cloudflare tunnel and ingress workloads and broke the public origin path. The existing health timer had no next trigger and monitored imagefs but not root nodefs.

## Validation

- `bash -n config/k3s/kyber-host-health.sh named-hosts/kyber/activate-user-service-priority.sh`
- ShellCheck on both changed scripts
- `make nix-format-check`
- `make shell-test` (2,126 ShellSpec examples and 454 Fish tests, all passing)

Tracked by `shunkakinokisoftware-sb8t`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Protects CLIProxy and K3s from host pressure and CoreDNS resolver loops. Previously kubelet evicted at 20% free and pods could inherit the host’s 127.0.0.53 stub; now kubelet keeps a 50 GiB nodefs reserve, host checks run every minute with a root headroom warning, pods use a dedicated upstream resolver, and the proxy has explicit CPU/IO priority.

- Kubelet: change `evictionHard.nodefs.available` from "20%" to "50Gi"; keep `imagefs.available` at "20%".
- Host health: add a root `nodefs` check (warn at 200 GiB; kubelet reserve 50 GiB) and schedule `kyber-host-health.timer` with `OnActiveSec=1min` + `OnUnitActiveSec=1min`.
- Pod DNS: set K3s `resolv-conf` to `/etc/rancher/k3s/resolv.conf` and ship a non-loopback resolver file to prevent CoreDNS forwarding loops.
- Workload pressure controls: give the `cliproxyapi` container `--cpu-shares 262144` and `--blkio-weight 1000`; install systemd drop-ins that set `CPUWeight=1000` and `IOWeight=1000` for `system.slice` and `user@<uid>.service`, applied at activation via `activate-user-service-priority.sh`.
- Rollout: run Home Manager activation on Kyber; then `systemctl daemon-reload && systemctl restart kyber-host-health.timer`.

Tracks Linear `shunkakinokisoftware-sb8t`.

<sup>Written for commit 89a5afb020f8f089bdadf89dcfe2a8c950c3623a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

