### PR TITLE
fix(cass): bound Galactica daily analytics work

### DIFF
--- a/home-manager/services/cass/daily.sh
+++ b/home-manager/services/cass/daily.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 CASS="$HOME/.local/bin/cass"
+TIMEOUT_BIN="${CASS_DAILY_TIMEOUT_BIN:-timeout}"
+SYNC_TIMEOUT="${CASS_DAILY_SYNC_TIMEOUT:-10m}"
+ANALYTICS_TIMEOUT="${CASS_DAILY_ANALYTICS_TIMEOUT:-15m}"
 
 if [ ! -x "$CASS" ]; then
   echo "cass binary not found at $CASS"
@@ -11,9 +14,17 @@ fi
 echo "$(date): starting cass daily sync + analytics"
 
 # Sync remote sources (ignore failures for unreachable hosts)
-"$CASS" sources sync || true
+if ! "$TIMEOUT_BIN" --signal=TERM --kill-after=30s "$SYNC_TIMEOUT" \
+  "$CASS" sources sync; then
+  echo "$(date): cass source sync failed or timed out; continuing to analytics" >&2
+fi
 
-# Rebuild analytics rollup tables
-"$CASS" analytics rebuild --since -1d
+# Rebuild analytics rollup tables, but never allow the daily job to wedge the
+# machine indefinitely on a large archive.
+if ! "$TIMEOUT_BIN" --signal=TERM --kill-after=30s "$ANALYTICS_TIMEOUT" \
+  "$CASS" analytics rebuild --since -1d; then
+  echo "$(date): cass analytics rebuild failed or timed out" >&2
+  exit 1
+fi
 
 echo "$(date): cass daily sync + analytics complete"

--- a/home-manager/services/cass/daily.sh
+++ b/home-manager/services/cass/daily.sh
@@ -2,7 +2,14 @@
 set -euo pipefail
 
 CASS="$HOME/.local/bin/cass"
-TIMEOUT_BIN="${CASS_DAILY_TIMEOUT_BIN:-timeout}"
+if [ -n "${CASS_DAILY_TIMEOUT_BIN:-}" ]; then
+  TIMEOUT_BIN="$CASS_DAILY_TIMEOUT_BIN"
+elif command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_BIN="$(command -v timeout)"
+else
+  echo "cass daily: timeout binary not found; refusing to run unbounded" >&2
+  exit 1
+fi
 SYNC_TIMEOUT="${CASS_DAILY_SYNC_TIMEOUT:-10m}"
 ANALYTICS_TIMEOUT="${CASS_DAILY_ANALYTICS_TIMEOUT:-15m}"
 

--- a/home-manager/services/cass/default.nix
+++ b/home-manager/services/cass/default.nix
@@ -1,6 +1,9 @@
 { pkgs, ... }:
 let
   inherit (pkgs) lib;
+  timeoutBin = "${pkgs.coreutils}/bin/timeout";
+  syncTimeout = "10m";
+  analyticsTimeout = "15m";
 in
 {
   # Do not run `cass index --watch` persistently. On large archives it can
@@ -16,9 +19,9 @@ in
         "${./daily.sh}"
       ];
       EnvironmentVariables = {
-        CASS_DAILY_TIMEOUT_BIN = "${pkgs.coreutils}/bin/timeout";
-        CASS_DAILY_SYNC_TIMEOUT = "10m";
-        CASS_DAILY_ANALYTICS_TIMEOUT = "15m";
+        CASS_DAILY_TIMEOUT_BIN = timeoutBin;
+        CASS_DAILY_SYNC_TIMEOUT = syncTimeout;
+        CASS_DAILY_ANALYTICS_TIMEOUT = analyticsTimeout;
       };
       StartCalendarInterval = [
         {
@@ -40,9 +43,9 @@ in
       Type = "oneshot";
       ExecStart = "${pkgs.bash}/bin/bash ${./daily.sh}";
       Environment = [
-        "CASS_DAILY_TIMEOUT_BIN=${pkgs.coreutils}/bin/timeout"
-        "CASS_DAILY_SYNC_TIMEOUT=10m"
-        "CASS_DAILY_ANALYTICS_TIMEOUT=15m"
+        "CASS_DAILY_TIMEOUT_BIN=${timeoutBin}"
+        "CASS_DAILY_SYNC_TIMEOUT=${syncTimeout}"
+        "CASS_DAILY_ANALYTICS_TIMEOUT=${analyticsTimeout}"
       ];
     };
   };

--- a/home-manager/services/cass/default.nix
+++ b/home-manager/services/cass/default.nix
@@ -15,6 +15,11 @@ in
         "${pkgs.bash}/bin/bash"
         "${./daily.sh}"
       ];
+      EnvironmentVariables = {
+        CASS_DAILY_TIMEOUT_BIN = "${pkgs.coreutils}/bin/timeout";
+        CASS_DAILY_SYNC_TIMEOUT = "10m";
+        CASS_DAILY_ANALYTICS_TIMEOUT = "15m";
+      };
       StartCalendarInterval = [
         {
           Hour = 4;
@@ -34,6 +39,11 @@ in
     Service = {
       Type = "oneshot";
       ExecStart = "${pkgs.bash}/bin/bash ${./daily.sh}";
+      Environment = [
+        "CASS_DAILY_TIMEOUT_BIN=${pkgs.coreutils}/bin/timeout"
+        "CASS_DAILY_SYNC_TIMEOUT=10m"
+        "CASS_DAILY_ANALYTICS_TIMEOUT=15m"
+      ];
     };
   };
 


### PR DESCRIPTION
## Summary\n\n- Bound Cass source sync to 10 minutes and analytics rebuild to 15 minutes with a 30-second termination grace period.\n- Prevented the 04:00 daily job from wedging Galactica indefinitely on large archives.\n- Configured the timeout path for both launchd and systemd.\n\n## Validation\n\n- Running: /etc/profiles/per-user/shunkakinoki/bin/bash [bash 5.3.9(1)-release]
............

Finished in 3.45 seconds (user 0.19 seconds, sys 0.18 seconds)
12 examples, 0 failures — 12 examples, 0 failures\n- \n- \n- Nix build/activation intentionally not run yet per user instruction.\n\nLinear: none — user-directed host incident fix\nBead: none — user-directed host incident fix