### PR TITLE
fix(dolt): accept Linear refs without trailing title slug

### DIFF
--- a/home-manager/services/dolt/linear-sync.sh
+++ b/home-manager/services/dolt/linear-sync.sh
@@ -123,6 +123,7 @@ repo_dir="$(cd "$repo_dir" && pwd -P)"
 repo_slug="${repo_name//\//%2F}"
 sync_checkpoint_file="$sync_state_dir/last-success-$repo_slug"
 reconciliation_lock_file="$sync_state_dir/reconcile-$repo_slug.lock"
+push_progress_file="$sync_state_dir/push-progress-$repo_slug"
 
 ensure_config() {
   local key="$1"
@@ -170,6 +171,12 @@ run_linear() {
 push_issue_batches() {
   local issue_ids="$1"
   local description="$2"
+  # Optional newline-delimited "id updated_at" lines aligned one-to-one with
+  # issue_ids. Each successfully pushed batch is appended to progress_file so
+  # a rate-limited (deferred) run resumes past those Beads instead of
+  # restarting the whole window and re-burning the API budget every retry.
+  local progress_entries="${3:-}"
+  local progress_file="${4:-}"
   local batch_size=10
   local batch_count
   local batch_ids
@@ -194,7 +201,11 @@ push_issue_batches() {
     log "Pushing $description Beads batch $batch_number/$batch_count"
 
     if run_linear @coreutils@/bin/timeout 120 "$bd_cli" -C "$repo_dir" linear sync --push --issues "$batch_ids" --no-wait; then
-      :
+      if [ -n "$progress_file" ] && [ -n "$progress_entries" ]; then
+        printf '%s\n' "$progress_entries" \
+          | @coreutils@/bin/tail -n +"$((batch_start + 1))" \
+          | @coreutils@/bin/head -n "$batch_size" >>"$progress_file"
+      fi
     else
       status=$?
       if [ "$status" -eq 75 ]; then
@@ -431,10 +442,18 @@ fi
 # Terminal Beads are authoritative after acceptance. Publish them before the
 # full inbound refresh so a stale active Linear record can never win during
 # the timer-latency window. On an initial run, publish every linked terminal
-# record once; later runs use the successful-cycle checkpoint.
+# record once; later runs use the successful-cycle checkpoint. Beads whose
+# exact revision was already pushed by an earlier deferred run in this window
+# are skipped; without that, a window larger than the API budget re-pushes the
+# same batches forever and the checkpoint never advances.
 issues_before_pull="$("$bd_cli" -C "$repo_dir" list --all --json --limit 0 --skip-labels)"
-closed_ids="$(@jq@/bin/jq -r --arg previous_sync "$previous_sync" '
+pushed_progress=""
+if [ -s "$push_progress_file" ]; then
+  pushed_progress="$(<"$push_progress_file")"
+fi
+closed_push_entries="$(@jq@/bin/jq -r --arg previous_sync "$previous_sync" --arg pushed "$pushed_progress" '
   (if type == "object" and has("issues") then .issues else . end)
+  | ($pushed | split("\n") | map(select(length > 0))) as $already_pushed
   | [
     .[]
     | select(
@@ -448,10 +467,12 @@ closed_ids="$(@jq@/bin/jq -r --arg previous_sync "$previous_sync" '
           )
         )
       )
-    | .id
+    | "\(.id) \(.updated_at // "")"
+    | select(. as $entry | ($already_pushed | index($entry)) | not)
   ]
-  | join(",")
+  | join("\n")
 ' <<<"$issues_before_pull")"
+closed_ids="$(printf '%s\n' "$closed_push_entries" | @gawk@/bin/awk 'NF { print $1 }' | @coreutils@/bin/paste -sd, -)"
 pending_completion_ids="$(@jq@/bin/jq -r '
   (if type == "object" and has("issues") then .issues else . end)
   | [
@@ -468,7 +489,7 @@ pending_completion_ids="$(@jq@/bin/jq -r '
   | join(",")
 ' <<<"$issues_before_pull")"
 
-if push_issue_batches "$closed_ids" "terminal"; then
+if push_issue_batches "$closed_ids" "terminal" "$closed_push_entries" "$push_progress_file"; then
   :
 else
   status=$?
@@ -573,5 +594,6 @@ federate_beads "post-sync"
 
 printf '%s\n' "$cycle_started" >"$sync_checkpoint_file.tmp"
 @coreutils@/bin/mv -f "$sync_checkpoint_file.tmp" "$sync_checkpoint_file"
+@coreutils@/bin/rm -f "$push_progress_file"
 
 "$bd_cli" -C "$repo_dir" linear status --json

--- a/home-manager/services/dolt/linear-sync.sh
+++ b/home-manager/services/dolt/linear-sync.sh
@@ -335,7 +335,7 @@ if [ "$operation" = "--complete" ]; then
   fi
 
   completion_reference_pending=0
-  if [[ ! $completion_ref =~ /issue/([A-Z][A-Z0-9]*-[0-9]+)/ ]]; then
+  if [[ ! $completion_ref =~ /issue/([A-Z][A-Z0-9]*-[0-9]+)(/|$) ]]; then
     # The marker is Beads-owned durable state, not a machine-local retry file.
     # It lets the periodic sole writer recover a rate-limited first publish
     # without selecting every unrelated locally closed Bead.
@@ -371,7 +371,7 @@ if [ "$operation" = "--complete" ]; then
 
   completion_issue="$("$bd_cli" -C "$repo_dir" show "$completion_bead_id" --json)"
   completion_ref="$(@jq@/bin/jq -r '.[0].external_ref // empty' <<<"$completion_issue")"
-  if [[ ! $completion_ref =~ /issue/([A-Z][A-Z0-9]*-[0-9]+)/ ]]; then
+  if [[ ! $completion_ref =~ /issue/([A-Z][A-Z0-9]*-[0-9]+)(/|$) ]]; then
     log "Accepted Bead does not have a Linear issue reference after push"
     exit 65
   fi
@@ -506,7 +506,7 @@ if [ -n "$pending_completion_ids" ]; then
   for pending_completion_id in "${pending_completion_id_array[@]}"; do
     pending_completion_issue="$("$bd_cli" -C "$repo_dir" show "$pending_completion_id" --json)"
     pending_completion_ref="$(@jq@/bin/jq -r '.[0].external_ref // empty' <<<"$pending_completion_issue")"
-    if [[ $pending_completion_ref =~ /issue/([A-Z][A-Z0-9]*-[0-9]+)/ ]]; then
+    if [[ $pending_completion_ref =~ /issue/([A-Z][A-Z0-9]*-[0-9]+)(/|$) ]]; then
       recovered_pending_id_array+=("$pending_completion_id")
     else
       unresolved_pending_completion=1

--- a/spec/beads_linear_sync_spec.sh
+++ b/spec/beads_linear_sync_spec.sh
@@ -534,6 +534,18 @@ The contents of file "$COMMAND_LOG" should not include 'linear sync --push --iss
 The contents of file "$ISSUE_REF_FILE" should include 'TEST-999'
 End
 
+It 'recovers pending completion when the Linear reference has no trailing title slug'
+printf '%s\n' closed >"$ISSUE_STATUS_FILE"
+printf '%s\n' 'https://linear.app/test/issue/TEST-999' >"$ISSUE_REF_FILE"
+mkdir -p "$(dirname "$CHECKPOINT_FILE")"
+printf '%s\n' '2099-01-01T00:00:00Z' >"$CHECKPOINT_FILE"
+pending_json='[{"id":"df-accepted","status":"closed","updated_at":"2020-01-01T00:00:00Z","metadata":{"linear_completion_pending":true}}]'
+When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MODE=push-no-reference FAKE_LIST_JSON="$pending_json" XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
+The status should be success
+The output should include 'Pulling complete Linear state'
+The contents of file "$COMMAND_LOG" should include 'update df-accepted --unset-metadata linear_completion_pending'
+End
+
 It 'keeps the retry marker when a successful push does not persist a Linear reference'
 printf '%s\n' closed >"$ISSUE_STATUS_FILE"
 mkdir -p "$(dirname "$CHECKPOINT_FILE")"

--- a/spec/beads_linear_sync_spec.sh
+++ b/spec/beads_linear_sync_spec.sh
@@ -118,6 +118,16 @@ When run bash -c "checkpoint=\$(grep -n '\"\$cycle_started\" >\"\$sync_checkpoin
 The status should be success
 End
 
+It 'skips terminal Beads already recorded in the deferred push progress'
+When run bash -c "grep -F 'push_progress_file=\"\$sync_state_dir/push-progress-\$repo_slug\"' '$SCRIPT' >/dev/null && grep -F '(\$already_pushed | index(\$entry)) | not' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
+It 'clears push progress only after the cycle checkpoint is durable'
+When run bash -c "checkpoint=\$(grep -n '\"\$cycle_started\" >\"\$sync_checkpoint_file.tmp\"' '$SCRIPT' | cut -d: -f1); clear=\$(grep -n 'rm -f \"\$push_progress_file\"' '$SCRIPT' | cut -d: -f1); test \"\$clear\" -gt \"\$checkpoint\""
+The status should be success
+End
+
 It 'federates Beads before and after Linear reconciliation'
 When run bash -c "grep -F 'federate_beads \"pre-sync\"' '$SCRIPT' >/dev/null && grep -F 'federate_beads \"post-sync\"' '$SCRIPT' >/dev/null && grep -F 'federate_beads \"post-completion push\"' '$SCRIPT' >/dev/null"
 The status should be success
@@ -142,6 +152,7 @@ setup_reconciliation() {
   FSCK_TIMEOUT_LOG="$TEST_ROOT/fsck-timeouts.log"
   DOLT_LOG="$TEST_ROOT/dolt-commands.log"
   SYNC_COUNT="$TEST_ROOT/sync-count"
+  PUSH_COUNT="$TEST_ROOT/push-count"
   ISSUE_STATUS_FILE="$TEST_ROOT/issue-status"
   ISSUE_REF_FILE="$TEST_ROOT/issue-ref"
   STATE_HOME="$TEST_ROOT/state"
@@ -158,7 +169,7 @@ setup_reconciliation() {
   CHECKPOINT_FILE="$STATE_HOME/beads-linear-sync/last-success-$repo_slug"
   export DOTFILES_ENV_FILE="$ENV_FILE"
   export DOLT_LOG FSCK_TIMEOUT_LOG ISSUE_REF_FILE ISSUE_STATUS_FILE
-  for command in cat chmod date env mkdir mv sleep timeout; do
+  for command in cat chmod date env head mkdir mv paste rm sleep tail timeout; do
     ln -s "$(command -v "$command")" "$COREUTILS/bin/$command"
   done
   cat >"$UTIL_LINUX/bin/flock" <<'EOF'
@@ -228,6 +239,19 @@ case "${1:-} ${2:-}" in
     case "${FAKE_LINEAR_MODE:-success}" in
       rate-limit)
         printf '%s\n' 'rate limit circuit breaker is open'
+        ;;
+      rate-limit-after-one)
+        if [[ " $* " == *" --push "* ]]; then
+          push_count=0
+          if [ -s "${PUSH_COUNT:?}" ]; then
+            push_count=$(<"$PUSH_COUNT")
+          fi
+          push_count=$((push_count + 1))
+          printf '%s\n' "$push_count" >"$PUSH_COUNT"
+          if [ "$push_count" -gt 1 ]; then
+            printf '%s\n' 'rate limit circuit breaker is open'
+          fi
+        fi
         ;;
       hard-failure)
         exit 23
@@ -341,6 +365,19 @@ When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MOD
 The status should be success
 The output should include 'next 900-second run will retry'
 The file "$CHECKPOINT_FILE" should not be exist
+End
+
+It 'resumes a deferred terminal push without repeating pushed batches'
+closed_json="$(jq -nc '[range(1;13) | {id:("df-" + tostring),status:"closed",updated_at:"2099-01-01T00:00:00Z",external_ref:("https://linear.app/test/issue/TEST-" + tostring + "/x")}]')"
+progress_file="$STATE_HOME/beads-linear-sync/push-progress-test%2Frepo-one"
+When run bash -c "env COMMAND_LOG='$COMMAND_LOG' SYNC_COUNT='$SYNC_COUNT' PUSH_COUNT='$PUSH_COUNT' FAKE_LINEAR_MODE=rate-limit-after-one FAKE_LIST_JSON='$closed_json' XDG_STATE_HOME='$STATE_HOME' HOME='$TEST_ROOT' LINEAR_API_KEY=test bash '$RENDERED_SCRIPT' && test -s '$progress_file' && env COMMAND_LOG='$COMMAND_LOG' SYNC_COUNT='$SYNC_COUNT' FAKE_LIST_JSON='$closed_json' XDG_STATE_HOME='$STATE_HOME' HOME='$TEST_ROOT' LINEAR_API_KEY=test bash '$RENDERED_SCRIPT' && test \"\$(grep -c -- '--issues df-1,df-2,df-3,df-4,df-5,df-6,df-7,df-8,df-9,df-10 --no-wait' '$COMMAND_LOG')\" -eq 1"
+The status should be success
+The output should include 'terminal Beads batch 1/2'
+The output should include 'next 900-second run will retry'
+The output should include 'terminal Beads batch 1/1'
+The contents of file "$COMMAND_LOG" should include 'linear sync --push --issues df-11,df-12 --no-wait'
+The file "$CHECKPOINT_FILE" should be exist
+The file "$progress_file" should not be exist
 End
 
 It 'fails closed after an ordinary Linear pull failure'


### PR DESCRIPTION
The pending-completion recovery regex required a trailing slash after the issue identifier (`/issue/([A-Z][A-Z0-9]*-[0-9]+)/`), so a short-form Linear URL without the title slug failed the match and the run exited 65 before the inbound pull -- surfaced on kyber once #2549 let the push phase complete. All three regex sites now accept `(/|$)`.

- Regression spec: pending bead whose stored ref has no trailing slug now completes the full cycle
- shellspec 54 examples, 0 failures; shellcheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Linear sync so short-form Linear URLs without a trailing title slug no longer fail pending-completion recovery with exit 65, and makes rate-limited terminal pushes resumable across runs instead of re-pushing the same batches and burning the API budget on every retry.

- Records each successfully pushed batch in a deferred push progress file and skips those entries on the next run.
- Keeps the progress file until the cycle checkpoint is written durably, then removes it.
- Adds a regression spec for slugless ref recovery and a spec confirming a deferred push resumes without repeating pushed batches.

<sup>Written for commit 8ed5705d2bd6b6f1b527af743a94307b2a8404ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

