### PR TITLE
fix(roborev): tolerate failing droid panel member

### DIFF
--- a/config/roborev/config.template.toml
+++ b/config/roborev/config.template.toml
@@ -18,6 +18,16 @@ model = 'free'
 review_type = 'default'
 allow_failure = true
 
+[review.subagents.antigravity]
+agent = 'antigravity'
+review_type = 'default'
+allow_failure = true
+
+[review.subagents.opencode]
+agent = 'opencode'
+review_type = 'default'
+allow_failure = true
+
 [review.subagents.droid]
 agent = 'droid'
 review_type = 'default'

--- a/config/roborev/config.template.toml
+++ b/config/roborev/config.template.toml
@@ -19,7 +19,10 @@ review_type = 'default'
 allow_failure = true
 
 [review.panels.full]
-members = ['antigravity', 'opencode', 'droid', 'pi-oxalpha', 'pi']
+# Droid currently exits with "Exec failed" on Kyber and consumes all three
+# retries before the fallback agent can run. Keep the panel drainable until
+# the Kyber Droid launcher is repaired.
+members = ['antigravity', 'opencode', 'pi-oxalpha', 'pi']
 synthesis_agent = 'gemini'
 
 [ci]

--- a/config/roborev/config.template.toml
+++ b/config/roborev/config.template.toml
@@ -18,11 +18,14 @@ model = 'free'
 review_type = 'default'
 allow_failure = true
 
+[review.subagents.droid]
+agent = 'droid'
+review_type = 'default'
+allow_failure = true
+
 [review.panels.full]
-# Droid currently exits with "Exec failed" on Kyber and consumes all three
-# retries before the fallback agent can run. Keep the panel drainable until
-# the Kyber Droid launcher is repaired.
-members = ['antigravity', 'opencode', 'pi-oxalpha', 'pi']
+# Droid is useful when available, but its Kyber launcher is currently flaky.
+members = ['antigravity', 'opencode', 'droid', 'pi-oxalpha', 'pi']
 synthesis_agent = 'gemini'
 
 [ci]


### PR DESCRIPTION
## Summary
- Keep all five full-panel reviewers enabled: Antigravity, OpenCode, Droid, Pi/Ox-Alpha, and Pi.
- Define every panel member explicitly with `allow_failure = true`.
- Preserve successful findings from any reviewer without letting a flaky member fail the panel.
- Gemini remains the required synthesis path with its existing fallback behavior.

## Validation
- `shellspec spec/roborev_hydrate_spec.sh spec/activate_roborev_spec.sh spec/roborev_hooks_spec.sh` — 37 examples, 0 failures
- `make nix-format-check` — passed
- Local Nix activation evaluation was environment-blocked by cache DNS failure and the Kyber x86_64-linux package being evaluated from aarch64-darwin.