### PR TITLE
feat(config): update model references to use 'free' for consistency

### DIFF
--- a/config/omp/config.tpl.yml
+++ b/config/omp/config.tpl.yml
@@ -317,8 +317,6 @@ retry:
   fallbackChains:
     default:
       - "cliproxyapi/__DEEPSEEK_FLASH__"
-      - "cliproxyapi/__GEMMA__"
-      - "cliproxyapi/free"
       - "cliproxyapi/free"
   # fallbackRevertPolicy
 

--- a/config/omp/config.tpl.yml
+++ b/config/omp/config.tpl.yml
@@ -61,24 +61,24 @@ disabledExtensions: []
 #   openrouter   — OpenRouter (access to many models)
 #
 # Examples:
-#   default: cliproxyapi/__DEEPSEEK_FLASH__
-#   fast:    cliproxyapi/__GLM__
+#   default: cliproxyapi/free
+#   fast:    cliproxyapi/free
 #   slow:    cliproxyapi/__DEEPSEEK_FLASH__
 modelRoles:
   # Default model role used as the fallback when no other role is selected.
-  default: "cliproxyapi/__DEEPSEEK_FLASH__"
+  default: "cliproxyapi/free"
   # Smaller / dumber model for cheap lightweight work.
-  smol: "cliproxyapi/__GLM__"
+  smol: "cliproxyapi/free"
   # Strongest model in the suite for hard tasks.
   slow: "cliproxyapi/__DEEPSEEK_FLASH__"
   # Keep vision on the main default model.
   vision: "cliproxyapi/__DEEPSEEK_FLASH__"
   # Planning / architecture model.
-  plan: "cliproxyapi/__DEEPSEEK_FLASH__"
+  plan: "cliproxyapi/free"
   # Commit message model.
-  commit: "cliproxyapi/__GLM__"
+  commit: "cliproxyapi/free"
   # Fast subagent path.
-  task: "cliproxyapi/__GLM__"
+  task: "cliproxyapi/free"
 # =============================================================================
 # DISPLAY
 # =============================================================================
@@ -312,13 +312,13 @@ retry:
   #
   #   Candidates are the entries AFTER the current model in its chain, so a role
   #   whose model sits last in the chain it inherits has no candidates at all.
-  #   Roles pinned to __GLM__ inherit `default` and still have `free` after
+  #   Roles pinned to free inherit `default` and still have `free` after
   #   them. Do not put a role on the last hop.
   fallbackChains:
     default:
       - "cliproxyapi/__DEEPSEEK_FLASH__"
       - "cliproxyapi/__GEMMA__"
-      - "cliproxyapi/__GLM__"
+      - "cliproxyapi/free"
       - "cliproxyapi/free"
   # fallbackRevertPolicy
 
@@ -498,13 +498,13 @@ task:
   disabledAgents: []
   agentModelOverrides:
     code-architect: "__DEEPSEEK_FLASH__"
-    code-explorer: "__GLM__"
+    code-explorer: "free"
     code-reviewer: "__DEEPSEEK_FLASH__"
-    code-simplifier: "__DEEPSEEK_FLASH__"
-    comment-analyzer: "__GLM__"
-    pr-test-analyzer: "__GLM__"
-    silent-failure-hunter: "__DEEPSEEK_FLASH__"
-    type-design-analyzer: "__DEEPSEEK_FLASH__"
+    code-simplifier: "free"
+    comment-analyzer: "free"
+    pr-test-analyzer: "free"
+    silent-failure-hunter: "free"
+    type-design-analyzer: "free"
 # --- Agent Definitions -------------------------------------------------------
 # Inline agent definitions (alternative to skill/agent files).
 # agents: {}

--- a/config/omp/config.yml
+++ b/config/omp/config.yml
@@ -61,24 +61,24 @@ disabledExtensions: []
 #   openrouter   — OpenRouter (access to many models)
 #
 # Examples:
-#   default: cliproxyapi/deepseek-v4-flash
-#   fast:    cliproxyapi/glm-4.7
+#   default: cliproxyapi/free
+#   fast:    cliproxyapi/free
 #   slow:    cliproxyapi/deepseek-v4-flash
 modelRoles:
   # Default model role used as the fallback when no other role is selected.
-  default: "cliproxyapi/deepseek-v4-flash"
+  default: "cliproxyapi/free"
   # Smaller / dumber model for cheap lightweight work.
-  smol: "cliproxyapi/glm-4.7"
+  smol: "cliproxyapi/free"
   # Strongest model in the suite for hard tasks.
   slow: "cliproxyapi/deepseek-v4-flash"
   # Keep vision on the main default model.
   vision: "cliproxyapi/deepseek-v4-flash"
   # Planning / architecture model.
-  plan: "cliproxyapi/deepseek-v4-flash"
+  plan: "cliproxyapi/free"
   # Commit message model.
-  commit: "cliproxyapi/glm-4.7"
+  commit: "cliproxyapi/free"
   # Fast subagent path.
-  task: "cliproxyapi/glm-4.7"
+  task: "cliproxyapi/free"
 # =============================================================================
 # DISPLAY
 # =============================================================================
@@ -498,13 +498,13 @@ task:
   disabledAgents: []
   agentModelOverrides:
     code-architect: "deepseek-v4-flash"
-    code-explorer: "glm-4.7"
+    code-explorer: "free"
     code-reviewer: "deepseek-v4-flash"
-    code-simplifier: "deepseek-v4-flash"
-    comment-analyzer: "glm-4.7"
-    pr-test-analyzer: "glm-4.7"
-    silent-failure-hunter: "deepseek-v4-flash"
-    type-design-analyzer: "deepseek-v4-flash"
+    code-simplifier: "free"
+    comment-analyzer: "free"
+    pr-test-analyzer: "free"
+    silent-failure-hunter: "free"
+    type-design-analyzer: "free"
 # --- Agent Definitions -------------------------------------------------------
 # Inline agent definitions (alternative to skill/agent files).
 # agents: {}

--- a/config/omp/config.yml
+++ b/config/omp/config.yml
@@ -317,8 +317,6 @@ retry:
   fallbackChains:
     default:
       - "cliproxyapi/deepseek-v4-flash"
-      - "cliproxyapi/gemma-4-31b-it"
-      - "cliproxyapi/glm-4.7"
       - "cliproxyapi/free"
   # fallbackRevertPolicy
 

--- a/config/pi/settings.json
+++ b/config/pi/settings.json
@@ -2,7 +2,7 @@
   "theme": "dark",
   "quietStartup": true,
   "defaultProvider": "cliproxyapi",
-  "defaultModel": "glm-4.7",
+  "defaultModel": "free",
   "defaultThinkingLevel": "medium",
   "enabledModels": [
     "cliproxyapi/*",

--- a/config/pi/settings.tpl.json
+++ b/config/pi/settings.tpl.json
@@ -2,7 +2,7 @@
   "theme": "dark",
   "quietStartup": true,
   "defaultProvider": "cliproxyapi",
-  "defaultModel": "__GLM__",
+  "defaultModel": "free",
   "defaultThinkingLevel": "medium",
   "enabledModels": [
     "cliproxyapi/*",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardizes model references to `cliproxyapi/free` across OMP and PI configs to align defaults, simplify routing, and reduce cost. Previously several roles and agents used GLM/Gemma; now they use `free`, while `slow` and `vision` stay on `deepseek-v4-flash`.

- modelRoles: `default`, `smol`, `plan`, `commit`, and `task` -> `cliproxyapi/free`; `slow` and `vision` remain `deepseek-v4-flash`.
- agentModelOverrides: `code-explorer`, `code-simplifier`, `comment-analyzer`, `pr-test-analyzer`, `silent-failure-hunter`, and `type-design-analyzer` -> `free`; `code-architect` remains `deepseek-v4-flash`.
- fallbackChains.default: removed deprecated `cliproxyapi/gemma-4-31b-it` and `cliproxyapi/glm-4.7`; chain is now `deepseek-v4-flash` → `free`.
- PI `defaultModel`: `free`.

Required action: Ensure `cliproxyapi/free` is enabled and routed in your environment before rollout.

<sup>Written for commit 2c64f8343bbf2f3dffb5cdd762a12e2a0bc51a84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

