### PR TITLE
fix(shell): export Bun global binaries in session PATH

### DIFF
--- a/home-manager/modules/npm-globals/default.nix
+++ b/home-manager/modules/npm-globals/default.nix
@@ -45,6 +45,7 @@ in
   # Add local and bun bins to PATH
   home.sessionPath = [
     "$HOME/.local/bin"
+    "$HOME/.bun/install/global/node_modules/.bin"
     "$HOME/.bun/bin"
   ];
 }


### PR DESCRIPTION
## Summary

- Export `~/.bun/install/global/node_modules/.bin` through Home Manager `home.sessionPath`.
- Make globally installed Bun CLIs, including Traces, available to non-interactive and GUI-launched processes such as Git hooks.

## Verification

- `git diff --check` passed.
- Commit hooks passed.
- Full `make nix-test` was started but intentionally bypassed per request after flake evaluation began.

## Root cause

Interactive shell startup already added the global Bun bin directory, but the session-wide Home Manager PATH only exported `~/.bun/bin`; processes that do not source shell init files could not resolve `traces`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `$HOME/.bun/install/global/node_modules/.bin` to `home.sessionPath` so globally installed Bun CLIs like Traces are available to non-interactive and GUI-launched processes (e.g., Git hooks). Previously only `~/.bun/bin` was in session PATH; interactive shells got the global binaries path from shell init.

<sup>Written for commit dc0df82793e5fc3e589f0c84dc97728acb276c63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

