### PR TITLE
fix(herdr): cap pane scrollback at 1MB so server stop beats timeout

### DIFF
--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -289,5 +289,7 @@ cjk_ime_cursor_shape = "steady_block"
 
 [advanced]
 # Maximum scrollback buffer size in bytes retained per pane terminal.
-# Matches Ghostty's default scrollback-limit behavior.
-scrollback_limit_bytes = 300000000
+# pane_history saves every pane's scrollback on shutdown; at 300 MB kyber's
+# headless server took ~28s to write, past the 15s the remote update flow waits
+# for the server to stop.
+scrollback_limit_bytes = 1000000


### PR DESCRIPTION
`herdr --remote kyber` failed its update with:

```
error: remote server stop failed: server did not stop within 15000ms; sockets are still reachable at /home/ubuntu/.config/herdr/herdr.sock
```

The server was not hung. `pane_history = true` makes herdr serialize every pane's
scrollback on shutdown, and kyber's `session-history.json` had grown to 134 MB
(26 panes, six of them 13-23 MB each). The persist step alone took ~28s:

```
14:06:58.65  completing server shutdown
14:07:26.78  session saved  path=session.json workspaces=24
14:07:29.75  herdr exiting
```

The remote update only waits 15s, and herdr exposes no knob for that timeout, so
the save has to get smaller. This drops `scrollback_limit_bytes` from 300 MB to
1 MB per pane: ~26 MB total, roughly 5s at the throughput measured above.

`pane_history` stays on, so pane screens still restore across server restarts.
The trade is shallower in-pane scrollback (~1 MB per pane instead of 300 MB) on
every host, not just kyber.

Takes effect on kyber after it pulls this and runs a home-manager switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps per-pane scrollback at 1 MB so the headless `herdr` server stops within the 15s remote update timeout. Previously `pane_history` wrote up to 300 MB per pane on shutdown, growing session-history to ~134 MB and pushing stop time to ~28s; now shutdown writes ~1 MB per pane and completes in ~5s. Side effect: shallower in-pane scrollback; pane screens still restore across restarts.

- Rollout: On kyber, pull and run home-manager switch to apply.

<sup>Written for commit 641b15d1fccf9b6b00b9db7dd007af392338f71d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

