### PR TITLE
fix(dolt): prevent overlapping Linear sync timers

### DIFF
--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -241,7 +241,6 @@ lib.mkIf enabled {
     Timer = {
       OnBootSec = "2min";
       OnCalendar = "*-*-* *:00/15:00";
-      OnUnitActiveSec = "${toString linearSyncIntervalSeconds}s";
       Persistent = true;
       Unit = "dolt-linear-sync.service";
     };

--- a/spec/beads_linear_sync_spec.sh
+++ b/spec/beads_linear_sync_spec.sh
@@ -551,7 +551,7 @@ The status should be success
 End
 
 It 'installs the Kyber Linux systemd timer'
-When run bash -c "grep -F 'systemd.user.timers.dolt-linear-sync' '$MODULE' >/dev/null && grep -F 'OnCalendar = \"*-*-* *:00/15:00\";' '$MODULE' >/dev/null && grep -F 'X-SwitchMethod = \"restart\";' '$MODULE' >/dev/null"
+When run bash -c "timer=\$(sed -n '/systemd.user.timers.dolt-linear-sync/,/^  };/p' '$MODULE'); grep -F 'OnCalendar = \"*-*-* *:00/15:00\";' <<<\"\$timer\" >/dev/null && ! grep -F 'OnUnitActiveSec' <<<\"\$timer\" >/dev/null && grep -F 'Persistent = true;' <<<\"\$timer\" >/dev/null && grep -F 'X-SwitchMethod = \"restart\";' '$MODULE' >/dev/null"
 The status should be success
 End
 End


### PR DESCRIPTION
## Summary
- keep the Kyber Beads/Linear timer on one fixed 15-minute calendar
- remove the redundant monotonic trigger that queued immediate follow-up runs after long reconciliations
- assert the timer remains persistent and has no `OnUnitActiveSec`

## Validation
- `shellspec spec/beads_linear_sync_spec.sh` (50 examples, 0 failures)
- `make nix-lint`
- `git diff --check`

Relates to dotfiles Bead `shunkakinokisoftware-w3nk`.