### PR TITLE
fix(k3s): rearm host health timer on activation

### DIFF
--- a/home-manager/services/k3s/activate.sh
+++ b/home-manager/services/k3s/activate.sh
@@ -173,6 +173,9 @@ fi
 
 if [ -f "$HEALTH_TIMER_FILE" ]; then
   run_sudo @systemctl@ enable --now kyber-host-health.timer
+  # `enable --now` does not rearm a timer that was already active but elapsed.
+  # Restart it so OnActiveSec is recalculated from this activation.
+  run_sudo @systemctl@ restart kyber-host-health.timer
 fi
 
 if [ -f "$K3S_KUBECONFIG" ]; then

--- a/spec/k3s_service_activate_spec.sh
+++ b/spec/k3s_service_activate_spec.sh
@@ -158,7 +158,7 @@ The status should be success
 End
 
 It 'schedules the host-health timer relative to activation'
-When run bash -c "grep -q '^OnActiveSec=1min$' '$PWD/config/k3s/kyber-host-health.timer' && grep -q '^OnUnitActiveSec=1min$' '$PWD/config/k3s/kyber-host-health.timer'"
+When run bash -c "grep -q '^OnActiveSec=1min$' '$PWD/config/k3s/kyber-host-health.timer' && grep -q '^OnUnitActiveSec=1min$' '$PWD/config/k3s/kyber-host-health.timer' && grep -q 'restart kyber-host-health.timer' '$SCRIPT'"
 The status should be success
 End
 


### PR DESCRIPTION
## Summary
- restart the Kyber host-health timer after enabling it
- rearm already-active but elapsed timers after unit updates
- extend activation regression coverage

## Verification
- `bash -n home-manager/services/k3s/activate.sh`
- `shellcheck home-manager/services/k3s/activate.sh`
- `shellspec spec/k3s_service_activate_spec.sh` (46 examples, 0 failures)

Follow-up to #2415 discovered during merged deployment verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rearms the kyber-host-health timer during k3s activation so scheduling is relative to activation time. Previously, enable --now left an already-active but elapsed timer unarmed; now we also restart the timer to recalculate OnActiveSec.

- Ensures timely health checks after unit updates by calling systemctl restart kyber-host-health.timer after enable.
- Extends the activation spec to assert the restart; no migration or manual action required.

<sup>Written for commit f10b629f796c321361e7215d0825049b74f8c75b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

