### PR TITLE
fix(matic): use --operator flag in extraSetFlags for tailscale

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -98,10 +98,10 @@ import ../../hosts/nixos {
         services.tailscale = {
           enable = true;
           useRoutingFeatures = "both";
-          operatorUser = username;
           extraSetFlags = [
             "--accept-dns=true"
             "--advertise-exit-node"
+            "--operator=${username}"
             "--ssh"
           ];
         };


### PR DESCRIPTION
Replaces non-existent `operatorUser` option with `--operator=${username}` in `extraSetFlags`, which is the correct way to grant non-root tailscale access in this nixpkgs version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the non-existent `operatorUser` option with `--operator=${username}` in `extraSetFlags` for `tailscale` on the matic host. Previously, the operator was not set due to the invalid option in this `nixpkgs` version; now the specified user gains non-root operator access as intended.

- Rollout: redeploy matic or restart `tailscaled` to apply; verify the operator user can run `tailscale` without sudo.

<sup>Written for commit 4a0439914c25238d57e62ea063995838e84f19be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

