### PR TITLE
fix(cass): limit analytics rebuild to last day

### DIFF
--- a/home-manager/services/cass/daily.sh
+++ b/home-manager/services/cass/daily.sh
@@ -14,6 +14,6 @@ echo "$(date): starting cass daily sync + analytics"
 "$CASS" sources sync || true
 
 # Rebuild analytics rollup tables
-"$CASS" analytics rebuild
+"$CASS" analytics rebuild --since -1d
 
 echo "$(date): cass daily sync + analytics complete"


### PR DESCRIPTION
Limit the daily cass analytics rebuild to the last day with `--since -1d` instead of rebuilding the full history every run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit the daily cass analytics rebuild to only the last day using --since -1d. Previously the job rebuilt the full history; now it processes just the last day to reduce runtime and database load.

- For a full backfill, run: cass analytics rebuild (without --since).
- This change only affects the daily script; ad‑hoc rebuilds remain unchanged.

<sup>Written for commit ef0a79fff924247e9c1f7262610df291689a3b76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

