### PR TITLE
docs(agents): generalize repository privacy guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,12 +36,11 @@ cp -rf source dest          # NOT: cp -r source dest
 - `apt-get` - use `-y` flag
 - `brew` - use `HOMEBREW_NO_AUTO_UPDATE=1` env var
 
-## Beads–Linear Repository Scope
+## Repository Privacy Guidance
 
-- Configure the managed service with `BEADS_LINEAR_SYNC_REPOS` in the untracked local dotenv.
-- The value is a comma-separated list of `org/repo` identifiers, never absolute checkout paths.
 - Never record private repository names, identifiers, checkout paths, or references in any tracked file, documentation, fixture, example, log, or generated configuration in this repository.
-- Use generic placeholders such as `org/repo` in tracked content; keep real repository scope only in the untracked local dotenv.
+- Use generic placeholders such as `org/repo` in tracked content; keep real repository scope only in untracked, machine-local configuration.
+- Express repository lists as comma-separated `org/repo` identifiers, never absolute checkout paths.
 - Never print, commit, or otherwise expose the local dotenv or its values.
 
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->


### PR DESCRIPTION
## Summary

- replace the service-specific repository scope section with repository-wide privacy guidance
- keep private repository names, identifiers, paths, and references out of all tracked content and generated configuration
- standardize generic org/repo placeholders and machine-local scope ownership

## Verification

- docs-only diff against current main
- git diff --check
- tracked-tree private-scope scan passed
- focused sync specs remain 37/37 from the amended implementation validation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generalizes the service-specific Beads–Linear repository-scope docs into repository-wide privacy guidance to prevent leaking private repository details in tracked content. Old: service-specific instructions tied to sync configuration. New: generalized rules to use `org/repo` placeholders in tracked content, keep real scope in untracked machine-local config, and express repo lists as comma-separated `org/repo` identifiers (not absolute paths).

- Use generic `org/repo` placeholders in tracked files; remove any private repo names/IDs/paths/refs from tracked content.
- Keep real repository scope only in untracked, machine-local configuration; never commit or print the local dotenv or its values.
- When listing repositories in local config, use comma-separated `org/repo` identifiers; do not use absolute checkout paths.

<sup>Written for commit 495b4b08cbb8eb4abb6e659ae6183a887e377cb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

