### PR TITLE
feat(claude): set outputStyle to Concise

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -562,6 +562,7 @@
       }
     ]
   },
+  "outputStyle": "Concise",
   "permissions": {
     "allow": [
       "Bash(bun:*)",


### PR DESCRIPTION
## Summary
- Set `"outputStyle": "Concise"` in `config/claude/settings.json` so Claude Code leads with the result and skips preamble/narration.
- Requires Claude Code v2.1.237+. Takes effect on a new session or `/clear`.

## Test plan
- [ ] After switch, `~/.claude/settings.json` has `"outputStyle": "Concise"`
- [ ] New Claude Code session is concise by default

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Claude Code concise by default so responses lead with the result and skip narration. Previously, replies often included preamble; now they default to "Concise".

- Requires Claude Code v2.1.237+.
- Takes effect for new sessions; run /clear to apply immediately.

<sup>Written for commit 0032e89c82614e195f52b025850a08ac89b148b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

