### PR TITLE
feat(beads): pull closed Linear issues into Beads

### DIFF
--- a/home-manager/services/dolt/linear-sync.sh
+++ b/home-manager/services/dolt/linear-sync.sh
@@ -129,14 +129,15 @@ else
   previous_sync="$(@jq@/bin/jq -r '.last_sync // ""' <<<"$("$bd_cli" -C "$repo_dir" linear status --json)")"
 fi
 
-# Pull only active work, and let Beads' staleness guard debounce calls made at
-# the five-minute timer boundary. A rate-limit failure is deferred to the next
-# scheduled run instead of making launchd hot-loop a failed job.
-log "Pulling active Linear work if stale"
+# Pull open and closed Linear work so cancels/Done land in Beads. Let Beads'
+# staleness guard debounce calls made at the five-minute timer boundary. A
+# rate-limit failure is deferred to the next scheduled run instead of making
+# launchd hot-loop a failed job.
+log "Pulling Linear work if stale"
 if run_linear "$bd_cli" -C "$repo_dir" linear sync \
   --pull-if-stale \
   --threshold 5m \
-  --state open \
+  --state all \
   --relations \
   --no-wait; then
   :

--- a/spec/beads_linear_sync_spec.sh
+++ b/spec/beads_linear_sync_spec.sh
@@ -48,8 +48,8 @@ End
 End
 
 Describe 'sync scope'
-It 'pulls active Linear work only when stale'
-When run bash -c "grep -F -- '--pull-if-stale' '$SCRIPT' >/dev/null && grep -F -- '--threshold 5m' '$SCRIPT' >/dev/null && grep -F -- '--state open' '$SCRIPT' >/dev/null"
+It 'pulls all Linear states when stale'
+When run bash -c "grep -F -- '--pull-if-stale' '$SCRIPT' >/dev/null && grep -F -- '--threshold 5m' '$SCRIPT' >/dev/null && grep -F -- '--state all' '$SCRIPT' >/dev/null"
 The status should be success
 End
 
@@ -178,7 +178,7 @@ When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" XDG_STATE_HOME=
 The status should be success
 The output should include 'Pushing changed active Beads'
 The file "$STATE_HOME/beads-linear-sync/last-success" should be exist
-The contents of file "$COMMAND_LOG" should include 'linear sync --pull-if-stale --threshold 5m --state open --relations --no-wait'
+The contents of file "$COMMAND_LOG" should include 'linear sync --pull-if-stale --threshold 5m --state all --relations --no-wait'
 The contents of file "$COMMAND_LOG" should include 'linear sync --push --issues df-test --no-wait'
 End
 


### PR DESCRIPTION
## Summary
- Change the launchd Linear sync pull from `--state open` to `--state all` so Linear Done/Canceled land in Beads.
- Update the Beads Linear sync spec to match.

## Test plan
- [ ] `shellspec spec/beads_linear_sync_spec.sh`
- [ ] After switch, a Linear cancel/Done appears as closed in `bd list`

Depends on #2453 (already merged).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pulls all Linear issue states into Beads during sync so Done/Canceled issues appear as closed. Previously we synced only open issues (`--state open`); now we use `--state all`, with the same staleness guard and rate-limit behavior.

**Review and rollout**
- Update in `home-manager/services/dolt/linear-sync.sh` to use `--state all` and adjust the log; other flags remain (`--pull-if-stale --threshold 5m --relations --no-wait`).
- Tests in `spec/beads_linear_sync_spec.sh` now expect `--state all`. No migration; after deploy, confirm a canceled/Done Linear issue shows as closed in `bd list`.

<sup>Written for commit fc64f063510cba4eb24b1d5641dd720c02d179b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

