### PR TITLE
fix(roborev): raise Kyber review headroom

### DIFF
--- a/home-manager/services/roborev/default.nix
+++ b/home-manager/services/roborev/default.nix
@@ -66,7 +66,7 @@ lib.mkIf enabled {
       TimeoutStopSec = 30;
       TasksMax = 1024;
       CPUQuota = "400%";
-      MemoryMax = "4G";
+      MemoryMax = "16G";
     };
     Install = {
       WantedBy = [ "default.target" ];

--- a/home-manager/services/roborev/default.nix
+++ b/home-manager/services/roborev/default.nix
@@ -64,7 +64,7 @@ lib.mkIf enabled {
       RestartSec = 30;
       KillMode = "control-group";
       TimeoutStopSec = 30;
-      TasksMax = 1024;
+      TasksMax = 2048;
       CPUQuota = "400%";
       MemoryMax = "16G";
     };

--- a/spec/activate_roborev_spec.sh
+++ b/spec/activate_roborev_spec.sh
@@ -94,7 +94,7 @@ The output should include '127.0.0.1:7373'
 End
 
 It 'bounds Kyber worker resources and restart behavior'
-When run grep -E 'optionalAttrs isKyber|RestartSec = 5|StartLimitIntervalSec = 300|StartLimitBurst = 3|RestartSec = 30|TimeoutStopSec = 30|TasksMax = 1024|CPUQuota = "400%"|MemoryMax = "4G"' "$PWD/home-manager/services/roborev/default.nix"
+When run grep -E 'optionalAttrs isKyber|RestartSec = 5|StartLimitIntervalSec = 300|StartLimitBurst = 3|RestartSec = 30|TimeoutStopSec = 30|TasksMax = 1024|CPUQuota = "400%"|MemoryMax = "16G"' "$PWD/home-manager/services/roborev/default.nix"
 The output should include 'optionalAttrs isKyber'
 The output should include 'RestartSec = 5'
 The output should include 'StartLimitIntervalSec = 300'
@@ -103,7 +103,7 @@ The output should include 'RestartSec = 30'
 The output should include 'TimeoutStopSec = 30'
 The output should include 'TasksMax = 1024'
 The output should include 'CPUQuota = "400%"'
-The output should include 'MemoryMax = "4G"'
+The output should include 'MemoryMax = "16G"'
 End
 End
 

--- a/spec/activate_roborev_spec.sh
+++ b/spec/activate_roborev_spec.sh
@@ -94,14 +94,14 @@ The output should include '127.0.0.1:7373'
 End
 
 It 'bounds Kyber worker resources and restart behavior'
-When run grep -E 'optionalAttrs isKyber|RestartSec = 5|StartLimitIntervalSec = 300|StartLimitBurst = 3|RestartSec = 30|TimeoutStopSec = 30|TasksMax = 1024|CPUQuota = "400%"|MemoryMax = "16G"' "$PWD/home-manager/services/roborev/default.nix"
+When run grep -E 'optionalAttrs isKyber|RestartSec = 5|StartLimitIntervalSec = 300|StartLimitBurst = 3|RestartSec = 30|TimeoutStopSec = 30|TasksMax = 2048|CPUQuota = "400%"|MemoryMax = "16G"' "$PWD/home-manager/services/roborev/default.nix"
 The output should include 'optionalAttrs isKyber'
 The output should include 'RestartSec = 5'
 The output should include 'StartLimitIntervalSec = 300'
 The output should include 'StartLimitBurst = 3'
 The output should include 'RestartSec = 30'
 The output should include 'TimeoutStopSec = 30'
-The output should include 'TasksMax = 1024'
+The output should include 'TasksMax = 2048'
 The output should include 'CPUQuota = "400%"'
 The output should include 'MemoryMax = "16G"'
 End


### PR DESCRIPTION
## Summary
- raise Kyber RoboRev's bounded memory ceiling from 4 GiB to 16 GiB
- raise the task ceiling from 1024 to 2048 after a normal review peaked at 1010 tasks
- preserve one-worker serialization, 400% CPU quota, bounded shutdown, and restart-rate controls

## Evidence
- the 4 GiB live canary recovered from two cgroup OOM kills during normal queued reviews
- the first 16 GiB canary reached 1010/1024 tasks without a limit event, leaving unsafe process headroom
- Kyber has 125 GiB RAM; 16 GiB and 2048 tasks remain explicit service-level ceilings

## Validation
- focused RoboRev ShellSpec: 31/31 pass
- nix-format-check: pass

Follow-up to #2507.
Bead: shunkakinokisoftware-9318
