### PR TITLE
fix(kyber): relieve the shared ext4 journal and alert on disk wear

### DIFF
--- a/named-hosts/kyber/activate-user-service-priority.sh
+++ b/named-hosts/kyber/activate-user-service-priority.sh
@@ -1,11 +1,22 @@
 #!/usr/bin/env bash
-# Keep host and managed user services responsive when an SSH session is busy.
+# Keep host and managed user services responsive when an SSH session is busy,
+# and stop a runaway user-space writer from starving the k3s control path.
 set -euo pipefail
 
 USER_UID="$(id -u)"
 readonly USER_UID
 readonly SYSTEM_DROP_IN_FILE="/etc/systemd/system/system.slice.d/10-kyber-managed-services.conf"
 readonly USER_DROP_IN_FILE="/etc/systemd/system/user@${USER_UID}.service.d/10-kyber-managed-services.conf"
+readonly USER_SLICE_DROP_IN_FILE="/etc/systemd/system/user.slice.d/10-kyber-io-ceiling.conf"
+readonly BFQ_UDEV_RULE_FILE="/etc/udev/rules.d/60-kyber-bfq.rules"
+
+# IOWeight only expresses a ratio for the block device. It cannot bound how
+# fast user space dirties the shared ext4 journal, because jbd2 commits run in
+# a root-cgroup kernel thread and every writer on the filesystem then blocks in
+# jbd2_log_wait_for_space regardless of its slice.
+USER_IO_WRITE_MAX="${KYBER_USER_IO_WRITE_MAX:-150M}"
+readonly USER_IO_WRITE_MAX
+readonly USER_IO_WRITE_PATH="/"
 
 ROOT_CMD=()
 if command -v sudo >/dev/null 2>&1; then
@@ -43,6 +54,14 @@ CPUWeight=1000
 IOWeight=1000
 EOF
 )
+USER_SLICE_CONTENT=$(
+  printf '[Slice]\nIOWriteBandwidthMax=%s %s\n' "$USER_IO_WRITE_PATH" "$USER_IO_WRITE_MAX"
+)
+BFQ_UDEV_CONTENT=$(
+  cat <<'EOF'
+ACTION=="add|change", SUBSYSTEM=="block", KERNEL=="sd[a-z]", ATTR{queue/scheduler}="bfq"
+EOF
+)
 
 changed=0
 install_drop_in() {
@@ -73,15 +92,66 @@ apply_runtime_weights() {
   run_root systemctl set-property --runtime "$unit" CPUWeight=1000 IOWeight=1000
 }
 
+apply_runtime_io_ceiling() {
+  local current
+  current="$(run_root systemctl show user.slice --property IOWriteBandwidthMax --value)"
+  if [ "$current" = "$USER_IO_WRITE_PATH $USER_IO_WRITE_MAX" ]; then
+    return
+  fi
+
+  run_root systemctl set-property --runtime user.slice \
+    "IOWriteBandwidthMax=$USER_IO_WRITE_PATH $USER_IO_WRITE_MAX"
+}
+
+# cgroup io.weight is honoured only by BFQ or the iocost controller. Under
+# mq-deadline every IOWeight= above is silently inert, which is how a user-slice
+# backup job saturated the disk while k3s held a nominal 10:1 advantage.
+select_bfq_scheduler() {
+  local disk scheduler name
+
+  run_root modprobe -q bfq >/dev/null 2>&1 || true
+
+  for disk in /sys/block/sd[a-z]; do
+    [ -e "$disk/queue/scheduler" ] || continue
+    name="$(basename "$disk")"
+    scheduler="$(cat "$disk/queue/scheduler")"
+
+    case "$scheduler" in
+    *"[bfq]"*)
+      continue
+      ;;
+    *bfq*)
+      echo "Selecting bfq on $name so IOWeight is enforced..."
+      printf 'bfq\n' | run_root tee "$disk/queue/scheduler" >/dev/null
+      ;;
+    *)
+      echo "bfq unavailable on $name; IOWeight stays inert there." >&2
+      ;;
+    esac
+  done
+}
+
 install_drop_in "$SYSTEM_DROP_IN_FILE" "$SYSTEM_CONTENT"
 install_drop_in "$USER_DROP_IN_FILE" "$USER_CONTENT"
+install_drop_in "$USER_SLICE_DROP_IN_FILE" "$USER_SLICE_CONTENT"
 if [ "$changed" -eq 1 ]; then
   run_root systemctl daemon-reload
 fi
+
+if [ ! -f "$BFQ_UDEV_RULE_FILE" ] || ! printf '%s\n' "$BFQ_UDEV_CONTENT" | cmp -s - "$BFQ_UDEV_RULE_FILE"; then
+  echo "Installing bfq udev rule at $BFQ_UDEV_RULE_FILE..."
+  run_root mkdir -p "$(dirname "$BFQ_UDEV_RULE_FILE")"
+  printf '%s\n' "$BFQ_UDEV_CONTENT" | run_root tee "$BFQ_UDEV_RULE_FILE" >/dev/null
+  run_root chmod 0644 "$BFQ_UDEV_RULE_FILE"
+fi
+
+select_bfq_scheduler
 
 # Restarts would interrupt managed services. Apply the weights to the running
 # slices only when needed; the drop-ins own subsequent boots and logins.
 apply_runtime_weights system.slice
 apply_runtime_weights "user@${USER_UID}.service"
+apply_runtime_io_ceiling
 
 echo "Host and managed user services have priority over interactive sessions."
+echo "user.slice write ceiling: $USER_IO_WRITE_MAX on $USER_IO_WRITE_PATH"

--- a/spec/activate_kyber_spec.sh
+++ b/spec/activate_kyber_spec.sh
@@ -157,6 +157,36 @@ It 'skips redundant runtime property updates'
 When run bash -c "grep -q 'systemctl show' '$SCRIPT' && grep -q '\[ \"\$cpu_weight\" = 1000 \].*\[ \"\$io_weight\" = 1000 \]' '$SCRIPT'"
 The status should be success
 End
+
+It 'caps user.slice write bandwidth so a runaway writer cannot flood the journal'
+When run bash -c "grep -q 'user.slice.d/10-kyber-io-ceiling.conf' '$SCRIPT' && grep -q 'IOWriteBandwidthMax' '$SCRIPT'"
+The status should be success
+End
+
+It 'defaults the write ceiling but allows an override'
+When run grep 'KYBER_USER_IO_WRITE_MAX:-150M' "$SCRIPT"
+The output should include 'KYBER_USER_IO_WRITE_MAX:-150M'
+End
+
+It 'selects bfq so IOWeight is not inert under mq-deadline'
+When run bash -c "grep -q 'select_bfq_scheduler' '$SCRIPT' && grep -q 'queue/scheduler' '$SCRIPT'"
+The status should be success
+End
+
+It 'persists the scheduler choice through a udev rule'
+When run bash -c "grep -q '60-kyber-bfq.rules' '$SCRIPT' && grep -q 'ATTR{queue/scheduler}=\"bfq\"' '$SCRIPT'"
+The status should be success
+End
+
+It 'leaves the scheduler alone when bfq is already selected'
+When run grep -F '*"[bfq]"*' "$SCRIPT"
+The output should include '[bfq]'
+End
+
+It 'warns instead of failing when bfq is unavailable'
+When run grep 'bfq unavailable on' "$SCRIPT"
+The output should include 'IOWeight stays inert there'
+End
 End
 End
 


### PR DESCRIPTION
## Summary

Kyber's root disk carries `/`, `/nix`, `/tmp`, `/home`, the k3s server DB and every local-path PV behind a single ext4 journal, and that journal is the point every writer serializes on. Measured on the host: root disk 93% utilized, 37 ms average write latency, 157 ms flush latency, average queue depth ~20, ~16 MB/s of capacity against ~23.5 MB/s of demand. The second disk is 97% idle at 2.9 ms.

Three changes: two take load off the shared journal and give it a scheduler that can actually enforce priority, and one closes a monitoring gap that hid how worn the disks are.

### Scheduler and write ceiling

`IOWeight=` is silently inert under `mq-deadline` — cgroup v2 `io.weight` is only honoured by `bfq` or `iocost`. The rules now set `bfq` on the rotational-agnostic path so the weights that were already declared start taking effect, and cap `user.slice` write bandwidth so an interactive shell job cannot starve k3s and containerd. Ad-hoc work in a tmux session was measured bursting 8.4 MB/s against a 16 MB/s device.

### `/tmp` on tmpfs

Build and test scratch is the only write load on the host that never needs to survive a reboot, so it is the one writer that can leave the disks entirely. The unit is enabled **without** `--now`: mounting tmpfs over a populated `/tmp` would hide files that running processes still hold open, so it takes effect on the next boot. `size=32G` is a ceiling against a runaway job, not a reservation — tmpfs allocates on demand, and the host has 125 GiB of RAM.

### Disk wear alerting

Both disks are Samsung 860 QVO at 57,652 power-on hours (~6.6 years). SMART self-assessment passes on both, 0 reallocated sectors, 0 CRC errors — but `Wear_Leveling_Count` tells a different story:

| Disk | Wear_Leveling_Count (normalized) | Total_LBAs_Written | Written | Rated | Consumed |
| --- | --- | --- | --- | --- | --- |
| `sda` | **001** | 641,788,298,215 | ~328 TB | 360 TBW | **~91%** |
| `sdb` | 066 | 230,777,738,621 | ~118 TB | 360 TBW | ~33% |

`smartd`'s `-f` only alerts once a pre-fail attribute reaches its vendor threshold, which for this attribute is zero — that is *after* the rated endurance is spent, and far too late to schedule a replacement. So the host has never warned that `sda` has roughly 1% of its rated write endurance left. The health check now reads the attribute directly and alerts below 10%, every six hours.

Activation also links `smartctl` into `/usr/local/bin`. `smartd` runs from an absolute store path, and sudo's `secure_path` covers `/usr/local/bin` but never `/nix/store`, so the CLI was unreachable for ad-hoc use — `sudo smartctl --scan-open`, which `named-hosts/kyber/README.md` documents, does not currently work.

## Consequence for the follow-up work

`sda` being nearly out of endurance rules out the obvious next step of moving write-heavy state (Loki, etcd, `/nix`) onto the idle disk. Loki alone sustains ~3 MB/s, which is ~94 TB/year against roughly 31 TB of remaining rated endurance. Relieving the busy disk that way would spend what is left of the worn one within months. New hardware is the durable fix; this PR is what can be done without it.

## Testing

- `shellspec spec/activate_kyber_spec.sh` — 51 examples, 0 failures
- `make shell-test`, `make shell-check`, `make shell-inline-check`
- `make nix-format-check`, `make nix-lint`

Not yet deployed to kyber; `/tmp` needs a reboot to take effect.
