### PR TITLE
feat(dsh): hydrate CLIProxy DeepSeek Flash defaults

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -122,6 +122,7 @@ Hermes also runs a Mixture-of-Agents preset: reference models
 | Pi | `defaultModel` | `glm-4.7` (provider `cliproxyapi`) | [settings.tpl.json](config/pi/settings.tpl.json) |
 | Factory (droid) | session default | `custom:deepseek-v4-flash-0` via `https://cliproxy.shunkakinoki.com/v1` | [settings.tpl.json](config/factory/settings.tpl.json) |
 | aichat | default | `cliproxy:glm-4.7` | [config.tpl.yaml](config/aichat/config.tpl.yaml) |
+| DSH web | default | `deepseek-v4-flash` via `https://cliproxy.shunkakinoki.com/v1` (native DeepSeek adapter) | [settings.tpl.yaml](config/dsh/settings.tpl.yaml) |
 | llm | default | `glm-4.7` | [default_model.tpl.txt](config/llm/default_model.tpl.txt) |
 | Handy | transcript post-process | `@preset/glm-4.7` (OpenRouter) | [settings_store.tpl.json](config/handy/settings_store.tpl.json) |
 

--- a/config/default.nix
+++ b/config/default.nix
@@ -16,6 +16,7 @@ in
   ./claude
   ./commandcode
   ./dcg
+  ./dsh
   ./direnv
   ./factory
   ./gemini

--- a/config/dsh/default.nix
+++ b/config/dsh/default.nix
@@ -1,0 +1,19 @@
+{
+  config,
+  pkgs,
+  ...
+}:
+let
+  hydrateScript = pkgs.writeText "dsh-hydrate.sh" (
+    builtins.replaceStrings [ "@template@" "@yq@" ] [ "${./settings.yaml}" "${pkgs.yq}/bin/yq" ] (
+      builtins.readFile ./hydrate.sh
+    )
+  );
+in
+{
+  # DSH owns settings.yaml at runtime, so merge the declarative defaults into
+  # it instead of replacing its onboarding and user-managed state.
+  home.activation.hydrateDshSettings = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    ${pkgs.bash}/bin/bash "${hydrateScript}" || true
+  '';
+}

--- a/config/dsh/hydrate.sh
+++ b/config/dsh/hydrate.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STATE_DIR="${HOME}/.dsh"
+SETTINGS_FILE="${STATE_DIR}/settings.yaml"
+TEMPLATE="@template@"
+
+mkdir -p "$STATE_DIR"
+
+if [ -f "$SETTINGS_FILE" ]; then
+  if ! @yq@ -y '.' "$SETTINGS_FILE" >/dev/null 2>&1; then
+    echo "Warning: DSH settings are malformed, leaving them unchanged: $SETTINGS_FILE" >&2
+    exit 0
+  fi
+
+  tmp="$(mktemp "${STATE_DIR}/.settings.yaml.XXXXXX")"
+  trap 'rm -f "$tmp"' EXIT
+  @yq@ -y -s '.[0] * .[1]' "$SETTINGS_FILE" "$TEMPLATE" >"$tmp"
+else
+  tmp="$(mktemp "${STATE_DIR}/.settings.yaml.XXXXXX")"
+  trap 'rm -f "$tmp"' EXIT
+  cp "$TEMPLATE" "$tmp"
+fi
+
+chmod 600 "$tmp"
+mv -f "$tmp" "$SETTINGS_FILE"
+trap - EXIT
+echo "Hydrated DSH settings at $SETTINGS_FILE" >&2

--- a/config/dsh/settings.tpl.yaml
+++ b/config/dsh/settings.tpl.yaml
@@ -1,0 +1,6 @@
+agent-default-model:
+  provider: deepseek-official
+  model: __DEEPSEEK_FLASH__
+llm-deepseek:
+  apiKeyEnv: CLIPROXY_API_KEY
+  baseURL: https://cliproxy.shunkakinoki.com/v1

--- a/config/dsh/settings.yaml
+++ b/config/dsh/settings.yaml
@@ -1,0 +1,6 @@
+agent-default-model:
+  provider: deepseek-official
+  model: deepseek-v4-flash
+llm-deepseek:
+  apiKeyEnv: CLIPROXY_API_KEY
+  baseURL: https://cliproxy.shunkakinoki.com/v1

--- a/config/factory/activate-settings.sh
+++ b/config/factory/activate-settings.sh
@@ -104,17 +104,18 @@ else
   ' >"$TEMP_SETTINGS"
 fi
 
-# shellcheck source=/dev/null
 ENV_FILE="${HOME}/dotfiles/.env"
 cliproxy_key="${CLIPROXY_API_KEY:-}"
 if [ -z "$cliproxy_key" ] && [ -f "$ENV_FILE" ]; then
   set -a
+  # shellcheck source=/dev/null
   . "$ENV_FILE"
   set +a
   cliproxy_key="${CLIPROXY_API_KEY:-}"
 fi
 if [ -n "$cliproxy_key" ]; then
   key_tmp="$(mktemp "$FACTORY_DIR/settings.json.XXXXXX")"
+  # shellcheck disable=SC2016
   "$JQ_BIN" --arg key "$cliproxy_key" '
     .customModels |= map(
       if .apiKey == "CLIPROXY_API_KEY" then .apiKey = $key else . end

--- a/scripts/llm-update.sh
+++ b/scripts/llm-update.sh
@@ -94,6 +94,7 @@ declare -A TEMPLATES=(
   ["config/llm/extra-openai-models.tpl.yaml"]=config/llm/extra-openai-models.yaml
   ["config/codex/config.tpl.toml"]=config/codex/config.toml
   ["config/cliproxyapi/config.tpl.yaml"]=config/cliproxyapi/config.template.yaml
+  ["config/dsh/settings.tpl.yaml"]=config/dsh/settings.yaml
   ["config/handy/settings_store.tpl.json"]=config/handy/settings_store.template.json
   ["config/factory/settings.tpl.json"]=config/factory/settings.json
   ["config/hermes/config.tpl.yaml"]=config/hermes/config.template.yaml

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -478,6 +478,7 @@ config/codex/sync-desktop-settings.sh
 config/copilot/activate.sh
 config/codex/hooks/atuin-history.sh
 config/dcg/activate.sh
+config/dsh/hydrate.sh
 config/codex/hooks/notify.sh
 config/codex/hooks/pushover.sh
 config/shared/hooks/block-gh-settings.sh

--- a/spec/dsh_config_spec.sh
+++ b/spec/dsh_config_spec.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+Describe 'DSH CLIProxy settings'
+PATCH="$PWD/config/dsh/settings.yaml"
+TEMPLATE="$PWD/config/dsh/settings.tpl.yaml"
+
+It 'selects DeepSeek Flash as the web profile default'
+When run grep -E '^  model: deepseek-v4-flash$' "$PATCH"
+The status should be success
+The output should include 'model: deepseek-v4-flash'
+End
+
+It 'routes the native adapter through remote CLIProxy'
+When run bash -c "grep -E '^(  apiKeyEnv: CLIPROXY_API_KEY|  baseURL: https://cliproxy.shunkakinoki.com/v1)$' '$PATCH'"
+The status should be success
+The output should include 'apiKeyEnv: CLIPROXY_API_KEY'
+The output should include 'baseURL: https://cliproxy.shunkakinoki.com/v1'
+End
+
+It 'keeps the generated settings aligned with its template'
+When run bash -c "diff -u <(sed 's/__DEEPSEEK_FLASH__/deepseek-v4-flash/g' '$TEMPLATE') '$PATCH'"
+The status should be success
+End
+
+It 'hydrates settings through a merge instead of replacing user state'
+When run bash -c "grep -F \".[0] * .[1]\" '$PWD/config/dsh/hydrate.sh'"
+The status should be success
+The output should include '.[0] * .[1]'
+End
+End

--- a/spec/hermes_hydrate_spec.sh
+++ b/spec/hermes_hydrate_spec.sh
@@ -148,7 +148,6 @@ The status should be success
 The output should include 'HERMES_GATEWAY_TOKEN=gateway-token'
 End
 
-
 It 'writes .env with Vercel billing credentials'
 When run bash -c 'unset CLIPROXY_API_KEY HERMES_GATEWAY_TOKEN GATEWAY_TOKEN HERMES_TELEGRAM_TOKEN TELEGRAM_TOKEN WHATSAPP_ALLOW_FROM VERCEL_TOKEN VERCEL_TEAM_ID; HOME="'"$TEMP_HOME"'" bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; cat "'"$TEMP_HOME"'/.hermes/.env"'
 The status should be success
@@ -182,7 +181,6 @@ It 'substitutes WHATSAPP_ALLOW_FROM in env template'
 When run bash -c "grep '__WHATSAPP_ALLOW_FROM__' '$SCRIPT'"
 The output should include 'WHATSAPP_ALLOW_FROM'
 End
-
 
 It 'substitutes Vercel credentials in env template'
 When run bash -c "grep -E '__VERCEL_(TOKEN|TEAM_ID)__' '$SCRIPT'"

--- a/spec/roborev_hooks_spec.sh
+++ b/spec/roborev_hooks_spec.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016
 
 Describe 'config/shared/hooks/roborev-agent.sh'
 It 'uses the local RoboRev daemon'


### PR DESCRIPTION
## Summary

- add declarative DSH settings template/generated output driven by `models.json`
- hydrate `agent-default-model` and `llm-deepseek` into `~/.dsh/settings.yaml`
- preserve DSH-owned onboarding and user settings through a `yq` merge
- route the native DeepSeek adapter to remote CLIProxy with `CLIPROXY_API_KEY`
- document the DSH default and add focused ShellSpec coverage

## Validation

- `make llm-update`
- `shellspec spec/dsh_config_spec.sh` (4 examples, 0 failures)
- `shellcheck config/dsh/hydrate.sh`
- `nixfmt --check config/dsh/default.nix`
- `yq -y -s '.[0] * .[1]' ~/.dsh/settings.yaml config/dsh/settings.yaml`
- `dsh --profile web --patch ... --dump-config` confirmed the native route/default

`make nix-flake-check` evaluated the new Home Manager module after staging the files, but the aggregate run stalled on a busy local Nix SQLite database. The repository-wide `make nix-format-check` also rewrites an unrelated baseline blank-line difference in `spec/hermes_hydrate_spec.sh`; that file is unchanged in this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets DSH’s default model to DeepSeek Flash and routes the native DeepSeek adapter through the remote CLIProxy. Previously no declarative default existed; hydration now merges a templated default into `~/.dsh/settings.yaml` and requires `CLIPROXY_API_KEY`, preserving user settings and file mode 600.

- Review notes
  - Adds `home.activation.hydrateDshSettings` to merge defaults with `yq` (in `config/dsh/default.nix`, wired via `config/default.nix`).
  - `scripts/llm-update.sh` now generates `config/dsh/settings.yaml` from `config/dsh/settings.tpl.yaml`; `MODELS.md` documents the DSH default and proxy route; `spec/dsh_config_spec.sh` covers defaults and merge behavior.
  - CI fixes: include `config/dsh/hydrate.sh` in coverage; add minimal shellcheck annotations. No runtime behavior changes.

- Rollout
  - Export `CLIPROXY_API_KEY` in the environment used by `dsh`.
  - If `~/.dsh/settings.yaml` is malformed, hydration leaves it unchanged; fix the YAML and re-run Home Manager or rerun the hydrate script.

<sup>Written for commit 9bed9e02fa4a26cde811579032ae2362647f2e3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

