### PR TITLE
fix(vpn): clear exit-node advertising before connecting to exit node

### DIFF
--- a/home-manager/programs/fish/functions/_vpn_function.fish
+++ b/home-manager/programs/fish/functions/_vpn_function.fish
@@ -3,6 +3,8 @@ function _vpn_function --description "Connect/disconnect Tailscale exit node thr
 
   switch "$argv[1]"
     case on
+      # Clear exit-node advertising first; can't both advertise and use an exit node.
+      tailscale set --advertise-exit-node=false
       # --accept-dns=true routes DNS through the exit node; without it
       # DNS queries break while tunnelled and name resolution fails.
       tailscale set --exit-node=$kyber_host --accept-dns=true
@@ -19,6 +21,7 @@ function _vpn_function --description "Connect/disconnect Tailscale exit node thr
         tailscale set --exit-node= --accept-dns=false
         and echo "VPN disconnected"
       else
+        tailscale set --advertise-exit-node=false
         tailscale set --exit-node=$kyber_host --accept-dns=true
         and echo "VPN connected through kyber"
       end


### PR DESCRIPTION
Fixes the error "Cannot advertise an exit node and use an exit node at the same time" by calling `tailscale set --advertise-exit-node=false` before setting an exit node to use.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Tailscale from erroring when connecting to an exit node by clearing exit-node advertising first. Previously the function connected while advertising and failed; now it disables advertising before setting the exit node.

- Adds `tailscale set --advertise-exit-node=false` before `--exit-node=...` in the "on" and "toggle to connect" paths of `_vpn_function.fish`.
- Connecting now always disables advertising on the local node; we do not re-enable advertising on disconnect.
- DNS handling (`--accept-dns=true/false`) and the "off" path are unchanged.

<sup>Written for commit 194b4734ccd9f471e9e247c849c031d94040d30e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

