### PR TITLE
feat(beads): load Linear credentials from dotfiles .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,8 @@ OPENCODE_API_KEY=your-opencode-api-key-here
 XAI_API_KEY=xai-your-key-here
 # Roborev CI repos (comma-separated)
 ROBOREV_CI_REPOS=org/repo1,org/repo2
+# Linear personal API key for Beads sync (`bd linear sync` / launchd dolt-linear-sync).
+# Settings → Security → Personal API keys. Team id is public and also set in Nix.
+LINEAR_API_KEY=lin_api_your-key-here
+LINEAR_TEAM_ID=679ab4ed-3df3-458d-8574-4962f3ebbf31
+

--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -52,6 +52,7 @@ lib.mkIf enabled {
     BEADS_SHARED_SERVER_DIR = sharedServerDir;
     DOLT_CLI_USER = "root";
     DOLT_CLI_PASSWORD = "";
+    LINEAR_TEAM_ID = linearTeamId;
   };
 
   launchd.agents.dolt = lib.mkIf pkgs.stdenv.isDarwin {

--- a/home-manager/services/dolt/linear-sync.sh
+++ b/home-manager/services/dolt/linear-sync.sh
@@ -62,6 +62,18 @@ run_linear() {
   return "$status"
 }
 
+# Prefer the machine-local dotfiles .env (same convention as other launchd
+# services) before the Linear CLI credential file or keyring.
+if [ -z "${LINEAR_API_KEY:-}" ]; then
+  env_file="${DOTFILES_ENV_FILE:-$HOME/dotfiles/.env}"
+  if [ -f "$env_file" ]; then
+    set -a
+    # shellcheck source=/dev/null
+    . "$env_file"
+    set +a
+  fi
+fi
+
 if [ -z "${LINEAR_API_KEY:-}" ] && [ -f "$linear_credentials_file" ] && [ ! -L "$linear_credentials_file" ]; then
   @coreutils@/bin/chmod 600 "$linear_credentials_file"
   LINEAR_API_KEY="$(@gawk@/bin/awk -F '[[:space:]]*=[[:space:]]*' -v workspace="$linear_workspace" '

--- a/spec/beads_linear_sync_spec.sh
+++ b/spec/beads_linear_sync_spec.sh
@@ -31,6 +31,11 @@ When run bash -c "grep -F '@coreutils@/bin/chmod 600 \"\$linear_credentials_file
 The status should be success
 End
 
+It 'loads Linear credentials from the local dotfiles .env when unset'
+When run bash -c "grep -F 'DOTFILES_ENV_FILE:-\$HOME/dotfiles/.env' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
 It 'invokes jq through the Nix package binary path'
 When run bash -c "grep -F '@jq@/bin/jq' '$SCRIPT' >/dev/null"
 The status should be success


### PR DESCRIPTION
## Summary
- Load `LINEAR_API_KEY` / `LINEAR_TEAM_ID` from the existing machine-local `~/dotfiles/.env` before the Linear CLI keyring, so `bd linear sync` and the launchd agent authenticate without a one-off `source .env`.
- Export `LINEAR_TEAM_ID` as a Home Manager session variable and document both keys in `.env.example`. No secrets in the diff.

## Test plan
- [x] `shellspec spec/beads_linear_sync_spec.sh` (24 examples, 0 failures)
- [ ] After switch: `bd linear sync --pull --dry-run` from a fresh shell (no manual `source .env`) lists Linear closes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Loads Linear credentials from the local dotfiles `.env` and exports the team id so `bd linear sync` and the `launchd` agent authenticate without manual sourcing. Previously the sync only read the Linear CLI keyring; now it prefers `~/dotfiles/.env` and falls back to the keyring.

- Adds `LINEAR_API_KEY` and `LINEAR_TEAM_ID` to `.env.example`, sources `DOTFILES_ENV_FILE` (default `~/dotfiles/.env`) when `LINEAR_API_KEY` is unset, and exports `LINEAR_TEAM_ID` via Home Manager session variables. Migration: add both keys to your `~/dotfiles/.env` and run your Home Manager switch; no secrets are in the repo.

<sup>Written for commit 873cd1e587d5a63cd73daef5eb143142067ebf99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

