### PR TITLE
feat(kyber): declare Tailscale Serve gateways

### DIFF
--- a/home-manager/activation/ensure-tailscale-serve.sh
+++ b/home-manager/activation/ensure-tailscale-serve.sh
@@ -3,12 +3,9 @@
 #
 # Usage: ensure-tailscale-serve.sh <https-port> <local-port>
 #
-# The T3 client discovers a remote environment via
-# https://<magicdns-name>[:<https-port>]/.well-known/t3/environment, so the
-# backend has to be reachable over HTTPS and the well-known path has to sit at
-# the serve root. A host already serving something else at :443 (kyber serves
-# openclaw there) therefore needs T3 on its own HTTPS port rather than a path
-# prefix.
+# Services that need the serve root must use distinct HTTPS ports rather than
+# path prefixes. The helper reconciles one exact HTTPS-port-to-local-port
+# mapping without disturbing other routes on the same node.
 #
 # `tailscale serve` persists in tailscaled state, so this is a no-op on every
 # activation after the first.
@@ -47,7 +44,19 @@ if ! "$TS" status >/dev/null 2>&1; then
   exit 0
 fi
 
-if "$TS" serve status 2>/dev/null | grep -qF "${TARGET}"; then
+SERVE_STATUS="$("$TS" serve status 2>/dev/null || true)"
+if printf '%s\n' "$SERVE_STATUS" | awk -v port="$HTTPS_PORT" -v target="$TARGET" '
+  /^https:\/\// {
+    if (port == "443") {
+      active = ($0 !~ /:[0-9]+ \(tailnet only\)$/)
+    } else {
+      active = ($0 ~ (":" port " \\(tailnet only\\)$"))
+    }
+    next
+  }
+  active && index($0, "proxy " target) { found = 1 }
+  END { exit found ? 0 : 1 }
+'; then
   exit 0
 fi
 
@@ -76,7 +85,7 @@ fi
 
 echo "Publishing ${TARGET} over Tailscale Serve on :${HTTPS_PORT}..."
 if [ -n "$SUDO_CMD" ]; then
-  "$SUDO_CMD" "$TS" serve --bg --https="${HTTPS_PORT}" "${TARGET}"
+  "$SUDO_CMD" "$TS" serve --yes --bg --https="${HTTPS_PORT}" "${TARGET}"
 else
-  "$TS" serve --bg --https="${HTTPS_PORT}" "${TARGET}"
+  "$TS" serve --yes --bg --https="${HTTPS_PORT}" "${TARGET}"
 fi

--- a/home-manager/services/hermes/hermes-dashboard-proxy.conf
+++ b/home-manager/services/hermes/hermes-dashboard-proxy.conf
@@ -15,6 +15,9 @@ http {
 
   server {
     listen 172.17.0.1:9119;
+    # Tailnet HTTPS terminates in tailscaled, then reaches this loopback-only
+    # listener so Hermes still sees its bound Host and Origin values.
+    listen 127.0.0.1:9120;
 
     location / {
       proxy_pass http://127.0.0.1:9119;

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -145,11 +145,13 @@ home-manager.lib.homeManagerConfiguration {
           $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-user-service-priority.sh}"
         '';
 
-        # Publish the T3 server over tailnet HTTPS. openclaw already owns :443
-        # here, and T3's discovery path must sit at the serve root, so T3 gets
-        # its own HTTPS port: https://kyber.tail950b36.ts.net:8443
-        home.activation.tailscaleServeT3 = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        # Publish every Kyber gateway over tailnet-only HTTPS. Each service
+        # needs the serve root, so OpenClaw keeps :443 while T3 and Hermes use
+        # dedicated ports.
+        home.activation.tailscaleServeGateways = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+          $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-tailscale-serve.sh}" 443 18789
           $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-tailscale-serve.sh}" 8443 3773
+          $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-tailscale-serve.sh}" 9443 9119
         '';
 
         # Tailscale configuration

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -151,7 +151,7 @@ home-manager.lib.homeManagerConfiguration {
         home.activation.tailscaleServeGateways = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
           $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-tailscale-serve.sh}" 443 18789
           $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-tailscale-serve.sh}" 8443 3773
-          $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-tailscale-serve.sh}" 9443 9119
+          $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-tailscale-serve.sh}" 9443 9120
         '';
 
         # Tailscale configuration

--- a/spec/activate_openclaw_hermes_spec.sh
+++ b/spec/activate_openclaw_hermes_spec.sh
@@ -127,6 +127,9 @@ End
 It 'bridges the loopback dashboard to the Kubernetes host endpoint'
 When run bash -c "cat '$PWD/home-manager/services/hermes/hermes-dashboard-proxy.conf'"
 The output should include 'listen 172.17.0.1:9119;'
+The output should include 'listen 127.0.0.1:9120;'
 The output should include 'proxy_pass http://127.0.0.1:9119;'
+The output should include 'proxy_set_header Host 127.0.0.1;'
+The output should include 'proxy_set_header Origin http://127.0.0.1;'
 End
 End

--- a/spec/tailscale_serve_spec.sh
+++ b/spec/tailscale_serve_spec.sh
@@ -134,7 +134,7 @@ End
 
 It 'publishes Hermes on 9443 for kyber'
 When run bash -c "cat '$KYBER'"
-The output should include 'ensure-tailscale-serve.sh}" 9443 9119'
+The output should include 'ensure-tailscale-serve.sh}" 9443 9120'
 End
 End
 

--- a/spec/tailscale_serve_spec.sh
+++ b/spec/tailscale_serve_spec.sh
@@ -78,7 +78,12 @@ printf '%s\n' "$0 $*" >>"$MOCK_LOG"
 case "${1:-}" in
 status) exit 0 ;;
 serve)
-  if [ "${2:-}" = status ]; then echo "|-- / proxy http://127.0.0.1:3773"; fi
+  if [ "${2:-}" = status ]; then
+    cat <<'EOF'
+https://kyber.tail950b36.ts.net (tailnet only)
+|-- / proxy http://127.0.0.1:3773
+EOF
+  fi
   exit 0
   ;;
 esac
@@ -98,13 +103,13 @@ After 'cleanup'
 # not re-issue the command.
 It 'does nothing when the target is already served'
 When run bash -c "bash '$SCRIPT' 443 3773 >/dev/null 2>&1; cat '$MOCK_LOG'"
-The output should not include 'serve --bg'
+The output should not include 'serve --yes --bg'
 The status should be success
 End
 
-It 'publishes when the target is not yet served'
-When run bash -c "bash '$SCRIPT' 8443 9999 >/dev/null 2>&1; cat '$MOCK_LOG'"
-The output should include 'serve --bg --https=8443 http://127.0.0.1:9999'
+It 'publishes when the target is served on a different HTTPS port'
+When run bash -c "bash '$SCRIPT' 8443 3773 >/dev/null 2>&1; cat '$MOCK_LOG'"
+The output should include 'serve --yes --bg --https=8443 http://127.0.0.1:3773'
 The status should be success
 End
 End
@@ -116,11 +121,20 @@ When run bash -c "cat '$MATIC'"
 The output should include 'ensure-tailscale-serve.sh}" 443 3773'
 End
 
-# openclaw owns :443 on kyber and the well-known path must be at the root, so
-# T3 needs a distinct HTTPS port rather than a path prefix.
+# Kyber owns all three current gateway routes declaratively.
+It 'publishes OpenClaw on 443 for kyber'
+When run bash -c "cat '$KYBER'"
+The output should include 'ensure-tailscale-serve.sh}" 443 18789'
+End
+
 It 'publishes T3 on 8443 for kyber to avoid the openclaw root'
 When run bash -c "cat '$KYBER'"
 The output should include 'ensure-tailscale-serve.sh}" 8443 3773'
+End
+
+It 'publishes Hermes on 9443 for kyber'
+When run bash -c "cat '$KYBER'"
+The output should include 'ensure-tailscale-serve.sh}" 9443 9119'
 End
 End
 


### PR DESCRIPTION
## Summary

- declare Kyber Tailscale Serve routes for OpenClaw, T3, and Hermes
- reconcile exact HTTPS port-to-target mappings during Home Manager activation
- proxy Hermes through loopback nginx so tailnet Host and Origin headers are accepted

## Live routes

- `https://kyber.tail950b36.ts.net/` -> OpenClaw (`127.0.0.1:18789`)
- `https://kyber.tail950b36.ts.net:8443/` -> T3 (`127.0.0.1:3773`)
- `https://kyber.tail950b36.ts.net:9443/` -> Hermes proxy (`127.0.0.1:9120` -> `127.0.0.1:9119`)

## Verification

- `shellspec spec/tailscale_serve_spec.sh spec/activate_openclaw_hermes_spec.sh spec/activate_kyber_spec.sh`: 68 examples, 0 failures
- `make nix-format-check`: pass
- exact-head Kyber Home Manager build: pass
- live probes: Hermes `overall=ok`, T3 environment response valid, OpenClaw HTTP 200
- Hermes Desktop: `Kyber Remote`, Gateway ready, backend v0.20.0 after removing the temporary SSH tunnel

## Activation note

A full `make switch` re-evaluation is currently blocked by unrelated existing host state: the upstream `llm-agents.nix` input lacks its expected `lib` path, and Home Manager detects an unmanaged `~/.config/systemd/user/code-syncer.service`. The exact-head generation built successfully; the generated Hermes units and declarative Tailscale Serve reconciliation were applied and verified live.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declares Kyber’s tailnet HTTPS gateways with `tailscale serve` and makes them idempotent per HTTPS port. Services that need the serve root now use dedicated ports; Hermes is proxied through loopback so Host and Origin match its expectations.

- Gateways are declarative: 443→OpenClaw (127.0.0.1:18789), 8443→T3 (127.0.0.1:3773), 9443→Hermes proxy (127.0.0.1:9120→127.0.0.1:9119).
- `ensure-tailscale-serve.sh` detects exact port-to-target mappings, avoids disturbing other routes, and uses `--yes` to suppress prompts.
- Hermes nginx adds a loopback listener on 127.0.0.1:9120 and forwards to 127.0.0.1:9119 with Host/Origin set to 127.0.0.1.
- Specs updated to assert port-aware serve status and the new Hermes proxy listener and headers.

<sup>Written for commit be1ed1df4b72a88f37621e2490ac24b7ddc382d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

