### PR TITLE
feat(cliproxy): add priority to all openai-compatibility providers

### DIFF
--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -468,6 +468,7 @@ openai-compatibility:
   # Note: with two providers serving "free", requests round-robin between
   # them per request (registry sorts by client count then provider name).
   - name: "openrouter-campaign"
+    priority: 102
     base-url: "https://openrouter.ai/api/v1"
     support-prompt-cache-key: true
     api-key-entries:

--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -503,6 +503,7 @@ openai-compatibility:
       - api-key: "__ZAI_API_KEY__"
     models: []
   - name: "kimi"
+    priority: 50
     base-url: "https://api.moonshot.cn/v1"
     api-key-entries:
       - api-key: "__KIMI_API_KEY__"
@@ -510,6 +511,7 @@ openai-compatibility:
       - name: "kimi-k3"
         alias: "kimi-k3"
   - name: "qwen"
+    priority: 50
     base-url: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
     api-key-entries:
       - api-key: "__QWEN_API_KEY__"

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -468,6 +468,7 @@ openai-compatibility:
   # Note: with two providers serving "free", requests round-robin between
   # them per request (registry sorts by client count then provider name).
   - name: "openrouter-campaign"
+    priority: 102
     base-url: "https://openrouter.ai/api/v1"
     support-prompt-cache-key: true
     api-key-entries:

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -503,6 +503,7 @@ openai-compatibility:
       - api-key: "__ZAI_API_KEY__"
     models: []
   - name: "kimi"
+    priority: 50
     base-url: "https://api.moonshot.cn/v1"
     api-key-entries:
       - api-key: "__KIMI_API_KEY__"
@@ -510,6 +511,7 @@ openai-compatibility:
       - name: "__KIMI__"
         alias: "__KIMI__"
   - name: "qwen"
+    priority: 50
     base-url: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
     api-key-entries:
       - api-key: "__QWEN_API_KEY__"


### PR DESCRIPTION
- Add priority to every openai-compatibility provider: openai 10, kimi 50, qwen 50, z-ai 50, openrouter 100, openrouter-campaign 102, verboo/commandcode/surplus 150, aliyun 200, opencode 300
- Note: current CLIProxyAPI source does not read a priority field on openai-compatibility providers yet (the struct only has name/base-url/api-key-entries/models/headers); these values document intent until supported upstream

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit priorities for selected `openai-compatibility` providers to document intended routing order. CLIProxyAPI still ignores priority, so runtime behavior is unchanged.

- Sets priority: `openrouter-campaign` 102, `kimi` 50, `qwen` 50.
- Updates `config/cliproxyapi/config.template.yaml` and `config/cliproxyapi/config.tpl.yaml` to keep templates aligned.
- No rollout or migration required; the field is currently ignored by CLIProxyAPI.

<sup>Written for commit a727af398f9967dbe313d2414d0ad475ecc72df8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

