### PR TITLE
fix(hermes): suppress busy task acknowledgments

### DIFF
--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -172,6 +172,7 @@ display:
   compact: true
   resume_display: full
   busy_input_mode: interrupt
+  busy_ack_enabled: false
   bell_on_complete: false
   show_reasoning: false
   streaming: false

--- a/config/hermes/config.tpl.yaml
+++ b/config/hermes/config.tpl.yaml
@@ -172,6 +172,7 @@ display:
   compact: true
   resume_display: full
   busy_input_mode: interrupt
+  busy_ack_enabled: false
   bell_on_complete: false
   show_reasoning: false
   streaming: false

--- a/spec/hermes_hydrate_spec.sh
+++ b/spec/hermes_hydrate_spec.sh
@@ -248,6 +248,14 @@ The output should not include 'opus'
 End
 End
 
+Describe 'busy input acknowledgments'
+It 'suppresses the interrupt acknowledgment while keeping interrupt mode'
+When run bash -c "sed -n '/^display:/,/^[^ ]/p' '$PWD/config/hermes/config.template.yaml'"
+The output should include 'busy_input_mode: interrupt'
+The output should include 'busy_ack_enabled: false'
+End
+End
+
 Describe 'execution'
 It 'reports config generation'
 When run bash -c "grep 'Generated hermes' '$SCRIPT'"


### PR DESCRIPTION
## Summary

- disable Hermes gateway busy-task acknowledgment bubbles
- preserve `busy_input_mode: interrupt` so incoming messages retain their existing behavior
- add a hydration regression spec for the canonical Hermes templates

## Validation

- `shellspec spec/hermes_hydrate_spec.sh` (32 examples, 0 failures)
- YAML parsing passed for both Hermes templates
- `git diff --check` passed
- `make nix-test` evaluated the flake/configurations but stalled in the host Nix daemon and was interrupted after about two minutes; no change-specific failure was emitted


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses Hermes busy task acknowledgment bubbles to reduce UI noise while preserving interrupt behavior. Previously the gateway showed a busy/interrupt acknowledgment; now it disables the bubble while keeping `busy_input_mode: interrupt`, so interrupts still work.

- Set `display.busy_ack_enabled: false` in both Hermes templates (config/hermes/config.template.yaml, config/hermes/config.tpl.yaml).
- Add a hydration regression spec to assert both `busy_ack_enabled: false` and `busy_input_mode: interrupt` in generated configs.
- No migration required; regenerate configs to pick up the new default. Custom configs should set `display.busy_ack_enabled: false` to match.

<sup>Written for commit 2c94f8fc540bf4580ccb34eb7a0d1394f0675d2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

