### PR TITLE
fix(ocxe): route through remote cliproxy.shunkakinoki.com

### DIFF
--- a/home-manager/programs/fish/functions/_ocxe_function.fish
+++ b/home-manager/programs/fish/functions/_ocxe_function.fish
@@ -4,14 +4,14 @@ function _ocxe_function --description "Run OpenCode with a free-form prompt"
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
     if test (count $argv) -gt 1
-      _caam_exec_function opencode -m 'cliproxyapi/deepseek-v4-flash' --session "$argv[2]"
+      _caam_exec_function opencode -m 'shunkakinoki/deepseek-v4-flash' --session "$argv[2]"
     else
-      _caam_exec_function opencode -m 'cliproxyapi/deepseek-v4-flash' --continue
+      _caam_exec_function opencode -m 'shunkakinoki/deepseek-v4-flash' --continue
     end
   else if test (count $argv) -eq 0
-    _caam_exec_function opencode -m 'cliproxyapi/deepseek-v4-flash'
+    _caam_exec_function opencode -m 'shunkakinoki/deepseek-v4-flash'
   else
     set -l prompt (string join " " -- $argv)
-    _caam_exec_function opencode run "$prompt" -m 'cliproxyapi/deepseek-v4-flash'
+    _caam_exec_function opencode run "$prompt" -m 'shunkakinoki/deepseek-v4-flash'
   end
 end

--- a/home-manager/programs/fish/functions/_ocxe_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_ocxe_function.tpl.fish
@@ -4,14 +4,14 @@ function _ocxe_function --description "Run OpenCode with a free-form prompt"
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
     if test (count $argv) -gt 1
-      _caam_exec_function opencode -m 'cliproxyapi/__DEEPSEEK_FLASH__' --session "$argv[2]"
+      _caam_exec_function opencode -m 'shunkakinoki/__DEEPSEEK_FLASH__' --session "$argv[2]"
     else
-      _caam_exec_function opencode -m 'cliproxyapi/__DEEPSEEK_FLASH__' --continue
+      _caam_exec_function opencode -m 'shunkakinoki/__DEEPSEEK_FLASH__' --continue
     end
   else if test (count $argv) -eq 0
-    _caam_exec_function opencode -m 'cliproxyapi/__DEEPSEEK_FLASH__'
+    _caam_exec_function opencode -m 'shunkakinoki/__DEEPSEEK_FLASH__'
   else
     set -l prompt (string join " " -- $argv)
-    _caam_exec_function opencode run "$prompt" -m 'cliproxyapi/__DEEPSEEK_FLASH__'
+    _caam_exec_function opencode run "$prompt" -m 'shunkakinoki/__DEEPSEEK_FLASH__'
   end
 end

--- a/home-manager/programs/fish/functions/_ocxeh_function.fish
+++ b/home-manager/programs/fish/functions/_ocxeh_function.fish
@@ -14,5 +14,5 @@ function _ocxeh_function --description "Run OpenCode headlessly with a prompted 
     return 1
   end
 
-  _caam_exec_function opencode run "$prompt" -m 'cliproxyapi/deepseek-v4-flash'
+  _caam_exec_function opencode run "$prompt" -m 'shunkakinoki/deepseek-v4-flash'
 end

--- a/home-manager/programs/fish/functions/_ocxeh_function.tpl.fish
+++ b/home-manager/programs/fish/functions/_ocxeh_function.tpl.fish
@@ -14,5 +14,5 @@ function _ocxeh_function --description "Run OpenCode headlessly with a prompted 
     return 1
   end
 
-  _caam_exec_function opencode run "$prompt" -m 'cliproxyapi/__DEEPSEEK_FLASH__'
+  _caam_exec_function opencode run "$prompt" -m 'shunkakinoki/__DEEPSEEK_FLASH__'
 end

--- a/spec/fish/_ocxe_function.tpl_test.fish
+++ b/spec/fish/_ocxe_function.tpl_test.fish
@@ -8,7 +8,7 @@ function opencode; echo $argv >> $log1; end
 
 _ocxe_function
 
-@test "no args calls opencode with templated CLIProxyAPI model" (grep -c "cliproxyapi/__DEEPSEEK_FLASH__" $log1) -ge 1
+@test "no args calls opencode with templated remote CLIProxy model" (grep -c "shunkakinoki/__DEEPSEEK_FLASH__" $log1) -ge 1
 @test "no args skips run subcommand" (grep -c "^run " $log1) -eq 0
 
 # ── with args: run mode ──────────────────────────────────

--- a/spec/fish/_ocxe_function_test.fish
+++ b/spec/fish/_ocxe_function_test.fish
@@ -8,7 +8,7 @@ function opencode; echo $argv >> $log1; end
 
 _ocxe_function
 
-@test "no args calls opencode with CLIProxyAPI model" (grep -c "cliproxyapi/deepseek-v4-flash" $log1) -ge 1
+@test "no args calls opencode with remote CLIProxy model" (grep -c "shunkakinoki/deepseek-v4-flash" $log1) -ge 1
 @test "no args skips run subcommand" (grep -c "^run " $log1) -eq 0
 
 # ── with args: run mode ──────────────────────────────────

--- a/spec/fish/_ocxeh_function.tpl_test.fish
+++ b/spec/fish/_ocxeh_function.tpl_test.fish
@@ -12,6 +12,6 @@ _ocxeh_function hello world
 
 @test "inline args forwards prompt" (grep -c "hello world" $log1) -ge 1
 @test "inline args uses run subcommand" (grep -c "^run " $log1) -ge 1
-@test "inline args uses templated CLIProxyAPI DeepSeek Flash model" (grep -c "cliproxyapi/__DEEPSEEK_FLASH__" $log1) -ge 1
+@test "inline args uses templated remote CLIProxy DeepSeek Flash model" (grep -c "shunkakinoki/__DEEPSEEK_FLASH__" $log1) -ge 1
 
 rm -f $log1

--- a/spec/fish/_ocxeh_function_test.fish
+++ b/spec/fish/_ocxeh_function_test.fish
@@ -12,6 +12,6 @@ _ocxeh_function hello world
 
 @test "inline args forwards prompt" (grep -c "hello world" $log1) -ge 1
 @test "inline args uses run subcommand" (grep -c "^run " $log1) -ge 1
-@test "inline args uses CLIProxyAPI DeepSeek Flash model" (grep -c "cliproxyapi/deepseek-v4-flash" $log1) -ge 1
+@test "inline args uses remote CLIProxy DeepSeek Flash model" (grep -c "shunkakinoki/deepseek-v4-flash" $log1) -ge 1
 
 rm -f $log1


### PR DESCRIPTION
`ocxe` was pinning local `cliproxyapi/` (localhost:8317). The OpenCode TUI already uses remote `shunkakinoki/` at https://cliproxy.shunkakinoki.com.

Point `ocxe` / `ocxeh` at that same provider.

Supersedes #2434

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route `ocxe` and `ocxeh` through the remote CLIProxy at https://cliproxy.shunkakinoki.com by switching the model from `cliproxyapi/deepseek-v4-flash` to `shunkakinoki/deepseek-v4-flash`. This matches the OpenCode TUI default and removes the localhost dependency; commands now use the remote provider.

**Review notes**
- Replace model strings in Fish functions and their templates; update tests to expect `shunkakinoki/...`.
- Behavior change: no more calls to localhost; network access to the remote proxy is required.
- No migrations. If you need the local proxy, override with `-m cliproxyapi/deepseek-v4-flash`.

<sup>Written for commit cc6ce819b3c38bb9145c61fa66596f8c7c164b4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

