### PR TITLE
fix(beads): scope Linear sync by repository

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,9 @@ ROBOREV_CI_REPOS=org/repo1,org/repo2
 # Settings → Security → Personal API keys. Team id is public and also set in Nix.
 LINEAR_API_KEY=lin_api_your-key-here
 LINEAR_TEAM_ID=679ab4ed-3df3-458d-8574-4962f3ebbf31
+# Comma-separated org/repo identifiers whose Beads databases are synchronized.
+# Keep checkout paths and real repository scope in the untracked local dotenv.
+BEADS_LINEAR_SYNC_REPOS=org/repo1,org/repo2
 
 # Per-host codex profile (fleet policy 2026-08-23): codex auth.json is host-shared,
 # so each machine must stay on ONE account to avoid mixing refresh-token lineages
@@ -43,4 +46,3 @@ LINEAR_TEAM_ID=679ab4ed-3df3-458d-8574-4962f3ebbf31
 #   matic     = shunkakinoki@shunkakinoki.com
 #   galactica = shunkakinoki@gmail.com
 CAAM_CODEX_PROFILE=your-per-host-codex-profile-here
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,14 @@ cp -rf source dest          # NOT: cp -r source dest
 - `apt-get` - use `-y` flag
 - `brew` - use `HOMEBREW_NO_AUTO_UPDATE=1` env var
 
+## Beads–Linear Repository Scope
+
+- Configure the managed service with `BEADS_LINEAR_SYNC_REPOS` in the untracked local dotenv.
+- The value is a comma-separated list of `org/repo` identifiers, never absolute checkout paths.
+- Never record private repository names, identifiers, checkout paths, or references in any tracked file, documentation, fixture, example, log, or generated configuration in this repository.
+- Use generic placeholders such as `org/repo` in tracked content; keep real repository scope only in the untracked local dotenv.
+- Never print, commit, or otherwise expose the local dotenv or its values.
+
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
 ## Beads Issue Tracker
 

--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -34,7 +34,7 @@ let
   linearSyncScript = pkgs.replaceVars ./linear-sync.sh {
     bd = "${homeDir}/.local/bin/bd";
     linear = "${homeDir}/.bun/install/global/node_modules/.bin/linear";
-    inherit repoDir linearWorkspace linearTeamId;
+    inherit linearWorkspace linearTeamId;
     inherit (pkgs) coreutils gawk jq;
   };
 in
@@ -101,7 +101,7 @@ lib.mkIf enabled {
       StartInterval = linearSyncIntervalSeconds;
       ThrottleInterval = linearSyncIntervalSeconds;
       RunAtLoad = true;
-      WorkingDirectory = repoDir;
+      WorkingDirectory = homeDir;
       EnvironmentVariables = {
         HOME = homeDir;
         PATH = linearSyncPath;

--- a/home-manager/services/dolt/linear-sync.sh
+++ b/home-manager/services/dolt/linear-sync.sh
@@ -4,16 +4,96 @@ set -euo pipefail
 
 bd_cli="@bd@"
 linear_cli="@linear@"
-repo_dir="@repoDir@"
 linear_workspace="@linearWorkspace@"
 linear_team_id="@linearTeamId@"
 linear_credentials_file="${XDG_CONFIG_HOME:-$HOME/.config}/linear/credentials.toml"
 sync_state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/beads-linear-sync"
-sync_checkpoint_file="$sync_state_dir/last-success"
 
 log() {
-  printf '[beads-linear-sync] %s\n' "$*"
+  local context=""
+
+  if [ -n "${repo_context:-}" ]; then
+    context="[$repo_context] "
+  fi
+  printf '[beads-linear-sync] %s%s\n' "$context" "$*"
 }
+
+# Repository scope and credentials are machine-local policy. The tracked Nix
+# module never embeds checkout paths or secret dotenv values in the store.
+env_file="${DOTFILES_ENV_FILE:-$HOME/dotfiles/.env}"
+if [ -f "$env_file" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$env_file"
+  set +a
+fi
+
+# The parent process dispatches each org/repo entry through an isolated child
+# so one repository cannot prevent later repositories from being attempted.
+if [ "${1:-}" != "--repo" ]; then
+  configured_repos="${BEADS_LINEAR_SYNC_REPOS:-}"
+  if [ -z "$configured_repos" ]; then
+    log "BEADS_LINEAR_SYNC_REPOS is required in the local dotenv file"
+    exit 1
+  fi
+
+  IFS=',' read -r -a repo_names <<<"$configured_repos"
+  declare -A seen_repo_names=()
+  overall_status=0
+
+  for repo_index in "${!repo_names[@]}"; do
+    configured_repo="${repo_names[$repo_index]}"
+    repo_context="repository $((repo_index + 1))/${#repo_names[@]}"
+    if [ -z "$configured_repo" ]; then
+      log "BEADS_LINEAR_SYNC_REPOS contains an empty repository name"
+      overall_status=1
+      continue
+    fi
+    if [[ ! $configured_repo =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+      log "Invalid org/repo entry in BEADS_LINEAR_SYNC_REPOS"
+      overall_status=1
+      continue
+    fi
+    if [ -n "${seen_repo_names[$configured_repo]:-}" ]; then
+      log "BEADS_LINEAR_SYNC_REPOS contains a duplicate repository entry"
+      overall_status=1
+      continue
+    fi
+    seen_repo_names[$configured_repo]=1
+
+    repo_path="$HOME/ghq/github.com/$configured_repo"
+    if BEADS_LINEAR_SYNC_REPO_DIR="$repo_path" BEADS_LINEAR_SYNC_REPO_NAME="$configured_repo" BEADS_LINEAR_SYNC_REPO_CONTEXT="$repo_context" "$BASH" "$0" --repo; then
+      :
+    else
+      status=$?
+      log "Repository sync failed with status $status"
+      if [ "$overall_status" -eq 0 ]; then
+        overall_status="$status"
+      fi
+    fi
+  done
+
+  exit "$overall_status"
+fi
+
+repo_dir="${BEADS_LINEAR_SYNC_REPO_DIR:-}"
+repo_name="${BEADS_LINEAR_SYNC_REPO_NAME:-}"
+repo_context="${BEADS_LINEAR_SYNC_REPO_CONTEXT:-}"
+if [ -z "$repo_dir" ] || [ -z "$repo_name" ] || [ -z "$repo_context" ]; then
+  log "Internal repository dispatch is incomplete"
+  exit 1
+fi
+
+if [ ! -d "$repo_dir" ] || [ ! -e "$repo_dir/.beads" ]; then
+  log "Configured checkout is not a Beads repository"
+  exit 1
+fi
+
+repo_dir="$(cd "$repo_dir" && pwd -P)"
+repo_slug="$repo_name"
+repo_slug="${repo_slug//\//_}"
+repo_slug="${repo_slug//[^[:alnum:]_.-]/_}"
+sync_checkpoint_file="$sync_state_dir/last-success-$repo_slug"
 
 ensure_config() {
   local key="$1"
@@ -22,7 +102,7 @@ ensure_config() {
 
   actual="$("$bd_cli" -C "$repo_dir" config get "$key" 2>/dev/null || true)"
   if [ "$actual" != "$expected" ]; then
-    "$bd_cli" -C "$repo_dir" config set "$key" "$expected"
+    "$bd_cli" -C "$repo_dir" config set "$key" "$expected" >/dev/null 2>&1
   fi
 }
 
@@ -49,10 +129,6 @@ run_linear() {
   status=$?
   set -e
 
-  if [ -n "$output" ]; then
-    printf '%s\n' "$output"
-  fi
-
   # bd may return zero after individual API operations were rejected. Treat
   # its circuit-breaker warning as a deferred run regardless of exit status.
   if [[ $output == *"rate limit circuit breaker"* ]]; then
@@ -62,17 +138,19 @@ run_linear() {
   return "$status"
 }
 
-# Prefer the machine-local dotfiles .env (same convention as other launchd
-# services) before the Linear CLI credential file or keyring.
-if [ -z "${LINEAR_API_KEY:-}" ]; then
-  env_file="${DOTFILES_ENV_FILE:-$HOME/dotfiles/.env}"
-  if [ -f "$env_file" ]; then
-    set -a
-    # shellcheck source=/dev/null
-    . "$env_file"
-    set +a
+federate_beads() {
+  local phase="$1"
+  local status
+
+  set +e
+  @coreutils@/bin/timeout 30 "$bd_cli" -C "$repo_dir" sync --yes >/dev/null 2>&1
+  status=$?
+  set -e
+
+  if [ "$status" -ne 0 ]; then
+    log "Dolt $phase federation failed with status $status; continuing with local Beads state"
   fi
-fi
+}
 
 if [ -z "${LINEAR_API_KEY:-}" ] && [ -f "$linear_credentials_file" ] && [ ! -L "$linear_credentials_file" ]; then
   @coreutils@/bin/chmod 600 "$linear_credentials_file"
@@ -117,11 +195,11 @@ ensure_config linear.state_map.duplicate closed
 ensure_config linear.outbound_state_map.open Todo
 ensure_config linear.outbound_state_map.in_progress "In Progress"
 ensure_config linear.outbound_state_map.closed Done
-"$bd_cli" -C "$repo_dir" dolt commit -m "chore(beads): configure Linear sync"
+"$bd_cli" -C "$repo_dir" dolt commit -m "chore(beads): configure Linear sync" >/dev/null 2>&1
 
-# Pull the Dolt remote first so Linear conflict resolution sees the newest
-# Beads timestamps from every machine.
-"$bd_cli" -C "$repo_dir" sync --yes
+# Prefer the newest federated Beads timestamps, but do not let a damaged backup
+# remote prevent independent Linear reconciliation.
+federate_beads "pre-sync"
 
 if [ -s "$sync_checkpoint_file" ]; then
   previous_sync="$(<"$sync_checkpoint_file")"
@@ -134,7 +212,7 @@ fi
 # rate-limit failure is deferred to the next scheduled run instead of making
 # launchd hot-loop a failed job.
 log "Pulling Linear work if stale"
-if run_linear "$bd_cli" -C "$repo_dir" linear sync \
+if run_linear @coreutils@/bin/timeout 60 "$bd_cli" -C "$repo_dir" linear sync \
   --pull-if-stale \
   --threshold 5m \
   --state all \
@@ -147,8 +225,7 @@ else
     log "Linear pull deferred; the next 300-second run will retry"
     exit 0
   fi
-  log "Linear pull failed with status $status"
-  exit "$status"
+  log "Linear pull failed with status $status; continuing with outbound Beads reconciliation"
 fi
 
 all_issues="$("$bd_cli" -C "$repo_dir" list --all --json --limit 0 --skip-labels)"
@@ -172,27 +249,40 @@ changed_ids="$(@jq@/bin/jq -r --arg previous_sync "$previous_sync" '
   | join(",")
 ' <<<"$all_issues")"
 
-# Push only the active local delta since the previous successful pull. The
-# first successful run seeds all active work; steady-state runs remain small.
+# Push only the active local delta since the previous successful pull. Bound
+# each batch so a large first run makes durable progress without pinning the
+# recurring service on one API call.
 if [ -n "$changed_ids" ]; then
-  log "Pushing changed active Beads"
-  if run_linear "$bd_cli" -C "$repo_dir" linear sync --push --issues "$changed_ids" --no-wait; then
-    :
-  else
-    status=$?
-    if [ "$status" -eq 75 ]; then
-      log "Linear push deferred; the next 300-second run will retry"
-      exit 0
+  push_batch_size=10
+  IFS=',' read -r -a changed_id_array <<<"$changed_ids"
+  push_batch_count=$(((${#changed_id_array[@]} + push_batch_size - 1) / push_batch_size))
+
+  for ((batch_start = 0; batch_start < ${#changed_id_array[@]}; batch_start += push_batch_size)); do
+    batch_number=$((batch_start / push_batch_size + 1))
+    batch_ids="$(
+      IFS=,
+      printf '%s' "${changed_id_array[*]:batch_start:push_batch_size}"
+    )"
+    log "Pushing changed active Beads batch $batch_number/$push_batch_count"
+
+    if run_linear @coreutils@/bin/timeout 120 "$bd_cli" -C "$repo_dir" linear sync --push --issues "$batch_ids" --no-wait; then
+      :
+    else
+      status=$?
+      if [ "$status" -eq 75 ]; then
+        log "Linear push deferred; the next 300-second run will retry"
+        exit 0
+      fi
+      log "Linear push failed with status $status"
+      exit "$status"
     fi
-    log "Linear push failed with status $status"
-    exit "$status"
-  fi
+  done
 else
   log "No changed active Beads to push"
 fi
 
-"$bd_cli" -C "$repo_dir" dolt commit -m "chore(beads): sync Linear"
-"$bd_cli" -C "$repo_dir" sync --yes
+"$bd_cli" -C "$repo_dir" dolt commit -m "chore(beads): sync Linear" >/dev/null 2>&1
+federate_beads "post-sync"
 
 printf '%s\n' "$cycle_started" >"$sync_checkpoint_file.tmp"
 @coreutils@/bin/mv -f "$sync_checkpoint_file.tmp" "$sync_checkpoint_file"

--- a/spec/beads_linear_sync_spec.sh
+++ b/spec/beads_linear_sync_spec.sh
@@ -36,6 +36,31 @@ When run bash -c "grep -F 'DOTFILES_ENV_FILE:-\$HOME/dotfiles/.env' '$SCRIPT' >/
 The status should be success
 End
 
+It 'requires a comma-separated org/repo list from the local dotenv file'
+When run bash -c "grep -F 'configured_repos=\"\${BEADS_LINEAR_SYNC_REPOS:-}\"' '$SCRIPT' >/dev/null && grep -F \"IFS=',' read -r -a repo_names\" '$SCRIPT' >/dev/null"
+The status should be success
+End
+
+It 'dispatches each repository through an isolated child run'
+When run bash -c "grep -F 'BEADS_LINEAR_SYNC_REPO_DIR=\"\$repo_path\" BEADS_LINEAR_SYNC_REPO_NAME=\"\$configured_repo\" BEADS_LINEAR_SYNC_REPO_CONTEXT=\"\$repo_context\" \"\$BASH\" \"\$0\" --repo' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
+It 'does not print configured repository identifiers or command output'
+When run bash -c "grep -F 'context=\"[\$repo_context] \"' '$SCRIPT' >/dev/null && ! grep -F 'context=\"[\$repo_name] \"' '$SCRIPT' >/dev/null && ! grep -F 'printf '\''%s\\n'\'' \"\$output\"' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
+It 'does not retain a Nix-substituted repository fallback'
+When run grep -F '@repoDir@' "$SCRIPT"
+The status should be failure
+End
+
+It 'uses an org/repo-specific checkpoint'
+When run bash -c "grep -F 'last-success-\$repo_slug' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
 It 'invokes jq through the Nix package binary path'
 When run bash -c "grep -F '@jq@/bin/jq' '$SCRIPT' >/dev/null"
 The status should be success
@@ -54,7 +79,7 @@ The status should be success
 End
 
 It 'pushes only changed active Beads'
-When run bash -c "grep -F '.updated_at >= \$previous_sync' '$SCRIPT' >/dev/null && grep -F 'linear sync --push --issues \"\$changed_ids\" --no-wait' '$SCRIPT' >/dev/null"
+When run bash -c "grep -F '.updated_at >= \$previous_sync' '$SCRIPT' >/dev/null && grep -F 'linear sync --push --issues \"\$batch_ids\" --no-wait' '$SCRIPT' >/dev/null"
 The status should be success
 End
 
@@ -63,23 +88,28 @@ When run bash -c "test \"\$(grep -c 'next 300-second run will retry' '$SCRIPT')\
 The status should be success
 End
 
-It 'propagates non-rate-limit pull and push failures'
-When run bash -c "test \"\$(grep -c 'failed with status \$status' '$SCRIPT')\" -eq 2 && test \"\$(grep -c 'exit \"\$status\"' '$SCRIPT')\" -eq 2"
+It 'continues after pull failures but propagates push failures'
+When run bash -c "grep -F 'continuing with outbound Beads reconciliation' '$SCRIPT' >/dev/null && grep -F 'log \"Linear push failed with status \$status\"' '$SCRIPT' >/dev/null && test \"\$(grep -c 'exit \"\$status\"' '$SCRIPT')\" -eq 1"
+The status should be success
+End
+
+It 'bounds federation, inbound pull, and small outbound batches'
+When run bash -c "grep -F '@coreutils@/bin/timeout 30 \"\$bd_cli\" -C \"\$repo_dir\" sync --yes' '$SCRIPT' >/dev/null && grep -F 'run_linear @coreutils@/bin/timeout 60 \"\$bd_cli\"' '$SCRIPT' >/dev/null && grep -F 'push_batch_size=10' '$SCRIPT' >/dev/null && grep -F 'run_linear @coreutils@/bin/timeout 120 \"\$bd_cli\"' '$SCRIPT' >/dev/null"
 The status should be success
 End
 
 It 'checkpoints a successful cycle for delta selection'
-When run bash -c "checkpoint=\$(grep -n '\"\$cycle_started\" >\"\$sync_checkpoint_file.tmp\"' '$SCRIPT' | cut -d: -f1); final_sync=\$(grep -n 'sync --yes' '$SCRIPT' | tail -1 | cut -d: -f1); test \"\$checkpoint\" -gt \"\$final_sync\""
+When run bash -c "checkpoint=\$(grep -n '\"\$cycle_started\" >\"\$sync_checkpoint_file.tmp\"' '$SCRIPT' | cut -d: -f1); final_sync=\$(grep -n 'federate_beads \"post-sync\"' '$SCRIPT' | cut -d: -f1); test \"\$checkpoint\" -gt \"\$final_sync\""
 The status should be success
 End
 
 It 'federates Beads before and after Linear reconciliation'
-When run bash -c "test \"\$(grep -c 'sync --yes' '$SCRIPT')\" -eq 2"
+When run bash -c "test \"\$(grep -c '^federate_beads \"' '$SCRIPT')\" -eq 2 && grep -F 'federate_beads \"pre-sync\"' '$SCRIPT' >/dev/null && grep -F 'federate_beads \"post-sync\"' '$SCRIPT' >/dev/null"
 The status should be success
 End
 
 It 'commits internal Linear config before the first federation pull'
-When run bash -c "config_commit=\$(grep -n 'configure Linear sync' '$SCRIPT' | cut -d: -f1); first_pull=\$(grep -n 'sync --yes' '$SCRIPT' | head -1 | cut -d: -f1); test \"\$config_commit\" -lt \"\$first_pull\""
+When run bash -c "config_commit=\$(grep -n 'configure Linear sync' '$SCRIPT' | cut -d: -f1); first_pull=\$(grep -n 'federate_beads \"pre-sync\"' '$SCRIPT' | cut -d: -f1); test \"\$config_commit\" -lt \"\$first_pull\""
 The status should be success
 End
 End
@@ -92,9 +122,18 @@ setup_reconciliation() {
   COMMAND_LOG="$TEST_ROOT/commands.log"
   SYNC_COUNT="$TEST_ROOT/sync-count"
   STATE_HOME="$TEST_ROOT/state"
+  ENV_FILE="$TEST_ROOT/dotenv"
   COREUTILS="$TEST_ROOT/coreutils"
+  TEST_REPO_ID="test/repo-one"
+  TEST_REPO="$TEST_ROOT/ghq/github.com/$TEST_REPO_ID"
   jq_prefix=$(dirname "$(dirname "$(command -v jq)")")
-  mkdir -p "$COREUTILS/bin"
+  mkdir -p "$COREUTILS/bin" "$TEST_REPO/.beads"
+  printf 'BEADS_LINEAR_SYNC_REPOS=%q\n' "$TEST_REPO_ID" >"$ENV_FILE"
+  canonical_test_repo="$(cd "$TEST_REPO" && pwd -P)"
+  repo_slug="${TEST_REPO_ID//\//_}"
+  repo_slug="${repo_slug//[^[:alnum:]_.-]/_}"
+  CHECKPOINT_FILE="$STATE_HOME/beads-linear-sync/last-success-$repo_slug"
+  export DOTFILES_ENV_FILE="$ENV_FILE"
   for command in chmod date env mkdir mv sleep timeout; do
     ln -s "$(command -v "$command")" "$COREUTILS/bin/$command"
   done
@@ -125,6 +164,9 @@ case "${1:-} ${2:-}" in
     if [ "${FAKE_LINEAR_MODE:-}" = "final-failure" ] && [ "$count" -eq 2 ]; then
       exit 42
     fi
+    if [ "${FAKE_LINEAR_MODE:-}" = "initial-federation-failure" ] && [ "$count" -eq 1 ]; then
+      exit 41
+    fi
     ;;
   "linear status")
     printf '%s\n' '{"last_sync":""}'
@@ -136,6 +178,11 @@ case "${1:-} ${2:-}" in
         ;;
       hard-failure)
         exit 23
+        ;;
+      pull-failure)
+        if [[ " $* " != *" --push "* ]]; then
+          exit 23
+        fi
         ;;
       push-failure)
         if [[ " $* " == *" --push "* ]]; then
@@ -157,7 +204,6 @@ EOF
   sed \
     -e "s|@bd@|$FAKE_BD|g" \
     -e 's|@linear@|/usr/bin/false|g' \
-    -e "s|@repoDir@|$TEST_ROOT|g" \
     -e 's|@linearWorkspace@|test-workspace|g' \
     -e 's|@linearTeamId@|test-team|g' \
     -e "s|@coreutils@|$COREUTILS|g" \
@@ -167,6 +213,7 @@ EOF
 }
 
 cleanup_reconciliation() {
+  unset DOTFILES_ENV_FILE
   rm -rf "$TEST_ROOT"
 }
 
@@ -177,46 +224,120 @@ It 'runs both federations around pull and delta push before checkpointing'
 When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
 The status should be success
 The output should include 'Pushing changed active Beads'
-The file "$STATE_HOME/beads-linear-sync/last-success" should be exist
+The file "$CHECKPOINT_FILE" should be exist
 The contents of file "$COMMAND_LOG" should include 'linear sync --pull-if-stale --threshold 5m --state all --relations --no-wait'
 The contents of file "$COMMAND_LOG" should include 'linear sync --push --issues df-test --no-wait'
+End
+
+It 'splits a large outbound delta into bounded batches'
+batch_json="$(jq -nc '[range(1;13) | {id:("df-" + tostring),status:"open",updated_at:"2099-01-01T00:00:00Z"}]')"
+When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LIST_JSON="$batch_json" XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
+The status should be success
+The output should include 'batch 1/2'
+The output should include 'batch 2/2'
+The contents of file "$COMMAND_LOG" should include 'linear sync --push --issues df-1,df-2,df-3,df-4,df-5,df-6,df-7,df-8,df-9,df-10 --no-wait'
+The contents of file "$COMMAND_LOG" should include 'linear sync --push --issues df-11,df-12 --no-wait'
 End
 
 It 'defers a Linear rate limit without advancing the checkpoint'
 When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MODE=rate-limit XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
 The status should be success
 The output should include 'next 300-second run will retry'
-The file "$STATE_HOME/beads-linear-sync/last-success" should not be exist
+The file "$CHECKPOINT_FILE" should not be exist
 End
 
-It 'propagates an ordinary Linear failure without advancing the checkpoint'
-When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MODE=hard-failure XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
-The status should equal 23
-The output should include 'Linear pull failed with status 23'
-The file "$STATE_HOME/beads-linear-sync/last-success" should not be exist
+It 'continues outbound reconciliation after an ordinary Linear pull failure'
+When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MODE=pull-failure XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
+The status should be success
+The output should include 'Linear pull failed with status 23; continuing with outbound Beads reconciliation'
+The output should include 'Pushing changed active Beads'
+The file "$CHECKPOINT_FILE" should be exist
 End
 
 It 'propagates a Linear push failure without advancing the checkpoint'
 When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MODE=push-failure XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
 The status should equal 24
 The output should include 'Linear push failed with status 24'
-The file "$STATE_HOME/beads-linear-sync/last-success" should not be exist
+The file "$CHECKPOINT_FILE" should not be exist
 End
 
 It 'pushes a locally closed linked issue from a steady-state delta'
 mkdir -p "$STATE_HOME/beads-linear-sync"
-printf '%s\n' '2026-01-01T00:00:00Z' >"$STATE_HOME/beads-linear-sync/last-success"
+printf '%s\n' '2026-01-01T00:00:00Z' >"$CHECKPOINT_FILE"
 When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LIST_JSON='[{"id":"df-closed","status":"closed","updated_at":"2099-01-01T00:00:00Z","external_ref":"https://linear.app/test/issue/TEST-1/closed"}]' XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
 The status should be success
 The output should include 'Pushing changed active Beads'
 The contents of file "$COMMAND_LOG" should include 'linear sync --push --issues df-closed --no-wait'
 End
 
-It 'does not checkpoint when final federation fails'
+It 'checkpoints Linear progress when final Dolt federation fails'
 When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MODE=final-failure XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
-The status should equal 42
+The status should be success
 The output should include 'Pushing changed active Beads'
-The file "$STATE_HOME/beads-linear-sync/last-success" should not be exist
+The output should include 'Dolt post-sync federation failed with status 42'
+The file "$CHECKPOINT_FILE" should be exist
+End
+
+It 'continues Linear reconciliation when initial Dolt federation fails'
+When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MODE=initial-federation-failure XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
+The status should be success
+The output should include 'Dolt pre-sync federation failed with status 41'
+The output should include 'Pushing changed active Beads'
+The file "$CHECKPOINT_FILE" should be exist
+End
+
+It 'fails closed when the repository list is absent'
+When run env -u BEADS_LINEAR_SYNC_REPOS DOTFILES_ENV_FILE="$TEST_ROOT/missing" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
+The status should equal 1
+The output should include 'BEADS_LINEAR_SYNC_REPOS is required'
+End
+
+It 'rejects an absolute checkout path instead of logging it'
+printf 'BEADS_LINEAR_SYNC_REPOS=%q\n' '/private/checkout' >"$TEST_ROOT/invalid-dotenv"
+When run env DOTFILES_ENV_FILE="$TEST_ROOT/invalid-dotenv" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
+The status should equal 1
+The output should include 'Invalid org/repo entry'
+The output should not include '/private/checkout'
+End
+
+It 'rejects an org/repo checkout that is not a Beads repository'
+printf 'BEADS_LINEAR_SYNC_REPOS=%q\n' 'test/not-beads' >"$TEST_ROOT/invalid-dotenv"
+mkdir -p "$TEST_ROOT/ghq/github.com/test/not-beads"
+When run env DOTFILES_ENV_FILE="$TEST_ROOT/invalid-dotenv" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
+The status should equal 1
+The output should include 'Configured checkout is not a Beads repository'
+The output should not include 'test/not-beads'
+End
+
+It 'syncs comma-separated repositories with distinct checkpoints'
+second_repo_id="test/repo-two"
+second_repo="$TEST_ROOT/ghq/github.com/$second_repo_id"
+mkdir -p "$second_repo/.beads"
+canonical_second_repo="$(cd "$second_repo" && pwd -P)"
+printf 'BEADS_LINEAR_SYNC_REPOS=%q,%q\n' "$TEST_REPO_ID" "$second_repo_id" >"$ENV_FILE"
+second_repo_slug="${second_repo_id//\//_}"
+second_repo_slug="${second_repo_slug//[^[:alnum:]_.-]/_}"
+second_checkpoint="$STATE_HOME/beads-linear-sync/last-success-$second_repo_slug"
+When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
+The status should be success
+The output should include 'repository 1/2'
+The output should include 'repository 2/2'
+The output should not include "$TEST_REPO_ID"
+The output should not include "$second_repo_id"
+The file "$CHECKPOINT_FILE" should be exist
+The file "$second_checkpoint" should be exist
+The contents of file "$COMMAND_LOG" should include "-C $canonical_test_repo"
+The contents of file "$COMMAND_LOG" should include "-C $canonical_second_repo"
+End
+
+It 'continues to the next repository after one repository fails'
+printf 'BEADS_LINEAR_SYNC_REPOS=%q,%q\n' 'test/not-beads' "$TEST_REPO_ID" >"$ENV_FILE"
+When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
+The status should equal 1
+The output should include 'Configured checkout is not a Beads repository'
+The output should not include 'test/not-beads'
+The output should include 'Pushing changed active Beads'
+The file "$CHECKPOINT_FILE" should be exist
 End
 End
 


### PR DESCRIPTION
## Summary

- select one or more Beads repositories from the untracked, comma-separated BEADS_LINEAR_SYNC_REPOS value
- isolate repository runs with separate checkpoints and privacy-safe ordinal logs
- keep Linear reconciliation independent from best-effort Dolt federation and bound outbound work in batches

## Verification

- shellspec spec/beads_linear_sync_spec.sh (37 examples)
- shellspec spec/coverage_spec.sh (113 examples)
- shellcheck home-manager/services/dolt/linear-sync.sh
- make nix-format-check
- make build
- managed launchd cycle completed all 35 batches, exited 0, and wrote its checkpoint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes Beads–Linear sync to specific repositories and removes Nix-coupled paths. Previously one global job ran against a Nix-substituted repo with a single checkpoint; now the service reads a comma-separated `org/repo` list from the local dotenv, runs each repo in isolation with its own checkpoint, and logs without exposing repo names. Outbound pushes are batched and federation/pull/push phases are time-bounded.

- Config: add `BEADS_LINEAR_SYNC_REPOS` to the untracked local dotenv; `.env.example` and `AGENTS.md` document the policy. `home-manager` now runs `linear-sync.sh` from `$HOME` and no longer embeds a repo path.
- Behavior: continue after Linear pull failures; still defer on rate-limit; push failures fail the run. Pre/post Dolt federation is best-effort and does not block Linear progress.
- Privacy: logs include only an ordinal repository context; no repo identifiers or command output are printed.
- Performance/safety: bound federation (30s), inbound pull (60s), and outbound batches of 10 issues (120s per batch); each repo uses `~/.local/state/beads-linear-sync/last-success-<slug>`.

**Rollout**
- Required: set `BEADS_LINEAR_SYNC_REPOS` in the local dotenv (comma-separated `org/repo` values).
- Required: ensure each listed checkout exists at `$HOME/ghq/github.com/<org>/<repo>` and contains a `.beads` directory. Do not commit or print real repo identifiers.

<sup>Written for commit 74f2eb15813c4b5f214ed041f2f73a6a53fc751d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

