### PR TITLE
feat(kyber): move /tmp to tmpfs and alert on disk wear

### DIFF
--- a/config/k3s/default.nix
+++ b/config/k3s/default.nix
@@ -54,6 +54,7 @@ let
       pkgs.gnugrep
       pkgs.k3s
       pkgs.procps
+      pkgs.smartmontools
       pkgs.systemd
       pkgs.util-linux
     ];
@@ -100,6 +101,11 @@ in
 
   home.file.".config/k3s/journald.conf.d/10-kyber-limits.conf" = lib.mkIf isKyber {
     source = ./journald.conf;
+    force = true;
+  };
+
+  home.file.".config/k3s/tmp.mount" = lib.mkIf isKyber {
+    source = ./kyber-tmp.mount;
     force = true;
   };
 

--- a/config/k3s/kyber-host-health.sh
+++ b/config/k3s/kyber-host-health.sh
@@ -14,6 +14,8 @@ readonly NODEFS_KUBELET_RESERVE_GIB=50
 readonly IMAGEFS_USAGE_THRESHOLD=70
 readonly CRI_LATENCY_THRESHOLD_SECONDS=5
 readonly CRI_ERROR_THRESHOLD=5
+readonly DISK_WEAR_WARNING_PERCENT=10
+readonly DISK_WEAR_CHECK_INTERVAL_SECONDS=21600
 
 set_alert() {
   local key="$1"
@@ -159,12 +161,48 @@ check_cri() {
   fi
 }
 
+check_disk_wear() {
+  local stamp="$STATE_DIR/disk-wear.checked"
+  local now last=0 disk name remaining
+
+  now="$(date +%s)"
+  if [ -r "$stamp" ]; then
+    read -r last <"$stamp" || last=0
+  fi
+  if [ $((now - last)) -lt "$DISK_WEAR_CHECK_INTERVAL_SECONDS" ]; then
+    return
+  fi
+  printf '%s\n' "$now" >"$stamp"
+
+  for disk in /dev/sd[a-z]; do
+    [ -b "$disk" ] || continue
+    name="$(basename "$disk")"
+    # Samsung publishes remaining write endurance as the normalized value of
+    # Wear_Leveling_Count. smartd's -f only fires once that reaches the vendor
+    # threshold of zero, which is after the rated endurance is already spent
+    # and far too late to schedule a replacement.
+    # shellcheck disable=SC2016
+    remaining="$(smartctl -A "$disk" 2>/dev/null |
+      awk '$2 == "Wear_Leveling_Count" { print $4 + 0; exit }')"
+    if [ -z "$remaining" ]; then
+      continue
+    fi
+
+    if [ "$remaining" -le "$DISK_WEAR_WARNING_PERCENT" ]; then
+      set_alert "disk-wear-$name" "$name has ${remaining}% of its rated write endurance left; schedule a replacement before moving write-heavy state onto it"
+    else
+      clear_alert "disk-wear-$name"
+    fi
+  done
+}
+
 main() {
   install -d --mode 0755 "$STATE_DIR"
   check_io_pressure
   check_d_state
   check_node_filesystem
   check_image_filesystem
+  check_disk_wear
   check_cri
   check_dns
 }

--- a/config/k3s/kyber-tmp.mount
+++ b/config/k3s/kyber-tmp.mount
@@ -1,0 +1,21 @@
+[Unit]
+Description=Temporary Directory /tmp
+Documentation=man:file-hierarchy(7)
+ConditionPathIsSymbolicLink=!/tmp
+DefaultDependencies=no
+Conflicts=umount.target
+Before=local-fs.target umount.target
+After=swap.target
+
+[Mount]
+What=tmpfs
+Where=/tmp
+Type=tmpfs
+# Build and test scratch is the only write load on Kyber that never needs to
+# survive a reboot, so it is the one writer that can leave the disks entirely.
+# tmpfs allocates on demand, so the size is a ceiling against a runaway job
+# rather than a reservation against the host's 125 GiB of RAM.
+Options=mode=1777,strictatime,nosuid,nodev,size=32G,nr_inodes=4m
+
+[Install]
+WantedBy=local-fs.target

--- a/home-manager/services/k3s/activate.sh
+++ b/home-manager/services/k3s/activate.sh
@@ -10,12 +10,15 @@ JOURNALD_FILE="$4"
 HEALTH_SERVICE_FILE="$5"
 HEALTH_TIMER_FILE="$6"
 SMARTD_SERVICE_FILE="$7"
+TMP_MOUNT_FILE="$8"
 SYSTEM_SERVICE="/etc/systemd/system/k3s.service"
 SYSTEM_MOUNT="/etc/systemd/system/var-lib-rancher-k3s-agent-containerd.mount"
 SYSTEM_JOURNALD="/etc/systemd/journald.conf.d/10-kyber-limits.conf"
 SYSTEM_HEALTH_SERVICE="/etc/systemd/system/kyber-host-health.service"
 SYSTEM_HEALTH_TIMER="/etc/systemd/system/kyber-host-health.timer"
 SYSTEM_SMARTD_SERVICE="/etc/systemd/system/kyber-smartd.service"
+SYSTEM_TMP_MOUNT="/etc/systemd/system/tmp.mount"
+SMARTCTL_LINK="/usr/local/bin/smartctl"
 MOUNT_POINT="/var/lib/rancher/k3s/agent/containerd"
 EXPECTED_CONTAINERD_UUID="90f29a7b-38ff-460b-b534-92a02f1412ec"
 K3S_KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
@@ -143,7 +146,8 @@ for systemd_file_pair in \
   "$SERVICE_FILE:$SYSTEM_SERVICE" \
   "$HEALTH_SERVICE_FILE:$SYSTEM_HEALTH_SERVICE" \
   "$HEALTH_TIMER_FILE:$SYSTEM_HEALTH_TIMER" \
-  "$SMARTD_SERVICE_FILE:$SYSTEM_SMARTD_SERVICE"; do
+  "$SMARTD_SERVICE_FILE:$SYSTEM_SMARTD_SERVICE" \
+  "$TMP_MOUNT_FILE:$SYSTEM_TMP_MOUNT"; do
   source_file="${systemd_file_pair%%:*}"
   target_file="${systemd_file_pair#*:}"
   if sync_root_file "$source_file" "$target_file"; then
@@ -169,6 +173,26 @@ run_sudo @systemctl@ enable --now k3s
 
 if [ -f "$SMARTD_SERVICE_FILE" ]; then
   run_sudo @systemctl@ enable --now kyber-smartd.service
+fi
+
+# smartd runs from an absolute store path, so the CLI is otherwise unreachable
+# for ad-hoc use; sudo's secure_path covers /usr/local/bin but never the store.
+if [ "$(readlink "$SMARTCTL_LINK" 2>/dev/null || true)" != "@smartctl@" ]; then
+  if require_sudo; then
+    run_sudo mkdir -p "$(dirname "$SMARTCTL_LINK")"
+    run_sudo ln -sfn "@smartctl@" "$SMARTCTL_LINK"
+  fi
+fi
+
+# Never `--now`: mounting tmpfs over a populated /tmp hides files that running
+# processes still hold open. The unit takes effect on the next boot instead.
+if [ -f "$TMP_MOUNT_FILE" ]; then
+  if require_sudo; then
+    run_sudo @systemctl@ enable tmp.mount
+    if ! @findmnt@ --types tmpfs --mountpoint /tmp >/dev/null 2>&1; then
+      echo "tmp.mount is enabled; /tmp moves to tmpfs on the next reboot"
+    fi
+  fi
 fi
 
 if [ -f "$HEALTH_TIMER_FILE" ]; then

--- a/home-manager/services/k3s/default.nix
+++ b/home-manager/services/k3s/default.nix
@@ -14,6 +14,7 @@ let
     diff = "${pkgs.diffutils}/bin/diff";
     find = "${pkgs.findutils}/bin/find";
     findmnt = "${pkgs.util-linux}/bin/findmnt";
+    smartctl = "${pkgs.smartmontools}/bin/smartctl";
     systemctl = "${pkgs.systemd}/bin/systemctl";
     tune2fs = "${pkgs.e2fsprogs}/bin/tune2fs";
   };
@@ -23,6 +24,7 @@ let
   healthServiceFile = "${homeDir}/.config/k3s/kyber-host-health.service";
   healthTimerFile = "${homeDir}/.config/k3s/kyber-host-health.timer";
   smartdServiceFile = "${homeDir}/.config/k3s/kyber-smartd.service";
+  tmpMountFile = "${homeDir}/.config/k3s/tmp.mount";
 in
 lib.mkIf (pkgs.stdenv.isLinux && host.isK3sServer) {
   home.activation.setupK3s = config.lib.dag.entryAfter [ "writeBoundary" ] ''
@@ -33,6 +35,7 @@ lib.mkIf (pkgs.stdenv.isLinux && host.isK3sServer) {
       "${journaldFile}" \
       "${healthServiceFile}" \
       "${healthTimerFile}" \
-      "${smartdServiceFile}"
+      "${smartdServiceFile}" \
+      "${tmpMountFile}"
   '';
 }

--- a/spec/activate_kyber_spec.sh
+++ b/spec/activate_kyber_spec.sh
@@ -232,3 +232,70 @@ The output should include 'sshd -t'
 End
 End
 End
+
+Describe 'config/k3s/tmp.mount'
+UNIT="$PWD/config/k3s/kyber-tmp.mount"
+
+It 'moves /tmp onto tmpfs'
+When run bash -c "grep -q 'What=tmpfs' '$UNIT' && grep -q 'Where=/tmp' '$UNIT'"
+The status should be success
+End
+
+It 'caps the tmpfs so a runaway job cannot consume host memory'
+When run grep 'Options=' "$UNIT"
+The output should include 'size=32G'
+End
+
+It 'keeps the sticky, nosuid, nodev semantics of a real /tmp'
+When run bash -c "grep -q 'mode=1777' '$UNIT' && grep -q 'nosuid' '$UNIT' && grep -q 'nodev' '$UNIT'"
+The status should be success
+End
+
+It 'installs into local-fs.target'
+When run grep 'WantedBy=' "$UNIT"
+The output should include 'local-fs.target'
+End
+End
+
+Describe 'home-manager/services/k3s/activate.sh'
+SCRIPT="$PWD/home-manager/services/k3s/activate.sh"
+
+It 'installs the tmpfs mount unit'
+When run bash -c "grep -q 'SYSTEM_TMP_MOUNT=' '$SCRIPT' && grep -q 'TMP_MOUNT_FILE:.SYSTEM_TMP_MOUNT' '$SCRIPT'"
+The status should be success
+End
+
+It 'enables tmp.mount without mounting over a live /tmp'
+When run bash -c "grep -q 'enable tmp.mount' '$SCRIPT' && ! grep -q 'enable --now tmp.mount' '$SCRIPT'"
+The status should be success
+End
+
+It 'exposes smartctl on the sudo secure_path'
+When run bash -c "grep -q '/usr/local/bin/smartctl' '$SCRIPT' && grep -q 'ln -sfn' '$SCRIPT'"
+The status should be success
+End
+End
+
+Describe 'config/k3s/kyber-host-health.sh'
+SCRIPT="$PWD/config/k3s/kyber-host-health.sh"
+
+It 'alerts before a disk exhausts its rated write endurance'
+When run bash -c "grep -q 'check_disk_wear' '$SCRIPT' && grep -q 'DISK_WEAR_WARNING_PERCENT=10' '$SCRIPT'"
+The status should be success
+End
+
+It 'reads remaining endurance from Wear_Leveling_Count'
+When run grep 'Wear_Leveling_Count' "$SCRIPT"
+The output should include 'Wear_Leveling_Count'
+End
+
+It 'rate-limits the SMART probe away from the one-minute timer'
+When run grep 'DISK_WEAR_CHECK_INTERVAL_SECONDS' "$SCRIPT"
+The output should include '21600'
+End
+
+It 'runs the wear check as part of main'
+When run bash -c "awk '/^main\(\)/,/^}/' '$SCRIPT' | grep -q check_disk_wear"
+The status should be success
+End
+End


### PR DESCRIPTION
## Summary

Kyber's root disk carries `/`, `/nix`, `/tmp`, `/home`, the k3s server DB and every local-path PV behind a single ext4 journal, and that journal is the point every writer serializes on. Measured on the host: root disk 93% utilized, 37 ms average write latency, 157 ms flush latency, average queue depth ~20, roughly 16 MB/s of capacity against 23.5 MB/s of demand. The second disk sits at 3% utilization and 2.9 ms.

#2484 gave that disk a scheduler that honours `IOWeight`. This follows it with the one writer that can leave the disks entirely, plus the monitoring that should have been warning all along.

### `/tmp` on tmpfs

Build and test scratch never needs to survive a reboot, so it does not belong on a journal that k3s is waiting behind. The unit is enabled **without** `--now`: mounting tmpfs over a populated `/tmp` would hide files that running processes still hold open, so it takes effect on the next boot. `size=32G` is a ceiling against a runaway job rather than a reservation - tmpfs allocates on demand and the host has 125 GiB of RAM.

### Disk wear alerting

Both disks are Samsung 860 QVO at 57,652 power-on hours (~6.6 years). Self-assessment passes on both, 0 reallocated sectors, 0 CRC errors. `Wear_Leveling_Count` tells a different story:

| Disk | `Wear_Leveling_Count` (normalized) | `Total_LBAs_Written` | Written | Rated | Consumed |
| --- | --- | --- | --- | --- | --- |
| `sda` | **001** | 641,788,298,215 | ~328 TB | 360 TBW | **~91%** |
| `sdb` | 066 | 230,777,738,621 | ~118 TB | 360 TBW | ~33% |

`smartd`'s `-f` only alerts once a pre-fail attribute reaches its vendor threshold, which for this attribute is zero. That is *after* the rated endurance is spent and far too late to schedule a replacement, which is why the host has never warned that `sda` has roughly 1% of its write endurance left. The health check now reads the attribute directly and alerts below 10%, at most once every six hours.

Activation also links `smartctl` into `/usr/local/bin`. `smartd` runs from an absolute store path and sudo's `secure_path` covers `/usr/local/bin` but never `/nix/store`, so the CLI was unreachable for ad-hoc use - `sudo smartctl --scan-open`, which `named-hosts/kyber/README.md` documents, does not currently work.

## Consequence for follow-up work

`sda` being nearly out of endurance rules out the obvious next step of moving write-heavy state (Loki, etcd, `/nix`) onto the idle disk. Loki alone sustains ~3 MB/s, which is ~94 TB/year against roughly 31 TB of remaining rated endurance; relieving the busy disk that way would spend what is left of the worn one within months. New hardware is the durable fix. This buys time.

## Testing

- `shellspec spec/activate_kyber_spec.sh` - 51 examples, 0 failures
- `make shell-test`, `make shell-check`, `make shell-inline-check`
- `make nix-format-check`, `make nix-lint`

`/tmp` needs a reboot to take effect.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves /tmp to tmpfs and adds proactive disk-wear alerting on Kyber to reduce contention on the root ext4 journal and warn before SSD endurance is exhausted. Previously /tmp writes hit the root disk and SMART alerts fired only at vendor thresholds; now /tmp is RAM-backed after reboot and health checks alert below 10% remaining endurance, rate-limited.

**Review and rollout**
- Mounts /tmp as tmpfs via systemd `tmp.mount`. Enabled without --now; takes effect on the next reboot. Caps size at 32G and keeps mode=1777, nosuid, nodev.
- Adds a host-health check that reads SMART Wear_Leveling_Count and alerts at 10% or less remaining, at most once every 6 hours; per-disk alert keys.
- Makes `smartctl` available on the sudo path by symlinking into `/usr/local/bin`; includes `smartmontools` in the k3s environment.
- Updates activation and tests to cover the mount unit, alert threshold, and rate limit.
- Action required: reboot Kyber when convenient to move /tmp onto tmpfs.

<sup>Written for commit 6ea7c1d026b43b48a8e4f450eaca703a656a4a02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

