### PR TITLE
fix(caam): pin codex to per-host profile in rotation wrapper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,13 @@ ROBOREV_CI_REPOS=org/repo1,org/repo2
 LINEAR_API_KEY=lin_api_your-key-here
 LINEAR_TEAM_ID=679ab4ed-3df3-458d-8574-4962f3ebbf31
 
+# Per-host codex profile (fleet policy 2026-08-23): codex auth.json is host-shared,
+# so each machine must stay on ONE account to avoid mixing refresh-token lineages
+# ("refresh token was revoked" when rotated to a different account). The fish
+# _caam_exec_function wrapper forces codex rotation to this profile instead of
+# caam's arbitrary recommendation. Set the value that matches THIS host:
+#   kyber     = admin@openfactor.ai
+#   matic     = shunkakinoki@shunkakinoki.com
+#   galactica = shunkakinoki@gmail.com
+CAAM_CODEX_PROFILE=your-per-host-codex-profile-here
+

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -15,6 +15,22 @@
 
       set -gx CAAM_ROTATION_ENABLED 1
 
+      # Per-host codex profile (fleet policy 2026-08-23). codex auth.json is
+      # host-shared and each machine must stay on ONE account; mixing lineages
+      # across hosts triggers "refresh token was revoked". Derived from hostname
+      # so it is committed and works on every host (no .env dependency). The
+      # fish _caam_exec_function wrapper forces codex rotation to this profile
+      # instead of caam's arbitrary recommendation. .env may override via
+      # CAAM_CODEX_PROFILE.
+      switch (hostname)
+        case matic
+          set -gx CAAM_CODEX_PROFILE shunkakinoki@shunkakinoki.com
+        case galactica
+          set -gx CAAM_CODEX_PROFILE shunkakinoki@gmail.com
+        case '*'
+          set -gx CAAM_CODEX_PROFILE admin@openfactor.ai
+      end
+
       # Set XDG_RUNTIME_DIR on Linux for consistent socket paths (e.g., zellij)
       if test (uname) = "Linux"
           set -gx XDG_RUNTIME_DIR /run/user/(id -u)

--- a/home-manager/programs/fish/functions/_caam_exec_function.fish
+++ b/home-manager/programs/fish/functions/_caam_exec_function.fish
@@ -46,7 +46,16 @@ function _caam_exec_function --description "Run an agent launcher through CAAM w
             end
 
             if test $should_switch -eq 1
-              if test -n "$recommended"
+              # codex is pinned to ONE per-host profile (fleet policy 2026-08-23):
+              # kyber=admin@openfactor.ai, matic=shunkakinoki@shunkakinoki.com,
+              # galactica=shunkakinoki@gmail.com. caam precheck may recommend a
+              # different account (e.g. admin on matic), and activating it mixes
+              # refresh-token lineages across hosts -> "refresh token was revoked"
+              # on the next session. Never trust $recommended for codex; force the
+              # per-host profile from CAAM_CODEX_PROFILE (set per-host in .env).
+              if test "$tool" = codex; and test -n "$CAAM_CODEX_PROFILE"
+                caam activate codex "$CAAM_CODEX_PROFILE" >/dev/null
+              else if test -n "$recommended"
                 caam activate "$tool" "$recommended" >/dev/null
               else
                 caam activate "$tool" --auto >/dev/null

--- a/spec/fish/_caam_exec_function_test.fish
+++ b/spec/fish/_caam_exec_function_test.fish
@@ -84,6 +84,24 @@ _caam_exec_function codex --dangerously-bypass-approvals-and-sandbox
 @test "runs codex directly after cooldown-driven activation" \
   (cat $direct_env_log) = "--dangerously-bypass-approvals-and-sandbox"
 
+# Per-host codex profile (fleet policy 2026-08-23): when CAAM_CODEX_PROFILE is
+# set, codex rotation must force that account instead of caam's recommended
+# backup (which can be a different host's profile -> "refresh token was
+# revoked" when lineages mix). precheck recommends backup@example.com here;
+# with CAAM_CODEX_PROFILE pinned, activation must use the pinned profile.
+set -gx CAAM_CODEX_PROFILE work@example.com
+set caam_log (mktemp)
+set direct_env_log (mktemp)
+_caam_exec_function codex --dangerously-bypass-approvals-and-sandbox
+
+@test "codex rotation forces CAAM_CODEX_PROFILE, not recommended" \
+  (tail -n 1 $caam_log) = "activate codex work@example.com"
+@test "codex rotation never activates recommended backup when pinned" \
+  (grep -c "activate codex backup@example.com" $caam_log) -eq 0
+@test "pinned codex rotation still runs codex directly" \
+  (cat $direct_env_log) = "--dangerously-bypass-approvals-and-sandbox"
+set -e CAAM_CODEX_PROFILE
+
 # Claude Code on macOS may prefer a stale Keychain credential. The selected
 # CAAM file token must be pinned only to the launched Claude child process.
 set test_home (mktemp -d)


### PR DESCRIPTION
## Problem

codex `auth.json` is **host-shared**. Each machine must stay on ONE codex account, but the CAAM rotation wrapper (`_caam_exec_function.fish`) runs `caam precheck` and activates caam's **recommended** backup profile — which can be a *different host's* profile.

**Real incident (2026-08-23, matic):** `caam precheck codex` recommended `admin@openfactor.ai` (kyber's profile) over matic's mapped `shunkakinoki@shunkakinoki.com`. At 14:37 the wrapper auto-activated admin, clobbering matic's per-machine profile; the relaunched codex orchestrator then died with `refresh token was revoked` because it mixed admin's lineage into matic's host-shared auth.json.

## Fix

- **`_caam_exec_function.fish`**: when `CAAM_CODEX_PROFILE` is set and `$tool = codex`, force `caam activate codex "$CAAM_CODEX_PROFILE"` instead of `$recommended`. Codex rotation can never leave the pinned per-host account.
- **`fish/default.nix`**: set `CAAM_CODEX_PROFILE` per-host (hostname-derived): kyber=`admin@openfactor.ai`, matic=`shunkakinoki@shunkakinoki.com`, galactica=`shunkakinoki@gmail.com`. Committed so it works on every host (incl. matic, which has no `.env`). `.env` can override.
- **`.env.example`**: document the mapping.
- **spec**: extend `_caam_exec_function_test.fish` — with `CAAM_CODEX_PROFILE` pinned, rotation activates the pinned profile and never the recommended backup.

## Verification

- `fish -n` syntax check on wrapper + test.
- Manual fish run confirming: with `CAAM_CODEX_PROFILE=work@example.com`, the wrapper activates `codex work@example.com` and **not** `backup@example.com`.
- Nix parse check on `fish/default.nix`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins codex rotation to a per-host CAAM profile to prevent cross-host token lineage mixups. Previously the wrapper activated CAAM’s recommended profile, which could switch hosts and corrupt the shared codex auth.json, causing “refresh token was revoked.”

- `_caam_exec_function.fish`: if tool is codex and `CAAM_CODEX_PROFILE` is set, activate that profile and ignore `recommended`; other tools keep existing behavior.
- `home-manager/programs/fish/default.nix`: derive `CAAM_CODEX_PROFILE` from `hostname` (kyber=admin@openfactor.ai, matic=shunkakinoki@shunkakinoki.com, galactica=shunkakinoki@gmail.com); `.env` may override.
- `.env.example`: documents the per-host mapping.
- `spec`: adds tests that codex rotation uses the pinned profile and never the recommended backup.

Migration
- If adding a new host, add its hostname→`CAAM_CODEX_PROFILE` mapping or set `CAAM_CODEX_PROFILE` in `.env`.

<sup>Written for commit 9081be54021841ca71a1bc9c4f6727429a449c75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

