### PR TITLE
Add Grok Bot to Dock after Cursor

### DIFF
--- a/nix-darwin/config/dock.nix
+++ b/nix-darwin/config/dock.nix
@@ -24,6 +24,7 @@
       "/Applications/ChatGPT.app"
       "/Applications/Claude.app"
       "/Applications/Cursor.app"
+      "/Applications/Grok Bot.app"
       "/Applications/OpenCode.app"
       "/Applications/Antigravity.app"
       "/Applications/Conductor.app"


### PR DESCRIPTION
## Summary

Pin Grok Bot immediately to the right of Cursor in `nix-darwin/config/dock.nix`.

## Change

- Add `"/Applications/Grok Bot.app"` after `"/Applications/Cursor.app"` and before `"/Applications/OpenCode.app"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins Grok Bot in the macOS Dock after Cursor and before OpenCode. Previously Grok Bot was not pinned; now it appears between Cursor and OpenCode to keep AI tools grouped and accessible.

- Rollout: Run `darwin-rebuild switch` to apply the Dock change; the Dock may relaunch.

<sup>Written for commit 89757269be191e8a7223a61d699c086acfd693d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

