### PR TITLE
feat(antigravity): allow inspect CLI commands

### DIFF
--- a/config/antigravity/settings.json
+++ b/config/antigravity/settings.json
@@ -4,9 +4,14 @@
     "allow": [
       "read_file(*)",
       "command(pwd)",
+      "command(wc)",
       "command(ls)",
-      "command(git)",
-      "command(wc)"
+      "command(cat)",
+      "command(head)",
+      "command(tail)",
+      "command(stat)",
+      "command(file)",
+      "command(git)"
     ]
   }
 }

--- a/config/antigravity/settings.tpl.json
+++ b/config/antigravity/settings.tpl.json
@@ -4,9 +4,14 @@
     "allow": [
       "read_file(*)",
       "command(pwd)",
+      "command(wc)",
       "command(ls)",
-      "command(git)",
-      "command(wc)"
+      "command(cat)",
+      "command(head)",
+      "command(tail)",
+      "command(stat)",
+      "command(file)",
+      "command(git)"
     ]
   }
 }

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -183,7 +183,7 @@ The output should equal 'true'
 End
 
 It 'keeps headless Antigravity review tool allows'
-When run jq -e '.permissions.allow | (index("read_file(*)") != null) and (index("command(pwd)") != null) and (index("command(ls)") != null)' config/antigravity/settings.tpl.json
+When run jq -e '.permissions.allow | (index("read_file(*)") != null) and (index("command(pwd)") != null) and (index("command(wc)") != null) and (index("command(ls)") != null) and (index("command(cat)") != null) and (index("command(head)") != null) and (index("command(tail)") != null) and (index("command(stat)") != null) and (index("command(file)") != null) and (index("command(git)") != null)' config/antigravity/settings.tpl.json
 The status should be success
 The output should equal 'true'
 End


### PR DESCRIPTION
## Summary
- Allow Antigravity headless review to run inspect commands (`cat`, `head`, `tail`, `stat`, `file`) without prompting.
- Keep the existing `git` grant and lock the full allow list in `spec/llm_update_spec.sh`.

## Test plan
- [x] `shellspec spec/antigravity_config_spec.sh spec/llm_update_spec.sh` (107 examples, 0 failures)
- [ ] After merge/activation, confirm `~/.gemini/antigravity-cli/settings.json` contains the new allow entries.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow headless Antigravity review to run read-only inspect commands without prompting. Previously only pwd/ls/wc/git were auto-allowed; now cat/head/tail/stat/file are also allowed, and tests lock the full allow list to prevent drift.

- Rollout: After activation, ensure ~/.gemini/antigravity-cli/settings.json includes the new allow entries.

<sup>Written for commit 0ae98c23c20afcd912489be7ed650ff11b58e64b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

