### PR TITLE
fix(beads): make Kyber the sole Linear sync owner

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -692,6 +692,22 @@
         "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
+    "nixpkgs-dolt": {
+      "locked": {
+        "lastModified": 1787394516,
+        "narHash": "sha256-pRGOQSClnXNI2iLUG6DYpsGvYcuw0drOutVZFTJNw90=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c8f90650c15282fa8656a041bfbbd2403997a9a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c8f90650c15282fa8656a041bfbbd2403997a9a7",
+        "type": "github"
+      }
+    },
     "nixpkgs-lib": {
       "locked": {
         "lastModified": 1777168982,
@@ -829,6 +845,7 @@
         "nixpkgs": [
           "nixpkgs-unstable"
         ],
+        "nixpkgs-dolt": "nixpkgs-dolt",
         "nixpkgs-nightly": "nixpkgs-nightly",
         "nixpkgs-stable": "nixpkgs-stable",
         "nixpkgs-unstable": "nixpkgs-unstable",

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,9 @@
     nixpkgs-unstable = {
       url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     };
+    nixpkgs-dolt = {
+      url = "github:NixOS/nixpkgs/c8f90650c15282fa8656a041bfbbd2403997a9a7";
+    };
     nixpkgs-nightly = {
       url = "github:NixOS/nixpkgs/master";
     };

--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 let
-  inherit (inputs.host) isKyber isGalactica;
+  inherit (inputs.host) isGalactica isKyber isMatic;
   homeDir = config.home.homeDirectory;
   repoDir = "${homeDir}/dotfiles";
   legacyBeadsDir = "${repoDir}/.beads";
@@ -20,9 +20,12 @@ let
   linearTeamId = "679ab4ed-3df3-458d-8574-4962f3ebbf31";
   linearSyncIntervalSeconds = 300;
   linearSyncPath = "${homeDir}/.local/bin:${homeDir}/.bun/bin:${homeDir}/.nix-profile/bin:/etc/profiles/per-user/${config.home.username}/bin:/run/current-system/sw/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
-  enabled = isKyber || isGalactica;
-  # 1.86+ adds the git+https:// remote scheme used by the beads_global GitHub backup.
-  doltMinVersion = "1.86";
+  enabled = isGalactica || isKyber || isMatic;
+  linearSyncEnabled = isKyber;
+  federationSyncEnabled = isGalactica || isMatic;
+  # 2.2.2 fixes gitblobstore pending-write pruning that could publish a
+  # manifest whose live archive later failed with "Blob not found".
+  doltMinVersion = "2.2.2";
   startScript = pkgs.replaceVars ./start.sh {
     inherit beadsDir legacyBeadsDir;
     inherit (pkgs) dolt;
@@ -37,12 +40,16 @@ let
     inherit linearWorkspace linearTeamId;
     inherit (pkgs) coreutils gawk jq;
   };
+  federationSyncScript = pkgs.replaceVars ./federation-sync.sh {
+    bd = "${homeDir}/.local/bin/bd";
+    inherit (pkgs) coreutils;
+  };
 in
 lib.mkIf enabled {
   assertions = [
     {
       assertion = lib.versionAtLeast pkgs.dolt.version doltMinVersion;
-      message = "pkgs.dolt is ${pkgs.dolt.version}; needs >= ${doltMinVersion} for git+https push (beads_global GitHub backup). Run 'nix flake update nixpkgs-unstable'.";
+      message = "pkgs.dolt is ${pkgs.dolt.version}; needs >= ${doltMinVersion} for git+https push (beads_global GitHub backup). Update the dedicated nixpkgs-dolt pin.";
     }
   ];
 
@@ -91,7 +98,7 @@ lib.mkIf enabled {
     };
   };
 
-  launchd.agents.dolt-linear-sync = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.dolt-linear-sync = lib.mkIf (pkgs.stdenv.isDarwin && linearSyncEnabled) {
     enable = true;
     config = {
       ProgramArguments = [
@@ -114,6 +121,31 @@ lib.mkIf enabled {
       };
       StandardOutPath = "/tmp/dolt-linear-sync.log";
       StandardErrorPath = "/tmp/dolt-linear-sync.error.log";
+    };
+  };
+
+  launchd.agents.dolt-federation-sync = lib.mkIf (pkgs.stdenv.isDarwin && federationSyncEnabled) {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "${pkgs.bash}/bin/bash"
+        "${federationSyncScript}"
+      ];
+      StartInterval = linearSyncIntervalSeconds;
+      ThrottleInterval = linearSyncIntervalSeconds;
+      RunAtLoad = true;
+      WorkingDirectory = homeDir;
+      EnvironmentVariables = {
+        HOME = homeDir;
+        PATH = linearSyncPath;
+        BEADS_DOLT_SHARED_SERVER = "1";
+        BEADS_DOLT_SERVER_PORT = "3307";
+        BEADS_SHARED_SERVER_DIR = sharedServerDir;
+        DOLT_CLI_USER = "root";
+        DOLT_CLI_PASSWORD = "";
+      };
+      StandardOutPath = "/tmp/dolt-federation-sync.log";
+      StandardErrorPath = "/tmp/dolt-federation-sync.error.log";
     };
   };
 
@@ -158,7 +190,7 @@ lib.mkIf enabled {
     };
   };
 
-  systemd.user.services.dolt-linear-sync = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.dolt-linear-sync = lib.mkIf (pkgs.stdenv.isLinux && linearSyncEnabled) {
     Unit = {
       Description = "Synchronize Beads with Linear";
       X-SwitchMethod = "restart";
@@ -187,7 +219,7 @@ lib.mkIf enabled {
     };
   };
 
-  systemd.user.timers.dolt-linear-sync = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.timers.dolt-linear-sync = lib.mkIf (pkgs.stdenv.isLinux && linearSyncEnabled) {
     Unit.Description = "Periodically synchronize Beads with Linear";
     Timer = {
       OnBootSec = "2min";
@@ -195,6 +227,48 @@ lib.mkIf enabled {
       OnUnitActiveSec = "${toString linearSyncIntervalSeconds}s";
       Persistent = true;
       Unit = "dolt-linear-sync.service";
+    };
+    Install.WantedBy = [ "timers.target" ];
+  };
+
+  systemd.user.services.dolt-federation-sync =
+    lib.mkIf (pkgs.stdenv.isLinux && federationSyncEnabled)
+      {
+        Unit = {
+          Description = "Synchronize Beads with the Dolt remote";
+          X-SwitchMethod = "restart";
+          After = [
+            "dolt.service"
+            "network-online.target"
+          ];
+          Wants = [
+            "dolt.service"
+            "network-online.target"
+          ];
+        };
+        Service = {
+          Type = "oneshot";
+          ExecStart = "${pkgs.bash}/bin/bash ${federationSyncScript}";
+          Environment = [
+            "HOME=${homeDir}"
+            "PATH=${linearSyncPath}"
+            "BEADS_DOLT_SHARED_SERVER=1"
+            "BEADS_DOLT_SERVER_PORT=3307"
+            "BEADS_SHARED_SERVER_DIR=${sharedServerDir}"
+            "DOLT_CLI_USER=root"
+            "DOLT_CLI_PASSWORD="
+          ];
+        };
+      };
+
+  systemd.user.timers.dolt-federation-sync = lib.mkIf (pkgs.stdenv.isLinux && federationSyncEnabled) {
+    Unit.Description = "Periodically synchronize Beads with the Dolt remote";
+    Timer = {
+      OnBootSec = "2min";
+      OnCalendar = "*-*-* *:00/5:00";
+      OnUnitActiveSec = "${toString linearSyncIntervalSeconds}s";
+      Persistent = true;
+      Unit = "dolt-federation-sync.service";
     };
     Install.WantedBy = [ "timers.target" ];
   };

--- a/home-manager/services/dolt/federation-sync.sh
+++ b/home-manager/services/dolt/federation-sync.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+bd_cli="@bd@"
+sync_state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/beads-federation-sync"
+
+log() {
+  local context=""
+
+  if [ -n "${repo_context:-}" ]; then
+    context="[$repo_context] "
+  fi
+  printf '[beads-federation-sync] %s%s\n' "$context" "$*"
+}
+
+# Repository scope is machine-local policy. Keep real org/repo identifiers in
+# the untracked dotenv file, never in the Nix store or tracked configuration.
+env_file="${DOTFILES_ENV_FILE:-$HOME/dotfiles/.env}"
+if [ -f "$env_file" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$env_file"
+  set +a
+fi
+
+if [ "${1:-}" != "--repo" ]; then
+  configured_repos="${BEADS_SYNC_REPOS:-${BEADS_LINEAR_SYNC_REPOS:-}}"
+  if [ -z "$configured_repos" ]; then
+    log "BEADS_SYNC_REPOS is required in the local dotenv file"
+    exit 1
+  fi
+
+  IFS=',' read -r -a repo_names <<<"$configured_repos"
+  declare -A seen_repo_names=()
+  overall_status=0
+
+  for repo_index in "${!repo_names[@]}"; do
+    configured_repo="${repo_names[$repo_index]}"
+    repo_context="repository $((repo_index + 1))/${#repo_names[@]}"
+    if [ -z "$configured_repo" ]; then
+      log "BEADS_SYNC_REPOS contains an empty repository name"
+      overall_status=1
+      continue
+    fi
+    if [[ ! $configured_repo =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+      log "Invalid org/repo entry in BEADS_SYNC_REPOS"
+      overall_status=1
+      continue
+    fi
+    if [ -n "${seen_repo_names[$configured_repo]:-}" ]; then
+      log "BEADS_SYNC_REPOS contains a duplicate repository entry"
+      overall_status=1
+      continue
+    fi
+    seen_repo_names[$configured_repo]=1
+
+    repo_path="$HOME/ghq/github.com/$configured_repo"
+    if BEADS_SYNC_REPO_DIR="$repo_path" BEADS_SYNC_REPO_NAME="$configured_repo" BEADS_SYNC_REPO_CONTEXT="$repo_context" "$BASH" "$0" --repo; then
+      :
+    else
+      status=$?
+      log "Repository federation failed with status $status"
+      if [ "$overall_status" -eq 0 ]; then
+        overall_status="$status"
+      fi
+    fi
+  done
+
+  exit "$overall_status"
+fi
+
+repo_dir="${BEADS_SYNC_REPO_DIR:-}"
+repo_name="${BEADS_SYNC_REPO_NAME:-}"
+repo_context="${BEADS_SYNC_REPO_CONTEXT:-}"
+if [ -z "$repo_dir" ] || [ -z "$repo_name" ] || [ -z "$repo_context" ]; then
+  log "Internal repository dispatch is incomplete"
+  exit 1
+fi
+
+if [ ! -d "$repo_dir" ] || [ ! -e "$repo_dir/.beads" ]; then
+  log "Configured checkout is not a Beads repository"
+  exit 1
+fi
+
+repo_dir="$(cd "$repo_dir" && pwd -P)"
+repo_slug="$repo_name"
+repo_slug="${repo_slug//\//_}"
+repo_slug="${repo_slug//[^[:alnum:]_.-]/_}"
+sync_checkpoint_file="$sync_state_dir/last-success-$repo_slug"
+
+for _attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+  if "$bd_cli" -C "$repo_dir" ping >/dev/null 2>&1; then
+    break
+  fi
+  if [ "$_attempt" -eq 12 ]; then
+    log "Beads did not become ready within 60 seconds"
+    exit 1
+  fi
+  @coreutils@/bin/sleep 5
+done
+
+cycle_started="$(@coreutils@/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')"
+log "Synchronizing Dolt remote"
+@coreutils@/bin/timeout 120 "$bd_cli" -C "$repo_dir" sync --yes >/dev/null 2>&1
+
+@coreutils@/bin/mkdir -p "$sync_state_dir"
+printf '%s\n' "$cycle_started" >"$sync_checkpoint_file.tmp"
+@coreutils@/bin/mv -f "$sync_checkpoint_file.tmp" "$sync_checkpoint_file"
+log "Dolt federation complete"

--- a/home-manager/services/dolt/linear-sync.sh
+++ b/home-manager/services/dolt/linear-sync.sh
@@ -143,12 +143,13 @@ federate_beads() {
   local status
 
   set +e
-  @coreutils@/bin/timeout 30 "$bd_cli" -C "$repo_dir" sync --yes >/dev/null 2>&1
+  @coreutils@/bin/timeout 120 "$bd_cli" -C "$repo_dir" sync --yes >/dev/null 2>&1
   status=$?
   set -e
 
   if [ "$status" -ne 0 ]; then
-    log "Dolt $phase federation failed with status $status; continuing with local Beads state"
+    log "Dolt $phase federation failed with status $status"
+    return "$status"
   fi
 }
 
@@ -197,8 +198,8 @@ ensure_config linear.outbound_state_map.in_progress "In Progress"
 ensure_config linear.outbound_state_map.closed Done
 "$bd_cli" -C "$repo_dir" dolt commit -m "chore(beads): configure Linear sync" >/dev/null 2>&1
 
-# Prefer the newest federated Beads timestamps, but do not let a damaged backup
-# remote prevent independent Linear reconciliation.
+# Kyber is the only Linear writer. Require federation first so Linear never
+# reconciles from a replica that could not ingest the shared Dolt state.
 federate_beads "pre-sync"
 
 if [ -s "$sync_checkpoint_file" ]; then
@@ -212,7 +213,7 @@ fi
 # rate-limit failure is deferred to the next scheduled run instead of making
 # launchd hot-loop a failed job.
 log "Pulling Linear work if stale"
-if run_linear @coreutils@/bin/timeout 60 "$bd_cli" -C "$repo_dir" linear sync \
+if run_linear @coreutils@/bin/timeout 240 "$bd_cli" -C "$repo_dir" linear sync \
   --pull-if-stale \
   --threshold 5m \
   --state all \
@@ -225,7 +226,8 @@ else
     log "Linear pull deferred; the next 300-second run will retry"
     exit 0
   fi
-  log "Linear pull failed with status $status; continuing with outbound Beads reconciliation"
+  log "Linear pull failed with status $status"
+  exit "$status"
 fi
 
 all_issues="$("$bd_cli" -C "$repo_dir" list --all --json --limit 0 --skip-labels)"

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -104,6 +104,11 @@
   )
   inputs.noctalia-shell.overlays.default
   (_: prev: {
+    # Keep the Dolt archive-integrity fix independent from the shared nixpkgs
+    # pin so storage recovery does not upgrade unrelated host packages.
+    dolt = inputs.nixpkgs-dolt.legacyPackages.${prev.system}.dolt;
+  })
+  (_: prev: {
     moshi-hook = prev.stdenv.mkDerivation rec {
       pname = "moshi-hook";
       version = "0.3.0";

--- a/spec/beads_federation_sync_spec.sh
+++ b/spec/beads_federation_sync_spec.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016,SC2329
+
+Describe 'Beads Dolt federation synchronization'
+SCRIPT="$PWD/home-manager/services/dolt/federation-sync.sh"
+MODULE="$PWD/home-manager/services/dolt/default.nix"
+
+Describe 'script properties'
+It 'uses strict bash mode and validates after placeholder replacement'
+When run bash -c "grep -F 'set -euo pipefail' '$SCRIPT' >/dev/null && sed 's|@[A-Za-z_][A-Za-z0-9_]*@|/usr|g' '$SCRIPT' | bash -n"
+The status should be success
+End
+
+It 'loads machine-local scope without exposing a tracked repository'
+When run bash -c "grep -F 'DOTFILES_ENV_FILE:-\$HOME/dotfiles/.env' '$SCRIPT' >/dev/null && grep -F 'BEADS_SYNC_REPOS:-\${BEADS_LINEAR_SYNC_REPOS:-}' '$SCRIPT' >/dev/null && ! grep -F '@repoDir@' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
+It 'bounds federation and checkpoints only afterward'
+When run bash -c "sync=\$(grep -n '@coreutils@/bin/timeout 120' '$SCRIPT' | cut -d: -f1); checkpoint=\$(grep -n '\"\$cycle_started\" >\"\$sync_checkpoint_file.tmp\"' '$SCRIPT' | cut -d: -f1); test \"\$checkpoint\" -gt \"\$sync\""
+The status should be success
+End
+End
+
+Describe 'runtime behavior'
+setup_federation() {
+  TEST_ROOT=$(mktemp -d)
+  FAKE_BD="$TEST_ROOT/bd"
+  RENDERED_SCRIPT="$TEST_ROOT/federation-sync.sh"
+  COMMAND_LOG="$TEST_ROOT/commands.log"
+  STATE_HOME="$TEST_ROOT/state"
+  ENV_FILE="$TEST_ROOT/dotenv"
+  COREUTILS="$TEST_ROOT/coreutils"
+  TEST_REPO_ID="test/repo-one"
+  TEST_REPO="$TEST_ROOT/ghq/github.com/$TEST_REPO_ID"
+  mkdir -p "$COREUTILS/bin" "$TEST_REPO/.beads"
+  printf 'BEADS_SYNC_REPOS=%q\n' "$TEST_REPO_ID" >"$ENV_FILE"
+  repo_slug="${TEST_REPO_ID//\//_}"
+  CHECKPOINT_FILE="$STATE_HOME/beads-federation-sync/last-success-$repo_slug"
+  export DOTFILES_ENV_FILE="$ENV_FILE"
+  for command in date mkdir mv sleep timeout; do
+    ln -s "$(command -v "$command")" "$COREUTILS/bin/$command"
+  done
+
+  cat >"$FAKE_BD" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$COMMAND_LOG"
+if [ "${1:-}" = "-C" ]; then
+  shift 2
+fi
+case "${1:-} ${2:-}" in
+  "ping ")
+    exit 0
+    ;;
+  "sync --yes")
+    exit "${FAKE_SYNC_STATUS:-0}"
+    ;;
+esac
+EOF
+  chmod +x "$FAKE_BD"
+  sed \
+    -e "s|@bd@|$FAKE_BD|g" \
+    -e "s|@coreutils@|$COREUTILS|g" \
+    "$SCRIPT" >"$RENDERED_SCRIPT"
+}
+
+cleanup_federation() {
+  unset DOTFILES_ENV_FILE
+  rm -rf "$TEST_ROOT"
+}
+
+Before 'setup_federation'
+After 'cleanup_federation'
+
+It 'writes a checkpoint after a successful federation'
+When run env COMMAND_LOG="$COMMAND_LOG" XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" bash "$RENDERED_SCRIPT"
+The status should be success
+The output should include 'Dolt federation complete'
+The file "$CHECKPOINT_FILE" should be exist
+The contents of file "$COMMAND_LOG" should include 'sync --yes'
+End
+
+It 'propagates a federation failure without advancing the checkpoint'
+When run env COMMAND_LOG="$COMMAND_LOG" FAKE_SYNC_STATUS=42 XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" bash "$RENDERED_SCRIPT"
+The status should equal 42
+The output should include 'Repository federation failed with status 42'
+The file "$CHECKPOINT_FILE" should not be exist
+End
+
+It 'rejects an absolute checkout path without logging it'
+printf 'BEADS_SYNC_REPOS=%q\n' '/private/checkout' >"$ENV_FILE"
+When run env COMMAND_LOG="$COMMAND_LOG" XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" bash "$RENDERED_SCRIPT"
+The status should equal 1
+The output should include 'Invalid org/repo entry'
+The output should not include '/private/checkout'
+End
+End
+
+Describe 'Home Manager ownership'
+It 'enables the shared Dolt server on Kyber, Galactica, and Matic'
+When run bash -c "grep -F 'enabled = isGalactica || isKyber || isMatic;' '$MODULE' >/dev/null"
+The status should be success
+End
+
+It 'runs federation-only sync on Galactica and Matic'
+When run bash -c "grep -F 'federationSyncEnabled = isGalactica || isMatic;' '$MODULE' >/dev/null && grep -F 'launchd.agents.dolt-federation-sync' '$MODULE' >/dev/null && grep -F 'systemd.user.timers.dolt-federation-sync' '$MODULE' >/dev/null"
+The status should be success
+End
+
+It 'requires a Dolt version containing the gitblobstore missing-blob fix'
+When run bash -c "grep -F 'doltMinVersion = \"2.2.2\";' '$MODULE' >/dev/null"
+The status should be success
+End
+End
+End

--- a/spec/beads_linear_sync_spec.sh
+++ b/spec/beads_linear_sync_spec.sh
@@ -88,13 +88,13 @@ When run bash -c "test \"\$(grep -c 'next 300-second run will retry' '$SCRIPT')\
 The status should be success
 End
 
-It 'continues after pull failures but propagates push failures'
-When run bash -c "grep -F 'continuing with outbound Beads reconciliation' '$SCRIPT' >/dev/null && grep -F 'log \"Linear push failed with status \$status\"' '$SCRIPT' >/dev/null && test \"\$(grep -c 'exit \"\$status\"' '$SCRIPT')\" -eq 1"
+It 'fails closed after ordinary pull, push, or federation failures'
+When run bash -c "! grep -F 'continuing with outbound Beads reconciliation' '$SCRIPT' >/dev/null && ! grep -F 'continuing with local Beads state' '$SCRIPT' >/dev/null && grep -F 'log \"Linear pull failed with status \$status\"' '$SCRIPT' >/dev/null && grep -F 'log \"Linear push failed with status \$status\"' '$SCRIPT' >/dev/null"
 The status should be success
 End
 
 It 'bounds federation, inbound pull, and small outbound batches'
-When run bash -c "grep -F '@coreutils@/bin/timeout 30 \"\$bd_cli\" -C \"\$repo_dir\" sync --yes' '$SCRIPT' >/dev/null && grep -F 'run_linear @coreutils@/bin/timeout 60 \"\$bd_cli\"' '$SCRIPT' >/dev/null && grep -F 'push_batch_size=10' '$SCRIPT' >/dev/null && grep -F 'run_linear @coreutils@/bin/timeout 120 \"\$bd_cli\"' '$SCRIPT' >/dev/null"
+When run bash -c "grep -F '@coreutils@/bin/timeout 120 \"\$bd_cli\" -C \"\$repo_dir\" sync --yes' '$SCRIPT' >/dev/null && grep -F 'run_linear @coreutils@/bin/timeout 240 \"\$bd_cli\"' '$SCRIPT' >/dev/null && grep -F 'push_batch_size=10' '$SCRIPT' >/dev/null && grep -F 'run_linear @coreutils@/bin/timeout 120 \"\$bd_cli\"' '$SCRIPT' >/dev/null"
 The status should be success
 End
 
@@ -246,12 +246,12 @@ The output should include 'next 300-second run will retry'
 The file "$CHECKPOINT_FILE" should not be exist
 End
 
-It 'continues outbound reconciliation after an ordinary Linear pull failure'
+It 'fails closed after an ordinary Linear pull failure'
 When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MODE=pull-failure XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
-The status should be success
-The output should include 'Linear pull failed with status 23; continuing with outbound Beads reconciliation'
-The output should include 'Pushing changed active Beads'
-The file "$CHECKPOINT_FILE" should be exist
+The status should equal 23
+The output should include 'Linear pull failed with status 23'
+The output should not include 'Pushing changed active Beads'
+The file "$CHECKPOINT_FILE" should not be exist
 End
 
 It 'propagates a Linear push failure without advancing the checkpoint'
@@ -270,20 +270,20 @@ The output should include 'Pushing changed active Beads'
 The contents of file "$COMMAND_LOG" should include 'linear sync --push --issues df-closed --no-wait'
 End
 
-It 'checkpoints Linear progress when final Dolt federation fails'
+It 'fails closed without checkpointing when final Dolt federation fails'
 When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MODE=final-failure XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
-The status should be success
+The status should equal 42
 The output should include 'Pushing changed active Beads'
 The output should include 'Dolt post-sync federation failed with status 42'
-The file "$CHECKPOINT_FILE" should be exist
+The file "$CHECKPOINT_FILE" should not be exist
 End
 
-It 'continues Linear reconciliation when initial Dolt federation fails'
+It 'fails closed before Linear reconciliation when initial Dolt federation fails'
 When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MODE=initial-federation-failure XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
-The status should be success
+The status should equal 41
 The output should include 'Dolt pre-sync federation failed with status 41'
-The output should include 'Pushing changed active Beads'
-The file "$CHECKPOINT_FILE" should be exist
+The output should not include 'Pushing changed active Beads'
+The file "$CHECKPOINT_FILE" should not be exist
 End
 
 It 'fails closed when the repository list is absent'
@@ -347,12 +347,12 @@ When run bash -c "grep -F 'linearSyncIntervalSeconds = 300;' '$MODULE' >/dev/nul
 The status should be success
 End
 
-It 'installs the macOS launchd agent'
-When run bash -c "grep -F 'launchd.agents.dolt-linear-sync' '$MODULE' >/dev/null"
+It 'restricts the Linear writer to Kyber'
+When run bash -c "grep -F 'linearSyncEnabled = isKyber;' '$MODULE' >/dev/null && grep -F 'launchd.agents.dolt-linear-sync = lib.mkIf (pkgs.stdenv.isDarwin && linearSyncEnabled)' '$MODULE' >/dev/null && grep -F 'systemd.user.services.dolt-linear-sync = lib.mkIf (pkgs.stdenv.isLinux && linearSyncEnabled)' '$MODULE' >/dev/null"
 The status should be success
 End
 
-It 'installs the Linux systemd timer'
+It 'installs the Kyber Linux systemd timer'
 When run bash -c "grep -F 'systemd.user.timers.dolt-linear-sync' '$MODULE' >/dev/null && grep -F 'OnCalendar = \"*-*-* *:00/5:00\";' '$MODULE' >/dev/null && grep -F 'X-SwitchMethod = \"restart\";' '$MODULE' >/dev/null"
 The status should be success
 End

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -285,6 +285,10 @@ It 'has spec file for home-manager/services/dolt/linear-sync.sh'
 The path "spec/beads_linear_sync_spec.sh" should be exist
 End
 
+It 'has spec file for home-manager/services/dolt/federation-sync.sh'
+The path "spec/beads_federation_sync_spec.sh" should be exist
+End
+
 It 'has spec file for home-manager/services/k3s/activate.sh'
 The path "spec/k3s_service_activate_spec.sh" should be exist
 End
@@ -588,6 +592,7 @@ home-manager/services/docker/docker-setup.sh
 home-manager/services/docker/setup-docker.sh
 home-manager/services/dolt/start.sh
 home-manager/services/dolt/backup-dolt-main.sh
+home-manager/services/dolt/federation-sync.sh
 home-manager/services/dolt/linear-sync.sh
 home-manager/services/dotfiles-updater/update.sh
 home-manager/services/gas-town/start.sh


### PR DESCRIPTION
## Summary
- make Kyber the only Beads to Linear reconciliation owner
- keep Galactica and Matic synchronized through a fail-closed Dolt federation timer
- require successful pre/post federation before advancing the Linear checkpoint
- pin only Dolt past the gitblobstore missing-blob fix, without advancing the shared package set

## Validation
- `shellspec spec/beads_linear_sync_spec.sh spec/beads_federation_sync_spec.sh spec/coverage_spec.sh` (160 examples, 0 failures)
- `shellcheck` on changed shell scripts/specs
- `make nix-format-check`
- exact config eval: Dolt 2.3.1 on all three hosts; Linear timer only on Kyber; federation timer only on Galactica and Matic
- `make build HOST=galactica` from exact head
- full ShellSpec: 2337 pass; one unrelated dotenv isolation test inherits an ambient secret and passes when that variable is unset