### PR TITLE
fix(dolt): federate beads with a local Dolt server per agent host

### DIFF
--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -213,7 +213,11 @@ lib.mkIf clientEnabled {
       # Kyber's WAN firewall drops all new public-interface ingress. Binding
       # all addresses makes the SQL service reachable on tailscale0 while
       # retaining the public-ingress deny boundary.
-      Environment = [ "BEADS_DOLT_LISTEN_HOST=0.0.0.0" ];
+      Environment = [
+        "BEADS_DOLT_LISTEN_HOST=0.0.0.0"
+        "DOLT_CLI_USER=root"
+        "DOLT_CLI_PASSWORD="
+      ];
     };
     Install = {
       WantedBy = [ "default.target" ];

--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -22,14 +22,20 @@ let
   federationSyncIntervalSeconds = 300;
   linearSyncPath = "${homeDir}/.local/bin:${homeDir}/.bun/bin:${homeDir}/.nix-profile/bin:/etc/profiles/per-user/${config.home.username}/bin:/run/current-system/sw/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
   clientEnabled = isGalactica || isKyber || isMatic;
-  serverEnabled = isKyber;
-  doltServerHost = if isKyber then "127.0.0.1" else "kyber.tail950b36.ts.net";
+  # bd opens its store with dozens of sequential round trips per invocation, so
+  # a direct client of Kyber's Chicago server costs seconds per command on the
+  # ~260ms agent hosts. Every host serves its own Dolt and converges through the
+  # shared remote instead.
+  serverEnabled = clientEnabled;
+  # Kyber alone publishes the shared history to the configured remotes.
+  publisherEnabled = isKyber;
+  doltServerHost = "127.0.0.1";
   beadsClientEnvironment = {
     BEADS_DOLT_AUTO_START = "0";
     BEADS_DOLT_SERVER_MODE = "1";
     BEADS_DOLT_SERVER_HOST = doltServerHost;
     BEADS_DOLT_SERVER_PORT = "3307";
-    BEADS_DOLT_SERVER_USER = "beads";
+    BEADS_DOLT_SERVER_USER = "root";
     DOLT_CLI_USER = "root";
     DOLT_CLI_PASSWORD = "";
   };
@@ -37,9 +43,7 @@ let
     inherit doltServerHost;
   };
   linearSyncEnabled = isKyber;
-  # Every supported agent host writes directly to Kyber's SQL server. Kyber
-  # alone publishes that shared history to the configured remotes.
-  federationSyncEnabled = isKyber;
+  federationSyncEnabled = clientEnabled;
   # 2.2.2 fixes gitblobstore pending-write pruning that could publish a
   # manifest whose live archive later failed with "Blob not found".
   doltMinVersion = "2.2.2";
@@ -123,7 +127,7 @@ lib.mkIf clientEnabled {
   # is visible in the GitHub UI (Dolt's native push only writes refs/dolt/data).
   # Triggered by manifest changes inside dolt's noms store; throttled to avoid
   # hammering on rapid writes.
-  launchd.agents.dolt-backup-main = lib.mkIf (pkgs.stdenv.isDarwin && serverEnabled) {
+  launchd.agents.dolt-backup-main = lib.mkIf (pkgs.stdenv.isDarwin && publisherEnabled) {
     enable = true;
     config = {
       ProgramArguments = [
@@ -158,7 +162,7 @@ lib.mkIf clientEnabled {
         BEADS_DOLT_SERVER_MODE = "1";
         BEADS_DOLT_SERVER_HOST = doltServerHost;
         BEADS_DOLT_SERVER_PORT = "3307";
-        BEADS_DOLT_SERVER_USER = "beads";
+        BEADS_DOLT_SERVER_USER = "root";
         DOLT_CLI_USER = "root";
         DOLT_CLI_PASSWORD = "";
         LINEAR_TEAM_ID = linearTeamId;
@@ -186,7 +190,7 @@ lib.mkIf clientEnabled {
         BEADS_DOLT_SERVER_MODE = "1";
         BEADS_DOLT_SERVER_HOST = doltServerHost;
         BEADS_DOLT_SERVER_PORT = "3307";
-        BEADS_DOLT_SERVER_USER = "beads";
+        BEADS_DOLT_SERVER_USER = "root";
         DOLT_CLI_USER = "root";
         DOLT_CLI_PASSWORD = "";
       };
@@ -209,11 +213,7 @@ lib.mkIf clientEnabled {
       # Kyber's WAN firewall drops all new public-interface ingress. Binding
       # all addresses makes the SQL service reachable on tailscale0 while
       # retaining the public-ingress deny boundary.
-      Environment = [
-        "BEADS_DOLT_LISTEN_HOST=0.0.0.0"
-        "DOLT_CLI_USER=root"
-        "DOLT_CLI_PASSWORD="
-      ];
+      Environment = [ "BEADS_DOLT_LISTEN_HOST=0.0.0.0" ];
     };
     Install = {
       WantedBy = [ "default.target" ];
@@ -224,7 +224,7 @@ lib.mkIf clientEnabled {
   # and other systemd-launched agents do not inherit a stale shared-server mode.
   systemd.user.sessionVariables = lib.mkIf pkgs.stdenv.isLinux beadsClientEnvironment;
 
-  systemd.user.services.dolt-backup-main = lib.mkIf (pkgs.stdenv.isLinux && serverEnabled) {
+  systemd.user.services.dolt-backup-main = lib.mkIf (pkgs.stdenv.isLinux && publisherEnabled) {
     Unit = {
       Description = "Push beads_global JSONL snapshot to GitHub main";
     };
@@ -235,7 +235,7 @@ lib.mkIf clientEnabled {
     };
   };
 
-  systemd.user.paths.dolt-backup-main = lib.mkIf (pkgs.stdenv.isLinux && serverEnabled) {
+  systemd.user.paths.dolt-backup-main = lib.mkIf (pkgs.stdenv.isLinux && publisherEnabled) {
     Unit = {
       Description = "Watch dolt manifest and trigger JSONL backup";
     };
@@ -271,7 +271,7 @@ lib.mkIf clientEnabled {
         "BEADS_DOLT_SERVER_MODE=1"
         "BEADS_DOLT_SERVER_HOST=${doltServerHost}"
         "BEADS_DOLT_SERVER_PORT=3307"
-        "BEADS_DOLT_SERVER_USER=beads"
+        "BEADS_DOLT_SERVER_USER=root"
         "DOLT_CLI_USER=root"
         "DOLT_CLI_PASSWORD="
         "LINEAR_TEAM_ID=${linearTeamId}"
@@ -315,7 +315,7 @@ lib.mkIf clientEnabled {
             "BEADS_DOLT_SERVER_MODE=1"
             "BEADS_DOLT_SERVER_HOST=${doltServerHost}"
             "BEADS_DOLT_SERVER_PORT=3307"
-            "BEADS_DOLT_SERVER_USER=beads"
+            "BEADS_DOLT_SERVER_USER=root"
             "DOLT_CLI_USER=root"
             "DOLT_CLI_PASSWORD="
           ];

--- a/spec/beads_federation_sync_spec.sh
+++ b/spec/beads_federation_sync_spec.sh
@@ -127,20 +127,19 @@ When run bash -c "grep -F 'BEADS_DOLT_SERVER_MODE = \"1\";' '$MODULE' >/dev/null
 The status should be success
 End
 
-It 'enables Kyber Dolt clients on Galactica, Kyber, and Matic'
-When run bash -c "grep -F 'clientEnabled = isGalactica || isKyber || isMatic;' '$MODULE' >/dev/null && grep -F 'doltServerHost = if isKyber then \"127.0.0.1\" else \"kyber.tail950b36.ts.net\";' '$MODULE' >/dev/null"
+It 'enables Dolt clients on Galactica, Kyber, and Matic'
+When run bash -c "grep -F 'clientEnabled = isGalactica || isKyber || isMatic;' '$MODULE' >/dev/null && grep -F 'doltServerHost = \"127.0.0.1\";' '$MODULE' >/dev/null"
 The status should be success
 End
 
-It 'runs the Dolt server and publisher only on Kyber'
-When run bash -c "grep -F 'serverEnabled = isKyber;' '$MODULE' >/dev/null && grep -F 'pkgs.stdenv.isLinux && serverEnabled' '$MODULE' >/dev/null"
+It 'serves Dolt locally on every client host'
+When run bash -c "grep -F 'serverEnabled = clientEnabled;' '$MODULE' >/dev/null && grep -F 'pkgs.stdenv.isLinux && serverEnabled' '$MODULE' >/dev/null && grep -F 'pkgs.stdenv.isDarwin && serverEnabled' '$MODULE' >/dev/null"
 The status should be success
 End
 
-It 'runs the single remote publisher only on Kyber'
-When run grep -F 'federationSyncEnabled = isKyber;' "$MODULE"
+It 'federates every client host and publishes only from Kyber'
+When run bash -c "grep -F 'federationSyncEnabled = clientEnabled;' '$MODULE' >/dev/null && grep -F 'publisherEnabled = isKyber;' '$MODULE' >/dev/null && ! grep -F 'dolt-backup-main = lib.mkIf (pkgs.stdenv.isLinux && serverEnabled)' '$MODULE' >/dev/null && ! grep -F 'dolt-backup-main = lib.mkIf (pkgs.stdenv.isDarwin && serverEnabled)' '$MODULE' >/dev/null"
 The status should be success
-The output should include 'federationSyncEnabled = isKyber;'
 End
 
 It 'keeps federation on the five-minute boundary without an active-time duplicate'

--- a/spec/dolt_start_spec.sh
+++ b/spec/dolt_start_spec.sh
@@ -152,23 +152,8 @@ When run grep -F 'beadsDir = "${sharedServerDir}/dolt";' "$MODULE"
 The output should include 'beadsDir = "${sharedServerDir}/dolt";'
 End
 
-It 'routes supported clients to the Kyber server'
-When run bash -c "grep -F 'doltServerHost = if isKyber then \"127.0.0.1\" else \"kyber.tail950b36.ts.net\";' '$MODULE' >/dev/null && grep -F 'BEADS_DOLT_SERVER_HOST = doltServerHost;' '$MODULE' >/dev/null && grep -F 'BEADS_DOLT_SERVER_USER = \"beads\";' '$MODULE' >/dev/null"
+It 'routes every client to its own local server'
+When run bash -c "grep -F 'doltServerHost = \"127.0.0.1\";' '$MODULE' >/dev/null && grep -F 'BEADS_DOLT_SERVER_HOST = doltServerHost;' '$MODULE' >/dev/null && grep -F 'BEADS_DOLT_SERVER_USER = \"root\";' '$MODULE' >/dev/null && ! grep -F 'kyber.tail950b36.ts.net' '$MODULE' >/dev/null"
 The status should be success
-End
-
-It 'binds the systemd dolt service to all interfaces for tailnet peers'
-When run grep -F 'BEADS_DOLT_LISTEN_HOST=0.0.0.0' "$MODULE"
-The output should include 'BEADS_DOLT_LISTEN_HOST=0.0.0.0'
-End
-
-It 'provides DOLT_CLI_USER=root in the systemd dolt service environment'
-When run grep -F '"DOLT_CLI_USER=root"' "$MODULE"
-The output should include '"DOLT_CLI_USER=root"'
-End
-
-It 'provides an explicit empty DOLT_CLI_PASSWORD in the systemd dolt service environment'
-When run grep -F '"DOLT_CLI_PASSWORD="' "$MODULE"
-The output should include '"DOLT_CLI_PASSWORD="'
 End
 End

--- a/spec/dolt_start_spec.sh
+++ b/spec/dolt_start_spec.sh
@@ -156,4 +156,19 @@ It 'routes every client to its own local server'
 When run bash -c "grep -F 'doltServerHost = \"127.0.0.1\";' '$MODULE' >/dev/null && grep -F 'BEADS_DOLT_SERVER_HOST = doltServerHost;' '$MODULE' >/dev/null && grep -F 'BEADS_DOLT_SERVER_USER = \"root\";' '$MODULE' >/dev/null && ! grep -F 'kyber.tail950b36.ts.net' '$MODULE' >/dev/null"
 The status should be success
 End
+
+It 'binds the systemd dolt service to all interfaces for tailnet peers'
+When run grep -F 'BEADS_DOLT_LISTEN_HOST=0.0.0.0' "$MODULE"
+The output should include 'BEADS_DOLT_LISTEN_HOST=0.0.0.0'
+End
+
+It 'provides DOLT_CLI_USER=root in the systemd dolt service environment'
+When run grep -F '"DOLT_CLI_USER=root"' "$MODULE"
+The output should include '"DOLT_CLI_USER=root"'
+End
+
+It 'provides an explicit empty DOLT_CLI_PASSWORD in the systemd dolt service environment'
+When run grep -F '"DOLT_CLI_PASSWORD="' "$MODULE"
+The output should include '"DOLT_CLI_PASSWORD="'
+End
 End


### PR DESCRIPTION
## Summary
- bd opens its store with dozens of sequential SQL round trips per invocation; a direct client of Kyber's Chicago server costs 6-25s per command from the ~260ms agent hosts (measured: `bd ping` 8.5s via Kyber vs 0.86s against a local server on galactica, 11ms on Kyber itself).
- Upstream beads designs multi-machine as peer replicas, not thin remote clients: each host maintains its own Dolt database and converges through the shared remote via `bd sync` (see `bd federation --help` / `bd sync --help`).
- Every supported agent host (galactica, kyber, matic) now serves Dolt locally on 127.0.0.1:3307 and runs the federation sync loop; Kyber remains the single publisher of backups, JSONL snapshots, and Linear sync (`publisherEnabled = isKyber`).
- Restores the `DOLT_CLI_USER`/`DOLT_CLI_PASSWORD` systemd service environment from #2546 that the first iteration of this change clobbered.

## Test plan
- `shellspec spec/dolt_start_spec.sh spec/beads_federation_sync_spec.sh` - 35 examples, 0 failures
- Verified `root` connects to Kyber's running Dolt server (`bd ping` 12ms) before switching `BEADS_DOLT_SERVER_USER` from `beads` to `root`
- Requires `darwin-rebuild switch` on galactica and `home-manager switch` on kyber/matic to activate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes every agent host serve its own local Dolt and converge through the shared remote, fixing the 6-25s-per-command latency of the old direct-SQL path to Kyber's Chicago server. Kyber remains the only publisher of backups, JSONL snapshots, and Linear sync, and the `DOLT_CLI_USER`/`DOLT_CLI_PASSWORD` service environment that the previous iteration clobbered is restored.

- Every supported host serves Dolt on `127.0.0.1:3307` and runs the federation sync loop.
- Dolt server connections now use the `root` user instead of `beads`.

**Migration**
- Requires `darwin-rebuild switch` on galactica and `home-manager switch` on kyber/matic to activate.

<sup>Written for commit 2b0994358f71cffe2bd553ee55075f3a5cd7e4f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

