### PR TITLE
fix(dolt): add CLI credentials to Kyber systemd dolt service

### DIFF
--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -209,7 +209,11 @@ lib.mkIf clientEnabled {
       # Kyber's WAN firewall drops all new public-interface ingress. Binding
       # all addresses makes the SQL service reachable on tailscale0 while
       # retaining the public-ingress deny boundary.
-      Environment = [ "BEADS_DOLT_LISTEN_HOST=0.0.0.0" ];
+      Environment = [
+        "BEADS_DOLT_LISTEN_HOST=0.0.0.0"
+        "DOLT_CLI_USER=root"
+        "DOLT_CLI_PASSWORD="
+      ];
     };
     Install = {
       WantedBy = [ "default.target" ];

--- a/spec/dolt_start_spec.sh
+++ b/spec/dolt_start_spec.sh
@@ -156,4 +156,19 @@ It 'routes supported clients to the Kyber server'
 When run bash -c "grep -F 'doltServerHost = if isKyber then \"127.0.0.1\" else \"kyber.tail950b36.ts.net\";' '$MODULE' >/dev/null && grep -F 'BEADS_DOLT_SERVER_HOST = doltServerHost;' '$MODULE' >/dev/null && grep -F 'BEADS_DOLT_SERVER_USER = \"beads\";' '$MODULE' >/dev/null"
 The status should be success
 End
+
+It 'binds the systemd dolt service to all interfaces for tailnet peers'
+When run grep -F 'BEADS_DOLT_LISTEN_HOST=0.0.0.0' "$MODULE"
+The output should include 'BEADS_DOLT_LISTEN_HOST=0.0.0.0'
+End
+
+It 'provides DOLT_CLI_USER=root in the systemd dolt service environment'
+When run grep -F '"DOLT_CLI_USER=root"' "$MODULE"
+The output should include '"DOLT_CLI_USER=root"'
+End
+
+It 'provides an explicit empty DOLT_CLI_PASSWORD in the systemd dolt service environment'
+When run grep -F '"DOLT_CLI_PASSWORD="' "$MODULE"
+The output should include '"DOLT_CLI_PASSWORD="'
+End
 End


### PR DESCRIPTION
## Summary

- The generated Kyber `dolt.service` systemd unit omitted `DOLT_CLI_USER` and `DOLT_CLI_PASSWORD` from its `Environment`, causing the Dolt server to prompt for a password on non-interactive startup
- Added `DOLT_CLI_USER=root` and explicit empty `DOLT_CLI_PASSWORD=` to the service environment alongside the existing `BEADS_DOLT_LISTEN_HOST=0.0.0.0`
- Added regression specs verifying the all-interface 0.0.0.0:3307 listener binding and both credential environment variables

## Test plan

- [x] `shellspec spec/dolt_start_spec.sh` - 22 examples, 0 failures
- [x] `make nix-format-check` - all files formatted
- [x] `make nix-lint` - clean
- [x] `make shell-test` - pass
- [x] `make shell-inline-check` - no inline scripts

Closes shunkakinokisoftware-fq3i4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Kyber `dolt.service` systemd unit so it starts without a TTY by adding the missing `DOLT_CLI_USER=root` and explicit empty `DOLT_CLI_PASSWORD` credentials to its environment. Adds regression specs verifying the listener binding and both credential variables.

<sup>Written for commit bfba2a92b4d24a5feaab57f8da77d7dffbbe9b9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

