### PR TITLE
fix(cliproxy): point DEEPSEEK_FLASH model to 0731 revision

### DIFF
--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -543,7 +543,7 @@ openai-compatibility:
     models:
       - name: "deepseek-v4-pro"
         alias: "deepseek-v4-pro"
-      - name: "deepseek-v4-flash"
+      - name: "deepseek-v4-flash-0731"
         alias: "deepseek-v4-flash"
   - name: "commandcode"
     priority: 150
@@ -554,7 +554,7 @@ openai-compatibility:
     models:
       - name: "deepseek-v4-pro"
         alias: "deepseek-v4-pro"
-      - name: "deepseek-v4-flash"
+      - name: "deepseek-v4-flash-0731"
         alias: "deepseek-v4-flash"
   - name: "openai"
     base-url: "https://api.openai.com/v1"
@@ -572,7 +572,7 @@ openai-compatibility:
     models:
       - name: "deepseek-v4-pro"
         alias: "deepseek-v4-pro"
-      - name: "deepseek-v4-flash"
+      - name: "deepseek-v4-flash-0731"
         alias: "deepseek-v4-flash"
 
 # Official OpenAI compatibility provider reference

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -543,7 +543,7 @@ openai-compatibility:
     models:
       - name: "__DEEPSEEK_PRO__"
         alias: "__DEEPSEEK_PRO__"
-      - name: "__DEEPSEEK_FLASH__"
+      - name: "__DEEPSEEK_FLASH_0731__"
         alias: "__DEEPSEEK_FLASH__"
   - name: "commandcode"
     priority: 150
@@ -554,7 +554,7 @@ openai-compatibility:
     models:
       - name: "__DEEPSEEK_PRO__"
         alias: "__DEEPSEEK_PRO__"
-      - name: "__DEEPSEEK_FLASH__"
+      - name: "__DEEPSEEK_FLASH_0731__"
         alias: "__DEEPSEEK_FLASH__"
   - name: "openai"
     base-url: "https://api.openai.com/v1"
@@ -572,7 +572,7 @@ openai-compatibility:
     models:
       - name: "__DEEPSEEK_PRO__"
         alias: "__DEEPSEEK_PRO__"
-      - name: "__DEEPSEEK_FLASH__"
+      - name: "__DEEPSEEK_FLASH_0731__"
         alias: "__DEEPSEEK_FLASH__"
 
 # Official OpenAI compatibility provider reference


### PR DESCRIPTION
Updates the cliproxyapi config so the DEEPSEEK_FLASH alias resolves to the 0731 model revision.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the `__DEEPSEEK_FLASH__` alias to the 0731 revision across `openai-compatibility` providers. Previously it resolved to the unversioned flash model; now it maps to `__DEEPSEEK_FLASH_0731__`/`deepseek-v4-flash-0731` for consistent, versioned routing.

- Updates three alias-to-model mappings in both `config/cliproxyapi/config.tpl.yaml` and `config/cliproxyapi/config.template.yaml`.
- No migration required; callers using `__DEEPSEEK_FLASH__` or `deepseek-v4-flash` now receive the 0731 revision.

<sup>Written for commit efa5e5a31a299312c2ac8ff15c566f590de37d96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

