### PR TITLE
fix(config): route droid through cliproxy and unblock agy

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -120,8 +120,7 @@ Hermes also runs a Mixture-of-Agents preset: reference models
 | Codex | `qwen-local` profile | `qwen3.5-0.8b-optiq` (LM Studio) | |
 | Antigravity | default | `gemini-3.7-flash-high` (native Antigravity provider) | [settings.tpl.json](config/antigravity/settings.tpl.json) |
 | Pi | `defaultModel` | `glm-4.7` (provider `cliproxyapi`) | [settings.tpl.json](config/pi/settings.tpl.json) |
-| Factory (droid) | session default | `deepseek-v4-flash` | [settings.tpl.json](config/factory/settings.tpl.json) |
-| Factory (droid) | custom local | `gemma3:4b` (Ollama) | |
+| Factory (droid) | session default | `custom:deepseek-v4-flash-0` via `https://cliproxy.shunkakinoki.com/v1` | [settings.tpl.json](config/factory/settings.tpl.json) |
 | aichat | default | `cliproxy:glm-4.7` | [config.tpl.yaml](config/aichat/config.tpl.yaml) |
 | llm | default | `glm-4.7` | [default_model.tpl.txt](config/llm/default_model.tpl.txt) |
 | Handy | transcript post-process | `@preset/glm-4.7` (OpenRouter) | [settings_store.tpl.json](config/handy/settings_store.tpl.json) |

--- a/config/antigravity/settings.json
+++ b/config/antigravity/settings.json
@@ -1,3 +1,12 @@
 {
-  "model": "gemini-3.7-flash-high"
+  "model": "gemini-3.7-flash-high",
+  "permissions": {
+    "allow": [
+      "read_file(*)",
+      "command(pwd)",
+      "command(ls)",
+      "command(git)",
+      "command(wc)"
+    ]
+  }
 }

--- a/config/antigravity/settings.tpl.json
+++ b/config/antigravity/settings.tpl.json
@@ -1,3 +1,12 @@
 {
-  "model": "gemini-3.7-flash-high"
+  "model": "gemini-3.7-flash-high",
+  "permissions": {
+    "allow": [
+      "read_file(*)",
+      "command(pwd)",
+      "command(ls)",
+      "command(git)",
+      "command(wc)"
+    ]
+  }
 }

--- a/config/factory/activate-settings.sh
+++ b/config/factory/activate-settings.sh
@@ -59,14 +59,19 @@ if [ -f "$SETTINGS" ]; then
     ($managed[0]) as $managed_settings
     | .sessionDefaultSettings =
         ((.sessionDefaultSettings // {}) * $managed_settings.sessionDefaultSettings)
+    | ($managed_settings.customModels // [] | map(.id)) as $managed_ids
     | .customModels =
         ((.customModels // [])
          | if type == "array" then
-             map(select(.id != $managed_settings.customModels[0].id))
+             map(select(.id as $id | ($managed_ids | index($id) | not)))
              + $managed_settings.customModels
            else
              $managed_settings.customModels
            end)
+    | .customModels |= map(select(
+        .id != "custom:gemma3:4b-0"
+        and .baseUrl != "http://127.0.0.1:11434/v1"
+      ))
     | .hooks = (.hooks // {})
     | .hooks |= with_entries(
         if ((.value | type) == "array") then
@@ -97,6 +102,25 @@ else
   "$JQ_BIN" --slurpfile managed "$MANAGED_SETTINGS" -n '
     ($managed[0])
   ' >"$TEMP_SETTINGS"
+fi
+
+# shellcheck source=/dev/null
+ENV_FILE="${HOME}/dotfiles/.env"
+cliproxy_key="${CLIPROXY_API_KEY:-}"
+if [ -z "$cliproxy_key" ] && [ -f "$ENV_FILE" ]; then
+  set -a
+  . "$ENV_FILE"
+  set +a
+  cliproxy_key="${CLIPROXY_API_KEY:-}"
+fi
+if [ -n "$cliproxy_key" ]; then
+  key_tmp="$(mktemp "$FACTORY_DIR/settings.json.XXXXXX")"
+  "$JQ_BIN" --arg key "$cliproxy_key" '
+    .customModels |= map(
+      if .apiKey == "CLIPROXY_API_KEY" then .apiKey = $key else . end
+    )
+  ' "$TEMP_SETTINGS" >"$key_tmp"
+  mv -f "$key_tmp" "$TEMP_SETTINGS"
 fi
 
 mv -f "$TEMP_SETTINGS" "$SETTINGS"

--- a/config/factory/settings.json
+++ b/config/factory/settings.json
@@ -1,16 +1,16 @@
 {
   "sessionDefaultSettings": {
-    "model": "deepseek-v4-flash",
+    "model": "custom:deepseek-v4-flash-0",
     "reasoningEffort": "high"
   },
   "customModels": [
     {
-      "model": "gemma3:4b",
-      "id": "custom:gemma3:4b-0",
+      "model": "deepseek-v4-flash",
+      "id": "custom:deepseek-v4-flash-0",
       "index": 0,
-      "baseUrl": "http://127.0.0.1:11434/v1",
-      "apiKey": "ollama",
-      "displayName": "Gemma3:4b",
+      "baseUrl": "https://cliproxy.shunkakinoki.com/v1",
+      "apiKey": "CLIPROXY_API_KEY",
+      "displayName": "Deepseek V4 Flash",
       "maxOutputTokens": 64000,
       "noImageSupport": true,
       "provider": "generic-chat-completion-api"

--- a/config/factory/settings.tpl.json
+++ b/config/factory/settings.tpl.json
@@ -1,16 +1,16 @@
 {
   "sessionDefaultSettings": {
-    "model": "__DEEPSEEK_FLASH__",
+    "model": "custom:__DEEPSEEK_FLASH__-0",
     "reasoningEffort": "high"
   },
   "customModels": [
     {
-      "model": "__GEMMA_LOCAL__",
-      "id": "custom:__GEMMA_LOCAL_NONDOT__-0",
+      "model": "__DEEPSEEK_FLASH__",
+      "id": "custom:__DEEPSEEK_FLASH__-0",
       "index": 0,
-      "baseUrl": "http://127.0.0.1:11434/v1",
-      "apiKey": "ollama",
-      "displayName": "__GEMMA_LOCAL_PRETTY__",
+      "baseUrl": "https://cliproxy.shunkakinoki.com/v1",
+      "apiKey": "CLIPROXY_API_KEY",
+      "displayName": "__DEEPSEEK_FLASH_PRETTY__",
       "maxOutputTokens": 64000,
       "noImageSupport": true,
       "provider": "generic-chat-completion-api"

--- a/spec/antigravity_config_spec.sh
+++ b/spec/antigravity_config_spec.sh
@@ -17,7 +17,7 @@ Before 'setup'
 After 'cleanup'
 
 It 'creates writable default-backend Antigravity CLI settings'
-When run bash -c 'HOME="$1" bash "$2" "$3" jq && jq -e '\''.model == "gemini-3.7-flash-high" and has("modelProvider") == false'\'' "$1/.gemini/antigravity-cli/settings.json" >/dev/null && find "$1/.gemini/antigravity-cli/settings.json" -prune -perm 600 -print -quit | grep -q .' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS"
+When run bash -c 'HOME="$1" bash "$2" "$3" jq && jq -e '\''.model == "gemini-3.7-flash-high" and has("modelProvider") == false and (.permissions.allow | index("read_file(*)") != null)'\'' "$1/.gemini/antigravity-cli/settings.json" >/dev/null && find "$1/.gemini/antigravity-cli/settings.json" -prune -perm 600 -print -quit | grep -q .' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS"
 The status should be success
 The path "$TEMP_HOME/.gemini/antigravity-cli/settings.json" should be file
 The path "$TEMP_HOME/.gemini/antigravity-cli/settings.json" should be writable
@@ -33,7 +33,7 @@ cat >"$TEMP_HOME/.gemini/antigravity-cli/settings.json" <<'JSON'
   "futureSetting": "preserved"
 }
 JSON
-When run bash -c 'HOME="$1" bash "$2" "$3" jq && jq -e '\''.model == "gemini-3.7-flash-high" and has("modelProvider") == false and .showTips == false and .futureSetting == "preserved"'\'' "$1/.gemini/antigravity-cli/settings.json" >/dev/null && find "$1/.gemini/antigravity-cli/settings.json" -prune -perm 600 -print -quit | grep -q .' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS"
+When run bash -c 'HOME="$1" bash "$2" "$3" jq && jq -e '\''.model == "gemini-3.7-flash-high" and has("modelProvider") == false and .showTips == false and .futureSetting == "preserved" and (.permissions.allow | index("read_file(*)") != null)'\'' "$1/.gemini/antigravity-cli/settings.json" >/dev/null && find "$1/.gemini/antigravity-cli/settings.json" -prune -perm 600 -print -quit | grep -q .' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS"
 The status should be success
 End
 

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -181,6 +181,20 @@ When run jq -e '.model == "gemini-3.7-flash-high" and has("modelProvider") == fa
 The status should be success
 The output should equal 'true'
 End
+
+It 'keeps headless Antigravity review tool allows'
+When run jq -e '.permissions.allow | (index("read_file(*)") != null) and (index("command(pwd)") != null) and (index("command(ls)") != null)' config/antigravity/settings.tpl.json
+The status should be success
+The output should equal 'true'
+End
+End
+
+Describe 'generated Factory settings'
+It 'pins Droid to the CLIProxy DeepSeek Flash custom model'
+When run jq -e '.sessionDefaultSettings.model == "custom:__DEEPSEEK_FLASH__-0" and (.customModels | length) == 1 and .customModels[0].id == "custom:__DEEPSEEK_FLASH__-0" and .customModels[0].baseUrl == "https://cliproxy.shunkakinoki.com/v1"' config/factory/settings.tpl.json
+The status should be success
+The output should equal 'true'
+End
 End
 
 Describe 'OpenCode runtime fallback'

--- a/spec/roborev_hooks_spec.sh
+++ b/spec/roborev_hooks_spec.sh
@@ -7,9 +7,28 @@ The output should include '127.0.0.1:7373'
 End
 
 Describe 'config/factory/activate-settings.sh'
+SCRIPT="$PWD/config/factory/activate-settings.sh"
+SETTINGS="$PWD/config/factory/settings.json"
+
 It 'recognizes the managed RoboRev hook'
-When run grep -F 'dotfiles/config/shared/hooks/roborev-agent.sh' "$PWD/config/factory/activate-settings.sh"
+When run grep -F 'dotfiles/config/shared/hooks/roborev-agent.sh' "$SCRIPT"
 The output should include 'dotfiles/config/shared/hooks/roborev-agent.sh'
+End
+
+It 'registers DeepSeek Flash as the Factory session default via CLIProxy'
+When run jq -e '.sessionDefaultSettings.model == "custom:deepseek-v4-flash-0" and (.customModels | length) == 1 and .customModels[0].id == "custom:deepseek-v4-flash-0" and .customModels[0].baseUrl == "https://cliproxy.shunkakinoki.com/v1" and .customModels[0].apiKey == "CLIPROXY_API_KEY"' "$SETTINGS"
+The status should be success
+The output should equal 'true'
+End
+
+It 'replaces every managed custom model id on merge'
+When run grep -F 'map(.id)) as $managed_ids' "$SCRIPT"
+The output should include '$managed_ids'
+End
+
+It 'drops the retired local Ollama Gemma custom model'
+When run grep -F 'custom:gemma3:4b-0' "$SCRIPT"
+The output should include 'custom:gemma3:4b-0'
 End
 End
 End


### PR DESCRIPTION
## Summary
- Allow headless Antigravity (`agy`) reviews by adding `permissions.allow` for `read_file(*)`, `pwd`, `ls`, `git`, and `wc`.
- Point Factory/Droid at `https://cliproxy.shunkakinoki.com/v1` DeepSeek Flash, same CLIProxy host as Pi and OMP.
- Remove the local Ollama Gemma custom model from Droid settings.

## Test plan
- [x] `shellspec spec/antigravity_config_spec.sh spec/llm_update_spec.sh spec/roborev_hooks_spec.sh`
- [ ] Confirm a Kyber Antigravity review no longer fails on `read_file` / `pwd` permission denials
- [ ] Confirm `droid exec` uses `custom:deepseek-v4-flash-0` via cliproxy.shunkakinoki.com, not `glm-5.2` Droid Core
- [ ] Confirm `~/.factory/settings.json` has no `custom:gemma3:4b-0` after activation


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Factory/Droid through CLIProxy DeepSeek Flash and unblocks headless Antigravity reviews. Previously, Droid used a direct `deepseek-v4-flash` and Antigravity reviews failed on denied tools; now Droid pins to `custom:deepseek-v4-flash-0` via `https://cliproxy.shunkakinoki.com/v1` and Antigravity allows read/file and basic shell commands. Side effect: we drop the local Ollama Gemma custom model.

- Factory/Droid: session default is `custom:deepseek-v4-flash-0` (CLIProxy, same host as Pi/OMP); activation merges managed custom models, prunes `custom:gemma3:4b-0`, and injects `CLIPROXY_API_KEY` from env or `~/dotfiles/.env`.
- Antigravity: adds `permissions.allow` for `read_file(*)`, `command(pwd|ls|git|wc)`; specs assert these allows and the new Factory default.

**Rollout**
- Set `CLIPROXY_API_KEY` in your environment or `~/dotfiles/.env`.
- Re-run Factory activation to update `~/.factory/settings.json`; confirm `custom:gemma3:4b-0` is absent and the session default is `custom:deepseek-v4-flash-0`.

<sup>Written for commit a1fb73156c787370711f0c07500d0474c9fff414. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

