### PR TITLE
docs(omp): update retry fallback comment to reference free router

### DIFF
--- a/config/omp/config.yml
+++ b/config/omp/config.yml
@@ -312,7 +312,7 @@ retry:
   #
   #   Candidates are the entries AFTER the current model in its chain, so a role
   #   whose model sits last in the chain it inherits has no candidates at all.
-  #   Roles pinned to glm-4.7 inherit `default` and still have `free` after
+  #   Roles pinned to free inherit `default` and still have `free` after
   #   them. Do not put a role on the last hop.
   fallbackChains:
     default:


### PR DESCRIPTION
Update the retry fallback chain comment to reference the free router instead of the pinned glm-4.7 model.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the retry fallback chain comment to reference the `free` router instead of the pinned `glm-4.7` model. This clarifies how roles inherit the `default` chain and retain `free` as a subsequent hop; no functional changes to routing.

<sup>Written for commit 45150995fa13ec7d6d0215a199868a45fb6b4608. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

