### PR TITLE
feat(dolt): sync Beads with Linear

### DIFF
--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -16,6 +16,10 @@ let
   mirrorDir = "${homeDir}/.cache/beads-jsonl-mirror";
   remoteUrl = "https://github.com/shunkakinoki/beads";
   userEmail = "shunkakinoki@gmail.com";
+  linearWorkspace = "shunkakinoki";
+  linearTeamId = "679ab4ed-3df3-458d-8574-4962f3ebbf31";
+  linearSyncIntervalSeconds = 300;
+  linearSyncPath = "${homeDir}/.local/bin:${homeDir}/.bun/bin:${homeDir}/.nix-profile/bin:/etc/profiles/per-user/${config.home.username}/bin:/run/current-system/sw/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
   enabled = isKyber || isGalactica;
   # 1.86+ adds the git+https:// remote scheme used by the beads_global GitHub backup.
   doltMinVersion = "1.86";
@@ -26,6 +30,12 @@ let
   backupScript = pkgs.replaceVars ./backup-dolt-main.sh {
     inherit mirrorDir remoteUrl userEmail;
     inherit (pkgs) git;
+  };
+  linearSyncScript = pkgs.replaceVars ./linear-sync.sh {
+    bd = "${homeDir}/.local/bin/bd";
+    linear = "${homeDir}/.bun/install/global/node_modules/.bin/linear";
+    inherit repoDir linearWorkspace linearTeamId;
+    inherit (pkgs) coreutils gawk jq;
   };
 in
 lib.mkIf enabled {
@@ -80,6 +90,32 @@ lib.mkIf enabled {
     };
   };
 
+  launchd.agents.dolt-linear-sync = lib.mkIf pkgs.stdenv.isDarwin {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "${pkgs.bash}/bin/bash"
+        "${linearSyncScript}"
+      ];
+      StartInterval = linearSyncIntervalSeconds;
+      ThrottleInterval = linearSyncIntervalSeconds;
+      RunAtLoad = true;
+      WorkingDirectory = repoDir;
+      EnvironmentVariables = {
+        HOME = homeDir;
+        PATH = linearSyncPath;
+        BEADS_DOLT_SHARED_SERVER = "1";
+        BEADS_DOLT_SERVER_PORT = "3307";
+        BEADS_SHARED_SERVER_DIR = sharedServerDir;
+        DOLT_CLI_USER = "root";
+        DOLT_CLI_PASSWORD = "";
+        LINEAR_TEAM_ID = linearTeamId;
+      };
+      StandardOutPath = "/tmp/dolt-linear-sync.log";
+      StandardErrorPath = "/tmp/dolt-linear-sync.error.log";
+    };
+  };
+
   systemd.user.services.dolt = lib.mkIf pkgs.stdenv.isLinux {
     Unit = {
       Description = "Dolt SQL server for dotfiles beads";
@@ -119,5 +155,46 @@ lib.mkIf enabled {
     Install = {
       WantedBy = [ "default.target" ];
     };
+  };
+
+  systemd.user.services.dolt-linear-sync = lib.mkIf pkgs.stdenv.isLinux {
+    Unit = {
+      Description = "Synchronize Beads with Linear";
+      X-SwitchMethod = "restart";
+      After = [
+        "dolt.service"
+        "network-online.target"
+      ];
+      Wants = [
+        "dolt.service"
+        "network-online.target"
+      ];
+    };
+    Service = {
+      Type = "oneshot";
+      ExecStart = "${pkgs.bash}/bin/bash ${linearSyncScript}";
+      Environment = [
+        "HOME=${homeDir}"
+        "PATH=${linearSyncPath}"
+        "BEADS_DOLT_SHARED_SERVER=1"
+        "BEADS_DOLT_SERVER_PORT=3307"
+        "BEADS_SHARED_SERVER_DIR=${sharedServerDir}"
+        "DOLT_CLI_USER=root"
+        "DOLT_CLI_PASSWORD="
+        "LINEAR_TEAM_ID=${linearTeamId}"
+      ];
+    };
+  };
+
+  systemd.user.timers.dolt-linear-sync = lib.mkIf pkgs.stdenv.isLinux {
+    Unit.Description = "Periodically synchronize Beads with Linear";
+    Timer = {
+      OnBootSec = "2min";
+      OnCalendar = "*-*-* *:00/5:00";
+      OnUnitActiveSec = "${toString linearSyncIntervalSeconds}s";
+      Persistent = true;
+      Unit = "dolt-linear-sync.service";
+    };
+    Install.WantedBy = [ "timers.target" ];
   };
 }

--- a/home-manager/services/dolt/linear-sync.sh
+++ b/home-manager/services/dolt/linear-sync.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+bd_cli="@bd@"
+linear_cli="@linear@"
+repo_dir="@repoDir@"
+linear_workspace="@linearWorkspace@"
+linear_team_id="@linearTeamId@"
+linear_credentials_file="${XDG_CONFIG_HOME:-$HOME/.config}/linear/credentials.toml"
+sync_state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/beads-linear-sync"
+sync_checkpoint_file="$sync_state_dir/last-success"
+
+log() {
+  printf '[beads-linear-sync] %s\n' "$*"
+}
+
+ensure_config() {
+  local key="$1"
+  local expected="$2"
+  local actual
+
+  actual="$("$bd_cli" -C "$repo_dir" config get "$key" 2>/dev/null || true)"
+  if [ "$actual" != "$expected" ]; then
+    "$bd_cli" -C "$repo_dir" config set "$key" "$expected"
+  fi
+}
+
+wait_for_beads() {
+  local _attempt
+
+  for _attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+    if "$bd_cli" -C "$repo_dir" ping >/dev/null 2>&1; then
+      return 0
+    fi
+    @coreutils@/bin/sleep 5
+  done
+
+  log "Beads did not become ready within 60 seconds"
+  return 1
+}
+
+run_linear() {
+  local output
+  local status
+
+  set +e
+  output="$("$@" 2>&1)"
+  status=$?
+  set -e
+
+  if [ -n "$output" ]; then
+    printf '%s\n' "$output"
+  fi
+
+  # bd may return zero after individual API operations were rejected. Treat
+  # its circuit-breaker warning as a deferred run regardless of exit status.
+  if [[ $output == *"rate limit circuit breaker"* ]]; then
+    return 75
+  fi
+
+  return "$status"
+}
+
+if [ -z "${LINEAR_API_KEY:-}" ] && [ -f "$linear_credentials_file" ] && [ ! -L "$linear_credentials_file" ]; then
+  @coreutils@/bin/chmod 600 "$linear_credentials_file"
+  LINEAR_API_KEY="$(@gawk@/bin/awk -F '[[:space:]]*=[[:space:]]*' -v workspace="$linear_workspace" '
+    $1 == workspace {
+      value = $2
+      sub(/^"/, "", value)
+      sub(/"$/, "", value)
+      print value
+      exit
+    }
+  ' "$linear_credentials_file")"
+fi
+
+if [ -z "${LINEAR_API_KEY:-}" ]; then
+  LINEAR_API_KEY="$(@coreutils@/bin/timeout 10 @coreutils@/bin/env -u LINEAR_API_KEY "$linear_cli" auth token --workspace "$linear_workspace" 2>/dev/null || true)"
+fi
+
+if [ -z "${LINEAR_API_KEY:-}" ]; then
+  log "No Linear credential is available from the environment or Linear CLI"
+  exit 1
+fi
+
+export LINEAR_API_KEY
+export LINEAR_TEAM_ID="${LINEAR_TEAM_ID:-$linear_team_id}"
+
+wait_for_beads
+@coreutils@/bin/mkdir -p "$sync_state_dir"
+cycle_started="$(@coreutils@/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+# Linear requires an explicit inbound type map and an explicit outbound state
+# name when a workflow has multiple states of the same type (for example,
+# "In Progress" and "In Review"). Commit this contract before pulling because
+# Beads deliberately refuses to auto-commit internal config keys during sync.
+ensure_config linear.state_map.triage open
+ensure_config linear.state_map.backlog open
+ensure_config linear.state_map.unstarted open
+ensure_config linear.state_map.started in_progress
+ensure_config linear.state_map.completed closed
+ensure_config linear.state_map.canceled closed
+ensure_config linear.state_map.duplicate closed
+ensure_config linear.outbound_state_map.open Todo
+ensure_config linear.outbound_state_map.in_progress "In Progress"
+ensure_config linear.outbound_state_map.closed Done
+"$bd_cli" -C "$repo_dir" dolt commit -m "chore(beads): configure Linear sync"
+
+# Pull the Dolt remote first so Linear conflict resolution sees the newest
+# Beads timestamps from every machine.
+"$bd_cli" -C "$repo_dir" sync --yes
+
+if [ -s "$sync_checkpoint_file" ]; then
+  previous_sync="$(<"$sync_checkpoint_file")"
+else
+  previous_sync="$(@jq@/bin/jq -r '.last_sync // ""' <<<"$("$bd_cli" -C "$repo_dir" linear status --json)")"
+fi
+
+# Pull only active work, and let Beads' staleness guard debounce calls made at
+# the five-minute timer boundary. A rate-limit failure is deferred to the next
+# scheduled run instead of making launchd hot-loop a failed job.
+log "Pulling active Linear work if stale"
+if run_linear "$bd_cli" -C "$repo_dir" linear sync \
+  --pull-if-stale \
+  --threshold 5m \
+  --state open \
+  --relations \
+  --no-wait; then
+  :
+else
+  status=$?
+  if [ "$status" -eq 75 ]; then
+    log "Linear pull deferred; the next 300-second run will retry"
+    exit 0
+  fi
+  log "Linear pull failed with status $status"
+  exit "$status"
+fi
+
+all_issues="$("$bd_cli" -C "$repo_dir" list --all --json --limit 0 --skip-labels)"
+changed_ids="$(@jq@/bin/jq -r --arg previous_sync "$previous_sync" '
+  (if type == "object" and has("issues") then .issues else . end)
+  | [
+    .[]
+    | select(
+        if .status == "closed" then
+          $previous_sync != ""
+          and .updated_at >= $previous_sync
+          and ((.external_ref // "") | contains("linear.app"))
+        else
+          $previous_sync == ""
+          or .updated_at >= $previous_sync
+          or ((.external_ref // "") | contains("linear.app") | not)
+        end
+      )
+    | .id
+  ]
+  | join(",")
+' <<<"$all_issues")"
+
+# Push only the active local delta since the previous successful pull. The
+# first successful run seeds all active work; steady-state runs remain small.
+if [ -n "$changed_ids" ]; then
+  log "Pushing changed active Beads"
+  if run_linear "$bd_cli" -C "$repo_dir" linear sync --push --issues "$changed_ids" --no-wait; then
+    :
+  else
+    status=$?
+    if [ "$status" -eq 75 ]; then
+      log "Linear push deferred; the next 300-second run will retry"
+      exit 0
+    fi
+    log "Linear push failed with status $status"
+    exit "$status"
+  fi
+else
+  log "No changed active Beads to push"
+fi
+
+"$bd_cli" -C "$repo_dir" dolt commit -m "chore(beads): sync Linear"
+"$bd_cli" -C "$repo_dir" sync --yes
+
+printf '%s\n' "$cycle_started" >"$sync_checkpoint_file.tmp"
+@coreutils@/bin/mv -f "$sync_checkpoint_file.tmp" "$sync_checkpoint_file"
+
+"$bd_cli" -C "$repo_dir" linear status --json

--- a/spec/beads_linear_sync_spec.sh
+++ b/spec/beads_linear_sync_spec.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016,SC2329
+
+Describe 'Beads Linear synchronization'
+SCRIPT="$PWD/home-manager/services/dolt/linear-sync.sh"
+MODULE="$PWD/home-manager/services/dolt/default.nix"
+
+Describe 'script properties'
+It 'uses strict bash mode'
+When run bash -c "grep -F 'set -euo pipefail' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
+It 'passes bash syntax validation after placeholder replacement'
+When run bash -c "sed 's|@[A-Za-z_][A-Za-z0-9_]*@|/usr|g' '$SCRIPT' | bash -n"
+The status should be success
+End
+
+It 'does not persist the Linear API key in Beads config'
+When run grep -F 'config set linear.api' "$SCRIPT"
+The status should be failure
+End
+
+It 'bounds workspace keyring lookup without forwarding an empty Linear key'
+When run bash -c "grep -F '@coreutils@/bin/env -u LINEAR_API_KEY' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
+It 'reads and protects the Linear CLI credential file for background use'
+When run bash -c "grep -F '@coreutils@/bin/chmod 600 \"\$linear_credentials_file\"' '$SCRIPT' >/dev/null && grep -F '@gawk@/bin/awk' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
+It 'invokes jq through the Nix package binary path'
+When run bash -c "grep -F '@jq@/bin/jq' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
+It 'supports the current Beads list envelope'
+When run bash -c "grep -F 'if type == \"object\" and has(\"issues\") then .issues else . end' '$SCRIPT' >/dev/null"
+The status should be success
+End
+End
+
+Describe 'sync scope'
+It 'pulls active Linear work only when stale'
+When run bash -c "grep -F -- '--pull-if-stale' '$SCRIPT' >/dev/null && grep -F -- '--threshold 5m' '$SCRIPT' >/dev/null && grep -F -- '--state open' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
+It 'pushes only changed active Beads'
+When run bash -c "grep -F '.updated_at >= \$previous_sync' '$SCRIPT' >/dev/null && grep -F 'linear sync --push --issues \"\$changed_ids\" --no-wait' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
+It 'defers rate-limited work to the next timer run'
+When run bash -c "test \"\$(grep -c 'next 300-second run will retry' '$SCRIPT')\" -eq 2 && grep -F 'rate limit circuit breaker' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
+It 'propagates non-rate-limit pull and push failures'
+When run bash -c "test \"\$(grep -c 'failed with status \$status' '$SCRIPT')\" -eq 2 && test \"\$(grep -c 'exit \"\$status\"' '$SCRIPT')\" -eq 2"
+The status should be success
+End
+
+It 'checkpoints a successful cycle for delta selection'
+When run bash -c "checkpoint=\$(grep -n '\"\$cycle_started\" >\"\$sync_checkpoint_file.tmp\"' '$SCRIPT' | cut -d: -f1); final_sync=\$(grep -n 'sync --yes' '$SCRIPT' | tail -1 | cut -d: -f1); test \"\$checkpoint\" -gt \"\$final_sync\""
+The status should be success
+End
+
+It 'federates Beads before and after Linear reconciliation'
+When run bash -c "test \"\$(grep -c 'sync --yes' '$SCRIPT')\" -eq 2"
+The status should be success
+End
+
+It 'commits internal Linear config before the first federation pull'
+When run bash -c "config_commit=\$(grep -n 'configure Linear sync' '$SCRIPT' | cut -d: -f1); first_pull=\$(grep -n 'sync --yes' '$SCRIPT' | head -1 | cut -d: -f1); test \"\$config_commit\" -lt \"\$first_pull\""
+The status should be success
+End
+End
+
+Describe 'reconciliation behavior'
+setup_reconciliation() {
+  TEST_ROOT=$(mktemp -d)
+  FAKE_BD="$TEST_ROOT/bd"
+  RENDERED_SCRIPT="$TEST_ROOT/linear-sync.sh"
+  COMMAND_LOG="$TEST_ROOT/commands.log"
+  SYNC_COUNT="$TEST_ROOT/sync-count"
+  STATE_HOME="$TEST_ROOT/state"
+  COREUTILS="$TEST_ROOT/coreutils"
+  jq_prefix=$(dirname "$(dirname "$(command -v jq)")")
+  mkdir -p "$COREUTILS/bin"
+  for command in chmod date env mkdir mv sleep timeout; do
+    ln -s "$(command -v "$command")" "$COREUTILS/bin/$command"
+  done
+
+  cat >"$FAKE_BD" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$COMMAND_LOG"
+if [ "${1:-}" = "-C" ]; then
+  shift 2
+fi
+case "${1:-} ${2:-}" in
+  "ping ")
+    exit 0
+    ;;
+  "config get")
+    exit 0
+    ;;
+  "config set" | "dolt commit")
+    exit 0
+    ;;
+  "sync --yes")
+    count=0
+    if [ -s "$SYNC_COUNT" ]; then
+      count=$(<"$SYNC_COUNT")
+    fi
+    count=$((count + 1))
+    printf '%s\n' "$count" >"$SYNC_COUNT"
+    if [ "${FAKE_LINEAR_MODE:-}" = "final-failure" ] && [ "$count" -eq 2 ]; then
+      exit 42
+    fi
+    ;;
+  "linear status")
+    printf '%s\n' '{"last_sync":""}'
+    ;;
+  "linear sync")
+    case "${FAKE_LINEAR_MODE:-success}" in
+      rate-limit)
+        printf '%s\n' 'rate limit circuit breaker is open'
+        ;;
+      hard-failure)
+        exit 23
+        ;;
+      push-failure)
+        if [[ " $* " == *" --push "* ]]; then
+          exit 24
+        fi
+        ;;
+    esac
+    ;;
+  "list --all")
+    if [ -n "${FAKE_LIST_JSON:-}" ]; then
+      printf '%s\n' "$FAKE_LIST_JSON"
+    else
+      printf '%s\n' '[{"id":"df-test","status":"open","updated_at":"2099-01-01T00:00:00Z"}]'
+    fi
+    ;;
+esac
+EOF
+  chmod +x "$FAKE_BD"
+  sed \
+    -e "s|@bd@|$FAKE_BD|g" \
+    -e 's|@linear@|/usr/bin/false|g' \
+    -e "s|@repoDir@|$TEST_ROOT|g" \
+    -e 's|@linearWorkspace@|test-workspace|g' \
+    -e 's|@linearTeamId@|test-team|g' \
+    -e "s|@coreutils@|$COREUTILS|g" \
+    -e 's|@gawk@|/usr|g' \
+    -e "s|@jq@|$jq_prefix|g" \
+    "$SCRIPT" >"$RENDERED_SCRIPT"
+}
+
+cleanup_reconciliation() {
+  rm -rf "$TEST_ROOT"
+}
+
+Before 'setup_reconciliation'
+After 'cleanup_reconciliation'
+
+It 'runs both federations around pull and delta push before checkpointing'
+When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
+The status should be success
+The output should include 'Pushing changed active Beads'
+The file "$STATE_HOME/beads-linear-sync/last-success" should be exist
+The contents of file "$COMMAND_LOG" should include 'linear sync --pull-if-stale --threshold 5m --state open --relations --no-wait'
+The contents of file "$COMMAND_LOG" should include 'linear sync --push --issues df-test --no-wait'
+End
+
+It 'defers a Linear rate limit without advancing the checkpoint'
+When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MODE=rate-limit XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
+The status should be success
+The output should include 'next 300-second run will retry'
+The file "$STATE_HOME/beads-linear-sync/last-success" should not be exist
+End
+
+It 'propagates an ordinary Linear failure without advancing the checkpoint'
+When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MODE=hard-failure XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
+The status should equal 23
+The output should include 'Linear pull failed with status 23'
+The file "$STATE_HOME/beads-linear-sync/last-success" should not be exist
+End
+
+It 'propagates a Linear push failure without advancing the checkpoint'
+When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MODE=push-failure XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
+The status should equal 24
+The output should include 'Linear push failed with status 24'
+The file "$STATE_HOME/beads-linear-sync/last-success" should not be exist
+End
+
+It 'pushes a locally closed linked issue from a steady-state delta'
+mkdir -p "$STATE_HOME/beads-linear-sync"
+printf '%s\n' '2026-01-01T00:00:00Z' >"$STATE_HOME/beads-linear-sync/last-success"
+When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LIST_JSON='[{"id":"df-closed","status":"closed","updated_at":"2099-01-01T00:00:00Z","external_ref":"https://linear.app/test/issue/TEST-1/closed"}]' XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
+The status should be success
+The output should include 'Pushing changed active Beads'
+The contents of file "$COMMAND_LOG" should include 'linear sync --push --issues df-closed --no-wait'
+End
+
+It 'does not checkpoint when final federation fails'
+When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MODE=final-failure XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
+The status should equal 42
+The output should include 'Pushing changed active Beads'
+The file "$STATE_HOME/beads-linear-sync/last-success" should not be exist
+End
+End
+
+Describe 'Home Manager service ownership'
+It 'runs every five minutes on launchd'
+When run bash -c "grep -F 'linearSyncIntervalSeconds = 300;' '$MODULE' >/dev/null && grep -F 'ThrottleInterval = linearSyncIntervalSeconds;' '$MODULE' >/dev/null && grep -F 'PATH = linearSyncPath;' '$MODULE' >/dev/null"
+The status should be success
+End
+
+It 'installs the macOS launchd agent'
+When run bash -c "grep -F 'launchd.agents.dolt-linear-sync' '$MODULE' >/dev/null"
+The status should be success
+End
+
+It 'installs the Linux systemd timer'
+When run bash -c "grep -F 'systemd.user.timers.dolt-linear-sync' '$MODULE' >/dev/null && grep -F 'OnCalendar = \"*-*-* *:00/5:00\";' '$MODULE' >/dev/null && grep -F 'X-SwitchMethod = \"restart\";' '$MODULE' >/dev/null"
+The status should be success
+End
+End
+End

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -265,6 +265,10 @@ It 'has spec file for home-manager/services/dolt/backup-dolt-main.sh'
 The path "spec/backup_dolt_main_spec.sh" should be exist
 End
 
+It 'has spec file for home-manager/services/dolt/linear-sync.sh'
+The path "spec/beads_linear_sync_spec.sh" should be exist
+End
+
 It 'has spec file for home-manager/services/k3s/activate.sh'
 The path "spec/k3s_service_activate_spec.sh" should be exist
 End
@@ -563,6 +567,7 @@ home-manager/services/docker/docker-setup.sh
 home-manager/services/docker/setup-docker.sh
 home-manager/services/dolt/start.sh
 home-manager/services/dolt/backup-dolt-main.sh
+home-manager/services/dolt/linear-sync.sh
 home-manager/services/dotfiles-updater/update.sh
 home-manager/services/gas-town/start.sh
 home-manager/services/k3s/activate.sh


### PR DESCRIPTION
## Summary

- add a declarative Home Manager Beads↔Linear sync service for launchd and systemd
- run active-work reconciliation every 300 seconds with staleness debounce, delta pushes, throttling, and a successful-cycle checkpoint
- harden non-interactive credential lookup without storing the Linear API key in Git or Beads config
- enforce Linear state mappings and federate Dolt before and after reconciliation

## Validation

- `make build`
- `shellspec spec/beads_linear_sync_spec.sh spec/dolt_start_spec.sh spec/backup_dolt_main_spec.sh` (49 examples)
- `shellcheck home-manager/services/dolt/linear-sync.sh`
- `nixfmt --check home-manager/services/dolt/default.nix`
- live launchd cycle: active pull debounced, 41 changed issues pushed, Dolt sync completed, exit 0, 300-second interval retained

## Tracking

- Beads: `shunkakinokisoftware-awz1` / Linear: `SHUN-1847`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates Beads↔Linear sync on macOS and Linux. Previously manual; now a 300-second job pulls stale open Linear work and pushes only changed active Beads, deferring on rate limits and federating Dolt before and after.

- Adds `home-manager` services: `launchd.agents.dolt-linear-sync` (macOS) and `systemd.user` oneshot service + timer (Linux), with PATH and Dolt shared server env configured; launchd logs to /tmp.
- Introduces `home-manager/services/dolt/linear-sync.sh`: waits for Beads; commits explicit Linear inbound/outbound state maps; federates; pulls only if stale (`--state open`, 5m threshold); selects a delta since the last successful run (or `bd linear status` fallback); pushes only changed active issues; federates again; checkpoints the cycle start; treats Linear “rate limit circuit breaker” as a deferred run.
- Hardens credentials: uses `LINEAR_API_KEY` from env, the `linear` CLI credentials file (chmod 600), or `linear auth token --workspace`; never stores the key in Beads; respects `LINEAR_TEAM_ID` with a default. Addresses SHUN-1847.
- Adds `spec/beads_linear_sync_spec.sh` covering strict mode, credential lookup, debounce/delta push behavior, federation order, and timer wiring; updates coverage.

Migration: export `LINEAR_API_KEY` or install/authenticate the `linear` CLI; set `LINEAR_TEAM_ID` if you need a non-default team.

<sup>Written for commit b3793685aab7caae9071fd6be2e11281a6b137a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

