### PR TITLE
feat(agents): wire traces agent hooks and drop entire

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -177,28 +177,6 @@
         "hooks": [
           {
             "async": true,
-            "command": "command -v entire \u003e/dev/null 2\u003e\u00261 \u0026\u0026 entire hooks claude-code post-task",
-            "timeout": 30,
-            "type": "command"
-          }
-        ],
-        "matcher": "Task"
-      },
-      {
-        "hooks": [
-          {
-            "async": true,
-            "command": "command -v entire \u003e/dev/null 2\u003e\u00261 \u0026\u0026 entire hooks claude-code post-todo",
-            "timeout": 30,
-            "type": "command"
-          }
-        ],
-        "matcher": "TodoWrite"
-      },
-      {
-        "hooks": [
-          {
-            "async": true,
             "command": "moshi-hook claude-hook",
             "type": "command"
           }
@@ -325,17 +303,6 @@
         "hooks": [
           {
             "async": true,
-            "command": "command -v entire \u003e/dev/null 2\u003e\u00261 \u0026\u0026 entire hooks claude-code pre-task",
-            "timeout": 30,
-            "type": "command"
-          }
-        ],
-        "matcher": "Task"
-      },
-      {
-        "hooks": [
-          {
-            "async": true,
             "command": "moshi-hook claude-hook",
             "type": "command"
           }
@@ -378,16 +345,6 @@
         "hooks": [
           {
             "async": true,
-            "command": "command -v entire \u003e/dev/null 2\u003e\u00261 \u0026\u0026 entire hooks claude-code session-end",
-            "timeout": 30,
-            "type": "command"
-          }
-        ]
-      },
-      {
-        "hooks": [
-          {
-            "async": true,
             "command": "moshi-hook claude-hook",
             "type": "command"
           }
@@ -402,6 +359,15 @@
             "type": "command"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "command -v traces >/dev/null 2>&1 && traces hook agent session-end --agent claude-code",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
       }
     ],
     "SessionStart": [
@@ -417,12 +383,6 @@
             "async": true,
             "command": "$HOME/.claude/hooks/pushover.sh",
             "timeout": 6,
-            "type": "command"
-          },
-          {
-            "async": true,
-            "command": "command -v entire \u003e/dev/null 2\u003e\u00261 \u0026\u0026 entire hooks claude-code session-start",
-            "timeout": 30,
             "type": "command"
           }
         ]
@@ -444,6 +404,15 @@
             "type": "command"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "command -v traces >/dev/null 2>&1 && traces hook agent session-start --agent claude-code",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
       }
     ],
     "Stop": [
@@ -462,12 +431,6 @@
             "type": "command"
           },
           {
-            "async": true,
-            "command": "command -v entire \u003e/dev/null 2\u003e\u00261 \u0026\u0026 entire hooks claude-code stop",
-            "timeout": 30,
-            "type": "command"
-          },
-          {
             "command": "$HOME/dotfiles/config/shared/hooks/roborev-agent.sh",
             "type": "command"
           }
@@ -481,6 +444,15 @@
             "type": "command"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "command -v traces >/dev/null 2>&1 && traces hook agent agent-done --agent claude-code",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
       }
     ],
     "StopFailure": [
@@ -520,12 +492,6 @@
             "command": "jq -c '{timestamp: (now | todate), prompt: .prompt[0:500]}' \u003e\u003e ~/.claude/prompt-history.jsonl",
             "timeout": 3,
             "type": "command"
-          },
-          {
-            "async": true,
-            "command": "command -v entire \u003e/dev/null 2\u003e\u00261 \u0026\u0026 entire hooks claude-code user-prompt-submit",
-            "timeout": 30,
-            "type": "command"
           }
         ]
       },
@@ -537,6 +503,15 @@
             "type": "command"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "command -v traces >/dev/null 2>&1 && traces hook agent prompt-submitted --agent claude-code",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
       }
     ],
     "WorktreeCreate": [

--- a/config/codex/hooks.json
+++ b/config/codex/hooks.json
@@ -176,6 +176,16 @@
           }
         ],
         "matcher": "startup|resume|clear"
+      },
+      {
+        "hooks": [
+          {
+            "command": "command -v traces >/dev/null 2>&1 && traces hook agent session-start --agent codex",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
       }
     ],
     "Stop": [
@@ -207,6 +217,16 @@
             "type": "command"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "command -v traces >/dev/null 2>&1 && traces hook agent agent-done --agent codex",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
       }
     ],
     "UserPromptSubmit": [
@@ -236,6 +256,28 @@
             "type": "command"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "command -v traces >/dev/null 2>&1 && traces hook agent prompt-submitted --agent codex",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "command": "command -v traces >/dev/null 2>&1 && traces hook agent session-end --agent codex",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
       }
     ]
   }

--- a/config/copilot/config.json
+++ b/config/copilot/config.json
@@ -29,6 +29,34 @@
         "command": "$HOME/dotfiles/config/shared/hooks/block-gh-settings.sh",
         "timeout": 5
       }
+    ],
+    "sessionStart": [
+      {
+        "type": "command",
+        "command": "command -v traces >/dev/null 2>&1 && traces hook agent session-start --agent copilot",
+        "timeout": 30
+      }
+    ],
+    "userPromptSubmitted": [
+      {
+        "type": "command",
+        "command": "command -v traces >/dev/null 2>&1 && traces hook agent prompt-submitted --agent copilot",
+        "timeout": 30
+      }
+    ],
+    "agentStop": [
+      {
+        "type": "command",
+        "command": "command -v traces >/dev/null 2>&1 && traces hook agent agent-done --agent copilot",
+        "timeout": 30
+      }
+    ],
+    "sessionEnd": [
+      {
+        "type": "command",
+        "command": "command -v traces >/dev/null 2>&1 && traces hook agent session-end --agent copilot",
+        "timeout": 30
+      }
     ]
   }
 }

--- a/config/cursor/hooks.json
+++ b/config/cursor/hooks.json
@@ -27,6 +27,9 @@
     "sessionStart": [
       {
         "command": "bd cursor-hook sessionStart"
+      },
+      {
+        "command": "command -v traces >/dev/null 2>&1 && traces hook agent session-start --agent cursor"
       }
     ],
     "beforeMCPExecution": [
@@ -79,6 +82,9 @@
       },
       {
         "command": "moshi-hook cursor-hook"
+      },
+      {
+        "command": "command -v traces >/dev/null 2>&1 && traces hook agent prompt-submitted --agent cursor"
       }
     ],
     "stop": [
@@ -92,6 +98,14 @@
       },
       {
         "command": "moshi-hook cursor-hook"
+      },
+      {
+        "command": "command -v traces >/dev/null 2>&1 && traces hook agent agent-done --agent cursor"
+      }
+    ],
+    "sessionEnd": [
+      {
+        "command": "command -v traces >/dev/null 2>&1 && traces hook agent session-end --agent cursor"
       }
     ]
   },

--- a/config/grok/plugin/hooks/hooks.json
+++ b/config/grok/plugin/hooks/hooks.json
@@ -20,6 +20,16 @@
             "async": true
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "command -v traces >/dev/null 2>&1 && traces hook agent session-start --agent grok",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
       }
     ],
     "UserPromptSubmit": [
@@ -31,6 +41,16 @@
             "async": true
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "command -v traces >/dev/null 2>&1 && traces hook agent prompt-submitted --agent grok",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
       }
     ],
     "PreToolUse": [
@@ -103,6 +123,16 @@
             "async": true
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "command -v traces >/dev/null 2>&1 && traces hook agent agent-done --agent grok",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
       }
     ],
     "SessionEnd": [
@@ -114,6 +144,16 @@
             "async": true
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "command -v traces >/dev/null 2>&1 && traces hook agent session-end --agent grok",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
       }
     ]
   }

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -137,7 +137,6 @@
       "docker-desktop"
       "droid"
       "dropbox"
-      "entire"
       "figma"
       "firefox"
       "flameshot"


### PR DESCRIPTION
Wires the [Traces agent hooks](https://traces.com/docs/sharing/agent-hooks) into every agent hook configuration in the repo, and removes the `entire` integration.

## Added

`traces hook agent <event> --agent <agent>` for the four lifecycle events (`session-start`, `prompt-submitted`, `agent-done`, `session-end`), each guarded with `command -v traces >/dev/null 2>&1 &&` to match the existing `dcg` / `graphify` hook pattern.

| Config | Events |
| --- | --- |
| `config/claude/settings.json` | `SessionStart`, `UserPromptSubmit`, `Stop`, `SessionEnd` |
| `config/codex/hooks.json` | `SessionStart`, `UserPromptSubmit`, `Stop`, `SessionEnd` |
| `config/grok/plugin/hooks/hooks.json` | `SessionStart`, `UserPromptSubmit`, `Stop`, `SessionEnd` |
| `config/cursor/hooks.json` | `sessionStart`, `beforeSubmitPrompt`, `stop`, `sessionEnd` |
| `config/copilot/config.json` | `sessionStart`, `userPromptSubmitted`, `agentStop`, `sessionEnd` |

Event names and commands mirror what `traces setup agent-hooks` generates.

## Removed

- All `entire hooks claude-code ...` entries from `config/claude/settings.json` (7 hooks; groups that became empty were pruned).
- The `entire` cask from `nix-darwin/config/homebrew.nix`.

## Not included

- Gemini: not a Traces-supported agent.
- OpenCode, Pi, Amp, OpenClaw, Hermes: Traces ships plugin/extension files for these rather than declarative hook entries, and this repo has no traces plugin vendored for them yet.

## Verification

- All five JSON files parse.
- `nix fmt` clean.
- `shellspec spec/agent_github_hook_wiring_spec.sh spec/beads_agent_hooks_spec.sh spec/moshi_hook_spec.sh` - 17 examples, 0 failures.

## One thing to check

Traces writes its Copilot hooks to `.github/hooks/traces.json` using a `bash` key. This PR instead adds them to `config/copilot/config.json` with the `command` key, matching the entries already in that file. If Copilot CLI's user-scope config expects `bash`, that needs a follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Traces agent lifecycle hooks to Claude, Codex, Cursor, Copilot, and Grok configs, and removes the `entire` integration.

**Refactors**
- Replaces all `entire hooks claude-code ...` entries with `traces hook agent <event>` equivalents across the affected configs.
- Drops the `entire` cask from `nix-darwin/config/homebrew.nix`.

**Dependencies**
- No new dependencies. Only existing `traces` CLI commands are invoked.

<sup>Written for commit 7cf371d23f15d1ad0b7610eff68400f814833b7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

