### PR TITLE
fix(pullfrog): pin reviews to OpenRouter free

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -27,6 +27,8 @@ jobs:
         uses: pullfrog/pullfrog@v0
         with:
           prompt: ${{ inputs.prompt }}
+          # OpenRouter Free Models Router; overrides console openai-compatible/byok
+          model: openrouter/openrouter/free
         env:
           # add at least one provider API key
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Pin the Pullfrog action to OpenRouter's `openrouter/free` (Free Models Router) via `model: openrouter/openrouter/free`.
- Overrides the console default (`openai-compatible/byok`) that failed CI with `OPENAI_COMPATIBLE_MODEL env var is required`.
- Uses the existing `OPENROUTER_API_KEY` secret.

Closes SHUN-1943

## Test plan
- [ ] Confirm the workflow YAML has `model: openrouter/openrouter/free`
- [ ] Confirm `OPENROUTER_API_KEY` is set in repo secrets
- [ ] After merge, trigger a Pullfrog run and verify it uses OpenRouter free instead of `openai-compatible/byok`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the `pullfrog/pullfrog` workflow to OpenRouter’s free router to stop CI failures. Previously the default `openai-compatible/byok` required `OPENAI_COMPATIBLE_MODEL` and failed; now `model: openrouter/openrouter/free` uses the existing `OPENROUTER_API_KEY` and removes that requirement. Addresses SHUN-1943.

- Verify `.github/workflows/pullfrog.yml` sets `model: openrouter/openrouter/free`.
- Confirm the `OPENROUTER_API_KEY` secret exists; no other env changes needed.
- After merge, trigger a Pullfrog run to confirm it uses OpenRouter free.

<sup>Written for commit cb19a1deaa71e08027b80f674070533b6c1ca386. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

