### PR TITLE
fix(roborev): enforce Kyber daemon ownership

### DIFF
--- a/home-manager/services/roborev/default.nix
+++ b/home-manager/services/roborev/default.nix
@@ -61,6 +61,10 @@ lib.mkIf enabled {
       ];
     }
     // lib.optionalAttrs isKyber {
+      # RoboRev processes launched by agent multiplexers can outlive their
+      # parent cgroup and take the daemon port. Reclaim it before the managed
+      # unit starts so systemd remains the single daemon owner on Kyber.
+      ExecStartPre = "-${pkgs.procps}/bin/pkill -KILL -f '[r]oborev daemon run'";
       RestartSec = 30;
       KillMode = "control-group";
       TimeoutStopSec = 30;

--- a/spec/activate_roborev_spec.sh
+++ b/spec/activate_roborev_spec.sh
@@ -105,6 +105,11 @@ The output should include 'TasksMax = 2048'
 The output should include 'CPUQuota = "400%"'
 The output should include 'MemoryMax = "16G"'
 End
+
+It 'reclaims the Kyber daemon port from escaped RoboRev processes'
+When run grep -F "ExecStartPre = \"-\${pkgs.procps}/bin/pkill -KILL -f '[r]oborev daemon run'\";" "$PWD/home-manager/services/roborev/default.nix"
+The output should include "ExecStartPre = \"-\${pkgs.procps}/bin/pkill -KILL -f '[r]oborev daemon run'\";"
+End
 End
 
 Describe 'shared RoboRev hooks'


### PR DESCRIPTION
## Summary

- reclaim escaped `roborev daemon run` processes before the managed Kyber unit starts
- keep systemd as the single owner of port 7373
- cover the Kyber-only pre-start guard with ShellSpec

## Live evidence

A RoboRev daemon launched from an agent-multiplexer cgroup repeatedly won port 7373, causing the managed unit to fail and auto-restart. Freezing the multiplexer briefly, removing only rogue daemons, and starting the managed unit restored health with the expected 2,048-task and 16 GiB limits.

## Verification

- focused RoboRev ShellSpec: 32 examples, 0 failures
- `make nix-format-check`
- live managed listener: health OK, 0 restarts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep `systemd` the sole owner of the Kyber RoboRev daemon by reclaiming port 7373 from escaped processes before the unit starts. Previously, stray RoboRev daemons from agent multiplexers could outlive their cgroup and bind 7373, causing the managed unit to fail and restart; now, any manual RoboRev daemons on Kyber are terminated at start time.

**Changes**
- Add Kyber-only ExecStartPre to kill existing "roborev daemon run" processes using `procps`/pkill, ensuring the managed unit binds 7373.
- Add a ShellSpec guard to assert the pre-start reclaim is present.

<sup>Written for commit 48f21a9277832a856ccebf409eba6821b26b5cf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

