### PR TITLE
fix(roborev): lower MemoryMax and rotate bloated opencode DB on start

### DIFF
--- a/home-manager/services/roborev/default.nix
+++ b/home-manager/services/roborev/default.nix
@@ -61,16 +61,18 @@ lib.mkIf enabled {
       ];
     }
     // lib.optionalAttrs isKyber {
-      # RoboRev processes launched by agent multiplexers can outlive their
-      # parent cgroup and take the daemon port. Reclaim it before the managed
-      # unit starts so systemd remains the single daemon owner on Kyber.
-      ExecStartPre = "-${pkgs.procps}/bin/pkill -KILL -f '[r]oborev daemon run'";
+      ExecStartPre = [
+        # Reclaim daemon port from orphaned processes
+        "-${pkgs.procps}/bin/pkill -KILL -f '[r]oborev daemon run'"
+        # Rotate opencode DB when it exceeds 500MB (accumulated session data from reviews)
+        "-${pkgs.bash}/bin/bash -c 'db=${homeDir}/.local/share/opencode/opencode-stable.db; [ -f \"$db\" ] && sz=$(stat -c%%s \"$db\" 2>/dev/null || echo 0) && [ \"$sz\" -gt 524288000 ] && mv \"$db\" \"$db.rotated-$(date +%%Y%%m%%dT%%H%%M%%S)\" && rm -f \"$db\"-wal \"$db\"-shm'"
+      ];
       RestartSec = 30;
       KillMode = "control-group";
       TimeoutStopSec = 30;
       TasksMax = 2048;
       CPUQuota = "400%";
-      MemoryMax = "16G";
+      MemoryMax = "8G";
     };
     Install = {
       WantedBy = [ "default.target" ];


### PR DESCRIPTION
## Summary

- MemoryMax 16G -> 8G: normal usage is ~350MB; 16G allowed opencode's session DB to grow to 2.8GB, causing 16GB memory peak and OOM kill after 4h37m CPU
- ExecStartPre rotates `opencode-stable.db` when >500MB on each restart, preventing the accumulated session/event data (471K events) from causing concurrent-write timeouts on the `INSERT INTO project` query

## Context

The roborev daemon on kyber hit a 16GB memory peak from 8 workers all loading a 2.8GB opencode SQLite DB. The service was killed, and after restart the bloated DB caused `INSERT INTO project ... ON CONFLICT DO UPDATE` failures (exit status 1) which put the required opencode lane into permanent retry/fail, blocking the `roborev` commit status on 8 PR heads.

Fix applied live: moved the 2.8GB DB aside, queue resumed, opencode reviews completing successfully, GitHub statuses landing again.

## Remaining

- reviews.db (679MB) needs a VACUUM during the next full restart (couldn't vacuum while service holds it open) - reduces context deadline exceeded on job claims
- Old rotated DBs on kyber (`opencode-stable.db.bak-20260825`) can be deleted after confirming stability