### PR TITLE
fix(pi): resolve provider API keys from env and match slashed model ids

### DIFF
--- a/config/pi/models.json
+++ b/config/pi/models.json
@@ -2,7 +2,7 @@
   "providers": {
     "cliproxyapi": {
       "baseUrl": "https://cliproxy.shunkakinoki.com/v1",
-      "apiKey": "CLIPROXY_API_KEY",
+      "apiKey": "$CLIPROXY_API_KEY",
       "api": "openai-responses",
       "models": [
         {
@@ -176,7 +176,7 @@
     },
     "openrouter-preset": {
       "baseUrl": "https://openrouter.ai/api/v1",
-      "apiKey": "OPENROUTER_API_KEY",
+      "apiKey": "$OPENROUTER_API_KEY",
       "api": "openai-completions",
       "models": [
         {

--- a/config/pi/models.tpl.json
+++ b/config/pi/models.tpl.json
@@ -2,7 +2,7 @@
   "providers": {
     "cliproxyapi": {
       "baseUrl": "https://cliproxy.shunkakinoki.com/v1",
-      "apiKey": "CLIPROXY_API_KEY",
+      "apiKey": "$CLIPROXY_API_KEY",
       "api": "openai-responses",
       "models": [
         {
@@ -176,7 +176,7 @@
     },
     "openrouter-preset": {
       "baseUrl": "https://openrouter.ai/api/v1",
-      "apiKey": "OPENROUTER_API_KEY",
+      "apiKey": "$OPENROUTER_API_KEY",
       "api": "openai-completions",
       "models": [
         {

--- a/config/pi/settings.json
+++ b/config/pi/settings.json
@@ -7,8 +7,8 @@
   "enabledModels": [
     "cliproxyapi/*",
     "lmstudio/*",
-    "openrouter/*",
-    "openrouter-preset/*",
+    "openrouter/**",
+    "openrouter-preset/**",
     "*gpt-5*",
     "*gemini*",
     "*claude*",

--- a/config/pi/settings.tpl.json
+++ b/config/pi/settings.tpl.json
@@ -7,8 +7,8 @@
   "enabledModels": [
     "cliproxyapi/*",
     "lmstudio/*",
-    "openrouter/*",
-    "openrouter-preset/*",
+    "openrouter/**",
+    "openrouter-preset/**",
     "*gpt-5*",
     "*gemini*",
     "*claude*",

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -264,7 +264,7 @@ End
 
 Describe 'runtime model fallback'
 It 'enables Pi OpenRouter catalog and preset models'
-When run bash -c "jq -e '(.enabledModels | index(\"openrouter/*\") != null) and (.enabledModels | index(\"openrouter-preset/*\") != null)' config/pi/settings.json >/dev/null && jq -e '(.enabledModels | index(\"openrouter/*\") != null) and (.enabledModels | index(\"openrouter-preset/*\") != null)' config/pi/settings.tpl.json >/dev/null"
+When run bash -c "jq -e '(.enabledModels | index(\"openrouter/**\") != null) and (.enabledModels | index(\"openrouter-preset/**\") != null)' config/pi/settings.json >/dev/null && jq -e '(.enabledModels | index(\"openrouter/**\") != null) and (.enabledModels | index(\"openrouter-preset/**\") != null)' config/pi/settings.tpl.json >/dev/null"
 The status should be success
 End
 


### PR DESCRIPTION
The pi reviewer failed on every roborev job. The reported symptom — `No models match pattern "openrouter-preset/*"` — was not the cause; it was just the only line on stderr, which roborev falls back to when pi produces no output.

## Bug 1 (the actual failure): API keys were literals, not env references

pi's `resolveConfigValue` only treats an `apiKey` as an environment reference when it starts with `$`. The config had `"apiKey": "CLIPROXY_API_KEY"`, so pi sent that literal string as the bearer token and every request 401'd.

Under `--mode json` the API error is emitted on stdout as a non-assistant event, so roborev's `parsePiJSON` returned an empty string and fell back to `stderrBuf` — recording the warning line as the review body.

Verified before/after against an isolated `PI_CODING_AGENT_DIR`, with the key unset:

| | result |
|---|---|
| before | `OpenAI API error (401): "Invalid API key"` — a request was sent with the literal |
| after | `No API key found for cliproxyapi` — now resolved as an env reference |

## Bug 2: the glob never matched

`enabledModels` patterns go through minimatch, where `*` does not cross a `/`. The only preset model id is `@preset/glm-4-7`, so `openrouter-preset/*` matched zero models. `openrouter/*` had the same problem. Both changed to `**`.

## Verification

- `shellspec spec/llm_update_spec.sh` — 103 examples, 0 failures
- `pi --list-models` against the fixed config lists `openrouter-preset  @preset/glm-4-7` and no longer warns on either openrouter pattern

## Reviewer notes

- **Not live until activation.** `~/.pi/agent/*.json` are nix-store symlinks, so this needs `make switch` to take effect. Not run here — that's a full `darwin-rebuild switch`.
- **`lmstudio` keeps its literal `"LM_API_TOKEN"`** deliberately. That variable is set nowhere in the repo and LM Studio ignores the key; pi's docs say keyless local servers should keep a dummy literal. Adding `$` would leave it unresolved and drop those models from the registry entirely.
- **`*kimi*` has the same slash-crossing problem** and warns locally, but not in the daemon, whose live OpenRouter catalog evidently has a match. Left alone as unrelated to this failure.
- `~/dotfiles/.env` could not be read to confirm `OPENROUTER_API_KEY` is present. It's inferred from the daemon not warning on `openrouter/*` while a plain shell does. Worth confirming before expecting the preset provider to authenticate.
- The spec at `spec/llm_update_spec.sh:267` pinned the old `/*` patterns and is updated to match.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `pi` reviewer failures by resolving provider API keys from the environment and by matching slashed model IDs. Previously `apiKey` values were sent as literals and `openrouter/*` patterns matched no models; now `pi` reads `$CLIPROXY_API_KEY` and `$OPENROUTER_API_KEY` and uses `openrouter/**` and `openrouter-preset/**`. If the env vars are missing, `pi` reports “No API key found …”.

- Updates: `cliproxyapi.apiKey` and `openrouter-preset.apiKey` now reference `$CLIPROXY_API_KEY` and `$OPENROUTER_API_KEY`; `lmstudio` keeps a literal placeholder by design.
- Matching: `enabledModels` patterns use `**` to match IDs like ``@preset/glm-4-7``.
- Tests: spec updated to assert the new patterns.
- Rollout: Run `make switch` to update `~/.pi/agent/*.json`. Set `OPENROUTER_API_KEY` and `CLIPROXY_API_KEY` in the environment available to `pi`.

<sup>Written for commit cd363bc7a9f616d2218ec1d6229ad465fd55f539. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

