### PR TITLE
fix(home-manager): restrict grok to linux-only platforms

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -70,7 +70,6 @@ with pkgs;
   google-cloud-sdk
   gping
   grc
-  pkgs.llm-agents.grok
   gron
   pkgs.llm-agents.herdr
   hexyl
@@ -159,6 +158,7 @@ with pkgs;
   gcc
   gemini-cli
   glib
+  pkgs.llm-agents.grok
   keychain
   libiconv
   libsecret


### PR DESCRIPTION
## Summary
- Moves `pkgs.llm-agents.grok` from the unconditional packages list to the `lib.optionals stdenv.isLinux` section
- `wrap-buddy-hook` (a dependency of `grok`) only supports Linux platforms and caused `make build` to fail on `aarch64-darwin`

## Error fixed
```
error: Refusing to evaluate package 'wrap-buddy-hook' because it is not available on the requested hostPlatform:
  hostPlatform.system = "aarch64-darwin"
```