### PR TITLE
fix(crabbox): trust kyber loopback proxy

### DIFF
--- a/home-manager/services/crabbox/README.md
+++ b/home-manager/services/crabbox/README.md
@@ -23,9 +23,11 @@ Generated database and auth secrets live in
 coordinator settings belong in the machine-local `~/dotfiles/.env`; no provider token is
 required merely to start the coordinator.
 
-The coordinator trusts forwarded origin and client headers only from Kyber's Kubernetes
-pod CIDR (`10.42.1.0/24` by default). Override `CRABBOX_TRUSTED_PROXY_CIDRS` in the
-machine-local environment if the cluster pod CIDR changes.
+The coordinator trusts forwarded origin and client headers only from loopback and
+Kyber's Kubernetes pod CIDR (`127.0.0.1/32,10.42.1.0/24` by default). Loopback is
+required because kube-proxy source-NATs the host-backed ingress endpoint on Kyber.
+Override `CRABBOX_TRUSTED_PROXY_CIDRS` in the machine-local environment if the cluster
+pod CIDR changes.
 
 After creating the Cloudflare Access application, put its audience tag in Kyber's
 `~/dotfiles/.env` as `CRABBOX_ACCESS_AUD`. The Access team domain defaults to

--- a/home-manager/services/crabbox/start.sh
+++ b/home-manager/services/crabbox/start.sh
@@ -70,7 +70,7 @@ fi
 export DATABASE_URL="postgresql://crabbox:${POSTGRES_PASSWORD}@127.0.0.1:${POSTGRES_PORT}/crabbox?sslmode=disable"
 export PORT="@coordinatorPort@"
 export CRABBOX_PUBLIC_URL="${CRABBOX_PUBLIC_URL:-https://crabbox.shunkakinoki.com}"
-export CRABBOX_TRUSTED_PROXY_CIDRS="${CRABBOX_TRUSTED_PROXY_CIDRS:-10.42.1.0/24}"
+export CRABBOX_TRUSTED_PROXY_CIDRS="${CRABBOX_TRUSTED_PROXY_CIDRS:-127.0.0.1/32,10.42.1.0/24}"
 export CRABBOX_ACCESS_TEAM_DOMAIN="${CRABBOX_ACCESS_TEAM_DOMAIN:-shunkakinoki.cloudflareaccess.com}"
 export CRABBOX_SHARED_OWNER="${CRABBOX_SHARED_OWNER:-kyber}"
 export CRABBOX_DEFAULT_ORG="${CRABBOX_DEFAULT_ORG:-personal}"

--- a/spec/crabbox_spec.sh
+++ b/spec/crabbox_spec.sh
@@ -76,10 +76,11 @@ The output should include '/v1/health'
 The output should include '/v1/ready'
 End
 
-It 'uses the public portal origin and trusts only the Kyber pod CIDR'
+It 'uses the public portal origin and trusts only the Kyber proxy paths'
 When run bash -c "cat '$START'"
 The output should include 'https://crabbox.shunkakinoki.com'
 The output should include 'CRABBOX_TRUSTED_PROXY_CIDRS'
+The output should include '127.0.0.1/32,10.42.1.0/24'
 The output should include '10.42.1.0/24'
 The output should include 'CRABBOX_ACCESS_TEAM_DOMAIN'
 The output should include 'shunkakinoki.cloudflareaccess.com'


### PR DESCRIPTION
## Summary

- trust kyber loopback in addition to the Kubernetes pod CIDR
- document kube-proxy source NAT for the host-backed ingress endpoint
- cover the exact trusted proxy default in the Crabbox spec

Kubernetes reaches the host endpoint with peer address `127.0.0.1`. Without loopback trust, Crabbox ignores nginx's forwarded HTTPS origin and authenticated portal requests can loop through the public Cloudflare URL.

## Verification

- `shellspec spec/crabbox_spec.sh` (11 examples, 0 failures)
- `shellcheck home-manager/services/crabbox/start.sh`
- `git diff --check`
- kyber process has `CRABBOX_TRUSTED_PROXY_CIDRS=127.0.0.1/32,10.42.1.0/24`
- ingress request no longer logs the untrusted-peer warning
- local readiness remains healthy