### PR TITLE
fix(roborev): use supported antigravity agent name

### DIFF
--- a/config/roborev/config.template.toml
+++ b/config/roborev/config.template.toml
@@ -19,7 +19,7 @@ review_type = 'default'
 allow_failure = true
 
 [review.subagents.antigravity]
-agent = 'antigravity'
+agent = 'acp.antigravity'
 review_type = 'default'
 allow_failure = true
 


### PR DESCRIPTION
## Summary
- use RoboRev's supported `acp.antigravity` named-agent identifier
- keep Antigravity explicitly best-effort with `allow_failure = true`

## Validation
- `shellspec spec/roborev_hydrate_spec.sh spec/activate_roborev_spec.sh spec/roborev_hooks_spec.sh`
- `make nix-format-check`

This follow-up is required because Kyber's RoboRev v0.66.0 rejected `antigravity` and fell back to defaults.