### PR TITLE
fix(roborev): size Kyber worker pool for host

### DIFF
--- a/config/roborev/config.template.toml
+++ b/config/roborev/config.template.toml
@@ -1,5 +1,5 @@
-# Kyber overrides this to one worker during hydration so a burst of full-panel
-# reviews cannot saturate the host. Desktop hosts retain the upstream default.
+# Kyber uses eight workers during hydration to match its host capacity while
+# keeping desktop hosts at the upstream default.
 max_workers = 4
 
 # Pi review subagents: ox-alpha via OpenRouter first, cliproxy free as fallback.

--- a/config/roborev/default.nix
+++ b/config/roborev/default.nix
@@ -11,7 +11,7 @@ let
     let
       vars = {
         ciEnabled = if inputs.host.isKyber then "true" else "false";
-        maxWorkers = if inputs.host.isKyber then "1" else "4";
+        maxWorkers = if inputs.host.isKyber then "8" else "4";
         sed = "${pkgs.gnused}/bin/sed";
         template = "${./config.template.toml}";
       };

--- a/spec/activate_roborev_spec.sh
+++ b/spec/activate_roborev_spec.sh
@@ -57,9 +57,9 @@ When run bash -c "grep 'ciEnabled = if inputs.host.isKyber then \"true\" else \"
 The output should include 'ciEnabled = if inputs.host.isKyber then "true" else "false";'
 End
 
-It 'serializes Kyber reviews while retaining desktop concurrency'
-When run bash -c "grep 'maxWorkers = if inputs.host.isKyber then \"1\" else \"4\";' '$PWD/config/roborev/default.nix'"
-The output should include 'maxWorkers = if inputs.host.isKyber then "1" else "4";'
+It 'sizes Kyber reviews for host capacity while retaining desktop concurrency'
+When run bash -c "grep 'maxWorkers = if inputs.host.isKyber then \"8\" else \"4\";' '$PWD/config/roborev/default.nix'"
+The output should include 'maxWorkers = if inputs.host.isKyber then "8" else "4";'
 End
 
 It 'runs roborev daemon run'


### PR DESCRIPTION
## Summary
- hydrate Kyber RoboRev with 8 workers instead of 1
- retain 4 workers on desktop hosts
- update the activation assertion to cover the Kyber capacity setting

## Validation
- `shellspec spec/roborev_hydrate_spec.sh spec/activate_roborev_spec.sh spec/roborev_hooks_spec.sh`
- `make nix-format-check`

The earlier one-worker containment removed the burst, but left Kyber as the throughput bottleneck. Kyber has 48 CPUs and a 16G RoboRev memory cap.