### PR TITLE
fix(agentsview): install token usage provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ requires-python = ">=3.13"
 [dependency-groups]
 tools = [
   "aider-chat>=0.86.2",
+  "agentsview>=0.37.3",
   "claude-swap>=0.21.0",
   "git-remote-s3>=0.3.2",
   "graphifyy>=0.9.44",


### PR DESCRIPTION
## Summary
- add `agentsview>=0.37.3` to the declarative `uv` tools group
- let the existing Home Manager uv-global installer provide the `agentsview` executable used by RoboRev token-cost reconciliation

## Validation
- `shellspec spec/uv_globals_spec.sh`
- `make nix-format-check`

This branch is stacked on #2524.