### PR TITLE
feat(omp): route all models through local CLIProxy

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -88,6 +88,7 @@ Rules:
 | OpenCode | `shunkakinoki/deepseek-v4-flash` | shared chain, `shunkakinoki/` prefix | [opencode-fallback.tpl.jsonc](config/opencode/opencode-fallback.tpl.jsonc) |
 | OpenClaw | `cliproxy/deepseek-v4-flash` | shared chain, `cliproxy/` prefix | [openclaw.tpl.json](config/openclaw/openclaw.tpl.json) |
 | Hermes | `cliproxy/deepseek-v4-flash` | shared chain via `fallback_providers` | [config.tpl.yaml](config/hermes/config.tpl.yaml) |
+| OMP | `cliproxyapi/deepseek-v4-flash` | shared chain, `cliproxyapi/` prefix | [config.tpl.yml](config/omp/config.tpl.yml) |
 
 OpenCode fallback is driven by the `opencode-runtime-fallback@0.2.3` plugin:
 
@@ -101,6 +102,7 @@ OpenCode fallback is driven by the `opencode-runtime-fallback@0.2.3` plugin:
 
 OpenClaw and Hermes have no equivalent error-pattern matcher, so they hard-fail
 on the `unknown provider for model <prefixed-name>` 400 that OpenCode absorbs.
+OMP uses native `retry.fallbackChains` instead of a plugin.
 
 Hermes also runs a Mixture-of-Agents preset: reference models
 `deepseek-v4-flash` + `minimax-m3`, aggregator `deepseek-v4-flash`.
@@ -111,11 +113,8 @@ Hermes also runs a Mixture-of-Agents preset: reference models
 | --- | --- | --- | --- |
 | OpenCode | `small_model` | `shunkakinoki/glm-4.7` | [opencode.tpl.jsonc](config/opencode/opencode.tpl.jsonc) |
 | OpenCode | `code-reviewer` agent | `shunkakinoki/deepseek-v4-flash` | [opencode.tpl.jsonc](config/opencode/opencode.tpl.jsonc) |
-| OMP | `default` | `cliproxyapi/deepseek-v4-flash` | [config.tpl.yml](config/omp/config.tpl.yml) |
-| OMP | `smol` | `openai-codex/gpt-5.6-luna` | |
-| OMP | `slow`, `vision`, `plan` | `openai-codex/gpt-5.6-sol` | |
-| OMP | `commit` | `openai/gpt-5.6-luna` | |
-| OMP | `task` | `openai-codex/gpt-5.6-luna` | |
+| OMP | `smol`, `commit`, `task` | `cliproxyapi/glm-4.7` | [config.tpl.yml](config/omp/config.tpl.yml) |
+| OMP | `slow`, `vision`, `plan` | `cliproxyapi/deepseek-v4-flash` | |
 | Codex | default | `gpt-5.6-sol` | [config.tpl.toml](config/codex/config.tpl.toml) |
 | Codex | subagents | `gpt-5.6-luna` | |
 | Codex | `qwen-local` profile | `qwen3.5-0.8b-optiq` (LM Studio) | |
@@ -127,10 +126,14 @@ Hermes also runs a Mixture-of-Agents preset: reference models
 | llm | default | `glm-4.7` | [default_model.tpl.txt](config/llm/default_model.tpl.txt) |
 | Handy | transcript post-process | `@preset/glm-4.7` (OpenRouter) | [settings_store.tpl.json](config/handy/settings_store.tpl.json) |
 
-OMP subagent overrides: `code-explorer`, `comment-analyzer`, and
-`pr-test-analyzer` use `gpt-5.6-luna`; the rest (`code-architect`,
-`code-reviewer`, `code-simplifier`, `silent-failure-hunter`,
-`type-design-analyzer`) use `gpt-5.6-sol`.
+OMP selects only `cliproxyapi/*`. Subagent overrides: `code-explorer`,
+`comment-analyzer`, and `pr-test-analyzer` use `glm-4.7`; the rest
+(`code-architect`, `code-reviewer`, `code-simplifier`,
+`silent-failure-hunter`, `type-design-analyzer`) use `deepseek-v4-flash`.
+The registry in [models.tpl.yml](config/omp/models.tpl.yml) lists the
+CLIProxy aliases and discovers the rest from local `/v1/models`.
+OMP fallback uses the shared chain (`deepseek-v4-flash` -> `gemma-4-31b-it`
+-> `glm-4.7` -> `free`).
 
 ### Fish shortcuts
 

--- a/config/omp/config.tpl.yml
+++ b/config/omp/config.tpl.yml
@@ -36,7 +36,8 @@ shellPath: null
 #   Empty arrays keep upstream discovery behavior unchanged.
 extensions:
   - "~/.omp/agent/extensions/swarm-extension"
-enabledModels: []
+enabledModels:
+  - cliproxyapi/*
 disabledProviders: []
 disabledExtensions: []
 # =============================================================================
@@ -59,24 +60,24 @@ disabledExtensions: []
 #   openrouter   — OpenRouter (access to many models)
 #
 # Examples:
-#   default: openai-codex/__GPT__
-#   fast:    openai-codex/__GPT_LUNA__
-#   slow:    openai-codex/__GPT__:high
+#   default: cliproxyapi/__DEEPSEEK_FLASH__
+#   fast:    cliproxyapi/__GLM__
+#   slow:    cliproxyapi/__DEEPSEEK_FLASH__
 modelRoles:
   # Default model role used as the fallback when no other role is selected.
   default: "cliproxyapi/__DEEPSEEK_FLASH__"
   # Smaller / dumber model for cheap lightweight work.
-  smol: "openai-codex/__GPT_LUNA__"
+  smol: "cliproxyapi/__GLM__"
   # Strongest model in the suite for hard tasks.
-  slow: "openai-codex/__GPT__"
+  slow: "cliproxyapi/__DEEPSEEK_FLASH__"
   # Keep vision on the main default model.
-  vision: "openai-codex/__GPT__"
+  vision: "cliproxyapi/__DEEPSEEK_FLASH__"
   # Planning / architecture model.
-  plan: "openai-codex/__GPT__"
+  plan: "cliproxyapi/__DEEPSEEK_FLASH__"
   # Commit message model.
-  commit: "openai/__GPT_LUNA__"
+  commit: "cliproxyapi/__GLM__"
   # Fast subagent path.
-  task: "openai-codex/__GPT_LUNA__"
+  task: "cliproxyapi/__GLM__"
 # =============================================================================
 # DISPLAY
 # =============================================================================
@@ -310,21 +311,14 @@ retry:
   #
   #   Candidates are the entries AFTER the current model in its chain, so a role
   #   whose model sits last in the chain it inherits has no candidates at all.
-  #   The roles pinned to __GPT__ therefore get their own chain rather than
-  #   inheriting `default`, which ends on __GPT__.
+  #   Roles pinned to __GLM__ inherit `default` and still have `free` after
+  #   them. Do not put a role on the last hop.
   fallbackChains:
     default:
-      - "openai-codex/__GPT_LUNA__"
-      - "openai-codex/__GPT__"
-    slow:
-      - "openai-codex/__GPT_LUNA__"
       - "cliproxyapi/__DEEPSEEK_FLASH__"
-    vision:
-      - "openai-codex/__GPT_LUNA__"
-      - "cliproxyapi/__DEEPSEEK_FLASH__"
-    plan:
-      - "openai-codex/__GPT_LUNA__"
-      - "cliproxyapi/__DEEPSEEK_FLASH__"
+      - "cliproxyapi/__GEMMA__"
+      - "cliproxyapi/__GLM__"
+      - "cliproxyapi/free"
   # fallbackRevertPolicy
 
   #   Return to the primary once its cooldown expires. Upstream default: cooldown-expiry
@@ -502,14 +496,14 @@ task:
   maxRecursionDepth: 2
   disabledAgents: []
   agentModelOverrides:
-    code-architect: "__GPT__"
-    code-explorer: "__GPT_LUNA__"
-    code-reviewer: "__GPT__"
-    code-simplifier: "__GPT__"
-    comment-analyzer: "__GPT_LUNA__"
-    pr-test-analyzer: "__GPT_LUNA__"
-    silent-failure-hunter: "__GPT__"
-    type-design-analyzer: "__GPT__"
+    code-architect: "__DEEPSEEK_FLASH__"
+    code-explorer: "__GLM__"
+    code-reviewer: "__DEEPSEEK_FLASH__"
+    code-simplifier: "__DEEPSEEK_FLASH__"
+    comment-analyzer: "__GLM__"
+    pr-test-analyzer: "__GLM__"
+    silent-failure-hunter: "__DEEPSEEK_FLASH__"
+    type-design-analyzer: "__DEEPSEEK_FLASH__"
 # --- Agent Definitions -------------------------------------------------------
 # Inline agent definitions (alternative to skill/agent files).
 # agents: {}

--- a/config/omp/config.yml
+++ b/config/omp/config.yml
@@ -36,7 +36,8 @@ shellPath: null
 #   Empty arrays keep upstream discovery behavior unchanged.
 extensions:
   - "~/.omp/agent/extensions/swarm-extension"
-enabledModels: []
+enabledModels:
+  - cliproxyapi/*
 disabledProviders: []
 disabledExtensions: []
 # =============================================================================
@@ -59,24 +60,24 @@ disabledExtensions: []
 #   openrouter   — OpenRouter (access to many models)
 #
 # Examples:
-#   default: openai-codex/gpt-5.6-sol
-#   fast:    openai-codex/gpt-5.6-luna
-#   slow:    openai-codex/gpt-5.6-sol:high
+#   default: cliproxyapi/deepseek-v4-flash
+#   fast:    cliproxyapi/glm-4.7
+#   slow:    cliproxyapi/deepseek-v4-flash
 modelRoles:
   # Default model role used as the fallback when no other role is selected.
   default: "cliproxyapi/deepseek-v4-flash"
   # Smaller / dumber model for cheap lightweight work.
-  smol: "openai-codex/gpt-5.6-luna"
+  smol: "cliproxyapi/glm-4.7"
   # Strongest model in the suite for hard tasks.
-  slow: "openai-codex/gpt-5.6-sol"
+  slow: "cliproxyapi/deepseek-v4-flash"
   # Keep vision on the main default model.
-  vision: "openai-codex/gpt-5.6-sol"
+  vision: "cliproxyapi/deepseek-v4-flash"
   # Planning / architecture model.
-  plan: "openai-codex/gpt-5.6-sol"
+  plan: "cliproxyapi/deepseek-v4-flash"
   # Commit message model.
-  commit: "openai/gpt-5.6-luna"
+  commit: "cliproxyapi/glm-4.7"
   # Fast subagent path.
-  task: "openai-codex/gpt-5.6-luna"
+  task: "cliproxyapi/glm-4.7"
 # =============================================================================
 # DISPLAY
 # =============================================================================
@@ -310,21 +311,14 @@ retry:
   #
   #   Candidates are the entries AFTER the current model in its chain, so a role
   #   whose model sits last in the chain it inherits has no candidates at all.
-  #   The roles pinned to gpt-5.6-sol therefore get their own chain rather than
-  #   inheriting `default`, which ends on gpt-5.6-sol.
+  #   Roles pinned to glm-4.7 inherit `default` and still have `free` after
+  #   them. Do not put a role on the last hop.
   fallbackChains:
     default:
-      - "openai-codex/gpt-5.6-luna"
-      - "openai-codex/gpt-5.6-sol"
-    slow:
-      - "openai-codex/gpt-5.6-luna"
       - "cliproxyapi/deepseek-v4-flash"
-    vision:
-      - "openai-codex/gpt-5.6-luna"
-      - "cliproxyapi/deepseek-v4-flash"
-    plan:
-      - "openai-codex/gpt-5.6-luna"
-      - "cliproxyapi/deepseek-v4-flash"
+      - "cliproxyapi/gemma-4-31b-it"
+      - "cliproxyapi/glm-4.7"
+      - "cliproxyapi/free"
   # fallbackRevertPolicy
 
   #   Return to the primary once its cooldown expires. Upstream default: cooldown-expiry
@@ -502,14 +496,14 @@ task:
   maxRecursionDepth: 2
   disabledAgents: []
   agentModelOverrides:
-    code-architect: "gpt-5.6-sol"
-    code-explorer: "gpt-5.6-luna"
-    code-reviewer: "gpt-5.6-sol"
-    code-simplifier: "gpt-5.6-sol"
-    comment-analyzer: "gpt-5.6-luna"
-    pr-test-analyzer: "gpt-5.6-luna"
-    silent-failure-hunter: "gpt-5.6-sol"
-    type-design-analyzer: "gpt-5.6-sol"
+    code-architect: "deepseek-v4-flash"
+    code-explorer: "glm-4.7"
+    code-reviewer: "deepseek-v4-flash"
+    code-simplifier: "deepseek-v4-flash"
+    comment-analyzer: "glm-4.7"
+    pr-test-analyzer: "glm-4.7"
+    silent-failure-hunter: "deepseek-v4-flash"
+    type-design-analyzer: "deepseek-v4-flash"
 # --- Agent Definitions -------------------------------------------------------
 # Inline agent definitions (alternative to skill/agent files).
 # agents: {}

--- a/config/omp/models.tpl.yml
+++ b/config/omp/models.tpl.yml
@@ -3,6 +3,8 @@ providers:
     baseUrl: http://127.0.0.1:8317/v1
     api: openai-completions
     auth: none
+    discovery:
+      type: openai-models-list
     models:
       - id: __DEEPSEEK_FLASH__
         name: __DEEPSEEK_FLASH_PRETTY__ (local CLIProxyAPI)
@@ -12,6 +14,209 @@ providers:
         supportsTools: true
         contextWindow: 1000000
         maxTokens: 384000
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: __DEEPSEEK_PRO__
+        name: __DEEPSEEK_PRO_PRETTY__ (local CLIProxyAPI)
+        reasoning: true
+        input:
+          - text
+        supportsTools: true
+        contextWindow: 1000000
+        maxTokens: 384000
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: __GLM__
+        name: __GLM_PRETTY__ (local CLIProxyAPI)
+        reasoning: false
+        input:
+          - text
+        supportsTools: true
+        contextWindow: 131072
+        maxTokens: 16384
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: __GEMMA__
+        name: __GEMMA_PRETTY__ (local CLIProxyAPI)
+        reasoning: false
+        input:
+          - text
+        supportsTools: true
+        contextWindow: 131072
+        maxTokens: 16384
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: __MINIMAX__
+        name: __MINIMAX_PRETTY__ (local CLIProxyAPI)
+        reasoning: true
+        input:
+          - text
+          - image
+        supportsTools: true
+        contextWindow: 1000000
+        maxTokens: 40960
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: __KIMI__
+        name: __KIMI_PRETTY__ (local CLIProxyAPI)
+        reasoning: true
+        input:
+          - text
+        supportsTools: true
+        contextWindow: 256000
+        maxTokens: 32768
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: __QWEN__
+        name: __QWEN_PRETTY__ (local CLIProxyAPI)
+        reasoning: true
+        input:
+          - text
+        supportsTools: true
+        contextWindow: 256000
+        maxTokens: 32768
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: __GROK__
+        name: __GROK_PRETTY__ (local CLIProxyAPI)
+        reasoning: true
+        input:
+          - text
+        supportsTools: true
+        contextWindow: 256000
+        maxTokens: 32768
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: __GPT__
+        name: __GPT_PRETTY__ (local CLIProxyAPI)
+        reasoning: true
+        input:
+          - text
+          - image
+        supportsTools: true
+        contextWindow: 400000
+        maxTokens: 128000
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: __GPT_LUNA__
+        name: __GPT_LUNA_PRETTY__ (local CLIProxyAPI)
+        reasoning: true
+        input:
+          - text
+          - image
+        supportsTools: true
+        contextWindow: 400000
+        maxTokens: 128000
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: __GEMINI_PRO__
+        name: __GEMINI_PRO_PRETTY__ (local CLIProxyAPI)
+        reasoning: true
+        input:
+          - text
+          - image
+        supportsTools: true
+        contextWindow: 1000000
+        maxTokens: 65536
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: __GEMINI_FLASH__
+        name: __GEMINI_FLASH_PRETTY__ (local CLIProxyAPI)
+        reasoning: false
+        input:
+          - text
+          - image
+        supportsTools: true
+        contextWindow: 1000000
+        maxTokens: 65536
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: __CLAUDE_OPUS__
+        name: __CLAUDE_OPUS_PRETTY__ (local CLIProxyAPI)
+        reasoning: true
+        input:
+          - text
+          - image
+        supportsTools: true
+        contextWindow: 200000
+        maxTokens: 32000
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: __CLAUDE_SONNET__
+        name: __CLAUDE_SONNET_PRETTY__ (local CLIProxyAPI)
+        reasoning: false
+        input:
+          - text
+          - image
+        supportsTools: true
+        contextWindow: 200000
+        maxTokens: 64000
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: __CLAUDE_HAIKU__
+        name: __CLAUDE_HAIKU_PRETTY__ (local CLIProxyAPI)
+        reasoning: false
+        input:
+          - text
+          - image
+        supportsTools: true
+        contextWindow: 200000
+        maxTokens: 8192
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: free
+        name: Free router fallback (local CLIProxyAPI)
+        reasoning: false
+        input:
+          - text
+        supportsTools: true
+        contextWindow: 131072
+        maxTokens: 16384
         cost:
           input: 0
           output: 0

--- a/config/omp/models.yml
+++ b/config/omp/models.yml
@@ -3,6 +3,8 @@ providers:
     baseUrl: http://127.0.0.1:8317/v1
     api: openai-completions
     auth: none
+    discovery:
+      type: openai-models-list
     models:
       - id: deepseek-v4-flash
         name: Deepseek V4 Flash (local CLIProxyAPI)
@@ -12,6 +14,209 @@ providers:
         supportsTools: true
         contextWindow: 1000000
         maxTokens: 384000
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: deepseek-v4-pro
+        name: Deepseek V4 Pro (local CLIProxyAPI)
+        reasoning: true
+        input:
+          - text
+        supportsTools: true
+        contextWindow: 1000000
+        maxTokens: 384000
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: glm-4.7
+        name: GLM 4.7 (local CLIProxyAPI)
+        reasoning: false
+        input:
+          - text
+        supportsTools: true
+        contextWindow: 131072
+        maxTokens: 16384
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: gemma-4-31b-it
+        name: Gemma 4 31b It (local CLIProxyAPI)
+        reasoning: false
+        input:
+          - text
+        supportsTools: true
+        contextWindow: 131072
+        maxTokens: 16384
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: minimax-m3
+        name: Minimax M3 (local CLIProxyAPI)
+        reasoning: true
+        input:
+          - text
+          - image
+        supportsTools: true
+        contextWindow: 1000000
+        maxTokens: 40960
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: kimi-k3
+        name: Kimi K3 (local CLIProxyAPI)
+        reasoning: true
+        input:
+          - text
+        supportsTools: true
+        contextWindow: 256000
+        maxTokens: 32768
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: qwen3.6-plus
+        name: Qwen3.6 Plus (local CLIProxyAPI)
+        reasoning: true
+        input:
+          - text
+        supportsTools: true
+        contextWindow: 256000
+        maxTokens: 32768
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: grok-4.5
+        name: Grok 4.5 (local CLIProxyAPI)
+        reasoning: true
+        input:
+          - text
+        supportsTools: true
+        contextWindow: 256000
+        maxTokens: 32768
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: gpt-5.6-sol
+        name: GPT 5.6 Sol (local CLIProxyAPI)
+        reasoning: true
+        input:
+          - text
+          - image
+        supportsTools: true
+        contextWindow: 400000
+        maxTokens: 128000
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: gpt-5.6-luna
+        name: GPT 5.6 Luna (local CLIProxyAPI)
+        reasoning: true
+        input:
+          - text
+          - image
+        supportsTools: true
+        contextWindow: 400000
+        maxTokens: 128000
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: gemini-3.1-pro-low
+        name: Gemini 3.1 Pro Low (local CLIProxyAPI)
+        reasoning: true
+        input:
+          - text
+          - image
+        supportsTools: true
+        contextWindow: 1000000
+        maxTokens: 65536
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: gemini-3.7-flash-high
+        name: Gemini 3.7 Flash High (local CLIProxyAPI)
+        reasoning: false
+        input:
+          - text
+          - image
+        supportsTools: true
+        contextWindow: 1000000
+        maxTokens: 65536
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: claude-opus-5
+        name: Claude Opus 5 (local CLIProxyAPI)
+        reasoning: true
+        input:
+          - text
+          - image
+        supportsTools: true
+        contextWindow: 200000
+        maxTokens: 32000
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: claude-sonnet-5
+        name: Claude Sonnet 5 (local CLIProxyAPI)
+        reasoning: false
+        input:
+          - text
+          - image
+        supportsTools: true
+        contextWindow: 200000
+        maxTokens: 64000
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: claude-haiku-4-5-20251001
+        name: Claude Haiku 4.5 (local CLIProxyAPI)
+        reasoning: false
+        input:
+          - text
+          - image
+        supportsTools: true
+        contextWindow: 200000
+        maxTokens: 8192
+        cost:
+          input: 0
+          output: 0
+          cacheRead: 0
+          cacheWrite: 0
+      - id: free
+        name: Free router fallback (local CLIProxyAPI)
+        reasoning: false
+        input:
+          - text
+        supportsTools: true
+        contextWindow: 131072
+        maxTokens: 16384
         cost:
           input: 0
           output: 0

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -219,6 +219,25 @@ When run bash -c "grep 'default: \"cliproxyapi/deepseek-v4-flash\"' config/omp/c
 The output should include 'cliproxyapi/deepseek-v4-flash'
 End
 
+It 'routes every OMP role through local CLIProxyAPI'
+When run bash -c "sed -n '/^modelRoles:/,/^# ====/p' config/omp/config.yml | grep -E '^  (default|smol|slow|vision|plan|commit|task):' | grep -v 'cliproxyapi/' || true"
+The output should equal ''
+End
+
+It 'restricts OMP selection to CLIProxyAPI models'
+When run bash -c "grep -A1 'enabledModels:' config/omp/config.yml | grep 'cliproxyapi/\*'"
+The output should include 'cliproxyapi/*'
+End
+
+It 'uses the shared CLIProxy fallback chain for OMP'
+When run bash -c "sed -n '/^  fallbackChains:/,/^  fallbackRevertPolicy/p' config/omp/config.yml"
+The output should include 'cliproxyapi/deepseek-v4-flash'
+The output should include 'cliproxyapi/gemma-4-31b-it'
+The output should include 'cliproxyapi/glm-4.7'
+The output should include 'cliproxyapi/free'
+The output should not include 'openai-codex/'
+End
+
 It 'keeps the OMP model registry placeholder in the template'
 When run bash -c "grep 'id: __DEEPSEEK_FLASH__' config/omp/models.tpl.yml"
 The output should include '__DEEPSEEK_FLASH__'
@@ -267,8 +286,8 @@ End
 End
 
 Describe 'CLIProxyAPI routing'
-It 'hydrates the OMP local CLIProxyAPI DeepSeek Flash provider'
-When run bash -c "grep -q 'baseUrl: http://127.0.0.1:8317/v1' config/omp/models.yml && grep -q 'id: deepseek-v4-flash' config/omp/models.yml && ! grep -q '__DEEPSEEK_FLASH__' config/omp/models.yml"
+It 'hydrates the OMP local CLIProxyAPI catalog'
+When run bash -c "grep -q 'baseUrl: http://127.0.0.1:8317/v1' config/omp/models.yml && grep -q 'type: openai-models-list' config/omp/models.yml && grep -q 'id: deepseek-v4-flash' config/omp/models.yml && grep -q 'id: glm-4.7' config/omp/models.yml && grep -q 'id: gemma-4-31b-it' config/omp/models.yml && grep -q 'id: free' config/omp/models.yml && ! grep -q '__DEEPSEEK_FLASH__' config/omp/models.yml"
 The status should be success
 End
 


### PR DESCRIPTION
## Summary
- Point every OMP role at local CLIProxy (`cliproxyapi/*`), with default/slow/vision/plan on `deepseek-v4-flash` and smol/commit/task on `glm-4.7`.
- Expand the OMP model registry with the CLIProxy catalog and live `/v1/models` discovery.
- Use the shared fallback chain (`deepseek-v4-flash` -> `gemma-4-31b-it` -> `glm-4.7` -> `free`).

## Test plan
- [ ] `shellspec spec/llm_update_spec.sh`
- [ ] Apply Home Manager so `~/.omp/agent/config.yml` and `models.yml` update
- [ ] Confirm `/model` only lists `cliproxyapi/*` and default is DeepSeek v4 Flash
- [ ] Confirm a cheap role (`smol`/`task`) resolves to `glm-4.7`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route all OMP model roles through the local CLIProxyAPI and restrict selection to `cliproxyapi/*`. Old behavior used `openai-codex/*` and `openai/*` models with role-specific fallbacks; new behavior sets default/slow/vision/plan to `cliproxyapi/deepseek-v4-flash`, smol/commit/task to `cliproxyapi/glm-4.7`, and uses a shared fallback chain `deepseek-v4-flash` -> `gemma-4-31b-it` -> `glm-4.7` -> `free`. This localizes traffic, simplifies routing, and aligns subagent overrides.

- Updates OMP config: `enabledModels: [cliproxyapi/*]`, revised `modelRoles`, shared `retry.fallbackChains`, and subagent `agentModelOverrides`.
- Expands the OMP model registry: template adds CLIProxy aliases and enables `/v1/models` discovery; hydrated `models.yml` includes the local catalog (DeepSeek, Gemma, GLM, and `free`).
- Refreshes docs to reflect OMP routing via CLIProxy and the shared fallback chain.
- Strengthens tests to assert CLIProxy routing, allowed models, shared fallback, and model catalog hydration.

Bolded sections:
- Rollout
  - Ensure the local CLIProxyAPI is running at http://127.0.0.1:8317/v1.
  - Regenerate OMP configs so `config.yml` and `models.yml` update.
  - Remove or update any custom role pins that referenced `openai-codex/*`; only `cliproxyapi/*` are allowed.

<sup>Written for commit a26715721dd76bcbf9edb34cc3678631a7714fb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

