### PR TITLE
fix(secure-dotenv): prune macOS Library from dotenv scan

### DIFF
--- a/home-manager/modules/secure-dotenv/secure-dotenv.sh
+++ b/home-manager/modules/secure-dotenv/secure-dotenv.sh
@@ -4,9 +4,13 @@ set -euo pipefail
 
 HOME_DIR="$1"
 
+# ~/Library is pruned: on macOS, opening app group containers blocks forever
+# on TCC app-data mediation, hanging activation. Dotenv files live in code
+# checkouts, never under Library.
 @find@ "${HOME_DIR}" \
   -maxdepth 4 \
-  \( -name '.env' -o -name '.env.*' -o -name '*.env' \) \
+  -path "${HOME_DIR}/Library" -prune -o \
+  \( -name '.env' -o -name '.env.*' -o -name '*.env' \) -print \
   2>/dev/null | while IFS= read -r f; do
   if [ -f "$f" ] && [ ! -L "$f" ]; then
     current=$(@stat@ -c '%a' "$f")

--- a/spec/secure_dotenv_spec.sh
+++ b/spec/secure_dotenv_spec.sh
@@ -130,4 +130,25 @@ The output should include 'maxdepth 4'
 End
 End
 
+Describe 'Library pruning'
+It 'prunes the macOS Library directory'
+When run bash -c "grep -F -- '-path \"\${HOME_DIR}/Library\" -prune' '$SCRIPT'"
+The output should include '-prune'
+End
+
+It 'skips .env files under Library'
+TEST_HOME="$(mktemp -d)"
+mkdir -p "$TEST_HOME/Library/Group Containers/app"
+echo "SECRET=value" >"$TEST_HOME/Library/Group Containers/app/.env"
+chmod 644 "$TEST_HOME/Library/Group Containers/app/.env"
+PROCESSED_SCRIPT="$TEST_HOME/secure-dotenv-test.sh"
+sed \
+  -e "s|@find@|$(command -v find)|g" \
+  -e "s|@stat@|$(command -v stat)|g" \
+  "$SCRIPT" >"$PROCESSED_SCRIPT"
+When run bash -c "bash '$PROCESSED_SCRIPT' '$TEST_HOME'; ls -l '$TEST_HOME/Library/Group Containers/app/.env' | cut -c1-10; rm -rf '$TEST_HOME'"
+The output should include 'rw-r--r--'
+End
+End
+
 End


### PR DESCRIPTION
## Problem

darwin-rebuild switch on galactica hung for 2+ hours inside home-manager activation. The secure-dotenv step runs find over the whole home directory (maxdepth 4), and on macOS every openat() into ~/Library/Group Containers/* blocks indefinitely on TCC app-data mediation, wedging find in an uninterruptible kernel call.

## Fix

Prune ~/Library from the scan. Dotenv files live in code checkouts, never under Library. Adds spec coverage for the prune expression and a functional test that a .env under Library/Group Containers is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `secure-dotenv` hanging for hours during macOS activation by pruning `~/Library` from the dotenv scan. Previously, the find command opened app group containers under `~/Library/Group Containers/`, which blocks indefinitely on TCC app-data mediation; those scans now skip Library entirely, so any `.env` files there are no longer secured.

**Tests**
- Adds spec coverage for the prune expression.
- Verifies a `.env` under `Library/Group Containers` is left untouched.

<sup>Written for commit 5a009bab524c5e7f109bff37574dd46ed0e3296f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

