### PR TITLE
feat(cliproxy): openrouter-campaign provider serving ox-alpha as free

### DIFF
--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -462,6 +462,20 @@ nonstream-keepalive-interval: 0
 
 # OpenAI compatibility providers
 openai-compatibility:
+  # Temporary campaign provider: serves stealth/ox-alpha under the same
+  # "free" alias so callers keep using "free" while ox-alpha is evaluated.
+  # Same OpenRouter token; remove when the trial ends.
+  # Note: with two providers serving "free", requests round-robin between
+  # them per request (registry sorts by client count then provider name).
+  - name: "openrouter-campaign"
+    base-url: "https://openrouter.ai/api/v1"
+    support-prompt-cache-key: true
+    api-key-entries:
+      - api-key: "__OPENROUTER_API_KEY__"
+    models:
+      - name: "stealth/ox-alpha"
+        alias: "free"
+        display-name: "Free (ox-alpha via openrouter-campaign)"
   - name: "openrouter"
     priority: 100
     base-url: "https://openrouter.ai/api/v1"
@@ -479,10 +493,6 @@ openai-compatibility:
         alias: "deepseek-v4-flash"
       - name: "@preset/deepseek-v4-pro"
         alias: "deepseek-v4-pro"
-      # "free" pool: ox-alpha first, free router as fallback.
-      - name: "stealth/ox-alpha"
-        alias: "free"
-        display-name: "Free (ox-alpha first)"
       - name: "openrouter/free"
         alias: "free"
   - name: "z-ai"

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -462,6 +462,20 @@ nonstream-keepalive-interval: 0
 
 # OpenAI compatibility providers
 openai-compatibility:
+  # Temporary campaign provider: serves stealth/ox-alpha under the same
+  # "free" alias so callers keep using "free" while ox-alpha is evaluated.
+  # Same OpenRouter token; remove when the trial ends.
+  # Note: with two providers serving "free", requests round-robin between
+  # them per request (registry sorts by client count then provider name).
+  - name: "openrouter-campaign"
+    base-url: "https://openrouter.ai/api/v1"
+    support-prompt-cache-key: true
+    api-key-entries:
+      - api-key: "__OPENROUTER_API_KEY__"
+    models:
+      - name: "stealth/ox-alpha"
+        alias: "free"
+        display-name: "Free (ox-alpha via openrouter-campaign)"
   - name: "openrouter"
     priority: 100
     base-url: "https://openrouter.ai/api/v1"
@@ -479,10 +493,6 @@ openai-compatibility:
         alias: "__DEEPSEEK_FLASH__"
       - name: "@preset/__DEEPSEEK_PRO_NONDOT__"
         alias: "__DEEPSEEK_PRO__"
-      # "free" pool: ox-alpha first, free router as fallback.
-      - name: "stealth/ox-alpha"
-        alias: "free"
-        display-name: "Free (ox-alpha first)"
       - name: "openrouter/free"
         alias: "free"
   - name: "z-ai"


### PR DESCRIPTION
- Add temporary openrouter-campaign openai-compatibility provider using the same OpenRouter token, serving stealth/ox-alpha under the existing "free" alias
- Remove the free-alias pool inside the openrouter provider (free maps only to openrouter/free again)
- Add priority to every openai-compatibility provider: openai 10, kimi 40, qwen 45, z-ai 50, openrouter 100, verboo/commandcode/surplus 150, aliyun 200, opencode 300, openrouter-campaign 102
- Note: current CLIProxyAPI source does not yet read a priority field on openai-compatibility providers; these values document intent until supported upstream
- Remove openrouter-campaign when the ox-alpha trial ends