### PR TITLE
feat(factory): use Droid DeepSeek Flash default

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -120,7 +120,8 @@ Hermes also runs a Mixture-of-Agents preset: reference models
 | Codex | `qwen-local` profile | `qwen3.5-0.8b-optiq` (LM Studio) | |
 | Antigravity | default | `gemini-3.7-flash-high` (native Antigravity provider) | [settings.tpl.json](config/antigravity/settings.tpl.json) |
 | Pi | `defaultModel` | `glm-4.7` (provider `cliproxyapi`) | [settings.tpl.json](config/pi/settings.tpl.json) |
-| Factory (droid) | session default | `custom:deepseek-v4-flash-0` via `https://cliproxy.shunkakinoki.com/v1` | [settings.tpl.json](config/factory/settings.tpl.json) |
+| Factory (droid) | session default | `deepseek-v4-flash-0731` (Droid Core) | [settings.tpl.json](config/factory/settings.tpl.json) |
+| Factory (droid) | custom models | `custom:deepseek-v4-flash-0`, `custom:free-1` via `https://cliproxy.shunkakinoki.com/v1` | [settings.tpl.json](config/factory/settings.tpl.json) |
 | aichat | default | `cliproxy:glm-4.7` | [config.tpl.yaml](config/aichat/config.tpl.yaml) |
 | DSH web | default | `deepseek-v4-flash` via `https://cliproxy.shunkakinoki.com/v1` (native DeepSeek adapter) | [settings.tpl.yaml](config/dsh/settings.tpl.yaml) |
 | llm | default | `glm-4.7` | [default_model.tpl.txt](config/llm/default_model.tpl.txt) |

--- a/config/factory/settings.json
+++ b/config/factory/settings.json
@@ -1,6 +1,6 @@
 {
   "sessionDefaultSettings": {
-    "model": "custom:deepseek-v4-flash-0",
+    "model": "deepseek-v4-flash-0731",
     "reasoningEffort": "high"
   },
   "customModels": [
@@ -11,6 +11,17 @@
       "baseUrl": "https://cliproxy.shunkakinoki.com/v1",
       "apiKey": "CLIPROXY_API_KEY",
       "displayName": "Deepseek V4 Flash",
+      "maxOutputTokens": 64000,
+      "noImageSupport": true,
+      "provider": "generic-chat-completion-api"
+    },
+    {
+      "model": "free",
+      "id": "custom:free-1",
+      "index": 1,
+      "baseUrl": "https://cliproxy.shunkakinoki.com/v1",
+      "apiKey": "CLIPROXY_API_KEY",
+      "displayName": "Free Router",
       "maxOutputTokens": 64000,
       "noImageSupport": true,
       "provider": "generic-chat-completion-api"

--- a/config/factory/settings.tpl.json
+++ b/config/factory/settings.tpl.json
@@ -1,6 +1,6 @@
 {
   "sessionDefaultSettings": {
-    "model": "custom:__DEEPSEEK_FLASH__-0",
+    "model": "__DEEPSEEK_FLASH_0731__",
     "reasoningEffort": "high"
   },
   "customModels": [
@@ -11,6 +11,17 @@
       "baseUrl": "https://cliproxy.shunkakinoki.com/v1",
       "apiKey": "CLIPROXY_API_KEY",
       "displayName": "__DEEPSEEK_FLASH_PRETTY__",
+      "maxOutputTokens": 64000,
+      "noImageSupport": true,
+      "provider": "generic-chat-completion-api"
+    },
+    {
+      "model": "free",
+      "id": "custom:free-1",
+      "index": 1,
+      "baseUrl": "https://cliproxy.shunkakinoki.com/v1",
+      "apiKey": "CLIPROXY_API_KEY",
+      "displayName": "Free Router",
       "maxOutputTokens": 64000,
       "noImageSupport": true,
       "provider": "generic-chat-completion-api"

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -190,8 +190,8 @@ End
 End
 
 Describe 'generated Factory settings'
-It 'pins Droid to the CLIProxy DeepSeek Flash custom model'
-When run jq -e '.sessionDefaultSettings.model == "custom:__DEEPSEEK_FLASH__-0" and (.customModels | length) == 1 and .customModels[0].id == "custom:__DEEPSEEK_FLASH__-0" and .customModels[0].baseUrl == "https://cliproxy.shunkakinoki.com/v1"' config/factory/settings.tpl.json
+It 'pins Droid to its built-in DeepSeek Flash model and keeps CLIProxy customs'
+When run jq -e '.sessionDefaultSettings.model == "__DEEPSEEK_FLASH_0731__" and (.customModels | length) == 2 and any(.customModels[]; .id == "custom:__DEEPSEEK_FLASH__-0" and .baseUrl == "https://cliproxy.shunkakinoki.com/v1") and any(.customModels[]; .id == "custom:free-1" and .model == "free" and .baseUrl == "https://cliproxy.shunkakinoki.com/v1")' config/factory/settings.tpl.json
 The status should be success
 The output should equal 'true'
 End

--- a/spec/roborev_hooks_spec.sh
+++ b/spec/roborev_hooks_spec.sh
@@ -16,8 +16,8 @@ When run grep -F 'dotfiles/config/shared/hooks/roborev-agent.sh' "$SCRIPT"
 The output should include 'dotfiles/config/shared/hooks/roborev-agent.sh'
 End
 
-It 'registers DeepSeek Flash as the Factory session default via CLIProxy'
-When run jq -e '.sessionDefaultSettings.model == "custom:deepseek-v4-flash-0" and (.customModels | length) == 1 and .customModels[0].id == "custom:deepseek-v4-flash-0" and .customModels[0].baseUrl == "https://cliproxy.shunkakinoki.com/v1" and .customModels[0].apiKey == "CLIPROXY_API_KEY"' "$SETTINGS"
+It 'uses Droid Core DeepSeek Flash as the Factory session default'
+When run jq -e '.sessionDefaultSettings.model == "deepseek-v4-flash-0731" and any(.customModels[]; .id == "custom:deepseek-v4-flash-0" and .baseUrl == "https://cliproxy.shunkakinoki.com/v1" and .apiKey == "CLIPROXY_API_KEY") and any(.customModels[]; .id == "custom:free-1" and .model == "free" and .baseUrl == "https://cliproxy.shunkakinoki.com/v1" and .apiKey == "CLIPROXY_API_KEY")' "$SETTINGS"
 The status should be success
 The output should equal 'true'
 End


### PR DESCRIPTION
## Summary
- use Droid Core `deepseek-v4-flash-0731` as the Factory session default
- retain the CLIProxy DeepSeek custom model
- add CLIProxy `free` as `custom:free-1`
- update generated settings, model documentation, and specs

## Validation
- `shellspec spec/llm_update_spec.sh spec/roborev_hooks_spec.sh`
- 108 examples, 0 failures
- `jq empty` on Factory settings
- ShellCheck and `git diff --check`

## Fallback
The Factory settings expose `custom:free-1` as a selectable custom model, but do not configure an automatic fallback chain. The built-in Droid model remains the sole session default.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets Factory’s session default model to Droid Core `deepseek-v4-flash-0731` instead of the CLIProxy custom `custom:deepseek-v4-flash-0`. This removes the default-path dependency on CLIProxy while keeping those models selectable and adds `custom:free-1`.

**Review notes**
- Update Factory settings and template to default to `deepseek-v4-flash-0731` and list two custom models: `custom:deepseek-v4-flash-0` and `custom:free-1` via `https://cliproxy.shunkakinoki.com/v1`.
- Update `MODELS.md` and specs to assert the new default and the presence of both custom models (including `apiKey` checks).
- No automatic fallback chain; the built-in Droid model is the only session default.
- No migration required; existing CLIProxy API key continues to be used when selecting custom models.

<sup>Written for commit e0ee724ade4151117b317006510322c6f92a799d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

