### PR TITLE
fix(galactica): set hostname to galactica and drop stale machine names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,8 +98,10 @@ endif
 # Machine detection for automatic host mapping
 DETECTED_HOST := $(shell \
 	if [ "$(OS)" = "Darwin" ] && [ "$(shell whoami)" = "shunkakinoki" ] && [ "$(ARCH)" = "arm64" ]; then \
-		computer_name=$$(scutil --get ComputerName 2>/dev/null || echo ""); \
-		if echo "$$computer_name" | grep -q "Shun's MacBook M4"; then \
+		hostname="$(MACHINE_HOSTNAME)"; \
+		tailscale_dns="$(TAILSCALE_DNS_NAME)"; \
+		if [ "$${hostname%%.*}" = "galactica" ] \
+			|| [ "$$tailscale_dns" = "galactica.tail950b36.ts.net" ]; then \
 			echo "galactica"; \
 		else \
 			echo ""; \
@@ -113,7 +115,6 @@ DETECTED_HOST := $(shell \
 			if [ "$$hostname" = "andor" ]; then \
 				echo "andor"; \
 			elif [ "$$hostname" = "kyber" ] \
-				|| [ "$$hostname" = "c2-small-x86-chi-1" ] \
 				|| [ "$$tailscale_dns" = "kyber.tail950b36.ts.net" ]; then \
 				echo "kyber"; \
 			elif [ "$$hostname" = "matic" ] \

--- a/home-manager/programs/cass/hydrate.sh
+++ b/home-manager/programs/cass/hydrate.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 # name|ssh target|platform|hostnames that identify this machine
 PEERS=(
-  "kyber|ubuntu@kyber|linux|kyber c2-small-x86-chi-1"
+  "kyber|ubuntu@kyber|linux|kyber"
   "matic|shunkakinoki@matic|linux|matic"
 )
 

--- a/home-manager/services/mempalace-exporter/export.sh
+++ b/home-manager/services/mempalace-exporter/export.sh
@@ -7,9 +7,9 @@ else
   _raw=$(hostname 2>/dev/null || echo "unknown")
 fi
 case "$_raw" in
-galactica* | aarch64-darwin*) HOST_NAME="galactica" ;;
+galactica*) HOST_NAME="galactica" ;;
 matic*) HOST_NAME="matic" ;;
-kyber* | c2-small-x86-chi-1*) HOST_NAME="kyber" ;;
+kyber*) HOST_NAME="kyber" ;;
 *) HOST_NAME="$_raw" ;;
 esac
 

--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -20,6 +20,7 @@ let
   };
   configuration = _: {
     networking.hostName = hostname;
+    networking.computerName = hostname;
     users.users.${username}.home = "/Users/${username}";
     system.stateVersion = 4;
   };

--- a/named-hosts/galactica/default.nix
+++ b/named-hosts/galactica/default.nix
@@ -4,7 +4,10 @@
   ...
 }:
 let
-  darwin-modules = import ../../hosts/darwin { inherit inputs username; };
+  darwin-modules = import ../../hosts/darwin {
+    inherit inputs username;
+    hostname = "galactica";
+  };
 in
 inputs.nix-darwin.lib.darwinSystem {
   system = "aarch64-darwin";

--- a/nix-darwin/config/system.nix
+++ b/nix-darwin/config/system.nix
@@ -1,4 +1,5 @@
 {
+  config,
   pkgs,
   isRunner,
   username,
@@ -181,7 +182,7 @@
       };
       smb = {
         NetBIOSName = "MAC";
-        ServerDescription = "Shun's MacBook M4 Pro Max";
+        ServerDescription = config.networking.hostName;
       };
       spaces.spans-displays = null;
       trackpad = {

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -1,4 +1,5 @@
 {
+  config,
   pkgs,
   lib,
   isRunner,
@@ -14,7 +15,14 @@ let
   nix = import ./config/nix.nix;
   security = import ./config/security.nix { inherit username; };
   serviceModules = import ./services { inherit lib isRunner pkgs; };
-  system = import ./config/system.nix { inherit isRunner pkgs username; };
+  system = import ./config/system.nix {
+    inherit
+      config
+      isRunner
+      pkgs
+      username
+      ;
+  };
   time = import ./config/time.nix;
 in
 {

--- a/spec/cass_indexer_spec.sh
+++ b/spec/cass_indexer_spec.sh
@@ -82,12 +82,6 @@ The output should include 'shunkakinoki@matic'
 The output should not include 'ubuntu@kyber'
 End
 
-It 'resolves the kyber provider hostname alias'
-When call render c2-small-x86-chi-1
-The output should include 'shunkakinoki@matic'
-The output should not include 'ubuntu@kyber'
-End
-
 It 'gives matic the kyber source only'
 When call render matic
 The output should include 'ubuntu@kyber'

--- a/spec/make_build_host_resolution_spec.sh
+++ b/spec/make_build_host_resolution_spec.sh
@@ -29,7 +29,7 @@ The output should not include '.#nixosConfigurations.matic.config.system.build.t
 End
 
 It 'detects kyber from its physical hostname'
-When run bash -c 'make build HOST= OS=Linux ARCH=x86_64 NIX_SYSTEM=x86_64-linux NIX_CONFIG_TYPE=homeConfigurations MACHINE_HOSTNAME=c2-small-x86-chi-1 TAILSCALE_DNS_NAME= NIX_EXEC=nix NIX_ENV=ok NIX_FLAGS= NIX_USER_TRUSTED=yes 2>/dev/null; cat "$MOCK_LOG"'
+When run bash -c 'make build HOST= OS=Linux ARCH=x86_64 NIX_SYSTEM=x86_64-linux NIX_CONFIG_TYPE=homeConfigurations MACHINE_HOSTNAME=kyber TAILSCALE_DNS_NAME= NIX_EXEC=nix NIX_ENV=ok NIX_FLAGS= NIX_USER_TRUSTED=yes 2>/dev/null; cat "$MOCK_LOG"'
 The status should be success
 The output should include '.#homeConfigurations.kyber.activationPackage'
 The output should not include '.#homeConfigurations."ubuntu@x86_64-linux".activationPackage'


### PR DESCRIPTION
This Mac has been `galactica` on the tailnet for a while, but its local identity
was still `aarch64-darwin` / "Shun's MacBook M4 Pro Max". This makes the local
names match, and removes the stale names those detection paths depended on.

## Naming

- `networking.hostName` is now `galactica` (passed from `named-hosts/galactica`
  instead of falling through to the generic `aarch64-darwin` default).
  `localHostName` follows it, so Bonjour becomes `galactica.local`.
- `networking.computerName` is now set alongside `hostName` in `hosts/darwin`,
  so ComputerName can't drift from it. Previously it was unset, which is why
  "Shun's MacBook M4 Pro Max" survived every switch.
- SMB `ServerDescription` derives from `networking.hostName` rather than
  repeating the marketing name. This required threading `config` into
  `nix-darwin/config/system.nix`.

## Stale names removed

- `c2-small-x86-chi-1` (kyber's old provider hostname) from the Makefile host
  detection, `cass/hydrate.sh` peer aliases, and the mempalace exporter. Kyber's
  hostname is plain `kyber` now — verified over SSH — and the Tailscale MagicDNS
  fallback already covers it regardless.
- `aarch64-darwin` as a galactica alias in the mempalace exporter.

## Makefile host detection

Darwin detection used to grep ComputerName for the literal `Shun's MacBook M4`.
That check would have gone stale the moment the machine was renamed, and its
failure mode is silent: `DETECTED_HOST` comes back empty and `make switch` falls
back to `.#aarch64-darwin`, quietly dropping agenix secrets, GPG signing, and
`services.openssh`.

It now matches on hostname or Tailscale MagicDNS, mirroring the Linux branch.
The MagicDNS arm is what makes this safe to land: the machine still reports
`aarch64-darwin` as its hostname until the first switch applies, and detection
already resolves to `galactica` today through Tailscale.

## Side effect worth knowing

`CAAM_CODEX_PROFILE` is derived from hostname in the fish config. Today
`aarch64-darwin` falls to the `'*'` case (`admin@openfactor.ai`); after the
rename it hits the `galactica` case (`shunkakinoki@gmail.com`), which is the
intended account for this machine. Expect a codex re-auth on first use.

## Verification

- `nix eval` on all three darwinConfigurations: galactica resolves hostName,
  computerName, localHostName, and SMB description all to `galactica`; the
  generic and runner configs are unchanged at `aarch64-darwin`.
- `DETECTED_HOST` still resolves to `galactica` on this machine pre-rename.
- `shellspec` host/cass/mempalace specs: 37 examples, 0 failures.
- `nix fmt --fail-on-change` and `deadnix` clean.

Not verified: the switch itself hasn't been applied yet, so the actual `scutil`
rename and the codex re-auth are untested in practice.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets the Darwin machine name to galactica and removes stale host aliases to keep host detection and services consistent. Old behavior: local names were “aarch64-darwin”/“Shun's MacBook M4 Pro Max” and Makefile checked ComputerName; new behavior: hostName/computerName/Bonjour/SMB all “galactica” and detection matches hostname or Tailscale; expect a codex re-auth because `CAAM_CODEX_PROFILE` now resolves to galactica.

- Host naming: set `networking.hostName` and `networking.computerName` to “galactica”; Bonjour becomes `galactica.local`; SMB `ServerDescription` derives from `config.networking.hostName` (threaded `config` through `nix-darwin` modules).
- Detection: Makefile matches “galactica” via hostname or Tailscale MagicDNS, mirroring Linux; safe pre-rename because MagicDNS already resolves to galactica.
- Cleanup: removed `c2-small-x86-chi-1` and `aarch64-darwin` aliases from `cass` hydrate and `mempalace-exporter`; updated specs to drop the provider hostname alias.
- Rollout: run `nix-darwin` switch on galactica to apply the `scutil` rename; expect codex re-auth on first use. Update any scripts that referenced `c2-small-x86-chi-1` or `aarch64-darwin` to `kyber` or `galactica`.

<sup>Written for commit ac570aa5403f7ae51238ea13d9d87dca29702da5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

