### PR TITLE
fix(matic): set tailscale operatorUser to allow non-root set

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -98,6 +98,7 @@ import ../../hosts/nixos {
         services.tailscale = {
           enable = true;
           useRoutingFeatures = "both";
+          operatorUser = username;
           extraSetFlags = [
             "--accept-dns=true"
             "--advertise-exit-node"


### PR DESCRIPTION
Sets `services.tailscale.operatorUser = username` on matic so `tailscale set` works without sudo, enabling `_vpn_function` to toggle the exit node without root.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables non-root `tailscale set` on `matic` by setting `services.tailscale.operatorUser = username`, so `_vpn_function` can toggle the exit node without sudo. Previously, toggling required root and could fail for non-root users; now the specified user can perform the action directly.

- Applies to `matic` only; no other hosts changed.
- Effect: the configured user can modify `tailscale` routing/exit-node state. Confirm `username` matches the user invoking `_vpn_function`.
- Deploy: `nixos-rebuild switch` (restarts `tailscale`).

<sup>Written for commit b8fa4d45ed2bed3d06f2a4678fff79b34ea380ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

