### PR TITLE
feat(claude): add anthropics/claude-plugins-community marketplace

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -63,6 +63,12 @@
         "source": "github"
       }
     },
+    "claude-plugins-community": {
+      "source": {
+        "repo": "anthropics/claude-plugins-community",
+        "source": "github"
+      }
+    },
     "mempalace": {
       "source": {
         "repo": "milla-jovovich/mempalace",


### PR DESCRIPTION
## Summary
- Add `anthropics/claude-plugins-community` to `config/claude/settings.json` `extraKnownMarketplaces`, matching the existing GitHub marketplace entries.
- Does not enable individual community plugins (including eli5); this only registers the marketplace.

## Test plan
- [ ] After switch, Claude settings include `claude-plugins-community`
- [ ] `eli5@claude-plugins-community` can be enabled without a one-off `claude plugin marketplace add`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers the community marketplace `anthropics/claude-plugins-community` in `config/claude/settings.json` so Claude discovers it by default. Previously, enabling plugins from this marketplace required a one-off `claude plugin marketplace add`; now plugins like `eli5@claude-plugins-community` can be enabled without that step.

- Adds `claude-plugins-community` to `extraKnownMarketplaces`; does not enable any individual plugins.
- No migration required; verify Claude settings list the marketplace and enabling `eli5@claude-plugins-community` works without prior marketplace registration.

<sup>Written for commit 6d6fde38f1c1c9d8046ba0e90f0e5b5aae0502a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

