### PR TITLE
fix(antigravity): use authenticated default backend

### DIFF
--- a/config/antigravity/activate.sh
+++ b/config/antigravity/activate.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # Merge declarative Antigravity CLI defaults into its writable settings file.
+# The explicit Gemini provider requires GEMINI_API_KEY and bypasses Antigravity's
+# authenticated default backend, so remove that legacy managed key on upgrade.
 # Usage: activate.sh <managed-settings-json> [jq]
 set -euo pipefail
 
@@ -19,9 +21,9 @@ tmp="$(mktemp "$SETTINGS_DIR/settings.json.XXXXXX")"
 trap 'rm -f "$tmp"' EXIT
 
 if [ -f "$SETTINGS_FILE" ]; then
-  "$JQ" -s '.[0] * .[1]' "$SETTINGS_FILE" "$MANAGED_SETTINGS" >"$tmp"
+  "$JQ" -s '.[0] * .[1] | del(.modelProvider)' "$SETTINGS_FILE" "$MANAGED_SETTINGS" >"$tmp"
 else
-  "$JQ" '.' "$MANAGED_SETTINGS" >"$tmp"
+  "$JQ" 'del(.modelProvider)' "$MANAGED_SETTINGS" >"$tmp"
 fi
 
 chmod 600 "$tmp"

--- a/config/antigravity/default.nix
+++ b/config/antigravity/default.nix
@@ -5,7 +5,7 @@
 }:
 {
   # Antigravity CLI persists interactive preferences in this file. Merge the
-  # provider/model pair instead of symlinking the whole file into the Nix store.
+  # model default instead of symlinking the whole file into the Nix store.
   home.activation.antigravityCliSettings = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" \
       "${./settings.json}" \

--- a/config/antigravity/settings.json
+++ b/config/antigravity/settings.json
@@ -1,4 +1,3 @@
 {
-  "modelProvider": "gemini",
   "model": "gemini-3.7-flash-high"
 }

--- a/config/antigravity/settings.tpl.json
+++ b/config/antigravity/settings.tpl.json
@@ -1,4 +1,3 @@
 {
-  "modelProvider": "gemini",
   "model": "gemini-3.7-flash-high"
 }

--- a/spec/antigravity_config_spec.sh
+++ b/spec/antigravity_config_spec.sh
@@ -16,14 +16,14 @@ cleanup() {
 Before 'setup'
 After 'cleanup'
 
-It 'creates writable Gemini-native Antigravity CLI settings'
-When run bash -c 'HOME="$1" bash "$2" "$3" jq && jq -e '\''.modelProvider == "gemini" and .model == "gemini-3.7-flash-high"'\'' "$1/.gemini/antigravity-cli/settings.json" >/dev/null && find "$1/.gemini/antigravity-cli/settings.json" -prune -perm 600 -print -quit | grep -q .' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS"
+It 'creates writable default-backend Antigravity CLI settings'
+When run bash -c 'HOME="$1" bash "$2" "$3" jq && jq -e '\''.model == "gemini-3.7-flash-high" and has("modelProvider") == false'\'' "$1/.gemini/antigravity-cli/settings.json" >/dev/null && find "$1/.gemini/antigravity-cli/settings.json" -prune -perm 600 -print -quit | grep -q .' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS"
 The status should be success
 The path "$TEMP_HOME/.gemini/antigravity-cli/settings.json" should be file
 The path "$TEMP_HOME/.gemini/antigravity-cli/settings.json" should be writable
 End
 
-It 'preserves runtime preferences while enforcing the managed provider and model'
+It 'preserves runtime preferences while removing the legacy explicit provider'
 mkdir -p "$TEMP_HOME/.gemini/antigravity-cli"
 cat >"$TEMP_HOME/.gemini/antigravity-cli/settings.json" <<'JSON'
 {
@@ -33,7 +33,7 @@ cat >"$TEMP_HOME/.gemini/antigravity-cli/settings.json" <<'JSON'
   "futureSetting": "preserved"
 }
 JSON
-When run bash -c 'HOME="$1" bash "$2" "$3" jq && jq -e '\''.modelProvider == "gemini" and .model == "gemini-3.7-flash-high" and .showTips == false and .futureSetting == "preserved"'\'' "$1/.gemini/antigravity-cli/settings.json" >/dev/null && find "$1/.gemini/antigravity-cli/settings.json" -prune -perm 600 -print -quit | grep -q .' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS"
+When run bash -c 'HOME="$1" bash "$2" "$3" jq && jq -e '\''.model == "gemini-3.7-flash-high" and has("modelProvider") == false and .showTips == false and .futureSetting == "preserved"'\'' "$1/.gemini/antigravity-cli/settings.json" >/dev/null && find "$1/.gemini/antigravity-cli/settings.json" -prune -perm 600 -print -quit | grep -q .' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS"
 The status should be success
 End
 

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -170,14 +170,14 @@ End
 End
 
 Describe 'generated Antigravity settings'
-It 'keeps the native Flash ID directly in the provider-owned Antigravity template'
-When run jq -e '.modelProvider == "gemini" and .model == "gemini-3.7-flash-high"' config/antigravity/settings.tpl.json
+It 'keeps the native Flash ID on the authenticated Antigravity backend'
+When run jq -e '.model == "gemini-3.7-flash-high" and has("modelProvider") == false' config/antigravity/settings.tpl.json
 The status should be success
 The output should equal 'true'
 End
 
-It 'generates the concrete Gemini model for Antigravity'
-When run jq -e '.modelProvider == "gemini" and .model == "gemini-3.7-flash-high"' config/antigravity/settings.json
+It 'generates the concrete model without forcing API-key authentication'
+When run jq -e '.model == "gemini-3.7-flash-high" and has("modelProvider") == false' config/antigravity/settings.json
 The status should be success
 The output should equal 'true'
 End


### PR DESCRIPTION
## Summary
- stop forcing AGY's API-key-only Gemini provider
- retain the Gemini 3.7 Flash model pin on the authenticated default backend
- migrate existing settings by deleting the stale modelProvider key

## Verification
- shellspec spec/antigravity_config_spec.sh spec/llm_update_spec.sh --format documentation (99 examples, 0 failures)
- shellcheck config/antigravity/activate.sh spec/antigravity_config_spec.sh spec/llm_update_spec.sh
- make nix-format-check
- make build
- Kyber sandbox probe: authenticated model catalog succeeds with only modelProvider removed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uses Antigravity’s authenticated default backend instead of forcing the API-key-only Gemini provider. Previously we set modelProvider=gemini (requiring GEMINI_API_KEY); now we remove that override and keep the model pinned to gemini-3.7-flash-high.

- Activation deletes the legacy modelProvider during settings merge, preserving other keys and 0600 perms.
- Removes modelProvider from settings templates; specs updated to assert its absence.
- Migration: no action. On next activation the stale provider key is removed; authenticated model catalog works without GEMINI_API_KEY.

<sup>Written for commit b5394a9404b96daa9a0e1fc6e52b01f7a52197dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

