### PR TITLE
fix(dolt): resume deferred Linear push across runs

### DIFF
--- a/home-manager/services/dolt/linear-sync.sh
+++ b/home-manager/services/dolt/linear-sync.sh
@@ -123,6 +123,7 @@ repo_dir="$(cd "$repo_dir" && pwd -P)"
 repo_slug="${repo_name//\//%2F}"
 sync_checkpoint_file="$sync_state_dir/last-success-$repo_slug"
 reconciliation_lock_file="$sync_state_dir/reconcile-$repo_slug.lock"
+push_progress_file="$sync_state_dir/push-progress-$repo_slug"
 
 ensure_config() {
   local key="$1"
@@ -170,6 +171,12 @@ run_linear() {
 push_issue_batches() {
   local issue_ids="$1"
   local description="$2"
+  # Optional newline-delimited "id updated_at" lines aligned one-to-one with
+  # issue_ids. Each successfully pushed batch is appended to progress_file so
+  # a rate-limited (deferred) run resumes past those Beads instead of
+  # restarting the whole window and re-burning the API budget every retry.
+  local progress_entries="${3:-}"
+  local progress_file="${4:-}"
   local batch_size=10
   local batch_count
   local batch_ids
@@ -194,7 +201,11 @@ push_issue_batches() {
     log "Pushing $description Beads batch $batch_number/$batch_count"
 
     if run_linear @coreutils@/bin/timeout 120 "$bd_cli" -C "$repo_dir" linear sync --push --issues "$batch_ids" --no-wait; then
-      :
+      if [ -n "$progress_file" ] && [ -n "$progress_entries" ]; then
+        printf '%s\n' "$progress_entries" \
+          | @coreutils@/bin/tail -n +"$((batch_start + 1))" \
+          | @coreutils@/bin/head -n "$batch_size" >>"$progress_file"
+      fi
     else
       status=$?
       if [ "$status" -eq 75 ]; then
@@ -431,10 +442,18 @@ fi
 # Terminal Beads are authoritative after acceptance. Publish them before the
 # full inbound refresh so a stale active Linear record can never win during
 # the timer-latency window. On an initial run, publish every linked terminal
-# record once; later runs use the successful-cycle checkpoint.
+# record once; later runs use the successful-cycle checkpoint. Beads whose
+# exact revision was already pushed by an earlier deferred run in this window
+# are skipped; without that, a window larger than the API budget re-pushes the
+# same batches forever and the checkpoint never advances.
 issues_before_pull="$("$bd_cli" -C "$repo_dir" list --all --json --limit 0 --skip-labels)"
-closed_ids="$(@jq@/bin/jq -r --arg previous_sync "$previous_sync" '
+pushed_progress=""
+if [ -s "$push_progress_file" ]; then
+  pushed_progress="$(<"$push_progress_file")"
+fi
+closed_push_entries="$(@jq@/bin/jq -r --arg previous_sync "$previous_sync" --arg pushed "$pushed_progress" '
   (if type == "object" and has("issues") then .issues else . end)
+  | ($pushed | split("\n") | map(select(length > 0))) as $already_pushed
   | [
     .[]
     | select(
@@ -448,10 +467,12 @@ closed_ids="$(@jq@/bin/jq -r --arg previous_sync "$previous_sync" '
           )
         )
       )
-    | .id
+    | "\(.id) \(.updated_at // "")"
+    | select(. as $entry | ($already_pushed | index($entry)) | not)
   ]
-  | join(",")
+  | join("\n")
 ' <<<"$issues_before_pull")"
+closed_ids="$(printf '%s\n' "$closed_push_entries" | @gawk@/bin/awk 'NF { print $1 }' | @coreutils@/bin/paste -sd, -)"
 pending_completion_ids="$(@jq@/bin/jq -r '
   (if type == "object" and has("issues") then .issues else . end)
   | [
@@ -468,7 +489,7 @@ pending_completion_ids="$(@jq@/bin/jq -r '
   | join(",")
 ' <<<"$issues_before_pull")"
 
-if push_issue_batches "$closed_ids" "terminal"; then
+if push_issue_batches "$closed_ids" "terminal" "$closed_push_entries" "$push_progress_file"; then
   :
 else
   status=$?
@@ -573,5 +594,6 @@ federate_beads "post-sync"
 
 printf '%s\n' "$cycle_started" >"$sync_checkpoint_file.tmp"
 @coreutils@/bin/mv -f "$sync_checkpoint_file.tmp" "$sync_checkpoint_file"
+@coreutils@/bin/rm -f "$push_progress_file"
 
 "$bd_cli" -C "$repo_dir" linear status --json

--- a/spec/beads_linear_sync_spec.sh
+++ b/spec/beads_linear_sync_spec.sh
@@ -118,6 +118,16 @@ When run bash -c "checkpoint=\$(grep -n '\"\$cycle_started\" >\"\$sync_checkpoin
 The status should be success
 End
 
+It 'skips terminal Beads already recorded in the deferred push progress'
+When run bash -c "grep -F 'push_progress_file=\"\$sync_state_dir/push-progress-\$repo_slug\"' '$SCRIPT' >/dev/null && grep -F '(\$already_pushed | index(\$entry)) | not' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
+It 'clears push progress only after the cycle checkpoint is durable'
+When run bash -c "checkpoint=\$(grep -n '\"\$cycle_started\" >\"\$sync_checkpoint_file.tmp\"' '$SCRIPT' | cut -d: -f1); clear=\$(grep -n 'rm -f \"\$push_progress_file\"' '$SCRIPT' | cut -d: -f1); test \"\$clear\" -gt \"\$checkpoint\""
+The status should be success
+End
+
 It 'federates Beads before and after Linear reconciliation'
 When run bash -c "grep -F 'federate_beads \"pre-sync\"' '$SCRIPT' >/dev/null && grep -F 'federate_beads \"post-sync\"' '$SCRIPT' >/dev/null && grep -F 'federate_beads \"post-completion push\"' '$SCRIPT' >/dev/null"
 The status should be success
@@ -142,6 +152,7 @@ setup_reconciliation() {
   FSCK_TIMEOUT_LOG="$TEST_ROOT/fsck-timeouts.log"
   DOLT_LOG="$TEST_ROOT/dolt-commands.log"
   SYNC_COUNT="$TEST_ROOT/sync-count"
+  PUSH_COUNT="$TEST_ROOT/push-count"
   ISSUE_STATUS_FILE="$TEST_ROOT/issue-status"
   ISSUE_REF_FILE="$TEST_ROOT/issue-ref"
   STATE_HOME="$TEST_ROOT/state"
@@ -158,7 +169,7 @@ setup_reconciliation() {
   CHECKPOINT_FILE="$STATE_HOME/beads-linear-sync/last-success-$repo_slug"
   export DOTFILES_ENV_FILE="$ENV_FILE"
   export DOLT_LOG FSCK_TIMEOUT_LOG ISSUE_REF_FILE ISSUE_STATUS_FILE
-  for command in cat chmod date env mkdir mv sleep timeout; do
+  for command in cat chmod date env head mkdir mv paste rm sleep tail timeout; do
     ln -s "$(command -v "$command")" "$COREUTILS/bin/$command"
   done
   cat >"$UTIL_LINUX/bin/flock" <<'EOF'
@@ -228,6 +239,19 @@ case "${1:-} ${2:-}" in
     case "${FAKE_LINEAR_MODE:-success}" in
       rate-limit)
         printf '%s\n' 'rate limit circuit breaker is open'
+        ;;
+      rate-limit-after-one)
+        if [[ " $* " == *" --push "* ]]; then
+          push_count=0
+          if [ -s "${PUSH_COUNT:?}" ]; then
+            push_count=$(<"$PUSH_COUNT")
+          fi
+          push_count=$((push_count + 1))
+          printf '%s\n' "$push_count" >"$PUSH_COUNT"
+          if [ "$push_count" -gt 1 ]; then
+            printf '%s\n' 'rate limit circuit breaker is open'
+          fi
+        fi
         ;;
       hard-failure)
         exit 23
@@ -341,6 +365,19 @@ When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MOD
 The status should be success
 The output should include 'next 900-second run will retry'
 The file "$CHECKPOINT_FILE" should not be exist
+End
+
+It 'resumes a deferred terminal push without repeating pushed batches'
+closed_json="$(jq -nc '[range(1;13) | {id:("df-" + tostring),status:"closed",updated_at:"2099-01-01T00:00:00Z",external_ref:("https://linear.app/test/issue/TEST-" + tostring + "/x")}]')"
+progress_file="$STATE_HOME/beads-linear-sync/push-progress-test%2Frepo-one"
+When run bash -c "env COMMAND_LOG='$COMMAND_LOG' SYNC_COUNT='$SYNC_COUNT' PUSH_COUNT='$PUSH_COUNT' FAKE_LINEAR_MODE=rate-limit-after-one FAKE_LIST_JSON='$closed_json' XDG_STATE_HOME='$STATE_HOME' HOME='$TEST_ROOT' LINEAR_API_KEY=test bash '$RENDERED_SCRIPT' && test -s '$progress_file' && env COMMAND_LOG='$COMMAND_LOG' SYNC_COUNT='$SYNC_COUNT' FAKE_LIST_JSON='$closed_json' XDG_STATE_HOME='$STATE_HOME' HOME='$TEST_ROOT' LINEAR_API_KEY=test bash '$RENDERED_SCRIPT' && test \"\$(grep -c -- '--issues df-1,df-2,df-3,df-4,df-5,df-6,df-7,df-8,df-9,df-10 --no-wait' '$COMMAND_LOG')\" -eq 1"
+The status should be success
+The output should include 'terminal Beads batch 1/2'
+The output should include 'next 900-second run will retry'
+The output should include 'terminal Beads batch 1/1'
+The contents of file "$COMMAND_LOG" should include 'linear sync --push --issues df-11,df-12 --no-wait'
+The file "$CHECKPOINT_FILE" should be exist
+The file "$progress_file" should not be exist
 End
 
 It 'fails closed after an ordinary Linear pull failure'


### PR DESCRIPTION
## Problem

The kyber Linear reconciler has been livelocked since Aug 25. Each 900s run selects every closed bead updated since the last successful-cycle checkpoint, pushes ~22 of 27 batches, hits Linear's rate-limit circuit breaker, and exits deferred without writing the checkpoint. The next run restarts from batch 1 with the same window, so the run never completes, the checkpoint never advances, and the inbound Linear pull (which follows the terminal push) has not executed since.

## Fix

Record each successfully pushed batch to a per-repo progress file (`push-progress-<slug>`, entries of `id updated_at`). The terminal selection skips beads whose exact revision was already pushed in the current window, so a deferred run resumes where the rate limit stopped it instead of starting over. A completed cycle removes the progress file after the checkpoint write; a bead updated after being recorded no longer matches its entry and is re-pushed.

## Tests

- shellspec `spec/beads_linear_sync_spec.sh`: 53 examples, 0 failures, including a new functional test that defers after one batch, asserts progress is recorded, and verifies the second run pushes only the remainder, checkpoints, and clears progress
- shellcheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Linear reconciler livelock where a rate-limited push restarted from batch 1 each 900s cycle, so the push never completed and the inbound Linear pull never ran.

- Records each successfully pushed batch to a per-repo `push-progress-<slug>` file so a deferred run resumes past the rate limit instead of re-pushing the whole window.
- Removes the progress file only after the checkpoint write; beads updated after being recorded no longer match their entry and are re-pushed.

<sup>Written for commit 589c2c05d978913fa833f1ff9cba4b823c122974. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

