### PR TITLE
test(beads): verify federation fsck environment

### DIFF
--- a/spec/beads_linear_sync_spec.sh
+++ b/spec/beads_linear_sync_spec.sh
@@ -126,6 +126,7 @@ setup_reconciliation() {
   FAKE_DOLT_ROOT="$TEST_ROOT/dolt"
   RENDERED_SCRIPT="$TEST_ROOT/linear-sync.sh"
   COMMAND_LOG="$TEST_ROOT/commands.log"
+  FSCK_TIMEOUT_LOG="$TEST_ROOT/fsck-timeouts.log"
   DOLT_LOG="$TEST_ROOT/dolt-commands.log"
   SYNC_COUNT="$TEST_ROOT/sync-count"
   STATE_HOME="$TEST_ROOT/state"
@@ -142,7 +143,7 @@ setup_reconciliation() {
   repo_slug="${repo_slug//[^[:alnum:]_.-]/_}"
   CHECKPOINT_FILE="$STATE_HOME/beads-linear-sync/last-success-$repo_slug"
   export DOTFILES_ENV_FILE="$ENV_FILE"
-  export DOLT_LOG
+  export DOLT_LOG FSCK_TIMEOUT_LOG
   for command in chmod date env mkdir mv sleep timeout; do
     ln -s "$(command -v "$command")" "$COREUTILS/bin/$command"
   done
@@ -164,6 +165,7 @@ case "${1:-} ${2:-}" in
     exit 0
     ;;
   "sync --yes")
+    printf '%s\n' "${BEADS_FSCK_TIMEOUT:-}" >>"$FSCK_TIMEOUT_LOG"
     count=0
     if [ -s "$SYNC_COUNT" ]; then
       count=$(<"$SYNC_COUNT")
@@ -225,7 +227,7 @@ EOF
 }
 
 cleanup_reconciliation() {
-  unset DOLT_LOG DOTFILES_ENV_FILE
+  unset DOLT_LOG DOTFILES_ENV_FILE FSCK_TIMEOUT_LOG
   rm -rf "$TEST_ROOT"
 }
 
@@ -239,6 +241,8 @@ The output should include 'Pushing changed active Beads'
 The file "$CHECKPOINT_FILE" should be exist
 The contents of file "$COMMAND_LOG" should include 'linear sync --pull --state all --relations --no-wait'
 The contents of file "$COMMAND_LOG" should include 'linear sync --push --issues df-test --no-wait'
+The contents of file "$FSCK_TIMEOUT_LOG" should equal "300s
+300s"
 End
 
 It 'splits a large outbound delta into bounded batches'


### PR DESCRIPTION
## Summary

- strengthen the focused Beads federation harness after the review on #2498
- record the fsck timeout seen by each fake federation subprocess
- assert both pre-sync and post-sync federation receive `BEADS_FSCK_TIMEOUT=300s`

## Before / after

| Surface | Before | After |
| --- | --- | --- |
| Federation timeout regression coverage | Static checks proved timeout declarations existed | The rendered managed script proves both actual `bd sync` subprocesses receive the 300-second fsck budget |

## Breaking and irreversible changes

- **Behavioral:** none; test-only.
- **Compile-time:** none.
- **Durable state and rollback:** none.

## Deliberate boundaries

- Production synchronization behavior is unchanged from #2498.
- Fixtures remain generic and contain no real repository scope or credentials.

## Verification

- `shellspec spec/beads_linear_sync_spec.sh spec/coverage_spec.sh` — 152 examples, 0 failures
- `shellcheck spec/beads_linear_sync_spec.sh`
- `git diff --check`



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens the Beads federation test harness to verify the fsck timeout environment. Previously tests only checked declarations; now they prove both sync subprocesses receive a 300s fsck timeout.

- Adds `FSCK_TIMEOUT_LOG` and records `BEADS_FSCK_TIMEOUT` during `sync --yes`; the spec asserts two lines: `300s` then `300s`.
- Exports and cleans up `FSCK_TIMEOUT_LOG` alongside `DOLT_LOG`; production behavior remains unchanged.
- Improves regression coverage by validating the managed script passes the fsck budget to both pre- and post-sync federation runs.

<sup>Written for commit eea94caadfac91cb2a9cf8d80ee6d81054092963. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

