### PR TITLE
fix(openclaw): configure ACP default agent and enable acpx backend

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -308,6 +308,15 @@
       }
     ]
   },
+  "acp": {
+    "enabled": true,
+    "backend": "acpx",
+    "defaultAgent": "codex",
+    "maxConcurrentSessions": 4,
+    "runtime": {
+      "ttlMinutes": 120
+    }
+  },
   "commitments": {
     "enabled": true
   },
@@ -456,6 +465,13 @@
       "memory": "memory-core"
     },
     "entries": {
+      "acpx": {
+        "enabled": true,
+        "config": {
+          "permissionMode": "approve-all",
+          "nonInteractivePermissions": "deny"
+        }
+      },
       "telegram": {
         "enabled": true
       },

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -308,6 +308,15 @@
       }
     ]
   },
+  "acp": {
+    "enabled": true,
+    "backend": "acpx",
+    "defaultAgent": "codex",
+    "maxConcurrentSessions": 4,
+    "runtime": {
+      "ttlMinutes": 120
+    }
+  },
   "commitments": {
     "enabled": true
   },
@@ -456,6 +465,13 @@
       "memory": "memory-core"
     },
     "entries": {
+      "acpx": {
+        "enabled": true,
+        "config": {
+          "permissionMode": "approve-all",
+          "nonInteractivePermissions": "deny"
+        }
+      },
       "telegram": {
         "enabled": true
       },

--- a/spec/openclaw_hydrate_spec.sh
+++ b/spec/openclaw_hydrate_spec.sh
@@ -272,6 +272,11 @@ The output should not include '{{delivery}}'
 The status should be success
 End
 
+It 'configures ACP with a default agent and enables the acpx backend'
+When run bash -c "jq -e '.acp.enabled == true and .acp.backend == \"acpx\" and .acp.defaultAgent == \"codex\" and .plugins.entries.acpx.enabled == true' '$PWD/config/openclaw/openclaw.tpl.json' '$PWD/config/openclaw/openclaw.template.json' >/dev/null"
+The status should be success
+End
+
 It 'caps the skills catalog injected above the cache boundary'
 When run bash -c "jq -c '.skills.limits' '$PWD/config/openclaw/openclaw.tpl.json' '$PWD/config/openclaw/openclaw.template.json'"
 The output should include '"maxSkillsInPrompt":20'


### PR DESCRIPTION
## Problem

Bare `/acp spawn` failed on this gateway with a three-error chain (Aug 17):

1. **`ACP target harness id is required`** — no `acp.defaultAgent` configured
2. **`configuredBackend: acpx` → run `openclaw plugins install acpx` then `openclaw config set plugins.entries.acpx.enabled true`** — the acpx plugin was never enabled in config
3. **`ACP_SESSION_INIT_FAILED: Session is not ACP-enabled`** — consequence of the backend never loading

The config declared ACP agents (`codex` / `amp` / `factory`, all `runtime.type: acp` with `backend: acpx`) but never wired up the top-level `acp` block or the `plugins.entries.acpx` entry.

## Fix

- Add top-level `acp` block: `backend: acpx`, `defaultAgent: codex`, bounded concurrency and runtime TTL
- Enable `plugins.entries.acpx` with `permissionMode: approve-all` and graceful non-interactive permission denial (`nonInteractivePermissions: deny` so ACP sessions degrade instead of crashing on permission prompts)
- Guard both templates with a spec assertion in `spec/openclaw_hydrate_spec.sh`

Both `openclaw.tpl.json` (source) and `openclaw.template.json` (generated by `scripts/llm-update.sh`) are updated in lockstep.

## Verification

- `shellspec spec/openclaw_hydrate_spec.sh` → 27 examples, 0 failures
- `jq` assertion on both templates passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ACP so bare /acp spawn starts a session by default. Previously it failed because there was no default agent and the `acpx` backend was disabled; now a default agent is configured and the backend is enabled with safe permission defaults.

- Sets the default agent to `codex`.
- Enables `acpx` with permissionMode approve-all and nonInteractivePermissions deny to avoid crashes on prompts.
- Limits concurrent sessions to 4 and sets a 120‑minute runtime TTL.
- Adds a spec asserting ACP and `acpx` are enabled in both `openclaw.tpl.json` and `openclaw.template.json`.

<sup>Written for commit 1afaed5385451fd5fbdc2b4fe344bbe01ad46e94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

