### PR TITLE
fix(matic): remove exit-node advertising from Tailscale config

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -97,10 +97,9 @@ import ../../hosts/nixos {
         # applies when authKeyFile is set; `tailscale set` is applied on every boot.
         services.tailscale = {
           enable = true;
-          useRoutingFeatures = "both";
+          useRoutingFeatures = "client";
           extraSetFlags = [
             "--accept-dns=true"
-            "--advertise-exit-node"
             "--operator=${username}"
             "--ssh"
           ];


### PR DESCRIPTION
Removes `--advertise-exit-node` flag and changes `useRoutingFeatures` from `"both"` to `"client"` for matic.

Tailscale errors with "Cannot advertise an exit node and use an exit node at the same time" when both flags are active simultaneously.

Closes tailscaled-set.service failure introduced after #2445.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop advertising an exit node on matic’s Tailscale config to fix a startup error. Previously it both used and advertised an exit node, causing `tailscaled-set.service` to fail; now it runs as a client only and no longer advertises an exit node.

- Side effect: matic is no longer available as an exit node. If something relied on it, move exit-node duties to another host. 
- Rollout: Deploy and restart `tailscaled-set.service` (or reboot) to clear the failure.

<sup>Written for commit 828c9d2b2fa561c98f6ea5ca4a288fe4564378cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

