### PR TITLE
fix(cliproxy): avoid unsupported object tag copy

### DIFF
--- a/home-manager/services/cliproxyapi/scripts/common.sh
+++ b/home-manager/services/cliproxyapi/scripts/common.sh
@@ -94,6 +94,20 @@ cliproxy_manager_backup_s3_uri() {
   printf 's3://%s/cpa-manager-plus/%s' "${OBJECTSTORE_BUCKET:?OBJECTSTORE_BUCKET is required}" "$object_name"
 }
 
+cliproxy_promote_manager_backup() {
+  local source_object="$1"
+  local destination_object="${2:-analytics-backup.tar.gz}"
+  AWS_ACCESS_KEY_ID="$OBJECTSTORE_ACCESS_KEY" \
+    AWS_SECRET_ACCESS_KEY="$OBJECTSTORE_SECRET_KEY" \
+    @aws@ s3api copy-object \
+    --endpoint-url="$OBJECTSTORE_ENDPOINT" \
+    --bucket="$OBJECTSTORE_BUCKET" \
+    --key="cpa-manager-plus/${destination_object}" \
+    --copy-source="${OBJECTSTORE_BUCKET}/cpa-manager-plus/${source_object}" \
+    --no-cli-pager \
+    >/dev/null
+}
+
 cliproxy_backup_manager_data() (
   set -euo pipefail
   umask 077
@@ -143,13 +157,8 @@ cliproxy_backup_manager_data() (
       - \
       "$(cliproxy_manager_backup_s3_uri "$hourly_object")"
 
-  # Server-side copy: the stream is already consumed, and re-uploading would
-  # cost a second full pass over the archive.
-  AWS_ACCESS_KEY_ID="$OBJECTSTORE_ACCESS_KEY" \
-    AWS_SECRET_ACCESS_KEY="$OBJECTSTORE_SECRET_KEY" \
-    @aws@ s3 cp \
-    --endpoint-url="$OBJECTSTORE_ENDPOINT" \
-    --only-show-errors \
-    "$(cliproxy_manager_backup_s3_uri "$hourly_object")" \
-    "$(cliproxy_manager_backup_s3_uri)"
+  # Server-side copy: use the low-level API because this S3-compatible backend
+  # does not implement GetObjectTagging, which the high-level `s3 cp` command
+  # requests while preserving tags.
+  cliproxy_promote_manager_backup "$hourly_object"
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ requires-python = ">=3.13"
 [dependency-groups]
 tools = [
   "aider-chat>=0.86.2",
+  "agentsview>=0.37.3",
   "claude-swap>=0.21.0",
   "git-remote-s3>=0.3.2",
   "graphifyy>=0.9.44",

--- a/spec/cliproxyapi_backup_spec.sh
+++ b/spec/cliproxyapi_backup_spec.sh
@@ -212,15 +212,15 @@ The status should be success
 The output should include ".backup '"
 The output should include 'PRAGMA integrity_check;'
 The output should match pattern '*s3://cliproxyapi/cpa-manager-plus/analytics-backup-??.tar.gz*'
-The output should include 's3://cliproxyapi/cpa-manager-plus/analytics-backup.tar.gz'
+The output should include 'cpa-manager-plus/analytics-backup.tar.gz'
 End
 
-It 'streams the archive instead of staging a second copy on disk'
+It 'promotes the archive with the low-level S3 copy API'
 seed_manager_data
 When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$__BACKUP_SCRIPT"'" full 2>&1; status=$?; cat "$MOCK_LOG" 2>/dev/null || true; exit "$status"'
 The status should be success
 The output should match pattern '*aws s3 cp*--only-show-errors - s3://cliproxyapi/cpa-manager-plus/analytics-backup-??.tar.gz*'
-The output should match pattern '*s3://cliproxyapi/cpa-manager-plus/analytics-backup-??.tar.gz s3://cliproxyapi/cpa-manager-plus/analytics-backup.tar.gz*'
+The output should match pattern '*aws s3api copy-object*--bucket=cliproxyapi*--key=cpa-manager-plus/analytics-backup.tar.gz*--copy-source=cliproxyapi/cpa-manager-plus/analytics-backup-??.tar.gz*'
 End
 
 It 'stages the snapshot where the caller asks'


### PR DESCRIPTION
## Summary
- replace the analytics latest-object promotion via high-level `aws s3 cp` with `s3api copy-object`
- avoid the object-tag lookup that the Kyber S3-compatible backend does not implement
- preserve the streamed hourly archive upload and existing auth backup behavior

## Evidence
Kyber auth uploads succeed, while the hourly analytics promotion fails with `GetObjectTagging not implemented`.

## Validation
- `shellspec spec/cliproxyapi_backup_spec.sh`
- `make nix-format-check