### PR TITLE
fix(dolt): register federation remote before sync

### DIFF
--- a/home-manager/services/dolt/federation-sync.sh
+++ b/home-manager/services/dolt/federation-sync.sh
@@ -101,6 +101,34 @@ for _attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
 done
 
 cycle_started="$(@coreutils@/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')"
+ensure_dolt_remote() {
+  local configured_remote
+  local current_remote
+
+  configured_remote="$("$bd_cli" -C "$repo_dir" config get sync.remote 2>/dev/null || true)"
+  if [ -z "$configured_remote" ]; then
+    log "Dolt sync remote is not configured"
+    return 1
+  fi
+
+  current_remote="$("$bd_cli" -C "$repo_dir" dolt remote list 2>/dev/null | awk '$1 == "origin" { print $2; exit }')"
+  if [ -z "$current_remote" ]; then
+    log "Registering configured Dolt remote"
+    "$bd_cli" -C "$repo_dir" dolt remote add origin "$configured_remote" --allow-git-origin >/dev/null
+    return 0
+  fi
+
+  if [ "$current_remote" != "$configured_remote" ]; then
+    log "Configured Dolt remote does not match sync.remote"
+    return 1
+  fi
+}
+
+if ! ensure_dolt_remote; then
+  log "Dolt remote setup failed"
+  exit 1
+fi
+
 log "Synchronizing Dolt remote"
 @coreutils@/bin/timeout 120 "$bd_cli" -C "$repo_dir" sync --yes >/dev/null 2>&1
 

--- a/spec/beads_federation_sync_spec.sh
+++ b/spec/beads_federation_sync_spec.sh
@@ -52,6 +52,25 @@ case "${1:-} ${2:-}" in
   "ping ")
     exit 0
     ;;
+  "config get")
+    if [ "${3:-}" = "sync.remote" ]; then
+      printf '%s\n' 'git+https://example.invalid/org/repo.git'
+      exit 0
+    fi
+    exit 1
+    ;;
+  "dolt remote")
+    if [ "${3:-}" = "list" ]; then
+      if [ "${FAKE_DOLT_REMOTE:-}" = "configured" ]; then
+        printf '%s\n' 'origin git+https://example.invalid/org/repo.git'
+      fi
+      exit 0
+    fi
+    if [ "${3:-}" = "add" ]; then
+      exit "${FAKE_REMOTE_ADD_STATUS:-0}"
+    fi
+    exit 1
+    ;;
   "sync --yes")
     exit "${FAKE_SYNC_STATUS:-0}"
     ;;
@@ -78,6 +97,7 @@ The status should be success
 The output should include 'Dolt federation complete'
 The file "$CHECKPOINT_FILE" should be exist
 The contents of file "$COMMAND_LOG" should include 'sync --yes'
+The contents of file "$COMMAND_LOG" should include 'dolt remote add origin git+https://example.invalid/org/repo.git --allow-git-origin'
 End
 
 It 'propagates a federation failure without advancing the checkpoint'


### PR DESCRIPTION
## Summary

- Explicitly verify and register the configured `origin` Dolt remote before federation.
- Fail closed on missing or mismatched remotes instead of checkpointing a `no-remote` no-op.
- Add ShellSpec coverage for remote registration.

## Validation

- `shellspec spec/beads_federation_sync_spec.sh` — 9 examples, 0 failures
- `make nix-format-check` — passed
- `make test` — Neovim and Nix checks passed; shell suite had one unrelated environment-sensitive failure because local `AMP_API_KEY` was inherited by `spec/load_env_file_spec.sh`.
- Live Matic NixOS activation and managed federation run — passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures the Dolt `origin` remote is registered and matches `sync.remote` before federation sync, failing fast if not. Previously, a missing or mismatched remote could lead to a no-op sync that still advanced the checkpoint; now the script auto-adds `origin` when absent and exits non-zero on mismatch.

- Ensure `sync.remote` is set to the correct URL; the script will add `origin` if missing, but will refuse to run if `origin` does not match `sync.remote`.

<sup>Written for commit 868f1f15f9d74547c03f357673a0bbe1894e667b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

