### PR TITLE
fix(beads): extend federation fsck budget

### DIFF
--- a/home-manager/services/dolt/linear-sync.sh
+++ b/home-manager/services/dolt/linear-sync.sh
@@ -9,6 +9,8 @@ linear_workspace="@linearWorkspace@"
 linear_team_id="@linearTeamId@"
 linear_credentials_file="${XDG_CONFIG_HOME:-$HOME/.config}/linear/credentials.toml"
 sync_state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/beads-linear-sync"
+federation_timeout_seconds=360
+federation_fsck_timeout=300s
 
 log() {
   local context=""
@@ -167,7 +169,9 @@ federate_beads() {
   local status
 
   set +e
-  @coreutils@/bin/timeout 120 "$bd_cli" -C "$repo_dir" sync --yes >/dev/null 2>&1
+  @coreutils@/bin/timeout "$federation_timeout_seconds" \
+    @coreutils@/bin/env BEADS_FSCK_TIMEOUT="$federation_fsck_timeout" \
+    "$bd_cli" -C "$repo_dir" sync --yes >/dev/null 2>&1
   status=$?
   set -e
 

--- a/spec/beads_linear_sync_spec.sh
+++ b/spec/beads_linear_sync_spec.sh
@@ -93,8 +93,13 @@ When run bash -c "! grep -F 'continuing with outbound Beads reconciliation' '$SC
 The status should be success
 End
 
-It 'bounds federation, inbound pull, and small outbound batches'
-When run bash -c "grep -F '@coreutils@/bin/timeout 120 \"\$bd_cli\" -C \"\$repo_dir\" sync --yes' '$SCRIPT' >/dev/null && grep -F 'run_linear @coreutils@/bin/timeout 720 \"\$bd_cli\"' '$SCRIPT' >/dev/null && grep -F 'push_batch_size=10' '$SCRIPT' >/dev/null && grep -F 'run_linear @coreutils@/bin/timeout 120 \"\$bd_cli\"' '$SCRIPT' >/dev/null"
+It 'gives federation fsck a bounded budget below the outer deadline'
+When run bash -c "grep -F 'federation_timeout_seconds=360' '$SCRIPT' >/dev/null && grep -F 'federation_fsck_timeout=300s' '$SCRIPT' >/dev/null && grep -F '@coreutils@/bin/timeout \"\$federation_timeout_seconds\"' '$SCRIPT' >/dev/null && grep -F '@coreutils@/bin/env BEADS_FSCK_TIMEOUT=\"\$federation_fsck_timeout\"' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
+It 'bounds inbound pull and small outbound batches'
+When run bash -c "grep -F 'run_linear @coreutils@/bin/timeout 720 \"\$bd_cli\"' '$SCRIPT' >/dev/null && grep -F 'push_batch_size=10' '$SCRIPT' >/dev/null && grep -F 'run_linear @coreutils@/bin/timeout 120 \"\$bd_cli\"' '$SCRIPT' >/dev/null"
 The status should be success
 End
 


### PR DESCRIPTION
## Summary

- give each managed pre-sync and post-sync Beads federation an explicit 300-second integrity-check budget
- preserve a 360-second hard deadline around the complete federation command so the service remains bounded
- keep repository-child isolation, privacy-safe logs, fail-closed Linear reconciliation, and checkpoint ordering unchanged

This is a narrow follow-up to #2497 after scheduled runs showed the default Beads integrity-check budget expiring before federation could complete.

## Contract diagram

```mermaid
sequenceDiagram
  participant Timer
  participant RepositoryChild
  participant OuterDeadline
  participant BeadsFsck
  participant LinearSync
  participant Checkpoint
  Timer->>RepositoryChild: Start isolated repository cycle
  RepositoryChild->>OuterDeadline: Start 360 second federation deadline
  OuterDeadline->>BeadsFsck: Run with 300 second integrity budget
  BeadsFsck-->>RepositoryChild: Federation succeeds
  RepositoryChild->>LinearSync: Reconcile Linear state
  RepositoryChild->>OuterDeadline: Run bounded post sync federation
  OuterDeadline-->>RepositoryChild: Federation succeeds
  RepositoryChild->>Checkpoint: Advance last success
```

## Before / after

| Surface | Before | After |
| --- | --- | --- |
| Managed Beads federation | The default integrity-check timeout could fail before the 120-second outer command deadline | Integrity checks receive 300 seconds while the complete command remains bounded to 360 seconds |
| Repository isolation | Each configured repository runs in a child process | Unchanged |
| Success checkpoint | Advances only after pre-sync, Linear reconciliation, and post-sync federation succeed | Unchanged |

## Breaking and irreversible changes

- **Behavioral:** a managed federation attempt may run for up to 360 seconds instead of 120 seconds. Reverting restores the prior deadlines.
- **Compile-time:** none.
- **Durable state and rollback:** no schema or persisted-record migration. Successful runs continue to advance the existing repository-specific checkpoint; failed runs do not. A revert requires no data operation.

## Deliberate boundaries

- Linear state mapping is unchanged; generic closed Beads continue to map to Done.
- Repository scope and credentials remain machine-local and are not included in source, fixtures, logs, or this PR.
- Linear pull and push deadlines and batching are unchanged.

## Verification

- `shellspec spec/beads_linear_sync_spec.sh` — 38 examples, 0 failures
- `shellspec spec/beads_linear_sync_spec.sh spec/coverage_spec.sh` — 152 examples, 0 failures
- `shellcheck home-manager/services/dolt/linear-sync.sh spec/beads_linear_sync_spec.sh`
- `env XDG_CACHE_HOME=/tmp/codex-dotfiles-fsck-nix-cache make nix-format-check`
- `env XDG_CACHE_HOME=/tmp/codex-dotfiles-fsck-nix-cache nix build .#homeConfigurations.kyber.activationPackage --no-link --impure`
- `git diff --check`



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the Beads federation integrity-check budget to avoid premature fsck timeouts while keeping the command bounded. Previously fsck used the default budget within a 120s outer timeout; now fsck has 300s and federation is limited to 360s.

- Update `home-manager/services/dolt/linear-sync.sh` to run `bd_cli sync` under `@coreutils@/bin/timeout` 360s and set `BEADS_FSCK_TIMEOUT=300s`.
- Preserve repository-child isolation, privacy-safe logs, Linear reconciliation, checkpoint ordering, and existing inbound pull (720s) and outbound batch settings.
- Update `spec/beads_linear_sync_spec.sh` to assert the new fsck and outer timeouts.
- No config or data migration; managed federation may now run up to 360s instead of 120s.

<sup>Written for commit 597ca3228a06ff77b819bd2efa7c95f06ef51eb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

