### PR TITLE
fix(k3s): probe containerd UUID as root

### DIFF
--- a/home-manager/services/k3s/activate.sh
+++ b/home-manager/services/k3s/activate.sh
@@ -109,7 +109,7 @@ configure_root_ext4_reserve
 
 if @findmnt@ --mountpoint "$MOUNT_POINT" >/dev/null 2>&1; then
   mounted_source="$(@findmnt@ --noheadings --output SOURCE --target "$MOUNT_POINT")"
-  mounted_uuid="$(@blkid@ --match-tag UUID --output value "$mounted_source")"
+  mounted_uuid="$(run_sudo @blkid@ --match-tag UUID --output value "$mounted_source")"
   if [ "$mounted_uuid" != "$EXPECTED_CONTAINERD_UUID" ]; then
     echo "Refusing to run k3s with unexpected containerd filesystem UUID: $mounted_uuid" >&2
     echo "Expected $EXPECTED_CONTAINERD_UUID at $MOUNT_POINT" >&2

--- a/spec/k3s_service_activate_spec.sh
+++ b/spec/k3s_service_activate_spec.sh
@@ -233,7 +233,13 @@ The status should be success
 End
 
 It 'rejects an already-mounted filesystem with the wrong UUID'
-When run bash -c "grep -q 'EXPECTED_CONTAINERD_UUID=\"90f29a7b-38ff-460b-b534-92a02f1412ec\"' '$SCRIPT' && grep -q 'mounted_uuid=.*@blkid@' '$SCRIPT' && grep -q 'unexpected containerd filesystem UUID' '$SCRIPT'"
+When run bash -c "grep -q 'EXPECTED_CONTAINERD_UUID=\"90f29a7b-38ff-460b-b534-92a02f1412ec\"' '$SCRIPT' && grep -q 'mounted_uuid=.*run_sudo @blkid@' '$SCRIPT' && grep -q 'unexpected containerd filesystem UUID' '$SCRIPT'"
+The status should be success
+End
+
+It 'reads the root-owned block-device UUID through sudo'
+When run grep 'mounted_uuid=.*run_sudo @blkid@' "$SCRIPT"
+The output should include 'run_sudo @blkid@'
 The status should be success
 End
 


### PR DESCRIPTION
## Summary

- read the mounted containerd block-device UUID through the activation script's existing privileged helper
- add a regression assertion that the root-owned device probe uses `run_sudo`

## Why

Post-merge activation of #2415 on Kyber correctly stopped at the containerd safety guard, but the UUID appeared empty because unprivileged `blkid /dev/sda` returns no value. `findmnt` and privileged `blkid` confirm the mounted filesystem is the expected `90f29a7b-38ff-460b-b534-92a02f1412ec` volume.

## Validation

- `bash -n home-manager/services/k3s/activate.sh`
- `shellcheck home-manager/services/k3s/activate.sh`
- `shellspec spec/k3s_service_activate_spec.sh` (46 examples, 0 failures)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Probe containerd filesystem UUID as root during k3s activation to avoid false negatives. Previously `blkid` ran unprivileged and often returned empty, causing the safety guard to halt k3s; now `blkid` runs via `run_sudo`, so the guard only rejects on a real UUID mismatch.

- Replace `mounted_uuid` assignment to use `run_sudo @blkid@`.
- Add shellspec assertions that enforce `run_sudo` is used and keep the expected UUID check.
- Validated via bash -n, shellcheck, and shellspec (all passing).

<sup>Written for commit 4f913bfa2054e114ff8204b274d4892083634bd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

