### PR TITLE
fix(dotenv): export all keys to macOS GUI

### DIFF
--- a/home-manager/modules/dotenv/default.nix
+++ b/home-manager/modules/dotenv/default.nix
@@ -6,16 +6,9 @@
 }:
 let
   inherit (pkgs.stdenv) isDarwin;
-  # Keys handed to GUI apps through launchctl. Every entry becomes readable by
-  # every GUI process in the session, so keep the list to what an app needs.
-  guiEnvKeys = [
-    "AMP_API_KEY"
-    "OPENCODE_API_KEY"
-  ];
   exportGuiEnv = pkgs.replaceVars ./export-gui-env.sh {
     launchctl = "/bin/launchctl";
     printer = "${./print-env-file.sh}";
-    keys = lib.concatStringsSep " " guiEnvKeys;
   };
 in
 {

--- a/home-manager/modules/dotenv/export-gui-env.sh
+++ b/home-manager/modules/dotenv/export-gui-env.sh
@@ -1,35 +1,21 @@
 #!/usr/bin/env bash
-# @launchctl@, @printer@ and @keys@ are substituted by pkgs.replaceVars.
+# @launchctl@ and @printer@ are substituted by pkgs.replaceVars.
 # GUI apps (CodexBar and friends) are started by launchd, not by a shell, so they
 # never see the .env values that _hm_load_env_file exports into fish/bash/zsh.
-# `launchctl setenv` puts them in the GUI session; apps pick them up on next launch.
+# `launchctl setenv` puts every parsed assignment in the GUI session; apps pick
+# them up on next launch. Values are never written to activation output.
 set -euo pipefail
 
 LAUNCHCTL="@launchctl@"
 PRINTER="@printer@"
-KEYS="@keys@"
 
-exported=""
 while IFS= read -r assignment; do
+  [ -n "$assignment" ] || continue
   key="${assignment%%=*}"
-  case " $KEYS " in
-  *" $key "*) ;;
-  *) continue ;;
-  esac
-
   value="${assignment#*=}"
-  [ -n "$value" ] || continue
 
   "$LAUNCHCTL" setenv "$key" "$value"
-  exported="$exported $key"
   echo "Exported $key to the GUI session"
 done <<EOF
 $(sh "$PRINTER")
 EOF
-
-for key in $KEYS; do
-  case " $exported " in
-  *" $key "*) ;;
-  *) echo "Warning: $key is unset in .env, skipping GUI environment export" >&2 ;;
-  esac
-done

--- a/spec/export_gui_env_spec.sh
+++ b/spec/export_gui_env_spec.sh
@@ -30,9 +30,9 @@ When run bash -c "grep '@printer@' '$SCRIPT'"
 The output should include '@printer@'
 End
 
-It 'references @keys@'
-When run bash -c "grep '@keys@' '$SCRIPT'"
-The output should include '@keys@'
+It 'does not contain a static GUI key allowlist'
+When run bash -c "! grep -Eq '@keys@|guiEnvKeys|AMP_API_KEY|OPENCODE_API_KEY' '$SCRIPT' '$PWD/home-manager/modules/dotenv/default.nix'"
+The status should be success
 End
 End
 
@@ -42,7 +42,7 @@ setup() {
   LAUNCHCTL_STUB="$TEST_HOME/launchctl"
   cat >"$LAUNCHCTL_STUB" <<'STUB'
 #!/usr/bin/env bash
-printf '%s\n' "$*" >>"${LAUNCHCTL_LOG}"
+printf '%s %s value=<%s>\n' "$1" "$2" "$3" >>"${LAUNCHCTL_LOG}"
 STUB
   chmod +x "$LAUNCHCTL_STUB"
 
@@ -53,7 +53,6 @@ STUB
   sed \
     -e "s|@launchctl@|$LAUNCHCTL_STUB|g" \
     -e "s|@printer@|$PWD/home-manager/modules/dotenv/print-env-file.sh|g" \
-    -e "s|@keys@|AMP_API_KEY OPENCODE_API_KEY|g" \
     "$SCRIPT" >"$PROCESSED_SCRIPT"
 
   export TEST_HOME LAUNCHCTL_STUB LAUNCHCTL_LOG PROCESSED_SCRIPT
@@ -71,26 +70,36 @@ run_with_env() {
   cat "$LAUNCHCTL_LOG"
 }
 
-It 'exports both allowlisted keys'
+It 'exports every valid assignment emitted by the shared parser'
 When call run_with_env 'AMP_API_KEY=amp-value
-OPENCODE_API_KEY=opencode-value'
-The line 1 of output should equal 'setenv AMP_API_KEY amp-value'
-The line 2 of output should equal 'setenv OPENCODE_API_KEY opencode-value'
+OPENCODE_API_KEY=opencode-value
+CLIPROXY_API_KEY=cliproxy-value'
+The line 1 of output should equal 'setenv AMP_API_KEY value=<amp-value>'
+The line 2 of output should equal 'setenv OPENCODE_API_KEY value=<opencode-value>'
+The line 3 of output should equal 'setenv CLIPROXY_API_KEY value=<cliproxy-value>'
 End
 
-It 'skips keys missing from the env file'
-When call run_with_env 'AMP_API_KEY=amp-value'
-The output should equal 'setenv AMP_API_KEY amp-value'
+It 'exports keys outside the previous allowlist'
+When call run_with_env 'ARBITRARY_GUI_VALUE=available'
+The output should equal 'setenv ARBITRARY_GUI_VALUE value=<available>'
 End
 
-It 'never exports keys outside the allowlist'
-When call run_with_env 'CLIPROXY_API_KEY=secret'
-The output should equal ''
+It 'preserves an explicitly empty value'
+When call run_with_env 'EMPTY_GUI_VALUE='
+The output should equal 'setenv EMPTY_GUI_VALUE value=<>'
 End
 
-It 'warns about a missing key'
-When run bash -c "printf 'AMP_API_KEY=amp-value\n' >'$TEST_HOME/env'; DOTFILES_ENV_FILE='$TEST_HOME/env' HOME='$TEST_HOME' bash '$PROCESSED_SCRIPT' 2>&1 >/dev/null"
-The output should include 'OPENCODE_API_KEY is unset'
+It 'reports the exported key without printing its value'
+When run bash -c "printf '%s\n' 'PRIVATE_GUI_VALUE=do-not-print' >'$TEST_HOME/env'; DOTFILES_ENV_FILE='$TEST_HOME/env' HOME='$TEST_HOME' bash '$PROCESSED_SCRIPT'"
+The output should equal 'Exported PRIVATE_GUI_VALUE to the GUI session'
+The output should not include 'do-not-print'
+End
+
+It 'still excludes invalid keys and comments through the shared parser'
+When call run_with_env 'VALID_GUI_VALUE=yes
+INVALID-GUI-VALUE=no
+# COMMENTED_GUI_VALUE=no'
+The output should equal 'setenv VALID_GUI_VALUE value=<yes>'
 End
 
 It 'succeeds when the env file is absent'


### PR DESCRIPTION
Follow-up to #2480.

Removes the fixed AMP_API_KEY / OPENCODE_API_KEY allowlist and exports every valid assignment emitted by the shared managed dotenv parser into the macOS launchd GUI session. Empty values remain valid; comments and invalid identifiers remain excluded. Activation output reports key names only and never values.

Validation:
- 39 focused ShellSpec examples
- 2,327 full ShellSpec examples
- 464 fishtape tests
- shellcheck
- shell-inline-check
- nix-format-check
- make build HOST=galactica

Bead: shunkakinokisoftware-ux13

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exports all valid `.env` assignments to the macOS GUI session via `launchctl`, replacing the previous fixed allowlist (`AMP_API_KEY`, `OPENCODE_API_KEY`). GUI apps now receive any key parsed by the shared dotenv parser; activation output reports key names only, never values.

- Removes the `guiEnvKeys` allowlist and the missing-key warnings; empty values export as-is, while comments and invalid identifiers remain excluded.
- No change to how shell sessions load `.env`; this only affects the GUI session started by launchd.

**Rollout/Migration**
- Review your `.env` and remove any keys you do not want exposed to all GUI processes; all parsed keys now export to the GUI session.
- Restart affected GUI apps to pick up updated environment variables.

<sup>Written for commit 3a96bfa54a5310740bdc1eefc0f87291f58795e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

