### PR TITLE
fix(kyber): move Crabbox off occupied port

### DIFF
--- a/home-manager/services/crabbox/README.md
+++ b/home-manager/services/crabbox/README.md
@@ -3,7 +3,7 @@
 Crabbox runs as two systemd user services on Kyber:
 
 - `crabbox-postgres.service` runs PostgreSQL on loopback port `55432`.
-- `crabbox.service` runs the upstream Node coordinator on loopback port `8080`.
+- `crabbox.service` runs the upstream Node coordinator on loopback port `18080`.
 
 The coordinator installation is intentionally separate from the service definition. Run
 `ulb crabbox` to clone/update Crabbox, install its locked npm dependencies, build
@@ -25,6 +25,6 @@ TLS, and WebSocket routing.
 ulb crabbox
 systemctl --user restart crabbox-postgres crabbox
 systemctl --user status crabbox-postgres crabbox
-curl --fail http://127.0.0.1:8080/v1/health
-curl --fail http://127.0.0.1:8080/v1/ready
+curl --fail http://127.0.0.1:18080/v1/health
+curl --fail http://127.0.0.1:18080/v1/ready
 ```

--- a/home-manager/services/crabbox/default.nix
+++ b/home-manager/services/crabbox/default.nix
@@ -12,7 +12,7 @@ let
   socketDir = "${homeDir}/.local/share/crabbox/postgres-socket";
   coordinatorBin = "${homeDir}/ghq/github.com/openclaw/crabbox/worker/dist-node/crabbox-coordinator";
   postgresPort = "55432";
-  coordinatorPort = "8080";
+  coordinatorPort = "18080";
   initPostgres = pkgs.replaceVars ./init-postgres.sh {
     inherit dataDir socketDir;
     databaseAdmin = config.home.username;

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -147,12 +147,12 @@ home-manager.lib.homeManagerConfiguration {
 
         # Publish every Kyber gateway over tailnet-only HTTPS. Each service
         # needs the serve root, so OpenClaw keeps :443 while T3 and Hermes use
-        # dedicated ports. Crabbox runs directly on the host on port 8080.
+        # dedicated ports. Crabbox runs directly on the host on port 18080.
         home.activation.tailscaleServeGateways = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
           $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-tailscale-serve.sh}" 443 18789
           $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-tailscale-serve.sh}" 8443 3773
           $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-tailscale-serve.sh}" 9443 9120
-          $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-tailscale-serve.sh}" 10443 8080
+          $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-tailscale-serve.sh}" 10443 18080
         '';
 
         # Tailscale configuration

--- a/spec/tailscale_serve_spec.sh
+++ b/spec/tailscale_serve_spec.sh
@@ -139,7 +139,7 @@ End
 
 It 'publishes the host Crabbox coordinator on 10443 for kyber'
 When run bash -c "cat '$KYBER'"
-The output should include 'ensure-tailscale-serve.sh}" 10443 8080'
+The output should include 'ensure-tailscale-serve.sh}" 10443 18080'
 End
 End
 


### PR DESCRIPTION
## Summary

- move the Crabbox Node coordinator backend from port 8080 to 18080
- update kyber Tailscale Serve routing and operator documentation
- preserve the existing service already bound to port 8080

## Root cause

The new `:10443` route proxied `127.0.0.1:8080`, which was already serving AgentsView. Crabbox consequently failed to bind its coordinator listener.

## Validation

- `git diff --check`
- `nixfmt --check home-manager/services/crabbox/default.nix named-hosts/kyber/default.nix`
- `shellspec --no-quick --fail-no-examples spec/tailscale_serve_spec.sh:140` (1 example, 0 failures)
- `HOST=kyber HOSTNAME=kyber NIXPKGS_ALLOW_UNFREE=1 nix build .#homeConfigurations.kyber.activationPackage --impure --no-update-lock-file --show-trace --no-link`

The complete `tailscale_serve_spec.sh` also reaches an unrelated environment-specific failure because its missing-Tailscale case hardcodes `/usr/bin:/bin` and this NixOS workstation has no `/usr/bin/bash`; the changed Crabbox wiring example passes directly.