### PR TITLE
fix(cliproxy): apply cgroup v2 I/O priority

### DIFF
--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -173,6 +173,39 @@ usage_export() {
   cliproxy_upload_usage_to_s3 "$USAGE_EXPORT_FILE"
 }
 
+apply_systemd_cgroup_weights() {
+  local container_id=""
+  local unit=""
+  local attempts=50
+  local -a root_cmd=()
+
+  command -v systemctl >/dev/null 2>&1 || return 0
+  if [ "$(id -u)" -ne 0 ]; then
+    if command -v sudo >/dev/null 2>&1; then
+      root_cmd=(sudo -n)
+    else
+      echo "⚠️  Cannot apply CLIProxy cgroup-v2 weights without non-interactive root access" >&2
+      return 0
+    fi
+  fi
+
+  while [ "$attempts" -gt 0 ]; do
+    container_id="$(docker inspect --format '{{.Id}}' cliproxyapi 2>/dev/null || true)"
+    if [ -n "$container_id" ]; then
+      unit="docker-${container_id}.scope"
+      if "${root_cmd[@]}" systemctl set-property --runtime "$unit" \
+        CPUWeight=10000 IOWeight=10000 2>/dev/null; then
+        echo "Applied CLIProxy cgroup-v2 CPU and I/O weights to $unit"
+        return 0
+      fi
+    fi
+    attempts=$((attempts - 1))
+    sleep 0.1
+  done
+
+  echo "⚠️  Could not apply CLIProxy cgroup-v2 weights; Docker limits remain in effect" >&2
+}
+
 wait_for_management() {
   if [ -z "$MANAGEMENT_KEY" ]; then
     return 0
@@ -260,6 +293,7 @@ if [ "$(uname)" = "Linux" ] && command -v docker >/dev/null 2>&1; then
     -e MANAGEMENT_PASSWORD="${MANAGEMENT_PASSWORD:-}" \
     "$docker_image" &
   child_pid=$!
+  apply_systemd_cgroup_weights
   wait "$child_pid"
   exit $?
 fi

--- a/spec/cliproxyapi_spec.sh
+++ b/spec/cliproxyapi_spec.sh
@@ -327,6 +327,11 @@ When run bash -c "grep -q -- '--cpu-shares 262144' '$SCRIPT' && grep -q -- '--bl
 The status should be success
 End
 
+It 'applies the intended weights to the actual systemd cgroup-v2 scope'
+When run bash -c "grep -q 'systemctl set-property --runtime' '$SCRIPT' && grep -q 'CPUWeight=10000 IOWeight=10000' '$SCRIPT' && grep -q '^  apply_systemd_cgroup_weights$' '$SCRIPT'"
+The status should be success
+End
+
 It 'supports a locally built canary image without pulling over it'
 When run bash -c "sed -n '/CLIPROXYAPI_IMAGE/,/\"\$docker_image\" \&/p' '$SCRIPT'"
 The output should include 'CLIPROXYAPI_IMAGE:-eceasy/cli-proxy-api:latest'


### PR DESCRIPTION
## Summary
- apply CPU and I/O weights to the transient Docker systemd scope after container start
- preserve Docker-native limits as the cross-platform baseline
- make unavailable root/systemd integration a non-fatal warning
- add regression coverage for the real cgroup-v2 application

## Verification
- `bash -n home-manager/services/cliproxyapi/scripts/start.sh`
- `shellcheck home-manager/services/cliproxyapi/scripts/start.sh`
- `shellspec spec/cliproxyapi_spec.sh` (35 examples, 0 failures)
- live Kyber proof: `io.weight` changed from `default 100` to `default 10000` with the same `systemctl set-property --runtime` operation

Follow-up discovered while verifying #2415 on the live systemd cgroup-v2 hierarchy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies cgroup v2 CPU and I/O weights to the CLIProxy container’s transient systemd scope after start to improve scheduling on cgroup v2 hosts. Previously we relied only on Docker limits; now we set CPUWeight=10000 and IOWeight=10000 via systemd. If systemd or non‑interactive root is unavailable, we warn and keep Docker limits.

**Review notes**
- Adds apply_systemd_cgroup_weights(): resolves the container ID, uses sudo -n when needed, and runs systemctl set-property --runtime on docker-<id>.scope; logs success or a non-fatal warning.
- Invokes the function immediately after `docker run` starts in the background and before `wait`; worst-case it retries for ~5s without failing the run.
- Keeps Docker-native CPU/blkio settings as the baseline for non-systemd or cgroup v1 systems.
- Updates shellspec to assert the systemd call with both CPUWeight=10000 and IOWeight=10000 and the function invocation.

<sup>Written for commit 38540e79320eb248c1654a3c35f8b0e4e2ea7804. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

