### PR TITLE
fix(cliproxyapi): keep the 812MB analytics backup off the auth path trigger

### DIFF
--- a/home-manager/services/cliproxyapi/README.md
+++ b/home-manager/services/cliproxyapi/README.md
@@ -7,14 +7,16 @@ This directory contains the Nix-based configuration for the cliproxyapi service 
 ### Services
 
 1. **cliproxyapi** - Main proxy server on port 8317
-2. **cliproxyapi-backup** - File watcher and wall-clock hourly job that syncs auth files and CPA Manager Plus analytics to S3
+2. **cliproxyapi-backup-auth** - File watcher that syncs only the auth cache to S3
+3. **cliproxyapi-backup** - Wall-clock hourly job that syncs auth files and CPA Manager Plus analytics to S3
 
 ### Scripts
 
 | Script | Purpose |
 |--------|---------|
 | `hydrate.sh` | Pull S3 → local (runs at activation) |
-| `backup.sh` | Push local → S3 (triggered by WatchPaths) |
+| `backup.sh auth` | Push auth cache local → S3 (triggered by WatchPaths) |
+| `backup.sh full` | Auth cache plus the CPA Manager Plus analytics snapshot (hourly) |
 | `start.sh` | Load .env, hydrate auth cache if needed, generate config, start service |
 | `wrapper.sh` | Load .env, sync auth cache, exec binary (for CLI usage) |
 
@@ -57,33 +59,46 @@ key error when S3 already has auths.
 
 1. Pull from S3 `auths/` → local
 
-### Backup (on auth-file change and each wall-clock hour)
+### Backup (auth, on auth-file change)
+
+1. Push local → S3 `auths/`
+
+CLIProxyAPI rewrites auth token files on every refresh, so this path fires many
+times per hour. It stays restricted to the kilobyte-scale auth cache.
+
+### Backup (full, each wall-clock hour)
 
 1. Push local → S3 `auths/`
 2. Create and integrity-check an online CPA Manager Plus SQLite snapshot
-3. Archive the snapshot with its matching `data.key` and upload it to S3
+3. Stream the snapshot and its matching `data.key` as a tarball into the UTC
+   hour slot, then server-side copy that object to the `latest` archive
 
 The SQLite online backup command is required because the live analytics database
 uses WAL mode. Copying only `usage.sqlite` while CPA Manager Plus is running can
 produce an incomplete backup. Each run updates the `latest` archive and its UTC
 hour slot, retaining up to 24 hourly rollback points without unbounded growth.
 
+The snapshot is as large as the live database. Set `CLIPROXY_BACKUP_STAGING_DIR`
+to stage it on a filesystem other than `$TMPDIR`.
+
 ### WatchPaths (file watchers)
 
-The `cliproxyapi-backup` service watches this directory:
+The `cliproxyapi-backup-auth` service watches this directory:
 - `~/.cli-proxy-api/objectstore/auths` - main auth cache
 
 **How it works (macOS launchd):**
 - launchd monitors the directories for any file changes
-- When a file is created, modified, or deleted, launchd triggers `backup.sh`
+- When a file is created, modified, or deleted, launchd triggers `backup.sh auth`
 - Changes are detected within ~1 second
 
 **How it works (Linux systemd):**
 - systemd path unit watches the directories
-- On change, triggers the `cliproxyapi-backup.service` oneshot
+- On change, triggers the `cliproxyapi-backup-auth.service` oneshot
 - Uses `PathChanged` directive for file monitoring
 
-When the directory changes, `backup.sh` syncs the CLIProxyAPI auth cache to S3.
+When the directory changes, `backup.sh auth` syncs the CLIProxyAPI auth cache to
+S3. The analytics snapshot is deliberately excluded: watch-driven runs of the
+full backup wrote roughly 9 GB/hour and exhausted the ext4 journal on kyber.
 
 ## Environment Variables
 
@@ -129,6 +144,7 @@ launchctl list | grep cliproxyapi
 # View logs
 tail -f /tmp/cliproxyapi.log
 tail -f /tmp/cliproxyapi-backup.log
+tail -f /tmp/cliproxyapi-backup-auth.log
 
 # OAuth login
 cliproxyapi --claude-login

--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -86,13 +86,43 @@ in
     };
   };
 
-  # Backup service - watches auth dir for changes
+  # Auth backup - watches auth dir for changes. CLIProxyAPI rewrites auth files
+  # on every token refresh, so this fires many times an hour and must stay cheap.
+  launchd.agents.cliproxyapi-backup-auth = lib.mkIf pkgs.stdenv.isDarwin {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "${pkgs.bash}/bin/bash"
+        "${backupScript}"
+        "auth"
+      ];
+      Environment = {
+        PATH = "${
+          lib.makeBinPath [
+            pkgs.bash
+            pkgs.coreutils
+            pkgs.awscli2
+          ]
+        }:/opt/homebrew/bin:/usr/local/bin:/usr/bin";
+      };
+      WatchPaths = [
+        "${homeDir}/.cli-proxy-api/objectstore/auths"
+      ];
+      RunAtLoad = true;
+      StandardOutPath = "/tmp/cliproxyapi-backup-auth.log";
+      StandardErrorPath = "/tmp/cliproxyapi-backup-auth.error.log";
+    };
+  };
+
+  # Full backup - auth files plus the multi-hundred-megabyte CPA Manager Plus
+  # analytics snapshot. Wall clock only; never wire this to a file watch.
   launchd.agents.cliproxyapi-backup = lib.mkIf pkgs.stdenv.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [
         "${pkgs.bash}/bin/bash"
         "${backupScript}"
+        "full"
       ];
       Environment = {
         PATH = "${
@@ -106,9 +136,6 @@ in
           ]
         }:/opt/homebrew/bin:/usr/local/bin:/usr/bin";
       };
-      WatchPaths = [
-        "${homeDir}/.cli-proxy-api/objectstore/auths"
-      ];
       StartCalendarInterval = [ { Minute = 0; } ];
       RunAtLoad = true;
       StandardOutPath = "/tmp/cliproxyapi-backup.log";
@@ -200,23 +227,43 @@ in
     Install.WantedBy = [ "default.target" ];
   };
 
-  systemd.user.paths.cliproxyapi-backup = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.paths.cliproxyapi-backup-auth = lib.mkIf pkgs.stdenv.isLinux {
     Unit.Description = "Watch auth directories for changes";
     Path = {
       PathChanged = [
         "%h/.cli-proxy-api/objectstore/auths"
       ];
-      Unit = "cliproxyapi-backup.service";
+      Unit = "cliproxyapi-backup-auth.service";
     };
     Install.WantedBy = [ "paths.target" ];
   };
 
-  systemd.user.services.cliproxyapi-backup = lib.mkIf pkgs.stdenv.isLinux {
+  # CLIProxyAPI rewrites auth files on every token refresh, so the path unit
+  # fires many times an hour. It gets the auth-only entrypoint and a PATH
+  # without sqlite/tar so the analytics snapshot cannot ride along.
+  systemd.user.services.cliproxyapi-backup-auth = lib.mkIf pkgs.stdenv.isLinux {
     Unit.Description = "CLIProxyAPI auth backup";
     Unit.X-SwitchMethod = "keep-old";
     Service = {
       Type = "oneshot";
-      ExecStart = "${pkgs.bash}/bin/bash ${backupScript}";
+      ExecStart = "${pkgs.bash}/bin/bash ${backupScript} auth";
+      Environment = "PATH=${
+        lib.makeBinPath [
+          pkgs.bash
+          pkgs.awscli2
+          pkgs.coreutils
+        ]
+      }";
+      UMask = "0077";
+    };
+  };
+
+  systemd.user.services.cliproxyapi-backup = lib.mkIf pkgs.stdenv.isLinux {
+    Unit.Description = "CLIProxyAPI auth and CPA Manager Plus analytics backup";
+    Unit.X-SwitchMethod = "keep-old";
+    Service = {
+      Type = "oneshot";
+      ExecStart = "${pkgs.bash}/bin/bash ${backupScript} full";
       Environment = "PATH=${
         lib.makeBinPath [
           pkgs.bash

--- a/home-manager/services/cliproxyapi/scripts/backup.sh
+++ b/home-manager/services/cliproxyapi/scripts/backup.sh
@@ -1,8 +1,22 @@
 #!/usr/bin/env bash
-# Push auth files from local cache to S3
+# Push CLIProxyAPI state to S3.
+#
+# "auth" syncs only the kilobyte-scale auth cache and is the mode wired to the
+# auth-directory watch, which fires on every CLIProxyAPI token refresh. "full"
+# adds the gigabyte-scale CPA Manager Plus analytics snapshot and must stay on a
+# wall-clock schedule; running it per token refresh saturated kyber's disk.
 # shellcheck source=/dev/null
 set -euo pipefail
 . "@common@"
+
+MODE="${1:-auth}"
+case "$MODE" in
+auth | full) ;;
+*)
+  echo "usage: backup.sh [auth|full]" >&2
+  exit 2
+  ;;
+esac
 
 AUTH_DIR="${HOME}/.cli-proxy-api/objectstore/auths"
 cliproxy_init_objectstore_env
@@ -19,6 +33,10 @@ if [ -d "$AUTH_DIR" ] && [ -n "$(ls -A "$AUTH_DIR" 2>/dev/null)" ]; then
   cliproxy_sync_auth_to_s3 "$AUTH_DIR"
 else
   echo "⚠️  No auth files to backup" >&2
+fi
+
+if [ "$MODE" != "full" ]; then
+  exit 0
 fi
 
 if [ -d "$CPA_MANAGER_PLUS_DATA_DIR" ]; then

--- a/home-manager/services/cliproxyapi/scripts/common.sh
+++ b/home-manager/services/cliproxyapi/scripts/common.sh
@@ -101,18 +101,21 @@ cliproxy_backup_manager_data() (
   local data_dir="$1"
   local database_path="${data_dir}/usage.sqlite"
   local data_key_path="${data_dir}/data.key"
-  local backup_root snapshot_dir snapshot_path archive_path integrity hourly_object
+  local staging_root backup_root snapshot_dir snapshot_path integrity hourly_object
 
   if [ ! -f "$database_path" ] || [ ! -f "$data_key_path" ]; then
     echo "⚠️  CPA Manager Plus database or data key is missing; skipping analytics backup" >&2
     return 0
   fi
 
-  backup_root="$(mktemp -d "${TMPDIR:-/tmp}/cpa-manager-plus-backup.XXXXXX")"
+  # The snapshot is as large as the live database, so let the caller stage it on
+  # a filesystem that is not the one the database itself is being written to.
+  staging_root="${CLIPROXY_BACKUP_STAGING_DIR:-${TMPDIR:-/tmp}}"
+  mkdir -p "$staging_root"
+  backup_root="$(mktemp -d "${staging_root%/}/cpa-manager-plus-backup.XXXXXX")"
   trap 'rm -rf -- "$backup_root"' EXIT
   snapshot_dir="${backup_root}/cpa-manager-plus"
   snapshot_path="${snapshot_dir}/usage.sqlite"
-  archive_path="${backup_root}/analytics-backup.tar.gz"
   mkdir -p "$snapshot_dir"
 
   # The live database uses WAL mode. SQLite's online backup command produces a
@@ -126,25 +129,27 @@ cliproxy_backup_manager_data() (
   fi
 
   install -m 600 "$data_key_path" "${snapshot_dir}/data.key"
-  @tar@ -czf "$archive_path" -C "$snapshot_dir" usage.sqlite data.key
-  chmod 600 "$archive_path"
 
   # Keep one rollback point per UTC hour in addition to the convenient latest
-  # object. Auth-file triggers within the same hour replace only that hour's slot.
+  # object. The archive is streamed rather than written next to the snapshot so
+  # the payload only hits the staging filesystem once.
   hourly_object="analytics-backup-$(date -u +%H).tar.gz"
-  AWS_ACCESS_KEY_ID="$OBJECTSTORE_ACCESS_KEY" \
-    AWS_SECRET_ACCESS_KEY="$OBJECTSTORE_SECRET_KEY" \
-    @aws@ s3 cp \
-    --endpoint-url="$OBJECTSTORE_ENDPOINT" \
-    --only-show-errors \
-    "$archive_path" \
-    "$(cliproxy_manager_backup_s3_uri "$hourly_object")"
+  @tar@ -czf - -C "$snapshot_dir" usage.sqlite data.key |
+    AWS_ACCESS_KEY_ID="$OBJECTSTORE_ACCESS_KEY" \
+      AWS_SECRET_ACCESS_KEY="$OBJECTSTORE_SECRET_KEY" \
+      @aws@ s3 cp \
+      --endpoint-url="$OBJECTSTORE_ENDPOINT" \
+      --only-show-errors \
+      - \
+      "$(cliproxy_manager_backup_s3_uri "$hourly_object")"
 
+  # Server-side copy: the stream is already consumed, and re-uploading would
+  # cost a second full pass over the archive.
   AWS_ACCESS_KEY_ID="$OBJECTSTORE_ACCESS_KEY" \
     AWS_SECRET_ACCESS_KEY="$OBJECTSTORE_SECRET_KEY" \
     @aws@ s3 cp \
     --endpoint-url="$OBJECTSTORE_ENDPOINT" \
     --only-show-errors \
-    "$archive_path" \
+    "$(cliproxy_manager_backup_s3_uri "$hourly_object")" \
     "$(cliproxy_manager_backup_s3_uri)"
 )

--- a/spec/cliproxyapi_backup_spec.sh
+++ b/spec/cliproxyapi_backup_spec.sh
@@ -89,6 +89,21 @@ Describe 'backup.sh'
 
 setup() {
   mock_bin_setup aws
+  # The analytics archive is streamed into `aws s3 cp -`, so the mock has to
+  # drain stdin or the producing tar dies on SIGPIPE.
+  cat >"$MOCK_BIN/aws" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+: "${MOCK_LOG:?MOCK_LOG must be set}"
+printf '%s\n' "$0 $*" >>"$MOCK_LOG"
+for arg in "$@"; do
+  if [ "$arg" = "-" ]; then
+    cat >/dev/null
+    break
+  fi
+done
+EOF
+  chmod +x "$MOCK_BIN/aws"
   cat >"$MOCK_BIN/sqlite3" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -124,6 +139,12 @@ ENV
   unset OBJECTSTORE_ENDPOINT
 }
 
+seed_manager_data() {
+  mkdir -p "$TEMP_HOME/.cpa-manager-plus"
+  touch "$TEMP_HOME/.cpa-manager-plus/usage.sqlite"
+  touch "$TEMP_HOME/.cpa-manager-plus/data.key"
+}
+
 cleanup() {
   rm -rf "$TEMP_HOME"
   mock_bin_cleanup
@@ -133,14 +154,14 @@ Before 'setup'
 After 'cleanup'
 
 It 'skips when auth directory is empty'
-When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$__BACKUP_SCRIPT"'" 2>&1'
+When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$__BACKUP_SCRIPT"'" auth 2>&1'
 The status should be success
 The output should include 'No auth files to backup'
 End
 
 It 'pushes to S3 when auth files exist'
 touch "$TEMP_HOME/.cli-proxy-api/objectstore/auths/test-auth.json"
-When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$__BACKUP_SCRIPT"'" 2>&1; status=$?; cat "$MOCK_LOG" 2>/dev/null || true; exit "$status"'
+When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$__BACKUP_SCRIPT"'" auth 2>&1; status=$?; cat "$MOCK_LOG" 2>/dev/null || true; exit "$status"'
 The status should be success
 The output should include 's3://cliproxyapi/auths/'
 End
@@ -153,16 +174,40 @@ OBJECTSTORE_ENDPOINT=https://test.endpoint.com
 OBJECTSTORE_BUCKET=custom-bucket
 ENV
 touch "$TEMP_HOME/.cli-proxy-api/objectstore/auths/test-auth.json"
-When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$__BACKUP_SCRIPT"'" 2>&1; status=$?; cat "$MOCK_LOG" 2>/dev/null || true; exit "$status"'
+When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$__BACKUP_SCRIPT"'" auth 2>&1; status=$?; cat "$MOCK_LOG" 2>/dev/null || true; exit "$status"'
 The status should be success
 The output should include 's3://custom-bucket/auths/'
 End
 
-It 'uploads a consistent CPA Manager Plus archive through the existing backup service'
-mkdir -p "$TEMP_HOME/.cpa-manager-plus"
-touch "$TEMP_HOME/.cpa-manager-plus/usage.sqlite"
-touch "$TEMP_HOME/.cpa-manager-plus/data.key"
+It 'leaves the analytics database alone in auth mode'
+touch "$TEMP_HOME/.cli-proxy-api/objectstore/auths/test-auth.json"
+seed_manager_data
+When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$__BACKUP_SCRIPT"'" auth 2>&1; status=$?; cat "$MOCK_LOG" 2>/dev/null || true; exit "$status"'
+The status should be success
+The output should include 's3://cliproxyapi/auths/'
+The output should not include 'CPA Manager Plus analytics'
+The output should not include '.backup'
+The output should not include 'cpa-manager-plus/'
+End
+
+It 'defaults to auth mode so a stray invocation cannot copy the analytics database'
+touch "$TEMP_HOME/.cli-proxy-api/objectstore/auths/test-auth.json"
+seed_manager_data
 When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$__BACKUP_SCRIPT"'" 2>&1; status=$?; cat "$MOCK_LOG" 2>/dev/null || true; exit "$status"'
+The status should be success
+The output should include 's3://cliproxyapi/auths/'
+The output should not include 'cpa-manager-plus/'
+End
+
+It 'rejects an unknown mode'
+When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$__BACKUP_SCRIPT"'" hourly 2>&1'
+The status should eq 2
+The output should include 'usage: backup.sh [auth|full]'
+End
+
+It 'uploads a consistent CPA Manager Plus archive in full mode'
+seed_manager_data
+When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$__BACKUP_SCRIPT"'" full 2>&1; status=$?; cat "$MOCK_LOG" 2>/dev/null || true; exit "$status"'
 The status should be success
 The output should include ".backup '"
 The output should include 'PRAGMA integrity_check;'
@@ -170,11 +215,25 @@ The output should match pattern '*s3://cliproxyapi/cpa-manager-plus/analytics-ba
 The output should include 's3://cliproxyapi/cpa-manager-plus/analytics-backup.tar.gz'
 End
 
+It 'streams the archive instead of staging a second copy on disk'
+seed_manager_data
+When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$__BACKUP_SCRIPT"'" full 2>&1; status=$?; cat "$MOCK_LOG" 2>/dev/null || true; exit "$status"'
+The status should be success
+The output should match pattern '*aws s3 cp*--only-show-errors - s3://cliproxyapi/cpa-manager-plus/analytics-backup-??.tar.gz*'
+The output should match pattern '*s3://cliproxyapi/cpa-manager-plus/analytics-backup-??.tar.gz s3://cliproxyapi/cpa-manager-plus/analytics-backup.tar.gz*'
+End
+
+It 'stages the snapshot where the caller asks'
+seed_manager_data
+STAGING_DIR="$TEMP_HOME/staging"
+When run bash -c 'HOME="'"$TEMP_HOME"'" CLIPROXY_BACKUP_STAGING_DIR="'"$STAGING_DIR"'" bash "'"$__BACKUP_SCRIPT"'" full 2>&1; status=$?; cat "$MOCK_LOG" 2>/dev/null || true; exit "$status"'
+The status should be success
+The output should include "$STAGING_DIR/cpa-manager-plus-backup."
+End
+
 It 'fails closed and skips analytics uploads when the snapshot is corrupt'
-mkdir -p "$TEMP_HOME/.cpa-manager-plus"
-touch "$TEMP_HOME/.cpa-manager-plus/usage.sqlite"
-touch "$TEMP_HOME/.cpa-manager-plus/data.key"
-When run bash -c 'HOME="'"$TEMP_HOME"'" SQLITE_INTEGRITY_RESULT=corrupt bash "'"$__BACKUP_SCRIPT"'" 2>&1; status=$?; cat "$MOCK_LOG" 2>/dev/null || true; exit "$status"'
+seed_manager_data
+When run bash -c 'HOME="'"$TEMP_HOME"'" SQLITE_INTEGRITY_RESULT=corrupt bash "'"$__BACKUP_SCRIPT"'" full 2>&1; status=$?; cat "$MOCK_LOG" 2>/dev/null || true; exit "$status"'
 The status should be failure
 The output should include 'SQLite snapshot failed its integrity check'
 The output should not include 's3://cliproxyapi/cpa-manager-plus/'
@@ -183,18 +242,37 @@ End
 It 'skips when credentials are missing'
 rm -f "$TEMP_HOME/dotfiles/.env"
 touch "$TEMP_HOME/.cli-proxy-api/objectstore/auths/test-auth.json"
-When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$__BACKUP_SCRIPT"'" 2>&1'
+When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$__BACKUP_SCRIPT"'" full 2>&1'
 The status should be success
 The output should include 'Missing S3 credentials'
 End
 End
 
 Describe 'backup scheduling'
-It 'uses wall-clock schedules independent of auth-file path triggers'
-When run grep -E 'StartCalendarInterval|OnCalendar = "hourly"' "$NIX_MODULE"
+It 'gives the auth-file watchers the auth-only entrypoint'
+When run bash -c "sed -n '/launchd.agents.cliproxyapi-backup-auth =/,/^  };/p' '$NIX_MODULE'; sed -n '/systemd.user.services.cliproxyapi-backup-auth =/,/^  };/p' '$NIX_MODULE'"
+The status should be success
+The output should include '"auth"'
+The output should include '${backupScript} auth'
+The output should not include 'pkgs.sqlite'
+The output should not include 'pkgs.gnutar'
+End
+
+It 'points the Linux path unit at the auth-only service'
+When run bash -c "sed -n '/systemd.user.paths.cliproxyapi-backup-auth =/,/^  };/p' '$NIX_MODULE'"
+The status should be success
+The output should include 'PathChanged'
+The output should include 'cliproxyapi-backup-auth.service'
+End
+
+It 'keeps the analytics snapshot on wall-clock schedules only'
+When run bash -c "sed -n '/launchd.agents.cliproxyapi-backup =/,/^  };/p' '$NIX_MODULE'; sed -n '/systemd.user.services.cliproxyapi-backup =/,/^  };/p' '$NIX_MODULE'; sed -n '/systemd.user.timers.cliproxyapi-backup =/,/^  };/p' '$NIX_MODULE'"
 The status should be success
 The output should include 'StartCalendarInterval'
 The output should include 'OnCalendar = "hourly"'
+The output should include '${backupScript} full'
+The output should include 'Unit = "cliproxyapi-backup.service"'
+The output should not include 'WatchPaths'
 End
 End
 

--- a/spec/cliproxyapi_spec.sh
+++ b/spec/cliproxyapi_spec.sh
@@ -428,7 +428,7 @@ The status should be success
 End
 
 It 'restarts the Linux service when the managed template changes'
-When run bash -c "sed -n '/systemd.user.services.cliproxyapi =/,/systemd.user.paths.cliproxyapi-backup =/p' '$PWD/home-manager/services/cliproxyapi/default.nix'"
+When run bash -c "sed -n '/systemd.user.services.cliproxyapi =/,/systemd.user.paths.cliproxyapi-backup-auth =/p' '$PWD/home-manager/services/cliproxyapi/default.nix'"
 The output should include 'X-Restart-Triggers'
 The output should include 'config.home.file.".cli-proxy-api/config.template.yaml".source'
 The status should be success

--- a/spec/cpa_manager_plus_spec.sh
+++ b/spec/cpa_manager_plus_spec.sh
@@ -5,6 +5,8 @@ Describe 'CPA Manager Plus service'
 NIX_MODULE="$PWD/home-manager/services/cpa-manager-plus/default.nix"
 START_SCRIPT="$PWD/home-manager/services/cpa-manager-plus/start.sh"
 DOCKER_START_SCRIPT="$PWD/home-manager/services/cpa-manager-plus/docker-start.sh"
+CLIPROXY_BACKUP_SCRIPT="$PWD/home-manager/services/cliproxyapi/scripts/backup.sh"
+CLIPROXY_NIX_MODULE="$PWD/home-manager/services/cliproxyapi/default.nix"
 
 It 'is enabled only on Kyber Linux'
 When run grep 'pkgs.stdenv.isLinux && host.isKyber' "$NIX_MODULE"
@@ -56,6 +58,19 @@ It 'restricts the persistent data directory to the service user'
 When run grep -E 'umask 077|chmod 700' "$START_SCRIPT"
 The output should include 'umask 077'
 The output should include 'chmod 700'
+End
+
+It 'snapshots its SQLite database only behind the full backup mode gate'
+When run bash -c "sed -n '/MODE\" != \"full\"/,\$p' '$CLIPROXY_BACKUP_SCRIPT'"
+The output should include 'CPA_MANAGER_PLUS_DATA_DIR'
+The output should include 'cliproxy_backup_manager_data'
+End
+
+It 'is never snapshotted by the auth-file watcher'
+When run bash -c "sed -n '/launchd.agents.cliproxyapi-backup-auth =/,/^  };/p' '$CLIPROXY_NIX_MODULE'; sed -n '/systemd.user.services.cliproxyapi-backup-auth =/,/^  };/p' '$CLIPROXY_NIX_MODULE'"
+The output should include 'auth'
+The output should not include 'full'
+The output should not include 'pkgs.sqlite'
 End
 
 It 'connects to the local CPA without exposing the management key'


### PR DESCRIPTION
## Problem

`systemd.user.paths.cliproxyapi-backup` watches `~/.cli-proxy-api/objectstore/auths`, and CLIProxyAPI rewrites auth token files on every refresh. `scripts/backup.sh` did two jobs unconditionally: the cheap auth sync **and** `cliproxy_backup_manager_data`, which takes a full `sqlite3 .backup` of the 812 MB `usage.sqlite`.

Measured on `kyber` 2026-08-23:

- 11 "Backing up CPA Manager Plus analytics" runs in 60 minutes — path trigger, not the hourly timer
- `sqlite3 .backup` writing 53 MB/s; ~9 GB/hour of avoidable writes
- staged through `/tmp` on the same disk (`/dev/sdb2`), so the payload was written twice before reaching S3
- 26 processes stuck in D-state in `jbd2_log_wait_for_space` (ext4 journal exhausted), avg queue depth 204, load 142
- Samsung 860 QVO (QLC) disks — sustained writes never let the SLC cache recover

Stopping the path unit at runtime took `jbd2_log_wait_for_space` waiters 26 → 0, queue depth 204 → ~20, load 142 → 66. A Cassandra node that had been crashlooping on a 30 s schema-readiness timeout immediately bootstrapped and joined.

## Change

`backup.sh` now takes a mode:

- `backup.sh auth` — auth cache sync only. Default when no argument is given, so a stray invocation cannot touch the analytics DB.
- `backup.sh full` — auth sync plus the CPA Manager Plus snapshot.
- Any other argument exits 2 with a usage message.

Wiring:

| Trigger | Unit | Entrypoint |
|---|---|---|
| `PathChanged` on the auth dir (Linux) | `cliproxyapi-backup-auth.path` → `cliproxyapi-backup-auth.service` | `backup.sh auth` |
| `WatchPaths` on the auth dir (Darwin) | `launchd.agents.cliproxyapi-backup-auth` | `backup.sh auth` |
| Hourly (Linux) | `cliproxyapi-backup.timer` → `cliproxyapi-backup.service` | `backup.sh full` |
| Hourly (Darwin) | `launchd.agents.cliproxyapi-backup` (`StartCalendarInterval`) | `backup.sh full` |

The `WatchPaths` key is gone from the Darwin full-backup agent — macOS ran the same script and had the same amplification. Both auth-only units also get a PATH without `sqlite`/`gnutar`/`gzip`, so the expensive path is not merely unused but unreachable.

## Secondary: staging writes

`cliproxy_backup_manager_data` wrote the snapshot **and** a `.tar.gz` of it to the staging filesystem before uploading. Now:

- the tarball is streamed straight into `aws s3 cp -`, so the payload hits the staging filesystem once instead of twice
- the `latest` object is a server-side copy of the hourly object rather than a second upload
- staging root is overridable via `CLIPROXY_BACKUP_STAGING_DIR` (defaults to `$TMPDIR`, then `/tmp`), so `/tmp` sharing a disk with the DB is now a host-config decision rather than hardcoded

**Retention semantics are unchanged**: still 24 UTC hourly slots plus `analytics-backup.tar.gz`. Worth watching the first hourly `full` run after deploy — the streamed upload and the server-side copy are new code paths against R2.

## Not done — flagging

A full `sqlite3 .backup` of an 812 MB DB is expensive even hourly. An incremental/WAL-aware approach, or pruning + `VACUUM` of old usage rows, would help further, but both change retention semantics so I left them alone. Happy to file a follow-up.

## Host reconciliation on `kyber` — please action after deploy

`kyber` currently has a **runtime-only** mitigation: `systemctl --user stop cliproxyapi-backup.path`. The unit is still `enabled`, so it returns on the next reboot or `home-manager` rebuild. Prior state is recorded in `/root/RESTORE-cliproxyapi-backup-path.txt` (was `enabled` + `active`). The hourly `cliproxyapi-backup.timer` was left armed and running.

This PR renames the path unit to `cliproxyapi-backup-auth.path`, so the deploy is self-reconciling: home-manager removes the old `cliproxyapi-backup.path` and enables the new auth-only unit fresh, unaffected by the manual stop. After the switch, verify:

```
systemctl --user status cliproxyapi-backup-auth.path
systemctl --user list-timers cliproxyapi-backup.timer
```

The path unit is fine to fire frequently now that it no longer copies the 812 MB DB. Once confirmed, `/root/RESTORE-cliproxyapi-backup-path.txt` can be removed.

Note `kyber`'s checkout is on `fix/codex-per-host-profile` while local `main` is at c14cc21d — it needs to pick up `main` before this lands there.

## Tests

- `spec/cliproxyapi_backup_spec.sh` — auth mode leaves the analytics DB untouched, no-arg defaults to auth, unknown mode exits 2, full mode still produces the hourly + latest objects, streaming/server-side-copy shape, `CLIPROXY_BACKUP_STAGING_DIR` is honoured, unit wiring per trigger
- `spec/cpa_manager_plus_spec.sh` — the SQLite snapshot sits behind the `full` gate and is unreachable from the auth watcher
- `spec/cliproxyapi_spec.sh` — updated for the renamed path unit

`make shell-test` 2292 examples / 0 failures · `make shell-check` · `make shell-inline-check` · `make nix-format-check` · `make nix-lint` · `make nix-test`. Linux wiring verified by evaluating `homeConfigurations.kyber`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops running the 812 MB analytics backup on auth-file change by splitting `backup.sh` into modes and rewiring watchers to the cheap path. Previously the path trigger ran a full SQLite `.backup`; now `auth` (default) syncs only the auth cache, and `full` runs hourly to snapshot CPA Manager Plus, reducing avoidable writes and disk contention.

- Rollout
  - Linux: `cliproxyapi-backup.path` is replaced by `cliproxyapi-backup-auth.path`. After deploy, verify the new path unit and the `cliproxyapi-backup.timer` are active on kyber; then remove the runtime RESTORE file.
  - macOS: `launchd.agents.cliproxyapi-backup-auth` watches auth; `launchd.agents.cliproxyapi-backup` runs hourly.
  - If any external scripts relied on the old behavior, call `backup.sh full` to include analytics; no-arg now defaults to `auth`.

- Notes
  - Streams the archive to S3 and copies server-side to `latest`; retention remains 24 hourly slots plus `latest`.
  - `CLIPROXY_BACKUP_STAGING_DIR` controls where the snapshot is staged (defaults to `$TMPDIR`, then `/tmp`).
  - Auth watchers run with a PATH that excludes `sqlite` and `gnutar` (`awscli2` only), so the analytics snapshot cannot run from a watch trigger.

<sup>Written for commit 0dc17aeb4177f3ff8358f3dfcbbf0106c3691966. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

