### PR TITLE
fix(cliproxy): drop empty hydrated provider keys

### DIFF
--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -94,14 +94,14 @@ cliproxy_drop_empty_compat_providers() {
         continue
       fi
 
-      if [[ "$line" == "#"* ]] || [[ "$line" =~ ^[A-Za-z] ]]; then
+      if [[ $line == "#"* ]] || [[ $line =~ ^[A-Za-z] ]]; then
         flush_item
         in_compat=0
         printf '%s\n' "$line"
         continue
       fi
 
-      if [[ "$line" == "  - "* ]]; then
+      if [[ $line == "  - "* ]]; then
         flush_item
         in_item=1
         item="${line}"$'\n'
@@ -110,7 +110,7 @@ cliproxy_drop_empty_compat_providers() {
 
       if [ "$in_item" -eq 1 ]; then
         item+="${line}"$'\n'
-        if [[ "$line" == *"api-key:"* ]]; then
+        if [[ $line == *"api-key:"* ]]; then
           keyval="${line#*api-key:}"
           keyval="${keyval#"${keyval%%[![:space:]]*}"}"
           keyval="${keyval%\"}"

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -61,6 +61,76 @@ render_opencode_api_key_entries() {
   done <"$template"
 }
 
+# Empty hydrated keys still register as clients. After a higher hop 429s,
+# session-affinity binds to that empty key and never reaches OpenRouter.
+cliproxy_drop_empty_compat_providers() {
+  local src="$1"
+  local dest="${2:-$1}"
+  local tmp in_compat=0 in_item=0 has_key=0
+  local item="" line keyval
+
+  flush_item() {
+    if [ "$in_item" -eq 0 ]; then
+      return 0
+    fi
+    if [ "$has_key" -eq 1 ]; then
+      printf '%s' "$item"
+    else
+      echo "⚠️  Dropping openai-compatibility provider with empty api-key" >&2
+    fi
+    item=""
+    in_item=0
+    has_key=0
+  }
+
+  tmp="$(mktemp "${TMPDIR:-/tmp}/cliproxy-compat.XXXXXX")"
+  {
+    while IFS= read -r line || [ -n "$line" ]; do
+      if [ "$in_compat" -eq 0 ]; then
+        printf '%s\n' "$line"
+        if [ "$line" = "openai-compatibility:" ]; then
+          in_compat=1
+        fi
+        continue
+      fi
+
+      if [[ "$line" == "#"* ]] || [[ "$line" =~ ^[A-Za-z] ]]; then
+        flush_item
+        in_compat=0
+        printf '%s\n' "$line"
+        continue
+      fi
+
+      if [[ "$line" == "  - "* ]]; then
+        flush_item
+        in_item=1
+        item="${line}"$'\n'
+        continue
+      fi
+
+      if [ "$in_item" -eq 1 ]; then
+        item+="${line}"$'\n'
+        if [[ "$line" == *"api-key:"* ]]; then
+          keyval="${line#*api-key:}"
+          keyval="${keyval#"${keyval%%[![:space:]]*}"}"
+          keyval="${keyval%\"}"
+          keyval="${keyval#\"}"
+          keyval="${keyval%\'}"
+          keyval="${keyval#\'}"
+          if [ -n "$keyval" ] && [ "$keyval" != "[]" ]; then
+            has_key=1
+          fi
+        fi
+        continue
+      fi
+
+      printf '%s\n' "$line"
+    done
+    flush_item
+  } <"$src" >"$tmp"
+  mv -f "$tmp" "$dest"
+} # cliproxy_drop_empty_compat_providers
+
 if cliproxy_has_objectstore_credentials; then
   mkdir -p "$AUTH_DIR"
 
@@ -114,6 +184,8 @@ if [ -f "$TEMPLATE" ]; then
       -e "s|^      to:|#       to:|" \
       "$CONFIG"
   fi
+
+  cliproxy_drop_empty_compat_providers "$CONFIG"
 fi
 
 # Keep objectstore-backed config in sync for management UI

--- a/spec/cliproxyapi_empty_compat_spec.sh
+++ b/spec/cliproxyapi_empty_compat_spec.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329,SC2016
+
+Describe 'cliproxyapi empty openai-compatibility entries'
+SCRIPT="$PWD/home-manager/services/cliproxyapi/scripts/start.sh"
+
+setup_empty_compat() {
+  TEMP_COMPAT=$(mktemp -d)
+  sed -n '/^cliproxy_drop_empty_compat_providers() {/,/^} # cliproxy_drop_empty_compat_providers$/p' "$SCRIPT" >"$TEMP_COMPAT/filter.sh"
+  cat >>"$TEMP_COMPAT/filter.sh" <<'BASH'
+cliproxy_drop_empty_compat_providers "$1" "$2"
+BASH
+  cat >"$TEMP_COMPAT/config.yaml" <<'YAML'
+port: 8317
+openai-compatibility:
+  - name: "openrouter"
+    priority: 100
+    api-key-entries:
+      - api-key: "DUMMY_PASSWORD"
+    models:
+      - name: "deepseek-v4-flash"
+        alias: "deepseek-v4-flash"
+  - name: "aliyun"
+    priority: 200
+    api-key-entries:
+      - api-key: ""
+    models:
+      - name: "deepseek-v4-flash-0731"
+        alias: "deepseek-v4-flash"
+  - name: "verboo"
+    priority: 150
+    api-key-entries:
+      - api-key: ""
+  - name: "opencode"
+    priority: 300
+    api-key-entries: []
+# Official OpenAI compatibility provider reference
+# openai-compatibility:
+#   - name: "openrouter"
+#     api-key-entries:
+#       - api-key: "DUMMY_PASSWORD"
+routing:
+  session-affinity: true
+YAML
+}
+
+cleanup_empty_compat() {
+  rm -rf "$TEMP_COMPAT"
+}
+
+Before 'setup_empty_compat'
+After 'cleanup_empty_compat'
+
+It 'drops empty-key providers after hydrate so later hops can bind'
+When run bash -c "bash '$TEMP_COMPAT/filter.sh' '$TEMP_COMPAT/config.yaml' '$TEMP_COMPAT/out.yaml'; cat '$TEMP_COMPAT/out.yaml'"
+The output should include 'name: "openrouter"'
+The output should include 'api-key: "DUMMY_PASSWORD"'
+The output should include 'session-affinity: true'
+The output should include '#   - name: "openrouter"'
+The output should not include 'name: "aliyun"'
+The output should not include 'name: "verboo"'
+The output should not include 'name: "opencode"'
+The error should include 'Dropping openai-compatibility provider with empty api-key'
+The status should be success
+End
+
+It 'invokes the empty-key filter after secret substitution'
+When run bash -c "grep -n 'cliproxy_drop_empty_compat_providers \"\$CONFIG\"' '$SCRIPT'"
+The output should include 'cliproxy_drop_empty_compat_providers "$CONFIG"'
+The status should be success
+End
+End


### PR DESCRIPTION
Empty Aliyun/Verboo keys were still being registered after hydrate. Once OpenCode 429s, session-affinity stuck on that empty key and `ocxe` died with `No API-key provided` instead of falling through to OpenRouter.

`start.sh` now drops openai-compat providers whose hydrated keys are empty.

Related: https://linear.app/shunkakinoki/issue/SHUN-1942/fix-cliproxy-empty-key-hydrate-blocking-ocxe

## Test plan
- [x] `shellspec spec/cliproxyapi_empty_compat_spec.sh spec/cliproxyapi_spec.sh`
- [x] `_ocxe_function` returned `pong` against the sanitized local config

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops `openai-compatibility` providers whose hydrated API keys are empty so session affinity no longer sticks to empty keys. Previously Aliyun/Verboo could register with empty keys; after an OpenCode 429, traffic pinned to that client and `ocxe` failed with "No API-key provided" instead of falling through to OpenRouter. Addresses SHUN-1942.

- Adds `cliproxy_drop_empty_compat_providers` to filter the hydrated config after secret substitution in `start.sh`; logs a warning and removes providers whose `api-key-entries` are blank or `[]`.
- Adds `spec/cliproxyapi_empty_compat_spec.sh` to verify filtering behavior and that the filter runs.
- Formatted the filter with shfmt; no behavior change.
- No migration required, but providers intentionally left without a key will now be dropped; ensure a non-empty key if it must remain routable.

<sup>Written for commit 5d1b133f714babfc630066fcdfd7ecf9f52f33d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

