### PR TITLE
fix(dolt): use tailnet beads account

### DIFF
--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -73,7 +73,7 @@ lib.mkIf clientEnabled {
     BEADS_DOLT_SERVER_MODE = "1";
     BEADS_DOLT_SERVER_HOST = doltServerHost;
     BEADS_DOLT_SERVER_PORT = "3307";
-    BEADS_DOLT_SERVER_USER = "root";
+    BEADS_DOLT_SERVER_USER = "beads";
     DOLT_CLI_USER = "root";
     DOLT_CLI_PASSWORD = "";
     LINEAR_TEAM_ID = linearTeamId;
@@ -137,7 +137,7 @@ lib.mkIf clientEnabled {
         BEADS_DOLT_SERVER_MODE = "1";
         BEADS_DOLT_SERVER_HOST = doltServerHost;
         BEADS_DOLT_SERVER_PORT = "3307";
-        BEADS_DOLT_SERVER_USER = "root";
+        BEADS_DOLT_SERVER_USER = "beads";
         DOLT_CLI_USER = "root";
         DOLT_CLI_PASSWORD = "";
         LINEAR_TEAM_ID = linearTeamId;
@@ -164,7 +164,7 @@ lib.mkIf clientEnabled {
         BEADS_DOLT_SERVER_MODE = "1";
         BEADS_DOLT_SERVER_HOST = doltServerHost;
         BEADS_DOLT_SERVER_PORT = "3307";
-        BEADS_DOLT_SERVER_USER = "root";
+        BEADS_DOLT_SERVER_USER = "beads";
         DOLT_CLI_USER = "root";
         DOLT_CLI_PASSWORD = "";
       };
@@ -240,7 +240,7 @@ lib.mkIf clientEnabled {
         "BEADS_DOLT_SERVER_MODE=1"
         "BEADS_DOLT_SERVER_HOST=${doltServerHost}"
         "BEADS_DOLT_SERVER_PORT=3307"
-        "BEADS_DOLT_SERVER_USER=root"
+        "BEADS_DOLT_SERVER_USER=beads"
         "DOLT_CLI_USER=root"
         "DOLT_CLI_PASSWORD="
         "LINEAR_TEAM_ID=${linearTeamId}"
@@ -283,7 +283,7 @@ lib.mkIf clientEnabled {
             "BEADS_DOLT_SERVER_MODE=1"
             "BEADS_DOLT_SERVER_HOST=${doltServerHost}"
             "BEADS_DOLT_SERVER_PORT=3307"
-            "BEADS_DOLT_SERVER_USER=root"
+            "BEADS_DOLT_SERVER_USER=beads"
             "DOLT_CLI_USER=root"
             "DOLT_CLI_PASSWORD="
           ];

--- a/spec/dolt_start_spec.sh
+++ b/spec/dolt_start_spec.sh
@@ -153,7 +153,7 @@ The output should include 'beadsDir = "${sharedServerDir}/dolt";'
 End
 
 It 'routes supported clients to the Kyber server'
-When run bash -c "grep -F 'doltServerHost = if isKyber then \"127.0.0.1\" else \"kyber.tail950b36.ts.net\";' '$MODULE' >/dev/null && grep -F 'BEADS_DOLT_SERVER_HOST = doltServerHost;' '$MODULE' >/dev/null"
+When run bash -c "grep -F 'doltServerHost = if isKyber then \"127.0.0.1\" else \"kyber.tail950b36.ts.net\";' '$MODULE' >/dev/null && grep -F 'BEADS_DOLT_SERVER_HOST = doltServerHost;' '$MODULE' >/dev/null && grep -F 'BEADS_DOLT_SERVER_USER = \"beads\";' '$MODULE' >/dev/null"
 The status should be success
 End
 End


### PR DESCRIPTION
Uses the dedicated Kyber beads SQL account for remote clients instead of the localhost-only root account. The account is limited to the df and beads databases; focused tests pass.