### PR TITLE
fix(crabbox): let Cloudflare own portal origin

### DIFF
--- a/home-manager/services/crabbox/README.md
+++ b/home-manager/services/crabbox/README.md
@@ -14,7 +14,9 @@ the service.
 
 Home Manager creates and starts the services. Cloudflare Tunnel and Access protect
 `https://crabbox.shunkakinoki.com`, then the production Kubernetes ingress proxies the
-request to the host service. Tailscale Serve retains the tailnet-only
+request to the host service. As with Kubernetes Dashboard, Cloudflare owns the public
+HTTPS boundary; the coordinator does not force a separate canonical public origin.
+Tailscale Serve retains the tailnet-only
 `https://kyber.tail950b36.ts.net:10443` compatibility endpoint. PostgreSQL is never
 exposed.
 
@@ -40,7 +42,8 @@ application's Service Auth policy. Store its client ID and secret in the client'
 `CRABBOX_ACCESS_CLIENT_ID` and `CRABBOX_ACCESS_CLIENT_SECRET`. The Access credential gets
 the request through Cloudflare; the normal Crabbox shared/user token is still required.
 
-Portal login requires a GitHub OAuth app with these URLs:
+GitHub OAuth is optional. If it is enabled for Crabbox portal sessions, configure the app
+with these URLs and make sure the proxy forwards the public HTTPS origin:
 
 - Homepage: `https://crabbox.shunkakinoki.com`
 - Callback: `https://crabbox.shunkakinoki.com/v1/auth/github/callback`

--- a/home-manager/services/crabbox/start.sh
+++ b/home-manager/services/crabbox/start.sh
@@ -69,7 +69,6 @@ fi
 
 export DATABASE_URL="postgresql://crabbox:${POSTGRES_PASSWORD}@127.0.0.1:${POSTGRES_PORT}/crabbox?sslmode=disable"
 export PORT="@coordinatorPort@"
-export CRABBOX_PUBLIC_URL="${CRABBOX_PUBLIC_URL:-https://crabbox.shunkakinoki.com}"
 export CRABBOX_TRUSTED_PROXY_CIDRS="${CRABBOX_TRUSTED_PROXY_CIDRS:-127.0.0.1/32,10.42.1.0/24}"
 export CRABBOX_ACCESS_TEAM_DOMAIN="${CRABBOX_ACCESS_TEAM_DOMAIN:-shunkakinoki.cloudflareaccess.com}"
 export CRABBOX_SHARED_OWNER="${CRABBOX_SHARED_OWNER:-kyber}"

--- a/spec/crabbox_spec.sh
+++ b/spec/crabbox_spec.sh
@@ -76,9 +76,9 @@ The output should include '/v1/health'
 The output should include '/v1/ready'
 End
 
-It 'uses the public portal origin and trusts only the Kyber proxy paths'
+It 'lets Cloudflare own the public portal origin and trusts only the Kyber proxy paths'
 When run bash -c "cat '$START'"
-The output should include 'https://crabbox.shunkakinoki.com'
+The output should not include 'CRABBOX_PUBLIC_URL'
 The output should include 'CRABBOX_TRUSTED_PROXY_CIDRS'
 The output should include '127.0.0.1/32,10.42.1.0/24'
 The output should include '10.42.1.0/24'


### PR DESCRIPTION
## Summary
- match the Kubernetes Dashboard proxy model by leaving the public HTTPS boundary to Cloudflare
- stop forcing `CRABBOX_PUBLIC_URL`, which caused the HTTP tunnel hop to redirect back to the same public URL
- document optional GitHub OAuth origin requirements

## Tests
- `shellspec spec/crabbox_spec.sh`
- `shellcheck home-manager/services/crabbox/start.sh home-manager/services/crabbox/init-postgres.sh home-manager/services/crabbox/health-check.sh`
- `git diff --check`
- live Kyber origin now redirects `/portal` to `/portal/login` instead of to itself