### PR TITLE
fix(beads): sync Linear against the software Beads repo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,8 @@ ROBOREV_CI_REPOS=org/repo1,org/repo2
 # Settings → Security → Personal API keys. Team id is public and also set in Nix.
 LINEAR_API_KEY=lin_api_your-key-here
 LINEAR_TEAM_ID=679ab4ed-3df3-458d-8574-4962f3ebbf31
+# Beads repo for launchd Linear sync. Must be shunkakinokisoftware Beads, not ~/dotfiles.
+BEADS_LINEAR_SYNC_REPO=$HOME/ghq/github.com/shunkakinokisoftware/shunkakinokisoftware
 
 # Per-host codex profile (fleet policy 2026-08-23): codex auth.json is host-shared,
 # so each machine must stay on ONE account to avoid mixing refresh-token lineages

--- a/.env.example
+++ b/.env.example
@@ -33,8 +33,8 @@ ROBOREV_CI_REPOS=org/repo1,org/repo2
 # Settings → Security → Personal API keys. Team id is public and also set in Nix.
 LINEAR_API_KEY=lin_api_your-key-here
 LINEAR_TEAM_ID=679ab4ed-3df3-458d-8574-4962f3ebbf31
-# Beads repo for launchd Linear sync. Must be shunkakinokisoftware Beads, not ~/dotfiles.
-BEADS_LINEAR_SYNC_REPO=$HOME/ghq/github.com/shunkakinokisoftware/shunkakinokisoftware
+# Beads repos for launchd Linear sync.
+BEADS_LINEAR_SYNC_REPO=org/repo1,org/repo2
 
 # Per-host codex profile (fleet policy 2026-08-23): codex auth.json is host-shared,
 # so each machine must stay on ONE account to avoid mixing refresh-token lineages

--- a/home-manager/services/dolt/linear-sync.sh
+++ b/home-manager/services/dolt/linear-sync.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 
 bd_cli="@bd@"
 linear_cli="@linear@"
-repo_dir="@repoDir@"
+default_repo_dir="@repoDir@"
+repo_dir="$default_repo_dir"
 linear_workspace="@linearWorkspace@"
 linear_team_id="@linearTeamId@"
 linear_credentials_file="${XDG_CONFIG_HOME:-$HOME/.config}/linear/credentials.toml"
@@ -63,15 +64,32 @@ run_linear() {
 }
 
 # Prefer the machine-local dotfiles .env (same convention as other launchd
-# services) before the Linear CLI credential file or keyring.
-if [ -z "${LINEAR_API_KEY:-}" ]; then
-  env_file="${DOTFILES_ENV_FILE:-$HOME/dotfiles/.env}"
-  if [ -f "$env_file" ]; then
-    set -a
-    # shellcheck source=/dev/null
-    . "$env_file"
-    set +a
-  fi
+# services) before the Linear CLI credential file or keyring. Keep already
+# exported Linear/Beads values ahead of the file.
+preset_api_key="${LINEAR_API_KEY:-}"
+preset_repo_dir="${BEADS_LINEAR_SYNC_REPO:-}"
+env_file="${DOTFILES_ENV_FILE:-$HOME/dotfiles/.env}"
+if [ -f "$env_file" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$env_file"
+  set +a
+fi
+if [ -n "$preset_api_key" ]; then
+  LINEAR_API_KEY="$preset_api_key"
+fi
+if [ -n "$preset_repo_dir" ]; then
+  BEADS_LINEAR_SYNC_REPO="$preset_repo_dir"
+fi
+
+repo_dir="${BEADS_LINEAR_SYNC_REPO:-$default_repo_dir}"
+if [ ! -d "$repo_dir/.beads" ]; then
+  log "Not a Beads repo: $repo_dir"
+  exit 1
+fi
+if [ "$repo_dir" != "$default_repo_dir" ]; then
+  repo_slug="${repo_dir##*/}"
+  sync_checkpoint_file="$sync_state_dir/last-success-$repo_slug"
 fi
 
 if [ -z "${LINEAR_API_KEY:-}" ] && [ -f "$linear_credentials_file" ] && [ ! -L "$linear_credentials_file" ]; then

--- a/spec/beads_linear_sync_spec.sh
+++ b/spec/beads_linear_sync_spec.sh
@@ -36,6 +36,21 @@ When run bash -c "grep -F 'DOTFILES_ENV_FILE:-\$HOME/dotfiles/.env' '$SCRIPT' >/
 The status should be success
 End
 
+It 'takes the Beads repo from the env file with the built-in path as fallback'
+When run bash -c "grep -F 'BEADS_LINEAR_SYNC_REPO:-\$default_repo_dir' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
+It 'keeps an already-exported credential and repo ahead of the env file'
+When run bash -c "grep -F 'preset_api_key=' '$SCRIPT' >/dev/null && grep -F 'preset_repo_dir=' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
+It 'scopes the success watermark per repo'
+When run bash -c "grep -F 'last-success-\$repo_slug' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
 It 'invokes jq through the Nix package binary path'
 When run bash -c "grep -F '@jq@/bin/jq' '$SCRIPT' >/dev/null"
 The status should be success
@@ -94,7 +109,7 @@ setup_reconciliation() {
   STATE_HOME="$TEST_ROOT/state"
   COREUTILS="$TEST_ROOT/coreutils"
   jq_prefix=$(dirname "$(dirname "$(command -v jq)")")
-  mkdir -p "$COREUTILS/bin"
+  mkdir -p "$COREUTILS/bin" "$TEST_ROOT/.beads"
   for command in chmod date env mkdir mv sleep timeout; do
     ln -s "$(command -v "$command")" "$COREUTILS/bin/$command"
   done
@@ -217,6 +232,31 @@ When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MOD
 The status should equal 42
 The output should include 'Pushing changed active Beads'
 The file "$STATE_HOME/beads-linear-sync/last-success" should not be exist
+End
+
+It 'reconciles the repo named in the env file instead of the built-in default'
+mkdir -p "$TEST_ROOT/other/.beads"
+printf '%s\n' "BEADS_LINEAR_SYNC_REPO=$TEST_ROOT/other" >"$TEST_ROOT/dotenv-fixture"
+When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" DOTFILES_ENV_FILE="$TEST_ROOT/dotenv-fixture" XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
+The status should be success
+The output should include 'Pushing changed active Beads'
+The contents of file "$COMMAND_LOG" should include "-C $TEST_ROOT/other"
+End
+
+It 'refuses a repo path that holds no Beads directory'
+printf '%s\n' "BEADS_LINEAR_SYNC_REPO=$TEST_ROOT/missing" >"$TEST_ROOT/dotenv-fixture"
+When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" DOTFILES_ENV_FILE="$TEST_ROOT/dotenv-fixture" XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
+The status should equal 1
+The output should include 'Not a Beads repo'
+End
+
+It 'keeps an exported repo ahead of the env file'
+mkdir -p "$TEST_ROOT/exported/.beads" "$TEST_ROOT/other/.beads"
+printf '%s\n' "BEADS_LINEAR_SYNC_REPO=$TEST_ROOT/other" >"$TEST_ROOT/dotenv-fixture"
+When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" DOTFILES_ENV_FILE="$TEST_ROOT/dotenv-fixture" BEADS_LINEAR_SYNC_REPO="$TEST_ROOT/exported" XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
+The status should be success
+The output should include 'Pushing changed active Beads'
+The contents of file "$COMMAND_LOG" should include "-C $TEST_ROOT/exported"
 End
 End
 


### PR DESCRIPTION
## Summary
- launchd `dolt-linear-sync` now takes `BEADS_LINEAR_SYNC_REPO` from `~/dotfiles/.env` (already set to the software checkout)
- exported env still wins; missing `.beads` fails closed
- per-repo watermark when the override is used

## Test plan
- [x] `shellspec spec/beads_linear_sync_spec.sh` (30 examples)
- [ ] after merge/switch, next 5m run uses `-C` the software repo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the launchd `dolt-linear-sync` job against the shunkakinokisoftware Beads repo instead of `~/dotfiles`, configurable via `BEADS_LINEAR_SYNC_REPO`. Previously it always used the built-in default; now it reads the repo from `~/dotfiles/.env`, preserves exported env values, and fails closed if the target is not a Beads repo.

- Reads `BEADS_LINEAR_SYNC_REPO` from `~/dotfiles/.env`; exported `BEADS_LINEAR_SYNC_REPO` and `LINEAR_API_KEY` take precedence; falls back to the built-in repo when unset.
- Validates the target repo contains `.beads`; otherwise logs and exits 1.
- Scopes the success watermark per repo (`last-success-$repo_slug`) when using a non-default repo.
- Updates `.env.example` and extends tests to cover the new behavior.

**Rollout**
- Set `BEADS_LINEAR_SYNC_REPO=$HOME/ghq/github.com/shunkakinokisoftware/shunkakinokisoftware` in `~/dotfiles/.env` and ensure the repo contains a `.beads` directory.
- No change needed if unset; the next scheduled run continues using the default repo.

<sup>Written for commit dbf28babfecd74ff28a70e2a90ec8947fefa312f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

