### PR TITLE
fix(beads): stagger Kyber maintenance timers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,10 @@ bd close <id>         # Complete work
 bd dolt push          # Push beads data to remote
 ```
 
+Use `bd ping` for routine connectivity checks. `bd doctor` is reserved for an
+explicit recovery owner because concurrent doctor runs can starve normal Beads
+transactions. Agents must not launch it as a generic timeout response.
+
 ## Non-Interactive Shell Commands
 
 **ALWAYS use non-interactive flags** with file operations to avoid hanging on confirmation prompts.

--- a/home-manager/services/dolt/client-environment.sh
+++ b/home-manager/services/dolt/client-environment.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+/bin/launchctl setenv BEADS_DOLT_AUTO_START 0
+/bin/launchctl setenv BEADS_DOLT_SERVER_MODE 1
+/bin/launchctl setenv BEADS_DOLT_SERVER_HOST "@doltServerHost@"
+/bin/launchctl setenv BEADS_DOLT_SERVER_PORT 3307
+/bin/launchctl setenv BEADS_DOLT_SERVER_USER beads
+/bin/launchctl setenv DOLT_CLI_USER root
+/bin/launchctl setenv DOLT_CLI_PASSWORD ""

--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -33,15 +33,9 @@ let
     DOLT_CLI_USER = "root";
     DOLT_CLI_PASSWORD = "";
   };
-  beadsLaunchctlEnvironmentScript = pkgs.writeShellScript "beads-dolt-client-environment" ''
-    /bin/launchctl setenv BEADS_DOLT_AUTO_START 0
-    /bin/launchctl setenv BEADS_DOLT_SERVER_MODE 1
-    /bin/launchctl setenv BEADS_DOLT_SERVER_HOST ${doltServerHost}
-    /bin/launchctl setenv BEADS_DOLT_SERVER_PORT 3307
-    /bin/launchctl setenv BEADS_DOLT_SERVER_USER beads
-    /bin/launchctl setenv DOLT_CLI_USER root
-    /bin/launchctl setenv DOLT_CLI_PASSWORD ""
-  '';
+  beadsLaunchctlEnvironmentScript = pkgs.replaceVars ./client-environment.sh {
+    inherit doltServerHost;
+  };
   linearSyncEnabled = isKyber;
   # Every supported agent host writes directly to Kyber's SQL server. Kyber
   # alone publishes that shared history to the configured remotes.
@@ -96,7 +90,10 @@ lib.mkIf clientEnabled {
   launchd.agents.beads-dolt-client-environment = lib.mkIf pkgs.stdenv.isDarwin {
     enable = true;
     config = {
-      ProgramArguments = [ beadsLaunchctlEnvironmentScript ];
+      ProgramArguments = [
+        "${pkgs.bash}/bin/bash"
+        beadsLaunchctlEnvironmentScript
+      ];
       RunAtLoad = true;
       ProcessType = "Background";
     };
@@ -281,8 +278,8 @@ lib.mkIf clientEnabled {
   systemd.user.timers.dolt-linear-sync = lib.mkIf (pkgs.stdenv.isLinux && linearSyncEnabled) {
     Unit.Description = "Periodically synchronize Beads with Linear";
     Timer = {
-      OnBootSec = "2min";
-      OnCalendar = "*-*-* *:00/15:00";
+      OnBootSec = "4min";
+      OnCalendar = "*-*-* *:02/15:00";
       Persistent = true;
       Unit = "dolt-linear-sync.service";
     };
@@ -326,7 +323,6 @@ lib.mkIf clientEnabled {
     Timer = {
       OnBootSec = "2min";
       OnCalendar = "*-*-* *:00/5:00";
-      OnUnitActiveSec = "${toString federationSyncIntervalSeconds}s";
       Persistent = true;
       Unit = "dolt-federation-sync.service";
     };

--- a/spec/beads_federation_sync_spec.sh
+++ b/spec/beads_federation_sync_spec.sh
@@ -117,6 +117,11 @@ End
 End
 
 Describe 'Home Manager ownership'
+It 'loads the launchctl client environment from an external script'
+When run bash -c "grep -F 'pkgs.replaceVars ./client-environment.sh' '$MODULE' >/dev/null && grep -F 'BEADS_DOLT_SERVER_HOST \"@doltServerHost@\"' '$PWD/home-manager/services/dolt/client-environment.sh' >/dev/null"
+The status should be success
+End
+
 It 'publishes centralized server selection without legacy shared-server variables'
 When run bash -c "grep -F 'BEADS_DOLT_SERVER_MODE = \"1\";' '$MODULE' >/dev/null && grep -F 'BEADS_DOLT_AUTO_START = \"0\";' '$MODULE' >/dev/null && ! grep -F 'BEADS_DOLT_SHARED_SERVER' '$MODULE' >/dev/null && ! grep -F 'BEADS_SHARED_SERVER_DIR' '$MODULE' >/dev/null && grep -F 'systemd.user.sessionVariables' '$MODULE' >/dev/null && grep -F 'launchd.agents.beads-dolt-client-environment' '$MODULE' >/dev/null"
 The status should be success
@@ -136,6 +141,11 @@ It 'runs the single remote publisher only on Kyber'
 When run grep -F 'federationSyncEnabled = isKyber;' "$MODULE"
 The status should be success
 The output should include 'federationSyncEnabled = isKyber;'
+End
+
+It 'keeps federation on the five-minute boundary without an active-time duplicate'
+When run bash -c "timer=\$(sed -n '/systemd.user.timers.dolt-federation-sync/,/^  };/p' '$MODULE'); grep -F 'OnBootSec = \"2min\";' <<<\"\$timer\" >/dev/null && grep -F 'OnCalendar = \"*-*-* *:00/5:00\";' <<<\"\$timer\" >/dev/null && ! grep -F 'OnUnitActiveSec' <<<\"\$timer\" >/dev/null && grep -F 'Persistent = true;' <<<\"\$timer\" >/dev/null"
+The status should be success
 End
 
 It 'requires a Dolt version containing the gitblobstore missing-blob fix'

--- a/spec/beads_linear_sync_spec.sh
+++ b/spec/beads_linear_sync_spec.sh
@@ -551,7 +551,7 @@ The status should be success
 End
 
 It 'installs the Kyber Linux systemd timer'
-When run bash -c "timer=\$(sed -n '/systemd.user.timers.dolt-linear-sync/,/^  };/p' '$MODULE'); grep -F 'OnCalendar = \"*-*-* *:00/15:00\";' <<<\"\$timer\" >/dev/null && ! grep -F 'OnUnitActiveSec' <<<\"\$timer\" >/dev/null && grep -F 'Persistent = true;' <<<\"\$timer\" >/dev/null && grep -F 'X-SwitchMethod = \"restart\";' '$MODULE' >/dev/null"
+When run bash -c "timer=\$(sed -n '/systemd.user.timers.dolt-linear-sync/,/^  };/p' '$MODULE'); grep -F 'OnBootSec = \"4min\";' <<<\"\$timer\" >/dev/null && grep -F 'OnCalendar = \"*-*-* *:02/15:00\";' <<<\"\$timer\" >/dev/null && ! grep -F 'OnUnitActiveSec' <<<\"\$timer\" >/dev/null && grep -F 'Persistent = true;' <<<\"\$timer\" >/dev/null && grep -F 'X-SwitchMethod = \"restart\";' '$MODULE' >/dev/null"
 The status should be success
 End
 End

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -277,6 +277,10 @@ It 'has spec file for home-manager/services/dolt/start.sh'
 The path "spec/dolt_start_spec.sh" should be exist
 End
 
+It 'has spec file for home-manager/services/dolt/client-environment.sh'
+The path "spec/beads_federation_sync_spec.sh" should be exist
+End
+
 It 'has spec file for home-manager/services/dolt/backup-dolt-main.sh'
 The path "spec/backup_dolt_main_spec.sh" should be exist
 End
@@ -598,6 +602,7 @@ home-manager/services/docker-postgres/start-postgres.sh
 home-manager/services/docker/docker-setup.sh
 home-manager/services/docker/setup-docker.sh
 home-manager/services/dolt/start.sh
+home-manager/services/dolt/client-environment.sh
 home-manager/services/dolt/backup-dolt-main.sh
 home-manager/services/dolt/beads-linear-complete.sh
 home-manager/services/dolt/federation-sync.sh


### PR DESCRIPTION
## Summary

- reserve `bd doctor` for explicit recovery ownership and use `bd ping` for routine checks
- run Linear synchronization two minutes after the fifteen-minute boundary
- keep federation publishing on the five-minute boundary while removing its duplicate active-time trigger
- externalize the existing launchctl environment setup required by the owning inline-script gate

## Verification

- `make shell-inline-check`
- `shellcheck home-manager/services/dolt/client-environment.sh`
- `shellspec spec/beads_linear_sync_spec.sh spec/beads_federation_sync_spec.sh spec/beads_agent_hooks_spec.sh`
- `nixfmt --check home-manager/services/dolt/default.nix`
- `nix build .#homeConfigurations.kyber.activationPackage --no-link`