### PR TITLE
fix(hermes): survive Kyber reboots

### DIFF
--- a/home-manager/services/hermes/activate.sh
+++ b/home-manager/services/hermes/activate.sh
@@ -5,7 +5,6 @@ set -euo pipefail
 HOME_DIR="$1"
 NPM_BIN="$2"
 
-mkdir -p /tmp/hermes
 mkdir -p "$HOME_DIR/.hermes"
 mkdir -p "$HOME_DIR/.hermes/sessions"
 mkdir -p "$HOME_DIR/.hermes/memories"

--- a/home-manager/services/hermes/default.nix
+++ b/home-manager/services/hermes/default.nix
@@ -46,12 +46,9 @@ lib.mkIf host.isKyber {
         "NPM_CONFIG_INCLUDE=optional"
         "NPM_CONFIG_IGNORE_SCRIPTS=false"
       ];
-      RuntimeDirectory = "hermes";
-      RuntimeDirectoryMode = "0700";
-      RuntimeDirectoryPreserve = "yes";
       WorkingDirectory = "${homeDir}/.hermes";
-      StandardOutput = "append:%t/hermes/hermes-gateway.log";
-      StandardError = "append:%t/hermes/hermes-gateway.log";
+      StandardOutput = "journal";
+      StandardError = "journal";
     };
     Install = {
       WantedBy = [ "default.target" ];
@@ -78,12 +75,9 @@ lib.mkIf host.isKyber {
         "NPM_CONFIG_INCLUDE=optional"
         "NPM_CONFIG_IGNORE_SCRIPTS=false"
       ];
-      RuntimeDirectory = "hermes";
-      RuntimeDirectoryMode = "0700";
-      RuntimeDirectoryPreserve = "yes";
       WorkingDirectory = "${homeDir}/.hermes";
-      StandardOutput = "append:%t/hermes/hermes-dashboard.log";
-      StandardError = "append:%t/hermes/hermes-dashboard.log";
+      StandardOutput = "journal";
+      StandardError = "journal";
     };
     Install = {
       WantedBy = [ "default.target" ];

--- a/home-manager/services/hermes/default.nix
+++ b/home-manager/services/hermes/default.nix
@@ -46,9 +46,12 @@ lib.mkIf host.isKyber {
         "NPM_CONFIG_INCLUDE=optional"
         "NPM_CONFIG_IGNORE_SCRIPTS=false"
       ];
+      RuntimeDirectory = "hermes";
+      RuntimeDirectoryMode = "0700";
+      RuntimeDirectoryPreserve = "yes";
       WorkingDirectory = "${homeDir}/.hermes";
-      StandardOutput = "append:/tmp/hermes/hermes-gateway.log";
-      StandardError = "append:/tmp/hermes/hermes-gateway.log";
+      StandardOutput = "append:%t/hermes/hermes-gateway.log";
+      StandardError = "append:%t/hermes/hermes-gateway.log";
     };
     Install = {
       WantedBy = [ "default.target" ];
@@ -75,9 +78,12 @@ lib.mkIf host.isKyber {
         "NPM_CONFIG_INCLUDE=optional"
         "NPM_CONFIG_IGNORE_SCRIPTS=false"
       ];
+      RuntimeDirectory = "hermes";
+      RuntimeDirectoryMode = "0700";
+      RuntimeDirectoryPreserve = "yes";
       WorkingDirectory = "${homeDir}/.hermes";
-      StandardOutput = "append:/tmp/hermes/hermes-dashboard.log";
-      StandardError = "append:/tmp/hermes/hermes-dashboard.log";
+      StandardOutput = "append:%t/hermes/hermes-dashboard.log";
+      StandardError = "append:%t/hermes/hermes-dashboard.log";
     };
     Install = {
       WantedBy = [ "default.target" ];

--- a/spec/activate_openclaw_hermes_spec.sh
+++ b/spec/activate_openclaw_hermes_spec.sh
@@ -114,12 +114,11 @@ When run bash -c "sed -n '/systemd.user.services.hermes-dashboard =/,/Install = 
 The output should include 'X-SwitchMethod = "restart";'
 End
 
-It 'provisions Hermes log storage before either service starts'
-When run bash -c "units=\$(sed -n '/systemd.user.services.hermes-gateway =/,/Install = {/p; /systemd.user.services.hermes-dashboard =/,/Install = {/p' '$PWD/home-manager/services/hermes/default.nix'); test \"\$(printf '%s' \"\$units\" | grep -cF 'RuntimeDirectory = \"hermes\";')\" -eq 2 && test \"\$(printf '%s' \"\$units\" | grep -cF 'RuntimeDirectoryMode = \"0700\";')\" -eq 2 && test \"\$(printf '%s' \"\$units\" | grep -cF 'RuntimeDirectoryPreserve = \"yes\";')\" -eq 2; printf '%s' \"\$units\""
+It 'routes Hermes logs through systemd without a filesystem prerequisite'
+When run bash -c "units=\$(sed -n '/systemd.user.services.hermes-gateway =/,/Install = {/p; /systemd.user.services.hermes-dashboard =/,/Install = {/p' '$PWD/home-manager/services/hermes/default.nix'); test \"\$(printf '%s' \"\$units\" | grep -cF 'StandardOutput = \"journal\";')\" -eq 2 && test \"\$(printf '%s' \"\$units\" | grep -cF 'StandardError = \"journal\";')\" -eq 2; printf '%s' \"\$units\""
 The status should be success
-The output should include 'append:%t/hermes/hermes-gateway.log'
-The output should include 'append:%t/hermes/hermes-dashboard.log'
-The output should not include 'append:/tmp/hermes/'
+The output should not include 'append:'
+The output should not include '/tmp/hermes/'
 End
 
 # The bridge moved from an inline socat invocation to nginx in #2302/#2306, so

--- a/spec/activate_openclaw_hermes_spec.sh
+++ b/spec/activate_openclaw_hermes_spec.sh
@@ -67,9 +67,9 @@ When run bash -c "head -1 '$SCRIPT'"
 The output should include '#!/usr/bin/env bash'
 End
 
-It 'creates /tmp/hermes'
+It 'does not depend on an activation-created temporary log directory'
 When run bash -c "grep '/tmp/hermes' '$SCRIPT'"
-The output should include '/tmp/hermes'
+The status should be failure
 End
 
 It 'creates .hermes directory'
@@ -112,6 +112,14 @@ End
 It 'restarts the dashboard when Home Manager changes the unit'
 When run bash -c "sed -n '/systemd.user.services.hermes-dashboard =/,/Install = {/p' '$PWD/home-manager/services/hermes/default.nix' | grep -F 'X-SwitchMethod = \"restart\";'"
 The output should include 'X-SwitchMethod = "restart";'
+End
+
+It 'provisions Hermes log storage before either service starts'
+When run bash -c "units=\$(sed -n '/systemd.user.services.hermes-gateway =/,/Install = {/p; /systemd.user.services.hermes-dashboard =/,/Install = {/p' '$PWD/home-manager/services/hermes/default.nix'); test \"\$(printf '%s' \"\$units\" | grep -cF 'RuntimeDirectory = \"hermes\";')\" -eq 2 && test \"\$(printf '%s' \"\$units\" | grep -cF 'RuntimeDirectoryMode = \"0700\";')\" -eq 2 && test \"\$(printf '%s' \"\$units\" | grep -cF 'RuntimeDirectoryPreserve = \"yes\";')\" -eq 2; printf '%s' \"\$units\""
+The status should be success
+The output should include 'append:%t/hermes/hermes-gateway.log'
+The output should include 'append:%t/hermes/hermes-dashboard.log'
+The output should not include 'append:/tmp/hermes/'
 End
 
 # The bridge moved from an inline socat invocation to nginx in #2302/#2306, so


### PR DESCRIPTION
## Summary
- stop depending on activation-created `/tmp/hermes` for service stdout
- route Hermes gateway and dashboard logs through journald
- add regression coverage for boot-safe logging

## Verification
- `shellspec spec/activate_openclaw_hermes_spec.sh`
- `make nix-format-check`
- `shellcheck home-manager/services/hermes/activate.sh`
- Kyber `make build HOST=kyber`
- live gateway/dashboard/proxy active; ports 9119/9120 return HTTP 200

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Hermes gateway and dashboard logs to journald and removes the activation-created /tmp/hermes dependency so services survive Kyber reboots. Previously both units appended to /tmp/hermes/*.log; now they write to journald, and activation no longer creates /tmp/hermes.

- Review notes
  - `home-manager/services/hermes/default.nix`: sets StandardOutput/StandardError to "journal" for gateway and dashboard; removes file append targets.
  - `home-manager/services/hermes/activate.sh`: drops mkdir for /tmp/hermes; spec updated to assert journald usage and no /tmp reliance.

- Migration
  - Update any log tailing or collectors to use `journalctl` instead of files under /tmp/hermes (e.g., `journalctl --user -u hermes-gateway -f` and `journalctl --user -u hermes-dashboard -f`).
  - Remove any references to /tmp/hermes/*.log in monitoring or log shipping configs. No config changes required for `systemd` units.

<sup>Written for commit d8cf505cc276c02e9b9a997b24dc23bfce742625. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

