### PR TITLE
fix(roborev): contain Kyber worker bursts

### DIFF
--- a/config/roborev/config.template.toml
+++ b/config/roborev/config.template.toml
@@ -1,3 +1,7 @@
+# Kyber overrides this to one worker during hydration so a burst of full-panel
+# reviews cannot saturate the host. Desktop hosts retain the upstream default.
+max_workers = 4
+
 # Pi review subagents: ox-alpha via OpenRouter first, cliproxy free as fallback.
 # Both are allow-failure; panels list pi-oxalpha before pi so ox-alpha runs first.
 [review.subagents.pi-oxalpha]

--- a/config/roborev/default.nix
+++ b/config/roborev/default.nix
@@ -11,6 +11,7 @@ let
     let
       vars = {
         ciEnabled = if inputs.host.isKyber then "true" else "false";
+        maxWorkers = if inputs.host.isKyber then "1" else "4";
         sed = "${pkgs.gnused}/bin/sed";
         template = "${./config.template.toml}";
       };

--- a/config/roborev/hydrate.sh
+++ b/config/roborev/hydrate.sh
@@ -17,6 +17,7 @@ fi
 
 ROBOREV_REPOS="${ROBOREV_REPOS:-}"
 ROBOREV_CI_ENABLED="@ciEnabled@"
+ROBOREV_MAX_WORKERS="@maxWorkers@"
 if [ -z "$ROBOREV_REPOS" ] && [ -n "${ROBOREV_CI_REPOS:-}" ]; then
   ROBOREV_REPOS="$ROBOREV_CI_REPOS"
   echo "Warning: ROBOREV_CI_REPOS is deprecated; rename it to ROBOREV_REPOS" >&2
@@ -56,6 +57,7 @@ fi
 mkdir -p "$CONFIG_DIR"
 
 @sed@ \
+  -e "s/^max_workers = .*$/max_workers = ${ROBOREV_MAX_WORKERS}/" \
   -e "s/^enabled = true$/enabled = ${ROBOREV_CI_ENABLED}/" \
   -e "s|\"__ROBOREV_REPOS__\"|${TOML_REPOS}|g" \
   "$TEMPLATE" >"$CONFIG"

--- a/home-manager/services/roborev/default.nix
+++ b/home-manager/services/roborev/default.nix
@@ -53,6 +53,7 @@ lib.mkIf enabled {
       Type = "notify";
       ExecStart = "${pkgs.bash}/bin/bash ${./start.sh} ${roborevBin} ${serverAddr}";
       Restart = "on-failure";
+      RestartSec = 5;
       Environment = [
         "HOME=${homeDir}"
         "ROBOREV_DATA_DIR=${dataDir}"

--- a/home-manager/services/roborev/default.nix
+++ b/home-manager/services/roborev/default.nix
@@ -63,8 +63,9 @@ lib.mkIf enabled {
       RestartSec = 30;
       KillMode = "control-group";
       TimeoutStopSec = 30;
-      TasksMax = 512;
+      TasksMax = 1024;
       CPUQuota = "400%";
+      MemoryMax = "4G";
     };
     Install = {
       WantedBy = [ "default.target" ];

--- a/home-manager/services/roborev/default.nix
+++ b/home-manager/services/roborev/default.nix
@@ -44,12 +44,18 @@ lib.mkIf enabled {
       Description = "roborev code review daemon";
       Documentation = [ "https://github.com/roborev-dev/roborev" ];
       After = [ "network.target" ];
+      StartLimitIntervalSec = 300;
+      StartLimitBurst = 3;
     };
     Service = {
       Type = "notify";
       ExecStart = "${pkgs.bash}/bin/bash ${./start.sh} ${roborevBin} ${serverAddr}";
       Restart = "on-failure";
-      RestartSec = 5;
+      RestartSec = 30;
+      KillMode = "control-group";
+      TimeoutStopSec = 30;
+      TasksMax = 512;
+      CPUQuota = "400%";
       Environment = [
         "HOME=${homeDir}"
         "ROBOREV_DATA_DIR=${dataDir}"

--- a/home-manager/services/roborev/default.nix
+++ b/home-manager/services/roborev/default.nix
@@ -44,6 +44,8 @@ lib.mkIf enabled {
       Description = "roborev code review daemon";
       Documentation = [ "https://github.com/roborev-dev/roborev" ];
       After = [ "network.target" ];
+    }
+    // lib.optionalAttrs isKyber {
       StartLimitIntervalSec = 300;
       StartLimitBurst = 3;
     };
@@ -51,16 +53,18 @@ lib.mkIf enabled {
       Type = "notify";
       ExecStart = "${pkgs.bash}/bin/bash ${./start.sh} ${roborevBin} ${serverAddr}";
       Restart = "on-failure";
-      RestartSec = 30;
-      KillMode = "control-group";
-      TimeoutStopSec = 30;
-      TasksMax = 512;
-      CPUQuota = "400%";
       Environment = [
         "HOME=${homeDir}"
         "ROBOREV_DATA_DIR=${dataDir}"
         "PATH=${homeDir}/.local/bin:${homeDir}/.bun/bin:/etc/profiles/per-user/${config.home.username}/bin:${homeDir}/.nix-profile/bin:/usr/local/bin:/usr/bin:/bin"
       ];
+    }
+    // lib.optionalAttrs isKyber {
+      RestartSec = 30;
+      KillMode = "control-group";
+      TimeoutStopSec = 30;
+      TasksMax = 512;
+      CPUQuota = "400%";
     };
     Install = {
       WantedBy = [ "default.target" ];

--- a/spec/activate_roborev_spec.sh
+++ b/spec/activate_roborev_spec.sh
@@ -94,8 +94,9 @@ The output should include '127.0.0.1:7373'
 End
 
 It 'bounds Kyber worker resources and restart behavior'
-When run grep -E 'optionalAttrs isKyber|StartLimitIntervalSec = 300|StartLimitBurst = 3|RestartSec = 30|TimeoutStopSec = 30|TasksMax = 1024|CPUQuota = "400%"|MemoryMax = "4G"' "$PWD/home-manager/services/roborev/default.nix"
+When run grep -E 'optionalAttrs isKyber|RestartSec = 5|StartLimitIntervalSec = 300|StartLimitBurst = 3|RestartSec = 30|TimeoutStopSec = 30|TasksMax = 1024|CPUQuota = "400%"|MemoryMax = "4G"' "$PWD/home-manager/services/roborev/default.nix"
 The output should include 'optionalAttrs isKyber'
+The output should include 'RestartSec = 5'
 The output should include 'StartLimitIntervalSec = 300'
 The output should include 'StartLimitBurst = 3'
 The output should include 'RestartSec = 30'

--- a/spec/activate_roborev_spec.sh
+++ b/spec/activate_roborev_spec.sh
@@ -57,6 +57,11 @@ When run bash -c "grep 'ciEnabled = if inputs.host.isKyber then \"true\" else \"
 The output should include 'ciEnabled = if inputs.host.isKyber then "true" else "false";'
 End
 
+It 'serializes Kyber reviews while retaining desktop concurrency'
+When run bash -c "grep 'maxWorkers = if inputs.host.isKyber then \"1\" else \"4\";' '$PWD/config/roborev/default.nix'"
+The output should include 'maxWorkers = if inputs.host.isKyber then "1" else "4";'
+End
+
 It 'runs roborev daemon run'
 When run bash -c "grep 'start.sh' '$PWD/home-manager/services/roborev/default.nix'"
 The output should include 'start.sh'
@@ -86,6 +91,16 @@ End
 It 'binds the daemon to the local host'
 When run grep -F '127.0.0.1:7373' "$PWD/home-manager/services/roborev/default.nix"
 The output should include '127.0.0.1:7373'
+End
+
+It 'bounds Kyber worker resources and restart behavior'
+When run grep -E 'StartLimitIntervalSec = 300|StartLimitBurst = 3|RestartSec = 30|TimeoutStopSec = 30|TasksMax = 512|CPUQuota = "400%"' "$PWD/home-manager/services/roborev/default.nix"
+The output should include 'StartLimitIntervalSec = 300'
+The output should include 'StartLimitBurst = 3'
+The output should include 'RestartSec = 30'
+The output should include 'TimeoutStopSec = 30'
+The output should include 'TasksMax = 512'
+The output should include 'CPUQuota = "400%"'
 End
 End
 

--- a/spec/activate_roborev_spec.sh
+++ b/spec/activate_roborev_spec.sh
@@ -94,14 +94,15 @@ The output should include '127.0.0.1:7373'
 End
 
 It 'bounds Kyber worker resources and restart behavior'
-When run grep -E 'optionalAttrs isKyber|StartLimitIntervalSec = 300|StartLimitBurst = 3|RestartSec = 30|TimeoutStopSec = 30|TasksMax = 512|CPUQuota = "400%"' "$PWD/home-manager/services/roborev/default.nix"
+When run grep -E 'optionalAttrs isKyber|StartLimitIntervalSec = 300|StartLimitBurst = 3|RestartSec = 30|TimeoutStopSec = 30|TasksMax = 1024|CPUQuota = "400%"|MemoryMax = "4G"' "$PWD/home-manager/services/roborev/default.nix"
 The output should include 'optionalAttrs isKyber'
 The output should include 'StartLimitIntervalSec = 300'
 The output should include 'StartLimitBurst = 3'
 The output should include 'RestartSec = 30'
 The output should include 'TimeoutStopSec = 30'
-The output should include 'TasksMax = 512'
+The output should include 'TasksMax = 1024'
 The output should include 'CPUQuota = "400%"'
+The output should include 'MemoryMax = "4G"'
 End
 End
 

--- a/spec/activate_roborev_spec.sh
+++ b/spec/activate_roborev_spec.sh
@@ -94,7 +94,8 @@ The output should include '127.0.0.1:7373'
 End
 
 It 'bounds Kyber worker resources and restart behavior'
-When run grep -E 'StartLimitIntervalSec = 300|StartLimitBurst = 3|RestartSec = 30|TimeoutStopSec = 30|TasksMax = 512|CPUQuota = "400%"' "$PWD/home-manager/services/roborev/default.nix"
+When run grep -E 'optionalAttrs isKyber|StartLimitIntervalSec = 300|StartLimitBurst = 3|RestartSec = 30|TimeoutStopSec = 30|TasksMax = 512|CPUQuota = "400%"' "$PWD/home-manager/services/roborev/default.nix"
+The output should include 'optionalAttrs isKyber'
 The output should include 'StartLimitIntervalSec = 300'
 The output should include 'StartLimitBurst = 3'
 The output should include 'RestartSec = 30'

--- a/spec/roborev_hydrate_spec.sh
+++ b/spec/roborev_hydrate_spec.sh
@@ -42,6 +42,11 @@ End
 End
 
 Describe 'CI timing defaults'
+It 'keeps the desktop worker default in valid TOML'
+When run grep -F 'max_workers = 4' "$PWD/config/roborev/config.template.toml"
+The output should include 'max_workers = 4'
+End
+
 It 'polls promptly without canceling running reviews'
 When run bash -c "grep -E 'poll_interval = \"1m\"|batch_timeout = \"0\"' '$PWD/config/roborev/config.template.toml'"
 The output should include 'poll_interval = "1m"'
@@ -64,6 +69,8 @@ setup_hydrate() {
     "$TEMP_HOME/ghq/github.com/org/repo2"
 
   cat >"$TEMP_HOME/template.toml" <<'TOML'
+max_workers = 4
+
 [ci]
 enabled = true
 poll_interval = "5m"
@@ -90,6 +97,7 @@ BASH
   sed \
     -e 's|@sed@|sed|g' \
     -e 's|@template@|'"$TEMP_HOME"'/template.toml|g' \
+    -e 's|@maxWorkers@|1|g' \
     "$SCRIPT" >"$PREPROCESSED_SCRIPT"
   chmod +x "$PREPROCESSED_SCRIPT"
 }
@@ -109,6 +117,12 @@ The output should include '"org/repo2"'
 The output should not include '"../evil"'
 The output should not include '"foo/.."'
 The output should not include '__ROBOREV_REPOS__'
+End
+
+It 'hydrates the Kyber worker limit'
+When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; cat "'"$TEMP_HOME"'/.roborev/config.toml"'
+The status should be success
+The output should include 'max_workers = 1'
 End
 
 It 'hydrates the complete approval gate'
@@ -153,6 +167,7 @@ TOML
   sed \
     -e 's|@sed@|sed|g' \
     -e 's|@template@|'"$TEMP_HOME"'/template.toml|g' \
+    -e 's|@maxWorkers@|1|g' \
     "$SCRIPT" >"$PREPROCESSED_SCRIPT"
   chmod +x "$PREPROCESSED_SCRIPT"
 }

--- a/spec/roborev_hydrate_spec.sh
+++ b/spec/roborev_hydrate_spec.sh
@@ -100,6 +100,14 @@ BASH
     -e 's|@maxWorkers@|1|g' \
     "$SCRIPT" >"$PREPROCESSED_SCRIPT"
   chmod +x "$PREPROCESSED_SCRIPT"
+
+  PREPROCESSED_DESKTOP_SCRIPT="$TEMP_HOME/hydrate-desktop.sh"
+  sed \
+    -e 's|@sed@|sed|g' \
+    -e 's|@template@|'"$TEMP_HOME"'/template.toml|g' \
+    -e 's|@maxWorkers@|4|g' \
+    "$SCRIPT" >"$PREPROCESSED_DESKTOP_SCRIPT"
+  chmod +x "$PREPROCESSED_DESKTOP_SCRIPT"
 }
 
 cleanup_hydrate() {
@@ -123,6 +131,12 @@ It 'hydrates the Kyber worker limit'
 When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; cat "'"$TEMP_HOME"'/.roborev/config.toml"'
 The status should be success
 The output should include 'max_workers = 1'
+End
+
+It 'hydrates the desktop worker limit'
+When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$PREPROCESSED_DESKTOP_SCRIPT"'" >/dev/null 2>&1; cat "'"$TEMP_HOME"'/.roborev/config.toml"'
+The status should be success
+The output should include 'max_workers = 4'
 End
 
 It 'hydrates the complete approval gate'


### PR DESCRIPTION
## Summary
- serialize RoboRev reviews on Kyber while retaining desktop concurrency
- bound the Kyber user unit to 1024 tasks, 400% CPU, and 4 GiB memory
- force wedged shutdown after 30 seconds and rate-limit restarts
- scope all new service constraints to Kyber only

## Validation
- focused RoboRev ShellSpec: 31/31 pass
- nix-format-check: pass
- exact-head Kyber Nix build and Home Manager activation: pass
- live canary: health OK, one worker, managed listener, zero restarts
- bounded restart under load: old process tree cleared; healthy replacement in 33 seconds
- full shell-test: 2344/2345 pass; unrelated existing load-env-file environment-leak test failed

Bead: shunkakinokisoftware-9318
