### PR TITLE
feat(config): point omp and pi at remote cliproxy

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -131,7 +131,7 @@ OMP selects only `cliproxyapi/*`. Subagent overrides: `code-explorer`,
 (`code-architect`, `code-reviewer`, `code-simplifier`,
 `silent-failure-hunter`, `type-design-analyzer`) use `deepseek-v4-flash`.
 The registry in [models.tpl.yml](config/omp/models.tpl.yml) lists the
-CLIProxy aliases and discovers the rest from local `/v1/models`.
+CLIProxy aliases and discovers the rest from remote `/v1/models`.
 OMP fallback uses the shared chain (`deepseek-v4-flash` -> `gemma-4-31b-it`
 -> `glm-4.7` -> `free`).
 
@@ -159,8 +159,8 @@ in particular means different endpoints in different harnesses.
 | `shunkakinoki/` | OpenCode | `https://cliproxy.shunkakinoki.com/v1` (remote) |
 | `cliproxy/` | OpenClaw, Hermes | `https://cliproxy.shunkakinoki.com/v1` (remote) |
 | `cliproxyapi/` | OpenCode | `http://localhost:8317/v1` (local) |
-| `cliproxyapi/` | OMP | `http://127.0.0.1:8317/v1` (local) |
-| `cliproxyapi/` | Pi | `http://127.0.0.1:8317/v1` (local) |
+| `cliproxyapi/` | OMP | `https://cliproxy.shunkakinoki.com/v1` (remote) |
+| `cliproxyapi/` | Pi | `https://cliproxy.shunkakinoki.com/v1` (remote) |
 
 Every one of them resolves through
 [config.tpl.yaml](config/cliproxyapi/config.tpl.yaml). Higher `priority` wins.

--- a/config/omp/models.tpl.yml
+++ b/config/omp/models.tpl.yml
@@ -1,13 +1,14 @@
 providers:
   cliproxyapi:
-    baseUrl: http://127.0.0.1:8317/v1
+    baseUrl: https://cliproxy.shunkakinoki.com/v1
     api: openai-completions
-    auth: none
+    apiKey: CLIPROXY_API_KEY
+    auth: apiKey
     discovery:
       type: openai-models-list
     models:
       - id: __DEEPSEEK_FLASH__
-        name: __DEEPSEEK_FLASH_PRETTY__ (local CLIProxyAPI)
+        name: __DEEPSEEK_FLASH_PRETTY__ (via shunkakinoki's CLIProxy)
         reasoning: true
         input:
           - text
@@ -20,7 +21,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: __DEEPSEEK_PRO__
-        name: __DEEPSEEK_PRO_PRETTY__ (local CLIProxyAPI)
+        name: __DEEPSEEK_PRO_PRETTY__ (via shunkakinoki's CLIProxy)
         reasoning: true
         input:
           - text
@@ -33,7 +34,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: __GLM__
-        name: __GLM_PRETTY__ (local CLIProxyAPI)
+        name: __GLM_PRETTY__ (via shunkakinoki's CLIProxy)
         reasoning: false
         input:
           - text
@@ -46,7 +47,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: __GEMMA__
-        name: __GEMMA_PRETTY__ (local CLIProxyAPI)
+        name: __GEMMA_PRETTY__ (via shunkakinoki's CLIProxy)
         reasoning: false
         input:
           - text
@@ -59,7 +60,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: __MINIMAX__
-        name: __MINIMAX_PRETTY__ (local CLIProxyAPI)
+        name: __MINIMAX_PRETTY__ (via shunkakinoki's CLIProxy)
         reasoning: true
         input:
           - text
@@ -73,7 +74,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: __KIMI__
-        name: __KIMI_PRETTY__ (local CLIProxyAPI)
+        name: __KIMI_PRETTY__ (via shunkakinoki's CLIProxy)
         reasoning: true
         input:
           - text
@@ -86,7 +87,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: __QWEN__
-        name: __QWEN_PRETTY__ (local CLIProxyAPI)
+        name: __QWEN_PRETTY__ (via shunkakinoki's CLIProxy)
         reasoning: true
         input:
           - text
@@ -99,7 +100,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: __GROK__
-        name: __GROK_PRETTY__ (local CLIProxyAPI)
+        name: __GROK_PRETTY__ (via shunkakinoki's CLIProxy)
         reasoning: true
         input:
           - text
@@ -112,7 +113,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: __GPT__
-        name: __GPT_PRETTY__ (local CLIProxyAPI)
+        name: __GPT_PRETTY__ (via shunkakinoki's CLIProxy)
         reasoning: true
         input:
           - text
@@ -126,7 +127,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: __GPT_LUNA__
-        name: __GPT_LUNA_PRETTY__ (local CLIProxyAPI)
+        name: __GPT_LUNA_PRETTY__ (via shunkakinoki's CLIProxy)
         reasoning: true
         input:
           - text
@@ -140,7 +141,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: __GEMINI_PRO__
-        name: __GEMINI_PRO_PRETTY__ (local CLIProxyAPI)
+        name: __GEMINI_PRO_PRETTY__ (via shunkakinoki's CLIProxy)
         reasoning: true
         input:
           - text
@@ -154,7 +155,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: __GEMINI_FLASH__
-        name: __GEMINI_FLASH_PRETTY__ (local CLIProxyAPI)
+        name: __GEMINI_FLASH_PRETTY__ (via shunkakinoki's CLIProxy)
         reasoning: false
         input:
           - text
@@ -168,7 +169,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: __CLAUDE_OPUS__
-        name: __CLAUDE_OPUS_PRETTY__ (local CLIProxyAPI)
+        name: __CLAUDE_OPUS_PRETTY__ (via shunkakinoki's CLIProxy)
         reasoning: true
         input:
           - text
@@ -182,7 +183,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: __CLAUDE_SONNET__
-        name: __CLAUDE_SONNET_PRETTY__ (local CLIProxyAPI)
+        name: __CLAUDE_SONNET_PRETTY__ (via shunkakinoki's CLIProxy)
         reasoning: false
         input:
           - text
@@ -196,7 +197,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: __CLAUDE_HAIKU__
-        name: __CLAUDE_HAIKU_PRETTY__ (local CLIProxyAPI)
+        name: __CLAUDE_HAIKU_PRETTY__ (via shunkakinoki's CLIProxy)
         reasoning: false
         input:
           - text
@@ -210,7 +211,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: free
-        name: Free router fallback (local CLIProxyAPI)
+        name: Free router fallback (via shunkakinoki's CLIProxy)
         reasoning: false
         input:
           - text

--- a/config/omp/models.yml
+++ b/config/omp/models.yml
@@ -1,13 +1,14 @@
 providers:
   cliproxyapi:
-    baseUrl: http://127.0.0.1:8317/v1
+    baseUrl: https://cliproxy.shunkakinoki.com/v1
     api: openai-completions
-    auth: none
+    apiKey: CLIPROXY_API_KEY
+    auth: apiKey
     discovery:
       type: openai-models-list
     models:
       - id: deepseek-v4-flash
-        name: Deepseek V4 Flash (local CLIProxyAPI)
+        name: Deepseek V4 Flash (via shunkakinoki's CLIProxy)
         reasoning: true
         input:
           - text
@@ -20,7 +21,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: deepseek-v4-pro
-        name: Deepseek V4 Pro (local CLIProxyAPI)
+        name: Deepseek V4 Pro (via shunkakinoki's CLIProxy)
         reasoning: true
         input:
           - text
@@ -33,7 +34,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: glm-4.7
-        name: GLM 4.7 (local CLIProxyAPI)
+        name: GLM 4.7 (via shunkakinoki's CLIProxy)
         reasoning: false
         input:
           - text
@@ -46,7 +47,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: gemma-4-31b-it
-        name: Gemma 4 31b It (local CLIProxyAPI)
+        name: Gemma 4 31b It (via shunkakinoki's CLIProxy)
         reasoning: false
         input:
           - text
@@ -59,7 +60,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: minimax-m3
-        name: Minimax M3 (local CLIProxyAPI)
+        name: Minimax M3 (via shunkakinoki's CLIProxy)
         reasoning: true
         input:
           - text
@@ -73,7 +74,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: kimi-k3
-        name: Kimi K3 (local CLIProxyAPI)
+        name: Kimi K3 (via shunkakinoki's CLIProxy)
         reasoning: true
         input:
           - text
@@ -86,7 +87,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: qwen3.6-plus
-        name: Qwen3.6 Plus (local CLIProxyAPI)
+        name: Qwen3.6 Plus (via shunkakinoki's CLIProxy)
         reasoning: true
         input:
           - text
@@ -99,7 +100,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: grok-4.5
-        name: Grok 4.5 (local CLIProxyAPI)
+        name: Grok 4.5 (via shunkakinoki's CLIProxy)
         reasoning: true
         input:
           - text
@@ -112,7 +113,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: gpt-5.6-sol
-        name: GPT 5.6 Sol (local CLIProxyAPI)
+        name: GPT 5.6 Sol (via shunkakinoki's CLIProxy)
         reasoning: true
         input:
           - text
@@ -126,7 +127,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: gpt-5.6-luna
-        name: GPT 5.6 Luna (local CLIProxyAPI)
+        name: GPT 5.6 Luna (via shunkakinoki's CLIProxy)
         reasoning: true
         input:
           - text
@@ -140,7 +141,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: gemini-3.1-pro-low
-        name: Gemini 3.1 Pro Low (local CLIProxyAPI)
+        name: Gemini 3.1 Pro Low (via shunkakinoki's CLIProxy)
         reasoning: true
         input:
           - text
@@ -154,7 +155,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: gemini-3.7-flash-high
-        name: Gemini 3.7 Flash High (local CLIProxyAPI)
+        name: Gemini 3.7 Flash High (via shunkakinoki's CLIProxy)
         reasoning: false
         input:
           - text
@@ -168,7 +169,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: claude-opus-5
-        name: Claude Opus 5 (local CLIProxyAPI)
+        name: Claude Opus 5 (via shunkakinoki's CLIProxy)
         reasoning: true
         input:
           - text
@@ -182,7 +183,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: claude-sonnet-5
-        name: Claude Sonnet 5 (local CLIProxyAPI)
+        name: Claude Sonnet 5 (via shunkakinoki's CLIProxy)
         reasoning: false
         input:
           - text
@@ -196,7 +197,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: claude-haiku-4-5-20251001
-        name: Claude Haiku 4.5 (local CLIProxyAPI)
+        name: Claude Haiku 4.5 (via shunkakinoki's CLIProxy)
         reasoning: false
         input:
           - text
@@ -210,7 +211,7 @@ providers:
           cacheRead: 0
           cacheWrite: 0
       - id: free
-        name: Free router fallback (local CLIProxyAPI)
+        name: Free router fallback (via shunkakinoki's CLIProxy)
         reasoning: false
         input:
           - text

--- a/config/pi/models.json
+++ b/config/pi/models.json
@@ -1,7 +1,7 @@
 {
   "providers": {
     "cliproxyapi": {
-      "baseUrl": "http://127.0.0.1:8317/v1",
+      "baseUrl": "https://cliproxy.shunkakinoki.com/v1",
       "apiKey": "CLIPROXY_API_KEY",
       "api": "openai-responses",
       "models": [

--- a/config/pi/models.tpl.json
+++ b/config/pi/models.tpl.json
@@ -1,7 +1,7 @@
 {
   "providers": {
     "cliproxyapi": {
-      "baseUrl": "http://127.0.0.1:8317/v1",
+      "baseUrl": "https://cliproxy.shunkakinoki.com/v1",
       "apiKey": "CLIPROXY_API_KEY",
       "api": "openai-responses",
       "models": [

--- a/home-manager/modules/local-scripts/clipboard-copy-file.sh
+++ b/home-manager/modules/local-scripts/clipboard-copy-file.sh
@@ -42,6 +42,8 @@ if is_ssh; then
   mime=application/octet-stream
   mime_b64=$(printf '%s' "$mime" | base64 | tr -d '\n')
   data_b64=$(base64 <"$file" | tr -d '\n')
+  # OSC 5522 terminator is ESC + backslash. SC1003 misreads the \\ in quotes.
+  # shellcheck disable=SC1003
   seq=$(printf '\033]5522;type=write:mime=%s;%s\033\\' "$mime_b64" "$data_b64")
   printf '%s' "$seq"
   exit 0

--- a/home-manager/modules/local-scripts/clipboard-copy-image.sh
+++ b/home-manager/modules/local-scripts/clipboard-copy-image.sh
@@ -22,12 +22,12 @@ image_mime() {
   local lower
   lower=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
   case $lower in
-    *.jpg | *.jpeg) printf 'image/jpeg' ;;
-    *.gif) printf 'image/gif' ;;
-    *.webp) printf 'image/webp' ;;
-    *.tif | *.tiff) printf 'image/tiff' ;;
-    *.bmp) printf 'image/bmp' ;;
-    *) printf 'image/png' ;;
+  *.jpg | *.jpeg) printf 'image/jpeg' ;;
+  *.gif) printf 'image/gif' ;;
+  *.webp) printf 'image/webp' ;;
+  *.tif | *.tiff) printf 'image/tiff' ;;
+  *.bmp) printf 'image/bmp' ;;
+  *) printf 'image/png' ;;
   esac
 }
 
@@ -38,6 +38,8 @@ if is_ssh; then
   mime=$(image_mime "$file")
   mime_b64=$(printf '%s' "$mime" | base64 | tr -d '\n')
   data_b64=$(base64 <"$file" | tr -d '\n')
+  # OSC 5522 terminator is ESC + backslash. SC1003 misreads the \\ in quotes.
+  # shellcheck disable=SC1003
   seq=$(printf '\033]5522;type=write:mime=%s;%s\033\\' "$mime_b64" "$data_b64")
   printf '%s' "$seq"
   if [[ -n ${SSH_TTY:-} && -w ${SSH_TTY} ]]; then

--- a/home-manager/programs/neovim/lua/config/settings.lua
+++ b/home-manager/programs/neovim/lua/config/settings.lua
@@ -13,9 +13,7 @@ vim.opt.mouse = "a"
 -- Fall back to Neovim OSC 52 when the scripts are missing on a remote host.
 -- ====================================================================================
 local function is_ssh()
-	return os.getenv("SSH_CLIENT") ~= nil
-		or os.getenv("SSH_TTY") ~= nil
-		or os.getenv("SSH_CONNECTION") ~= nil
+	return os.getenv("SSH_CLIENT") ~= nil or os.getenv("SSH_TTY") ~= nil or os.getenv("SSH_CONNECTION") ~= nil
 end
 
 local clipboard_copy = vim.fn.expand("~/.local/scripts/clipboard-copy")

--- a/home-manager/programs/neovim/lua/config/utils.lua
+++ b/home-manager/programs/neovim/lua/config/utils.lua
@@ -53,9 +53,7 @@ end
 -- Detect if running in SSH session for clipboard handling
 -- ====================================================================================
 function M.is_ssh()
-	return os.getenv("SSH_CLIENT") ~= nil
-		or os.getenv("SSH_TTY") ~= nil
-		or os.getenv("SSH_CONNECTION") ~= nil
+	return os.getenv("SSH_CLIENT") ~= nil or os.getenv("SSH_TTY") ~= nil or os.getenv("SSH_CONNECTION") ~= nil
 end
 
 -- ====================================================================================

--- a/spec/clipboard_paste_spec.sh
+++ b/spec/clipboard_paste_spec.sh
@@ -137,11 +137,9 @@ setup() {
   MOCK_ORIGINAL_XDG_CACHE_HOME="${XDG_CACHE_HOME:-}"
   mkdir -p "$MOCK_CACHE/clipboard"
   printf 'from-cache' >"$MOCK_CACHE/clipboard/data"
-  local cmd bash_dir
+  local bash_dir
   bash_dir="$(resolve_cmd_dir bash)"
-  for cmd in cat; do
-    ln -sf "$(command -v "$cmd")" "$MOCK_BIN/$cmd"
-  done
+  ln -sf "$(command -v cat)" "$MOCK_BIN/cat"
   export PATH="$MOCK_BIN:$bash_dir"
   unset WAYLAND_DISPLAY
   # Non-device SSH_TTY so OSC 52 query is skipped and cache is used.

--- a/spec/cliproxyapi_spec.sh
+++ b/spec/cliproxyapi_spec.sh
@@ -278,7 +278,8 @@ The output should include 'priority: 150'
 The output should include 'base-url: "https://code.verboo.ai/router/v1"'
 The output should include 'api-key: "__VERBOO_API_KEY__"'
 The output should include 'name: "deepseek-v4-pro"'
-The output should include 'name: "deepseek-v4-flash"'
+The output should include 'name: "deepseek-v4-flash-0731"'
+The output should include 'alias: "deepseek-v4-flash"'
 The status should be success
 End
 End
@@ -297,7 +298,8 @@ The output should include 'priority: 150'
 The output should include 'base-url: "https://api.commandcode.ai/provider/v1"'
 The output should include 'api-key: "__COMMANDCODE_API_KEY__"'
 The output should include 'name: "deepseek-v4-pro"'
-The output should include 'name: "deepseek-v4-flash"'
+The output should include 'name: "deepseek-v4-flash-0731"'
+The output should include 'alias: "deepseek-v4-flash"'
 The status should be success
 End
 End
@@ -316,7 +318,8 @@ The output should include 'priority: 150'
 The output should include 'base-url: "https://api.surplusintelligence.ai/v1"'
 The output should include 'api-key: "__SURPLUS_API_KEY__"'
 The output should include 'name: "deepseek-v4-pro"'
-The output should include 'name: "deepseek-v4-flash"'
+The output should include 'name: "deepseek-v4-flash-0731"'
+The output should include 'alias: "deepseek-v4-flash"'
 The status should be success
 End
 End

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -219,7 +219,7 @@ When run bash -c "grep 'default: \"cliproxyapi/deepseek-v4-flash\"' config/omp/c
 The output should include 'cliproxyapi/deepseek-v4-flash'
 End
 
-It 'routes every OMP role through local CLIProxyAPI'
+It 'routes every OMP role through remote CLIProxyAPI'
 When run bash -c "sed -n '/^modelRoles:/,/^# ====/p' config/omp/config.yml | grep -E '^  (default|smol|slow|vision|plan|commit|task):' | grep -v 'cliproxyapi/' || true"
 The output should equal ''
 End
@@ -256,8 +256,8 @@ When run bash -c "jq -e '(.enabledModels | index(\"openrouter/*\") != null) and 
 The status should be success
 End
 
-It 'points Pi cliproxyapi at local CLIProxy'
-When run bash -c "jq -e '.providers.cliproxyapi.baseUrl == \"http://127.0.0.1:8317/v1\"' config/pi/models.json >/dev/null && jq -e '.providers.cliproxyapi.baseUrl == \"http://127.0.0.1:8317/v1\"' config/pi/models.tpl.json >/dev/null"
+It 'points Pi cliproxyapi at remote CLIProxy'
+When run bash -c "jq -e '.providers.cliproxyapi.baseUrl == \"https://cliproxy.shunkakinoki.com/v1\"' config/pi/models.json >/dev/null && jq -e '.providers.cliproxyapi.baseUrl == \"https://cliproxy.shunkakinoki.com/v1\"' config/pi/models.tpl.json >/dev/null"
 The status should be success
 End
 
@@ -302,8 +302,8 @@ End
 End
 
 Describe 'CLIProxyAPI routing'
-It 'hydrates the OMP local CLIProxyAPI catalog'
-When run bash -c "grep -q 'baseUrl: http://127.0.0.1:8317/v1' config/omp/models.yml && grep -q 'type: openai-models-list' config/omp/models.yml && grep -q 'id: deepseek-v4-flash' config/omp/models.yml && grep -q 'id: glm-4.7' config/omp/models.yml && grep -q 'id: gemma-4-31b-it' config/omp/models.yml && grep -q 'id: free' config/omp/models.yml && ! grep -q '__DEEPSEEK_FLASH__' config/omp/models.yml"
+It 'hydrates the OMP remote CLIProxyAPI catalog'
+When run bash -c "grep -q 'baseUrl: https://cliproxy.shunkakinoki.com/v1' config/omp/models.yml && grep -q 'auth: apiKey' config/omp/models.yml && grep -q 'type: openai-models-list' config/omp/models.yml && grep -q 'id: deepseek-v4-flash' config/omp/models.yml && grep -q 'id: glm-4.7' config/omp/models.yml && grep -q 'id: gemma-4-31b-it' config/omp/models.yml && grep -q 'id: free' config/omp/models.yml && ! grep -q '__DEEPSEEK_FLASH__' config/omp/models.yml"
 The status should be success
 End
 

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -38,7 +38,7 @@ for role, model in roles.items():
         index = [base(entry) for entry in chain].index(base(model))
     else:
         continue
-    if index == len(chain) - 1:
+    if index == len(chain) - 1 and base(model) != "free":
         stranded.append(f"{role} ({model}) is last in its chain")
 
 if stranded:
@@ -214,9 +214,9 @@ When run bash -c "sed -n '/\"cliproxyapi\"/,/\"lmstudio\"/p' config/opencode/ope
 The status should be success
 End
 
-It 'generates the OMP Flash default role'
-When run bash -c "grep 'default: \"cliproxyapi/deepseek-v4-flash\"' config/omp/config.yml"
-The output should include 'cliproxyapi/deepseek-v4-flash'
+It 'generates the OMP free default role'
+When run bash -c "grep 'default: \"cliproxyapi/free\"' config/omp/config.yml"
+The output should include 'cliproxyapi/free'
 End
 
 It 'routes every OMP role through remote CLIProxyAPI'
@@ -235,11 +235,9 @@ The output should include 'cliproxyapi/*'
 The output should include 'openrouter/*'
 End
 
-It 'uses the shared CLIProxy fallback chain for OMP'
+It 'uses the free-tier CLIProxy fallback chain for OMP'
 When run bash -c "sed -n '/^  fallbackChains:/,/^  fallbackRevertPolicy/p' config/omp/config.yml"
 The output should include 'cliproxyapi/deepseek-v4-flash'
-The output should include 'cliproxyapi/gemma-4-31b-it'
-The output should include 'cliproxyapi/glm-4.7'
 The output should include 'cliproxyapi/free'
 The output should not include 'openai-codex/'
 End


### PR DESCRIPTION
## Summary
- Point OMP and Pi at `https://cliproxy.shunkakinoki.com/v1` instead of localhost
- Keep the `cliproxyapi/` prefix so `pixe` / `ompxe` still resolve
- Auth is the same `CLIPROXY_API_KEY` env var OpenCode and Codex already use. No local cliproxyapi fallback.

## Test plan
- [ ] `config/omp/models.yml` and `config/pi/models.json` use `https://cliproxy.shunkakinoki.com/v1`
- [ ] Both configs resolve `CLIPROXY_API_KEY` as an env var name, not a literal token
- [ ] `pixe` / `omp` hit the remote host after Home Manager activation
- [ ] `CLIPROXY_API_KEY` is loaded from `~/dotfiles/.env` (same key as OpenCode)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route OMP and Pi through the remote CLIProxy at https://cliproxy.shunkakinoki.com/v1 instead of localhost to remove the local dependency and unify routing. OMP now defaults to the free-tier router (was deepseek-v4-flash), tests track the 0731 DeepSeek alias, and we silence OSC 5522 ShellCheck false positives.

- OMP: remote `baseUrl`, `auth: apiKey` via `CLIPROXY_API_KEY`, discovery stays `openai-models-list`, model labels say “via shunkakinoki’s CLIProxy,” default role is `cliproxyapi/free`, and specs assert remote URL, API key auth, and `deepseek-v4-flash-0731` with alias `deepseek-v4-flash`.
- Pi: remote `baseUrl` with `openai-responses` and `apiKey: CLIPROXY_API_KEY`.
- Docs/CI: `MODELS.md` maps `cliproxyapi/` for OMP and Pi to the remote; specs align with free-router defaults and 0731 aliases; formatting fixes for clipboard scripts and Neovim; OSC 5522 ShellCheck false positives disabled.
- Required: set `CLIPROXY_API_KEY` in your environment; local-only workflows are no longer supported.

<sup>Written for commit 9836d0472da7a7cf7f6f6ed6f6d8daa7e2bb4ebf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

