### PR TITLE
fix(ulb): auto-install JS deps before Makefile build

### DIFF
--- a/scripts/update-local-binaries.sh
+++ b/scripts/update-local-binaries.sh
@@ -144,6 +144,26 @@ build_repo() {
     (cd "$build_dir" && mise install 2>&1) || true
   fi
 
+  # Install JS deps for any package.json in build_dir or its direct subdirs
+  # where node_modules is missing or empty (handles embedded web UIs like roborev).
+  _js_install_cmd=""
+  if command -v bun >/dev/null 2>&1; then
+    _js_install_cmd="bun install"
+  elif command -v npm >/dev/null 2>&1; then
+    _js_install_cmd="npm install"
+  fi
+  if [ -n "$_js_install_cmd" ]; then
+    for _pkg_json in "$build_dir/package.json" "$build_dir"/*/package.json; do
+      [ -f "$_pkg_json" ] || continue
+      _pkg_dir="$(dirname "$_pkg_json")"
+      _nm="$_pkg_dir/node_modules"
+      if [ ! -d "$_nm" ] || [ -z "$(ls -A "$_nm" 2>/dev/null)" ]; then
+        log_step "  Installing JS deps in $(basename "$_pkg_dir")..."
+        (cd "$_pkg_dir" && $_js_install_cmd 2>&1) || true
+      fi
+    done
+  fi
+
   # Initialize git submodules if .gitmodules exists
   if [ -f "$repo_dir/.gitmodules" ]; then
     log_step "  Initializing submodules..."


### PR DESCRIPTION
## Changes
- In `scripts/update-local-binaries.sh`, scan the build dir and its direct subdirectories for `package.json` files with missing or empty `node_modules`, and run `bun install` (falling back to `npm install`) before invoking `make build`

## Technical Details
- Triggered by `roborev` which embeds a Svelte web UI into the Go binary; on a fresh clone `web/node_modules` is absent so `make build` → `web-build` → `bun run build` fails with `Cannot find package '@sveltejs/vite-plugin-svelte'`
- The roborev repo (`roborev-dev/roborev`) is upstream-only so the fix lives here
- Mirrors the existing `mise install` pattern already in the script
- Skips install when `node_modules` is already populated (idempotent)

## Testing
- Confirmed `make build` fails on fresh clone without the fix
- Confirmed `ulb roborev` succeeds end-to-end with the fix applied

Generated with [Claude Code](https://claude.ai/code) by [claude-sonnet-4-6]

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-installs JS dependencies in `scripts/update-local-binaries.sh` before `make build` so fresh clones of repos that embed a web UI (e.g., `roborev`) don’t fail. Previously the script ran `make build` without ensuring `node_modules` existed; now it installs via `bun install` (fallback to `npm install`) when needed.

- Scans the build dir and its direct subdirectories for `package.json`; installs only if `node_modules` is missing or empty (idempotent).
- Prefers `bun`; falls back to `npm`.
- Side effect: first build may take longer due to dependency install; no change when modules are already present.

<sup>Written for commit 52da8fd496809fa589467104f4f96ce85f1458e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

