### PR TITLE
fix(dolt): use tailnet beads account

### DIFF
--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -21,9 +21,13 @@ let
   linearSyncIntervalSeconds = 900;
   federationSyncIntervalSeconds = 300;
   linearSyncPath = "${homeDir}/.local/bin:${homeDir}/.bun/bin:${homeDir}/.nix-profile/bin:/etc/profiles/per-user/${config.home.username}/bin:/run/current-system/sw/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
-  enabled = isGalactica || isKyber || isMatic;
+  clientEnabled = isGalactica || isKyber || isMatic;
+  serverEnabled = isKyber;
+  doltServerHost = if isKyber then "127.0.0.1" else "kyber.tail950b36.ts.net";
   linearSyncEnabled = isKyber;
-  federationSyncEnabled = isGalactica || isMatic;
+  # Every supported agent host writes directly to Kyber's SQL server. Kyber
+  # alone publishes that shared history to the configured remotes.
+  federationSyncEnabled = isKyber;
   # 2.2.2 fixes gitblobstore pending-write pruning that could publish a
   # manifest whose live archive later failed with "Blob not found".
   doltMinVersion = "2.2.2";
@@ -57,7 +61,7 @@ let
     inherit (pkgs) coreutils;
   };
 in
-lib.mkIf enabled {
+lib.mkIf clientEnabled {
   assertions = [
     {
       assertion = lib.versionAtLeast pkgs.dolt.version doltMinVersion;
@@ -66,9 +70,10 @@ lib.mkIf enabled {
   ];
 
   home.sessionVariables = {
-    BEADS_DOLT_SHARED_SERVER = "1";
+    BEADS_DOLT_SERVER_MODE = "1";
+    BEADS_DOLT_SERVER_HOST = doltServerHost;
     BEADS_DOLT_SERVER_PORT = "3307";
-    BEADS_SHARED_SERVER_DIR = sharedServerDir;
+    BEADS_DOLT_SERVER_USER = "root";
     DOLT_CLI_USER = "root";
     DOLT_CLI_PASSWORD = "";
     LINEAR_TEAM_ID = linearTeamId;
@@ -79,7 +84,7 @@ lib.mkIf enabled {
     executable = true;
   };
 
-  launchd.agents.dolt = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.dolt = lib.mkIf (pkgs.stdenv.isDarwin && serverEnabled) {
     enable = true;
     config = {
       ProgramArguments = [
@@ -98,7 +103,7 @@ lib.mkIf enabled {
   # is visible in the GitHub UI (Dolt's native push only writes refs/dolt/data).
   # Triggered by manifest changes inside dolt's noms store; throttled to avoid
   # hammering on rapid writes.
-  launchd.agents.dolt-backup-main = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.dolt-backup-main = lib.mkIf (pkgs.stdenv.isDarwin && serverEnabled) {
     enable = true;
     config = {
       ProgramArguments = [
@@ -129,9 +134,10 @@ lib.mkIf enabled {
       EnvironmentVariables = {
         HOME = homeDir;
         PATH = linearSyncPath;
-        BEADS_DOLT_SHARED_SERVER = "1";
+        BEADS_DOLT_SERVER_MODE = "1";
+        BEADS_DOLT_SERVER_HOST = doltServerHost;
         BEADS_DOLT_SERVER_PORT = "3307";
-        BEADS_SHARED_SERVER_DIR = sharedServerDir;
+        BEADS_DOLT_SERVER_USER = "root";
         DOLT_CLI_USER = "root";
         DOLT_CLI_PASSWORD = "";
         LINEAR_TEAM_ID = linearTeamId;
@@ -155,9 +161,10 @@ lib.mkIf enabled {
       EnvironmentVariables = {
         HOME = homeDir;
         PATH = linearSyncPath;
-        BEADS_DOLT_SHARED_SERVER = "1";
+        BEADS_DOLT_SERVER_MODE = "1";
+        BEADS_DOLT_SERVER_HOST = doltServerHost;
         BEADS_DOLT_SERVER_PORT = "3307";
-        BEADS_SHARED_SERVER_DIR = sharedServerDir;
+        BEADS_DOLT_SERVER_USER = "root";
         DOLT_CLI_USER = "root";
         DOLT_CLI_PASSWORD = "";
       };
@@ -166,7 +173,7 @@ lib.mkIf enabled {
     };
   };
 
-  systemd.user.services.dolt = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.dolt = lib.mkIf (pkgs.stdenv.isLinux && serverEnabled) {
     Unit = {
       Description = "Dolt SQL server for dotfiles beads";
       After = [ "network.target" ];
@@ -177,13 +184,17 @@ lib.mkIf enabled {
       Restart = "always";
       RestartSec = 5;
       WorkingDirectory = repoDir;
+      # Kyber's WAN firewall drops all new public-interface ingress. Binding
+      # all addresses makes the SQL service reachable on tailscale0 while
+      # retaining the public-ingress deny boundary.
+      Environment = [ "BEADS_DOLT_LISTEN_HOST=0.0.0.0" ];
     };
     Install = {
       WantedBy = [ "default.target" ];
     };
   };
 
-  systemd.user.services.dolt-backup-main = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.dolt-backup-main = lib.mkIf (pkgs.stdenv.isLinux && serverEnabled) {
     Unit = {
       Description = "Push beads_global JSONL snapshot to GitHub main";
     };
@@ -194,7 +205,7 @@ lib.mkIf enabled {
     };
   };
 
-  systemd.user.paths.dolt-backup-main = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.paths.dolt-backup-main = lib.mkIf (pkgs.stdenv.isLinux && serverEnabled) {
     Unit = {
       Description = "Watch dolt manifest and trigger JSONL backup";
     };
@@ -226,9 +237,10 @@ lib.mkIf enabled {
       Environment = [
         "HOME=${homeDir}"
         "PATH=${linearSyncPath}"
-        "BEADS_DOLT_SHARED_SERVER=1"
+        "BEADS_DOLT_SERVER_MODE=1"
+        "BEADS_DOLT_SERVER_HOST=${doltServerHost}"
         "BEADS_DOLT_SERVER_PORT=3307"
-        "BEADS_SHARED_SERVER_DIR=${sharedServerDir}"
+        "BEADS_DOLT_SERVER_USER=root"
         "DOLT_CLI_USER=root"
         "DOLT_CLI_PASSWORD="
         "LINEAR_TEAM_ID=${linearTeamId}"
@@ -268,9 +280,10 @@ lib.mkIf enabled {
           Environment = [
             "HOME=${homeDir}"
             "PATH=${linearSyncPath}"
-            "BEADS_DOLT_SHARED_SERVER=1"
+            "BEADS_DOLT_SERVER_MODE=1"
+            "BEADS_DOLT_SERVER_HOST=${doltServerHost}"
             "BEADS_DOLT_SERVER_PORT=3307"
-            "BEADS_SHARED_SERVER_DIR=${sharedServerDir}"
+            "BEADS_DOLT_SERVER_USER=root"
             "DOLT_CLI_USER=root"
             "DOLT_CLI_PASSWORD="
           ];

--- a/home-manager/services/dolt/start.sh
+++ b/home-manager/services/dolt/start.sh
@@ -2,7 +2,27 @@
 # @beadsDir@, @legacyBeadsDir@, and @dolt@ are substituted by pkgs.replaceVars.
 set -euo pipefail
 
+listen_host="${BEADS_DOLT_LISTEN_HOST:-127.0.0.1}"
+incoming_df="@beadsDir@-incoming/df"
+retired_df="@beadsDir@-retired/df"
+
 mkdir -p "@beadsDir@"
+
+# Adopt a fully copied replacement while the old sql-server process is down.
+# Home Manager restarts this service during activation, so both renames happen
+# on one filesystem before the replacement server accepts any connections.
+if [ -d "$incoming_df/.dolt" ]; then
+  if [ -e "$retired_df" ]; then
+    echo "Refusing Dolt cutover: $retired_df already exists" >&2
+    exit 1
+  fi
+
+  mkdir -p "@beadsDir@-retired"
+  if [ -e "@beadsDir@/df" ]; then
+    mv -f -- "@beadsDir@/df" "$retired_df"
+  fi
+  mv -f -- "$incoming_df" "@beadsDir@/df"
+fi
 
 # Move databases served by the pre-shared-server configuration into the
 # canonical root. Existing destinations win, so activation never overwrites a
@@ -31,7 +51,7 @@ done
 # by that name.
 
 exec "@dolt@/bin/dolt" sql-server \
-  -H 127.0.0.1 \
+  -H "$listen_host" \
   -P 3307 \
   --data-dir "@beadsDir@" \
   --loglevel info

--- a/spec/beads_federation_sync_spec.sh
+++ b/spec/beads_federation_sync_spec.sh
@@ -117,14 +117,20 @@ End
 End
 
 Describe 'Home Manager ownership'
-It 'enables the shared Dolt server on Kyber, Galactica, and Matic'
-When run bash -c "grep -F 'enabled = isGalactica || isKyber || isMatic;' '$MODULE' >/dev/null"
+It 'enables Kyber Dolt clients on Galactica, Kyber, and Matic'
+When run bash -c "grep -F 'clientEnabled = isGalactica || isKyber || isMatic;' '$MODULE' >/dev/null && grep -F 'doltServerHost = if isKyber then \"127.0.0.1\" else \"kyber.tail950b36.ts.net\";' '$MODULE' >/dev/null"
 The status should be success
 End
 
-It 'runs federation-only sync on Galactica and Matic'
-When run bash -c "grep -F 'federationSyncEnabled = isGalactica || isMatic;' '$MODULE' >/dev/null && grep -F 'launchd.agents.dolt-federation-sync' '$MODULE' >/dev/null && grep -F 'systemd.user.timers.dolt-federation-sync' '$MODULE' >/dev/null"
+It 'runs the Dolt server and publisher only on Kyber'
+When run bash -c "grep -F 'serverEnabled = isKyber;' '$MODULE' >/dev/null && grep -F 'pkgs.stdenv.isLinux && serverEnabled' '$MODULE' >/dev/null"
 The status should be success
+End
+
+It 'runs the single remote publisher only on Kyber'
+When run grep -F 'federationSyncEnabled = isKyber;' "$MODULE"
+The status should be success
+The output should include 'federationSyncEnabled = isKyber;'
 End
 
 It 'requires a Dolt version containing the gitblobstore missing-blob fix'

--- a/spec/dolt_start_spec.sh
+++ b/spec/dolt_start_spec.sh
@@ -94,12 +94,36 @@ The status should be success
 The path "$SHARED_DIR/dolt/.dolt" should be directory
 The path "$SHARED_DIR/df" should not be exist
 End
+
+It 'atomically adopts a staged df database and retains the old one'
+mkdir -p "$SHARED_DIR/df/.dolt" "$SHARED_DIR-incoming/df/.dolt"
+touch "$SHARED_DIR/df/.dolt/old-marker"
+touch "$SHARED_DIR-incoming/df/.dolt/new-marker"
+When run bash "$RENDERED_SCRIPT"
+The status should be success
+The path "$SHARED_DIR/df/.dolt/new-marker" should be file
+The path "$SHARED_DIR-retired/df/.dolt/old-marker" should be file
+The path "$SHARED_DIR-incoming/df" should not be exist
+End
+
+It 'refuses to overwrite a retained df database during cutover'
+mkdir -p "$SHARED_DIR/df/.dolt" "$SHARED_DIR-incoming/df/.dolt" "$SHARED_DIR-retired/df/.dolt"
+When run bash "$RENDERED_SCRIPT"
+The status should be failure
+The stderr should include 'Refusing Dolt cutover'
+The path "$SHARED_DIR-incoming/df/.dolt" should be directory
+End
 End
 
 Describe 'sql-server invocation'
-It 'binds to localhost'
-When run bash -c "grep -- '-H 127.0.0.1' '$SCRIPT'"
-The output should include '-H 127.0.0.1'
+It 'defaults the listen host to localhost'
+When run grep -F 'BEADS_DOLT_LISTEN_HOST:-127.0.0.1' "$SCRIPT"
+The output should include 'BEADS_DOLT_LISTEN_HOST:-127.0.0.1'
+End
+
+It 'passes the selected listen host to Dolt'
+When run grep -F -- '-H "$listen_host"' "$SCRIPT"
+The output should include '-H "$listen_host"'
 End
 
 It 'listens on port 3307'
@@ -128,8 +152,8 @@ When run grep -F 'beadsDir = "${sharedServerDir}/dolt";' "$MODULE"
 The output should include 'beadsDir = "${sharedServerDir}/dolt";'
 End
 
-It 'exports the same shared-server directory to bd'
-When run grep -F 'BEADS_SHARED_SERVER_DIR = sharedServerDir;' "$MODULE"
-The output should include 'BEADS_SHARED_SERVER_DIR = sharedServerDir;'
+It 'routes supported clients to the Kyber server'
+When run bash -c "grep -F 'doltServerHost = if isKyber then \"127.0.0.1\" else \"kyber.tail950b36.ts.net\";' '$MODULE' >/dev/null && grep -F 'BEADS_DOLT_SERVER_HOST = doltServerHost;' '$MODULE' >/dev/null"
+The status should be success
 End
 End


### PR DESCRIPTION
Uses the dedicated Kyber beads SQL account for remote clients instead of the localhost-only root account. The account is limited to the df and beads databases; focused tests and Linux evaluations pass.