### PR TITLE
feat(dotenv): share one .env parser across shells and GUI apps

### DIFF
--- a/home-manager/modules/default.nix
+++ b/home-manager/modules/default.nix
@@ -1,6 +1,7 @@
 [
   ./bin-shells
   ./cargo-globals
+  ./dotenv
   ./local-binaries
   ./local-scripts
   ./npm-globals

--- a/home-manager/modules/dotenv/default.nix
+++ b/home-manager/modules/dotenv/default.nix
@@ -1,0 +1,34 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (pkgs.stdenv) isDarwin;
+  # Keys handed to GUI apps through launchctl. Every entry becomes readable by
+  # every GUI process in the session, so keep the list to what an app needs.
+  guiEnvKeys = [
+    "AMP_API_KEY"
+    "OPENCODE_API_KEY"
+  ];
+  exportGuiEnv = pkgs.replaceVars ./export-gui-env.sh {
+    launchctl = "/bin/launchctl";
+    printer = "${./print-env-file.sh}";
+    keys = lib.concatStringsSep " " guiEnvKeys;
+  };
+in
+{
+  home.file.".config/shell/print-env-file.sh" = {
+    source = ./print-env-file.sh;
+    executable = true;
+  };
+
+  home.file.".config/shell/load-env-file.sh".source = ./load-env-file.sh;
+
+  home.activation = lib.mkIf isDarwin {
+    exportGuiDotenv = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+      $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${exportGuiEnv}"
+    '';
+  };
+}

--- a/home-manager/modules/dotenv/export-gui-env.sh
+++ b/home-manager/modules/dotenv/export-gui-env.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# @launchctl@, @printer@ and @keys@ are substituted by pkgs.replaceVars.
+# GUI apps (CodexBar and friends) are started by launchd, not by a shell, so they
+# never see the .env values that _hm_load_env_file exports into fish/bash/zsh.
+# `launchctl setenv` puts them in the GUI session; apps pick them up on next launch.
+set -euo pipefail
+
+LAUNCHCTL="@launchctl@"
+PRINTER="@printer@"
+KEYS="@keys@"
+
+exported=""
+while IFS= read -r assignment; do
+  key="${assignment%%=*}"
+  case " $KEYS " in
+  *" $key "*) ;;
+  *) continue ;;
+  esac
+
+  value="${assignment#*=}"
+  [ -n "$value" ] || continue
+
+  "$LAUNCHCTL" setenv "$key" "$value"
+  exported="$exported $key"
+  echo "Exported $key to the GUI session"
+done <<EOF
+$(sh "$PRINTER")
+EOF
+
+for key in $KEYS; do
+  case " $exported " in
+  *" $key "*) ;;
+  *) echo "Warning: $key is unset in .env, skipping GUI environment export" >&2 ;;
+  esac
+done

--- a/home-manager/modules/dotenv/load-env-file.sh
+++ b/home-manager/modules/dotenv/load-env-file.sh
@@ -1,0 +1,29 @@
+# shellcheck shell=sh
+# Sourced by bash and zsh; the fish counterpart lives in
+# home-manager/programs/fish/functions/_hm_load_env_file.fish. Both only apply
+# what print-env-file.sh emits.
+
+_hm_load_env_file() {
+  _hm_printer="${HM_PRINT_ENV_FILE:-$HOME/.config/shell/print-env-file.sh}"
+
+  if [ ! -f "$_hm_printer" ]; then
+    unset _hm_printer
+    return 0
+  fi
+
+  while IFS= read -r _hm_assignment; do
+    case "$_hm_assignment" in
+    *=*) ;;
+    *) continue ;;
+    esac
+
+    _hm_key="${_hm_assignment%%=*}"
+    _hm_value="${_hm_assignment#*=}"
+    export "${_hm_key}=${_hm_value}"
+  done <<EOF
+$(sh "$_hm_printer")
+EOF
+
+  unset _hm_printer _hm_assignment _hm_key _hm_value
+  return 0
+}

--- a/home-manager/modules/dotenv/print-env-file.sh
+++ b/home-manager/modules/dotenv/print-env-file.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env sh
+# Single .env parser for every shell and for the GUI exporter: each consumer only
+# applies the KEY=VALUE lines printed here, so the parsing rules cannot drift.
+set -eu
+
+env_file=""
+for candidate in "${DOTFILES_ENV_FILE:-}" "$HOME/dotfiles/.env" "$HOME/.env"; do
+  [ -n "$candidate" ] || continue
+  if [ -f "$candidate" ]; then
+    env_file="$candidate"
+    break
+  fi
+done
+
+[ -n "$env_file" ] || exit 0
+
+# `|| [ -n "$line" ]` keeps a trailing line that has no newline.
+while IFS= read -r line || [ -n "$line" ]; do
+  line="${line#"${line%%[![:space:]]*}"}"
+  line="${line%"${line##*[![:space:]]}"}"
+
+  case "$line" in
+  '' | '#'*) continue ;;
+  export[[:space:]]*)
+    line="${line#export}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    ;;
+  esac
+
+  case "$line" in
+  *=*) ;;
+  *) continue ;;
+  esac
+
+  key="${line%%=*}"
+  value="${line#*=}"
+
+  key="${key%"${key##*[![:space:]]}"}"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+
+  case "$key" in
+  '' | [0-9]* | *[!A-Za-z0-9_]*) continue ;;
+  esac
+
+  case "$value" in
+  \"*\") value="${value%\"}" && value="${value#\"}" ;;
+  \'*\') value="${value%\'}" && value="${value#\'}" ;;
+  esac
+
+  printf '%s=%s\n' "$key" "$value"
+done <"$env_file"

--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -53,6 +53,11 @@
       # Allow aliases defined in the managed bashrc to expand in non-interactive shells.
       shopt -s expand_aliases
 
+      if [ -f "$HOME/.config/shell/load-env-file.sh" ]; then
+          . "$HOME/.config/shell/load-env-file.sh"
+          _hm_load_env_file
+      fi
+
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
       if [ "$(uname)" = "Linux" ]; then
           export XDG_RUNTIME_DIR="/run/user/$(id -u)"

--- a/home-manager/programs/fish/functions/_hm_load_env_file.fish
+++ b/home-manager/programs/fish/functions/_hm_load_env_file.fish
@@ -1,46 +1,21 @@
 function _hm_load_env_file --description 'Load environment variables from .env'
-  set -l candidate_paths
-  if set -q DOTFILES_ENV_FILE
-    set -a candidate_paths $DOTFILES_ENV_FILE
-  end
-  set -a candidate_paths $HOME/dotfiles/.env $HOME/.env
-
-  set -l env_file
-  for candidate in $candidate_paths
-    if test -f $candidate
-      set env_file $candidate
-      break
-    end
+  # Parsing lives in home-manager/modules/dotenv/print-env-file.sh so fish, bash
+  # and zsh cannot disagree about what a .env line means.
+  set -l printer $HM_PRINT_ENV_FILE
+  if test -z "$printer"
+    set printer $HOME/.config/shell/print-env-file.sh
   end
 
-  if test -z "$env_file"
-    return
+  if not test -f $printer
+    return 0
   end
 
-  while read -l line
-    set -l trimmed (string trim $line)
-    if test -z "$trimmed"
-      continue
+  sh $printer | while read -l assignment
+    set -l parts (string split -m1 '=' -- $assignment)
+    if test (count $parts) -eq 2
+      set -gx $parts[1] $parts[2]
     end
-    if string match -qr '^#' -- $trimmed
-      continue
-    end
+  end
 
-    set trimmed (string replace -r '^export\\s+' '' -- $trimmed)
-    set -l parts (string split -m2 '=' -- $trimmed)
-    if test (count $parts) -lt 2
-      continue
-    end
-
-    set -l key (string trim $parts[1])
-    set -l value (string trim $parts[2])
-
-    if string match -qr "^'.*'\z" -- $value
-      set value (string trim --chars "'" -- $value)
-    else if string match -qr '^".*"$' -- $value
-      set value (string trim --chars '"' -- $value)
-    end
-
-    set -gx $key $value
-  end < $env_file
+  return 0
 end

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -63,6 +63,11 @@
     '';
 
     initContent = ''
+      if [ -f "$HOME/.config/shell/load-env-file.sh" ]; then
+          . "$HOME/.config/shell/load-env-file.sh"
+          _hm_load_env_file
+      fi
+
       # Go configuration
       export GOPATH="$HOME/go"
 

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -217,6 +217,18 @@ It 'has spec file for home-manager/modules/npm-globals/install-npm-globals.sh'
 The path "spec/npm_globals_spec.sh" should be exist
 End
 
+It 'has spec file for home-manager/modules/dotenv/print-env-file.sh'
+The path "spec/print_env_file_spec.sh" should be exist
+End
+
+It 'has spec file for home-manager/modules/dotenv/load-env-file.sh'
+The path "spec/load_env_file_spec.sh" should be exist
+End
+
+It 'has spec file for home-manager/modules/dotenv/export-gui-env.sh'
+The path "spec/export_gui_env_spec.sh" should be exist
+End
+
 It 'has spec file for home-manager/modules/secure-dotenv/secure-dotenv.sh'
 The path "spec/secure_dotenv_spec.sh" should be exist
 End
@@ -528,6 +540,9 @@ home-manager/modules/local-scripts/decafinate.sh
 home-manager/modules/local-scripts/notify-local.sh
 home-manager/modules/local-scripts/pushover-notify.sh
 home-manager/modules/local-scripts/tmux-bridge.sh
+home-manager/modules/dotenv/export-gui-env.sh
+home-manager/modules/dotenv/load-env-file.sh
+home-manager/modules/dotenv/print-env-file.sh
 home-manager/modules/npm-globals/install-npm-globals.sh
 home-manager/modules/secure-dotenv/secure-dotenv.sh
 home-manager/services/firewall/activate.sh

--- a/spec/export_gui_env_spec.sh
+++ b/spec/export_gui_env_spec.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329,SC2016
+
+Describe 'home-manager/modules/dotenv/export-gui-env.sh'
+SCRIPT="$PWD/home-manager/modules/dotenv/export-gui-env.sh"
+
+Describe 'script properties'
+It 'uses bash shebang'
+When run bash -c "head -1 '$SCRIPT'"
+The output should include '#!/usr/bin/env bash'
+End
+
+It 'uses strict mode'
+When run bash -c "head -8 '$SCRIPT'"
+The output should include 'set -euo pipefail'
+End
+
+It 'passes bash syntax check after stripping placeholders'
+When run bash -c "sed 's|@[A-Za-z_][A-Za-z0-9_]*@|/usr/bin/true|g' '$SCRIPT' | bash -n"
+The status should be success
+End
+
+It 'references @launchctl@'
+When run bash -c "grep '@launchctl@' '$SCRIPT'"
+The output should include '@launchctl@'
+End
+
+It 'references @printer@'
+When run bash -c "grep '@printer@' '$SCRIPT'"
+The output should include '@printer@'
+End
+
+It 'references @keys@'
+When run bash -c "grep '@keys@' '$SCRIPT'"
+The output should include '@keys@'
+End
+End
+
+Describe 'functional behavior'
+setup() {
+  TEST_HOME="$(mktemp -d)"
+  LAUNCHCTL_STUB="$TEST_HOME/launchctl"
+  cat >"$LAUNCHCTL_STUB" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${LAUNCHCTL_LOG}"
+STUB
+  chmod +x "$LAUNCHCTL_STUB"
+
+  LAUNCHCTL_LOG="$TEST_HOME/launchctl.log"
+  : >"$LAUNCHCTL_LOG"
+
+  PROCESSED_SCRIPT="$TEST_HOME/export-gui-env-test.sh"
+  sed \
+    -e "s|@launchctl@|$LAUNCHCTL_STUB|g" \
+    -e "s|@printer@|$PWD/home-manager/modules/dotenv/print-env-file.sh|g" \
+    -e "s|@keys@|AMP_API_KEY OPENCODE_API_KEY|g" \
+    "$SCRIPT" >"$PROCESSED_SCRIPT"
+
+  export TEST_HOME LAUNCHCTL_STUB LAUNCHCTL_LOG PROCESSED_SCRIPT
+}
+cleanup() {
+  rm -rf "$TEST_HOME"
+  unset TEST_HOME LAUNCHCTL_STUB LAUNCHCTL_LOG PROCESSED_SCRIPT
+}
+Before 'setup'
+After 'cleanup'
+
+run_with_env() {
+  printf '%s\n' "$1" >"$TEST_HOME/env"
+  DOTFILES_ENV_FILE="$TEST_HOME/env" HOME="$TEST_HOME" bash "$PROCESSED_SCRIPT" >/dev/null 2>&1
+  cat "$LAUNCHCTL_LOG"
+}
+
+It 'exports both allowlisted keys'
+When call run_with_env 'AMP_API_KEY=amp-value
+OPENCODE_API_KEY=opencode-value'
+The line 1 of output should equal 'setenv AMP_API_KEY amp-value'
+The line 2 of output should equal 'setenv OPENCODE_API_KEY opencode-value'
+End
+
+It 'skips keys missing from the env file'
+When call run_with_env 'AMP_API_KEY=amp-value'
+The output should equal 'setenv AMP_API_KEY amp-value'
+End
+
+It 'never exports keys outside the allowlist'
+When call run_with_env 'CLIPROXY_API_KEY=secret'
+The output should equal ''
+End
+
+It 'warns about a missing key'
+When run bash -c "printf 'AMP_API_KEY=amp-value\n' >'$TEST_HOME/env'; DOTFILES_ENV_FILE='$TEST_HOME/env' HOME='$TEST_HOME' bash '$PROCESSED_SCRIPT' 2>&1 >/dev/null"
+The output should include 'OPENCODE_API_KEY is unset'
+End
+
+It 'succeeds when the env file is absent'
+When run bash -c "DOTFILES_ENV_FILE='$TEST_HOME/missing' HOME='$TEST_HOME' bash '$PROCESSED_SCRIPT' 2>/dev/null"
+The status should be success
+End
+End
+End

--- a/spec/fish/_hm_load_env_file_test.fish
+++ b/spec/fish/_hm_load_env_file_test.fish
@@ -1,6 +1,8 @@
 set fn (status dirname)/../../home-manager/programs/fish/functions
 source $fn/_hm_load_env_file.fish
 
+set -x HM_PRINT_ENV_FILE (status dirname)/../../home-manager/modules/dotenv/print-env-file.sh
+
 set tmpdir (mktemp -d)
 
 # ── KEY=VALUE ──────────────────────────────────────────────

--- a/spec/load_env_file_spec.sh
+++ b/spec/load_env_file_spec.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329,SC2016
+
+Describe 'home-manager/modules/dotenv/load-env-file.sh'
+SCRIPT="$PWD/home-manager/modules/dotenv/load-env-file.sh"
+PRINTER="$PWD/home-manager/modules/dotenv/print-env-file.sh"
+
+setup() {
+  TEST_HOME="$(mktemp -d)"
+  export TEST_HOME
+}
+cleanup() {
+  rm -rf "$TEST_HOME"
+  unset TEST_HOME
+}
+Before 'setup'
+After 'cleanup'
+
+load_with() {
+  printf '%s\n' "$1" >"$TEST_HOME/env"
+  DOTFILES_ENV_FILE="$TEST_HOME/env" HM_PRINT_ENV_FILE="$PRINTER" HOME="$TEST_HOME" \
+    "$2" -c ". '$SCRIPT'; _hm_load_env_file; printf '%s' \"\${$3:-<unset>}\""
+}
+
+Describe 'script properties'
+It 'declares the sh shellcheck dialect'
+When run bash -c "head -1 '$SCRIPT'"
+The output should include 'shellcheck shell=sh'
+End
+
+It 'passes sh syntax check'
+When run bash -c "sh -n '$SCRIPT'"
+The status should be success
+End
+
+It 'delegates parsing to print-env-file.sh'
+When run bash -c "grep -c 'print-env-file.sh' '$SCRIPT'"
+The output should not equal '0'
+End
+End
+
+Describe 'applying printer output'
+It 'exports a plain assignment'
+When call load_with 'AMP_API_KEY=amp-value' bash AMP_API_KEY
+The output should equal 'amp-value'
+End
+
+It 'exports a dequoted value'
+When call load_with 'OPENCODE_API_KEY="sk-quoted"' bash OPENCODE_API_KEY
+The output should equal 'sk-quoted'
+End
+
+It 'keeps values containing spaces'
+When call load_with 'AMP_API_KEY="two words"' bash AMP_API_KEY
+The output should equal 'two words'
+End
+
+It 'keeps equals signs inside the value'
+When call load_with 'AMP_API_KEY=a=b' bash AMP_API_KEY
+The output should equal 'a=b'
+End
+
+It 'skips comments'
+When call load_with '# AMP_API_KEY=commented' bash AMP_API_KEY
+The output should equal '<unset>'
+End
+
+It 'works under dash-style sh'
+When call load_with 'AMP_API_KEY=posix' sh AMP_API_KEY
+The output should equal 'posix'
+End
+End
+
+Describe 'missing printer'
+It 'succeeds when the printer is absent'
+When run bash -c "HM_PRINT_ENV_FILE='$TEST_HOME/missing' bash -c \". '$SCRIPT'; _hm_load_env_file\""
+The status should be success
+End
+
+It 'leaves no helper variables behind'
+When run bash -c "HM_PRINT_ENV_FILE='$PRINTER' HOME='$TEST_HOME' bash -c \". '$SCRIPT'; _hm_load_env_file; printf '%s' \\\"\\\${_hm_printer-<unset>}\\\"\""
+The output should equal '<unset>'
+End
+End
+End

--- a/spec/print_env_file_spec.sh
+++ b/spec/print_env_file_spec.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329,SC2016
+
+Describe 'home-manager/modules/dotenv/print-env-file.sh'
+SCRIPT="$PWD/home-manager/modules/dotenv/print-env-file.sh"
+
+setup() {
+  TEST_HOME="$(mktemp -d)"
+  export TEST_HOME
+}
+cleanup() {
+  rm -rf "$TEST_HOME"
+  unset TEST_HOME
+}
+Before 'setup'
+After 'cleanup'
+
+print_env() {
+  printf '%s\n' "$1" >"$TEST_HOME/env"
+  DOTFILES_ENV_FILE="$TEST_HOME/env" HOME="$TEST_HOME" sh "$SCRIPT"
+}
+
+Describe 'script properties'
+It 'uses sh shebang'
+When run bash -c "head -1 '$SCRIPT'"
+The output should include '#!/usr/bin/env sh'
+End
+
+It 'passes sh syntax check'
+When run bash -c "sh -n '$SCRIPT'"
+The status should be success
+End
+End
+
+Describe 'parsing'
+It 'prints a plain assignment'
+When call print_env 'AMP_API_KEY=amp-value'
+The output should equal 'AMP_API_KEY=amp-value'
+End
+
+It 'strips double quotes'
+When call print_env 'OPENCODE_API_KEY="sk-quoted"'
+The output should equal 'OPENCODE_API_KEY=sk-quoted'
+End
+
+It 'strips single quotes'
+When call print_env "OPENCODE_API_KEY='sk-single'"
+The output should equal 'OPENCODE_API_KEY=sk-single'
+End
+
+It 'strips an export prefix'
+When call print_env 'export AMP_API_KEY=exported'
+The output should equal 'AMP_API_KEY=exported'
+End
+
+It 'keeps values containing spaces'
+When call print_env 'AMP_API_KEY="two words"'
+The output should equal 'AMP_API_KEY=two words'
+End
+
+It 'keeps equals signs inside the value'
+When call print_env 'AMP_API_KEY=a=b'
+The output should equal 'AMP_API_KEY=a=b'
+End
+
+It 'trims surrounding whitespace'
+When call print_env '  AMP_API_KEY = spaced  '
+The output should equal 'AMP_API_KEY=spaced'
+End
+
+It 'skips comments'
+When call print_env '# AMP_API_KEY=commented'
+The output should equal ''
+End
+
+It 'skips lines without an assignment'
+When call print_env 'not-an-assignment'
+The output should equal ''
+End
+
+It 'skips keys that are not identifiers'
+When call print_env 'AMP-API-KEY=dashed'
+The output should equal ''
+End
+
+It 'prints every valid line'
+When call print_env 'AMP_API_KEY=amp
+# comment
+OPENCODE_API_KEY=opencode'
+The line 1 of output should equal 'AMP_API_KEY=amp'
+The line 2 of output should equal 'OPENCODE_API_KEY=opencode'
+End
+End
+
+Describe 'candidate resolution'
+It 'falls back to $HOME/dotfiles/.env'
+When run bash -c "mkdir -p '$TEST_HOME/dotfiles' && printf 'AMP_API_KEY=from-dotfiles\n' >'$TEST_HOME/dotfiles/.env' && HOME='$TEST_HOME' sh '$SCRIPT'"
+The output should equal 'AMP_API_KEY=from-dotfiles'
+End
+
+It 'falls back to $HOME/.env'
+When run bash -c "printf 'AMP_API_KEY=from-home\n' >'$TEST_HOME/.env' && HOME='$TEST_HOME' sh '$SCRIPT'"
+The output should equal 'AMP_API_KEY=from-home'
+End
+
+It 'succeeds when no env file exists'
+When run bash -c "HOME='$TEST_HOME' sh '$SCRIPT'"
+The status should be success
+The output should equal ''
+End
+End
+End


### PR DESCRIPTION
## Summary

`.env` was only loaded by fish, and macOS GUI apps (CodexBar) never saw any of it because launchd does not pass shell environment. This adds `home-manager/modules/dotenv`:

- `print-env-file.sh` - the single `.env` parser. Prints `KEY=VALUE` lines. Every consumer applies only what this emits, so parsing rules cannot drift.
- `load-env-file.sh` - sourced by bash and zsh, applies the printer output.
- `_hm_load_env_file.fish` - rewritten to delegate to the same printer instead of parsing `.env` itself.
- `export-gui-env.sh` - `launchctl setenv` for an allowlist (`AMP_API_KEY`, `OPENCODE_API_KEY`) on Darwin activation, so CodexBar and other GUI apps can read them.

Lookup order is unchanged: `$DOTFILES_ENV_FILE`, `~/dotfiles/.env`, `~/.env`.

## Tests

- `spec/print_env_file_spec.sh`, `spec/load_env_file_spec.sh`, `spec/export_gui_env_spec.sh` (new), coverage spec updated.
- `spec/fish/_hm_load_env_file_test.fish` points at the shared printer.
- `shellspec` green, `shellcheck` clean, `check-nix-inline-scripts.sh` clean, `nixfmt` applied.

## Not done

`.env.example` still has no `AMP_API_KEY` entry - the local sandbox denies reads/writes of `.env*`, so a documentation line for it has to be added manually, matching the existing `OPENCODE_API_KEY` entry and noting that the value is exported to the macOS GUI session for CodexBar (see `home-manager/modules/dotenv`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share a single .env parser across fish, bash, and zsh, and export an allowlist of keys to macOS GUI apps. Previously only fish loaded .env and GUI apps saw nothing; now all shells use the same rules and CodexBar can read AMP_API_KEY and OPENCODE_API_KEY.

- Adds home-manager/modules/dotenv: a single `print-env-file.sh` parser, a `load-env-file.sh` for bash/zsh, and a Darwin activation script that `launchctl setenv`s AMP_API_KEY and OPENCODE_API_KEY for the GUI session.
- Fish now delegates parsing to the shared printer; bash and zsh init scripts source the loader and call `_hm_load_env_file`.
- Lookup order remains: `$DOTFILES_ENV_FILE`, `~/dotfiles/.env`, `~/.env`. Set `HM_PRINT_ENV_FILE` to override the printer path.
- Side effect on macOS: allowlisted keys become readable by all GUI processes in the user session. Keep the list minimal.

**Migration**
- If CodexBar needs API access, add AMP_API_KEY to your `.env` (it will be exported to the macOS GUI session). No action required on Linux.

<sup>Written for commit d4b0bb65890228c5e885cb77b35eda5c21641ef8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

