### PR TITLE
feat(pi): Enable OpenRouter models in Pi and OMP

### DIFF
--- a/config/omp/config.tpl.yml
+++ b/config/omp/config.tpl.yml
@@ -38,6 +38,7 @@ extensions:
   - "~/.omp/agent/extensions/swarm-extension"
 enabledModels:
   - cliproxyapi/*
+  - openrouter/*
 disabledProviders: []
 disabledExtensions: []
 # =============================================================================

--- a/config/omp/config.yml
+++ b/config/omp/config.yml
@@ -38,6 +38,7 @@ extensions:
   - "~/.omp/agent/extensions/swarm-extension"
 enabledModels:
   - cliproxyapi/*
+  - openrouter/*
 disabledProviders: []
 disabledExtensions: []
 # =============================================================================

--- a/config/pi/settings.json
+++ b/config/pi/settings.json
@@ -7,6 +7,8 @@
   "enabledModels": [
     "cliproxyapi/*",
     "lmstudio/*",
+    "openrouter/*",
+    "openrouter-preset/*",
     "*gpt-5*",
     "*gemini*",
     "*claude*",

--- a/config/pi/settings.tpl.json
+++ b/config/pi/settings.tpl.json
@@ -7,6 +7,8 @@
   "enabledModels": [
     "cliproxyapi/*",
     "lmstudio/*",
+    "openrouter/*",
+    "openrouter-preset/*",
     "*gpt-5*",
     "*gemini*",
     "*claude*",

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -224,9 +224,15 @@ When run bash -c "sed -n '/^modelRoles:/,/^# ====/p' config/omp/config.yml | gre
 The output should equal ''
 End
 
-It 'restricts OMP selection to CLIProxyAPI models'
-When run bash -c "grep -A1 'enabledModels:' config/omp/config.yml | grep 'cliproxyapi/\*'"
+It 'keeps CLIProxyAPI as the primary OMP model source'
+When run bash -c "grep -A2 'enabledModels:' config/omp/config.yml | grep 'cliproxyapi/\*'"
 The output should include 'cliproxyapi/*'
+End
+
+It 'enables OMP OpenRouter models alongside CLIProxyAPI'
+When run bash -c "grep -A2 'enabledModels:' config/omp/config.yml"
+The output should include 'cliproxyapi/*'
+The output should include 'openrouter/*'
 End
 
 It 'uses the shared CLIProxy fallback chain for OMP'
@@ -245,6 +251,11 @@ End
 End
 
 Describe 'runtime model fallback'
+It 'enables Pi OpenRouter catalog and preset models'
+When run bash -c "jq -e '(.enabledModels | index(\"openrouter/*\") != null) and (.enabledModels | index(\"openrouter-preset/*\") != null)' config/pi/settings.json >/dev/null && jq -e '(.enabledModels | index(\"openrouter/*\") != null) and (.enabledModels | index(\"openrouter-preset/*\") != null)' config/pi/settings.tpl.json >/dev/null"
+The status should be success
+End
+
 It 'points Pi cliproxyapi at local CLIProxy'
 When run bash -c "jq -e '.providers.cliproxyapi.baseUrl == \"http://127.0.0.1:8317/v1\"' config/pi/models.json >/dev/null && jq -e '.providers.cliproxyapi.baseUrl == \"http://127.0.0.1:8317/v1\"' config/pi/models.tpl.json >/dev/null"
 The status should be success


### PR DESCRIPTION
Pi already has a built-in `openrouter` catalog plus the `openrouter-preset` GLM entry, and OMP already knows `OPENROUTER_API_KEY`. The selector allowlists just never let those models through.

This adds `openrouter/*` (and Pi's `openrouter-preset/*`) to `enabledModels` so they show up in the model picker. CLIProxy stays the default and still owns the role fallbacks.

Needs `OPENROUTER_API_KEY` in the environment, which fish already loads from `.env`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose OpenRouter models in Pi and OMP by allowing `openrouter/*` (and Pi’s `openrouter-preset/*`) in enabledModels. Previously only `cliproxyapi/*` was allowed; now OpenRouter models appear in the picker while `cliproxyapi` remains the default and retains the fallback chain.

**Notes for review / rollout**
- OMP: added `openrouter/*` to `enabledModels`; tests confirm `cliproxyapi/*` and `openrouter/*` are enabled and the fallback chain is unchanged.
- Pi: added `openrouter/*` and `openrouter-preset/*` to `enabledModels`; tests assert both entries.
- Set `OPENROUTER_API_KEY` to use these models; without it, selections appear but requests will fail. No other migration required.

<sup>Written for commit 9a13374f3733bb2ea4a16a0b33476872b464a8a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

