### PR TITLE
feat(agents): wire traces hooks for antigravity and pi

### DIFF
--- a/config/antigravity/activate.sh
+++ b/config/antigravity/activate.sh
@@ -2,13 +2,20 @@
 # Merge declarative Antigravity CLI defaults into its writable settings file.
 # The explicit Gemini provider requires GEMINI_API_KEY and bypasses Antigravity's
 # authenticated default backend, so remove that legacy managed key on upgrade.
-# Usage: activate.sh <managed-settings-json> [jq]
+#
+# Also merges the managed named hooks into the global customization root at
+# ~/.gemini/config/hooks.json. That file is a shared merge point -- moshi-hook
+# and orca write their own named hooks into it -- so merge rather than replace.
+# Usage: activate.sh <managed-settings-json> <managed-hooks-json> [jq]
 set -euo pipefail
 
 MANAGED_SETTINGS="$1"
-JQ="${2:-jq}"
+MANAGED_HOOKS="$2"
+JQ="${3:-jq}"
 SETTINGS_DIR="${HOME}/.gemini/antigravity-cli"
 SETTINGS_FILE="${SETTINGS_DIR}/settings.json"
+HOOKS_DIR="${HOME}/.gemini/config"
+HOOKS_FILE="${HOOKS_DIR}/hooks.json"
 
 mkdir -p "$SETTINGS_DIR"
 
@@ -28,4 +35,24 @@ fi
 
 chmod 600 "$tmp"
 mv -f "$tmp" "$SETTINGS_FILE"
+trap - EXIT
+
+mkdir -p "$HOOKS_DIR"
+
+if [ -f "$HOOKS_FILE" ] && ! "$JQ" -e 'type == "object"' "$HOOKS_FILE" >/dev/null; then
+  echo "ERROR: refusing to replace invalid Antigravity hooks: $HOOKS_FILE" >&2
+  exit 1
+fi
+
+hooks_tmp="$(mktemp "$HOOKS_DIR/hooks.json.XXXXXX")"
+trap 'rm -f "$hooks_tmp"' EXIT
+
+if [ -f "$HOOKS_FILE" ]; then
+  "$JQ" -s '.[0] * .[1]' "$HOOKS_FILE" "$MANAGED_HOOKS" >"$hooks_tmp"
+else
+  "$JQ" '.' "$MANAGED_HOOKS" >"$hooks_tmp"
+fi
+
+chmod 644 "$hooks_tmp"
+mv -f "$hooks_tmp" "$HOOKS_FILE"
 trap - EXIT

--- a/config/antigravity/default.nix
+++ b/config/antigravity/default.nix
@@ -9,6 +9,7 @@
   home.activation.antigravityCliSettings = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" \
       "${./settings.json}" \
+      "${./hooks.json}" \
       "${pkgs.jq}/bin/jq"
   '';
 }

--- a/config/antigravity/hooks.json
+++ b/config/antigravity/hooks.json
@@ -1,0 +1,12 @@
+{
+  "traces-share-to-traces": {
+    "enabled": true,
+    "Stop": [
+      {
+        "type": "command",
+        "command": "command -v traces >/dev/null 2>&1 && traces hook agent agent-done --agent antigravity >/dev/null 2>&1; printf %s '{\"decision\":\"\"}'",
+        "timeout": 30
+      }
+    ]
+  }
+}

--- a/config/pi/default.nix
+++ b/config/pi/default.nix
@@ -15,6 +15,10 @@ _: {
     source = ./moshi-hooks.ts;
     force = true;
   };
+  home.file.".pi/agent/extensions/traces-hooks.ts" = {
+    source = ./traces-hooks.ts;
+    force = true;
+  };
   home.file.".pi/agent/fallback.json" = {
     source = ./fallback.json;
     force = true;

--- a/config/pi/traces-hooks.ts
+++ b/config/pi/traces-hooks.ts
@@ -1,0 +1,64 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { spawn } from "node:child_process";
+
+function sendTraces(event: string, sessionId: string) {
+  try {
+    const child = spawn("traces", ["hook", "agent", event, "--agent", "pi"], {
+      stdio: ["pipe", "ignore", "ignore"],
+      detached: true,
+    });
+    // spawn ENOENT is async; the try/catch above cannot see it.
+    child.on("error", () => {});
+    child.stdin.end(JSON.stringify({ session_id: sessionId }));
+    child.unref();
+  } catch {
+    // Hooks should never interrupt the user's Pi turn when Traces is absent.
+  }
+}
+
+function sessionID(ctx: unknown): string {
+  const manager = (ctx as { sessionManager?: { getSessionId?: () => unknown } })
+    ?.sessionManager;
+  const sid = manager?.getSessionId?.();
+  return typeof sid === "string" ? sid : "";
+}
+
+export default function tracesPiHook(pi: ExtensionAPI): void {
+  // Traces keys a session by Pi's own session id, so a turn is dropped rather
+  // than filed under a guessed id.
+  let session = "";
+
+  function report(event: string, ctx: unknown) {
+    session = sessionID(ctx) || session;
+    if (session) sendTraces(event, session);
+  }
+
+  // Pi emits agent_end once per attempt from inside its retry/compaction loop,
+  // but agent_settled once per prompt. Extensions cannot tell a retry from a
+  // real ending, so prefer settled. agent_settled only exists from Pi 0.80.5,
+  // and Pi's loader accepts a subscription to an unknown event without firing
+  // it, so agent_end stays registered as the fallback for older Pi.
+  let sawAgentSettled = false;
+
+  pi.on("session_start", (_event, ctx) => {
+    report("session-start", ctx);
+  });
+
+  pi.on("before_agent_start", (_event, ctx) => {
+    report("prompt-submitted", ctx);
+  });
+
+  pi.on("agent_end", (_event, ctx) => {
+    if (!sawAgentSettled) report("agent-done", ctx);
+  });
+
+  pi.on("agent_settled", (_event, ctx) => {
+    sawAgentSettled = true;
+    report("agent-done", ctx);
+  });
+
+  pi.on("session_shutdown", (_event, ctx) => {
+    report("session-end", ctx);
+    session = "";
+  });
+}

--- a/spec/antigravity_config_spec.sh
+++ b/spec/antigravity_config_spec.sh
@@ -4,6 +4,7 @@
 Describe 'config/antigravity'
 SCRIPT="$PWD/config/antigravity/activate.sh"
 SETTINGS="$PWD/config/antigravity/settings.json"
+HOOKS="$PWD/config/antigravity/hooks.json"
 
 setup() {
   TEMP_HOME=$(mktemp -d)
@@ -17,7 +18,7 @@ Before 'setup'
 After 'cleanup'
 
 It 'creates writable default-backend Antigravity CLI settings'
-When run bash -c 'HOME="$1" bash "$2" "$3" jq && jq -e '\''.model == "gemini-3.7-flash-high" and has("modelProvider") == false and (.permissions.allow | index("read_file(*)") != null)'\'' "$1/.gemini/antigravity-cli/settings.json" >/dev/null && find "$1/.gemini/antigravity-cli/settings.json" -prune -perm 600 -print -quit | grep -q .' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS"
+When run bash -c 'HOME="$1" bash "$2" "$3" "$4" jq && jq -e '\''.model == "gemini-3.7-flash-high" and has("modelProvider") == false and (.permissions.allow | index("read_file(*)") != null)'\'' "$1/.gemini/antigravity-cli/settings.json" >/dev/null && find "$1/.gemini/antigravity-cli/settings.json" -prune -perm 600 -print -quit | grep -q .' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS" "$HOOKS"
 The status should be success
 The path "$TEMP_HOME/.gemini/antigravity-cli/settings.json" should be file
 The path "$TEMP_HOME/.gemini/antigravity-cli/settings.json" should be writable
@@ -33,17 +34,52 @@ cat >"$TEMP_HOME/.gemini/antigravity-cli/settings.json" <<'JSON'
   "futureSetting": "preserved"
 }
 JSON
-When run bash -c 'HOME="$1" bash "$2" "$3" jq && jq -e '\''.model == "gemini-3.7-flash-high" and has("modelProvider") == false and .showTips == false and .futureSetting == "preserved" and (.permissions.allow | index("read_file(*)") != null)'\'' "$1/.gemini/antigravity-cli/settings.json" >/dev/null && find "$1/.gemini/antigravity-cli/settings.json" -prune -perm 600 -print -quit | grep -q .' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS"
+When run bash -c 'HOME="$1" bash "$2" "$3" "$4" jq && jq -e '\''.model == "gemini-3.7-flash-high" and has("modelProvider") == false and .showTips == false and .futureSetting == "preserved" and (.permissions.allow | index("read_file(*)") != null)'\'' "$1/.gemini/antigravity-cli/settings.json" >/dev/null && find "$1/.gemini/antigravity-cli/settings.json" -prune -perm 600 -print -quit | grep -q .' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS" "$HOOKS"
 The status should be success
 End
 
 It 'fails closed without overwriting malformed runtime settings'
 mkdir -p "$TEMP_HOME/.gemini/antigravity-cli"
 printf '%s\n' '{broken' >"$TEMP_HOME/.gemini/antigravity-cli/settings.json"
-When run bash -c 'HOME="$1" bash "$2" "$3" jq' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS"
+When run bash -c 'HOME="$1" bash "$2" "$3" "$4" jq' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS" "$HOOKS"
 The status should be failure
 The error should include 'refusing to replace invalid Antigravity settings'
 The contents of file "$TEMP_HOME/.gemini/antigravity-cli/settings.json" should equal '{broken'
+End
+
+It 'installs the traces hook into the global customization root'
+When run bash -c 'HOME="$1" bash "$2" "$3" "$4" jq && jq -e '\''.["traces-share-to-traces"].enabled == true and (.["traces-share-to-traces"].Stop[0].command | contains("traces hook agent agent-done --agent antigravity"))'\'' "$1/.gemini/config/hooks.json" >/dev/null && find "$1/.gemini/config/hooks.json" -prune -perm 644 -print -quit | grep -q .' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS" "$HOOKS"
+The status should be success
+The path "$TEMP_HOME/.gemini/config/hooks.json" should be file
+End
+
+It 'keeps named hooks written by other tools'
+mkdir -p "$TEMP_HOME/.gemini/config"
+cat >"$TEMP_HOME/.gemini/config/hooks.json" <<'JSON'
+{
+  "moshi-hook": {
+    "enabled": true,
+    "Stop": [
+      {
+        "type": "command",
+        "command": "moshi-hook antigravity-hook Stop",
+        "timeout": 5
+      }
+    ]
+  }
+}
+JSON
+When run bash -c 'HOME="$1" bash "$2" "$3" "$4" jq && jq -e '\''.["moshi-hook"].Stop[0].command == "moshi-hook antigravity-hook Stop" and has("traces-share-to-traces")'\'' "$1/.gemini/config/hooks.json" >/dev/null' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS" "$HOOKS"
+The status should be success
+End
+
+It 'fails closed without overwriting malformed hooks'
+mkdir -p "$TEMP_HOME/.gemini/config"
+printf '%s\n' '{broken' >"$TEMP_HOME/.gemini/config/hooks.json"
+When run bash -c 'HOME="$1" bash "$2" "$3" "$4" jq' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS" "$HOOKS"
+The status should be failure
+The error should include 'refusing to replace invalid Antigravity hooks'
+The contents of file "$TEMP_HOME/.gemini/config/hooks.json" should equal '{broken'
 End
 
 It 'contains no remaining CCS integration outside this regression check'


### PR DESCRIPTION
Completes the traces agent-hook coverage started in #2543, which already wired grok and copilot. Only antigravity and pi were missing.

## Antigravity

Antigravity reads named hooks from its global customization root, which is `~/.gemini/config/hooks.json` — not `~/.agents/`. `traces setup` writes a project-local `.agents/hooks.json`, which never takes effect globally, so the hook is managed declaratively here instead.

That file is a shared merge point: `moshi-hook` and `orca-status` write their own named hooks into it. `config/antigravity/activate.sh` therefore jq-merges the managed fragment rather than replacing the file, and fails closed if the existing file is not valid JSON.

The hook is named `traces-share-to-traces` to match what `traces setup` writes, so a manual `traces setup` run overwrites in place instead of duplicating.

Antigravity requires hooks to emit JSON on stdout, so the command uses `;` before the `printf` rather than `&&` — the decision object is emitted even when the `traces` CLI is absent.

## Pi

`config/pi/traces-hooks.ts` is a standalone extension installed alongside `moshi-hooks.ts`. It only imports `ExtensionAPI` as a type; value imports from `@earendil-works/pi-coding-agent` are not safe here because the package has no materialized `dist/`, and type imports are erased before resolution.

Pi emits `agent_end` once per attempt from inside its retry/compaction loop but `agent_settled` once per prompt, so `agent_settled` is preferred and `agent_end` stays registered as the fallback for Pi older than 0.80.5.

## Tests

`spec/antigravity_config_spec.sh` gains three examples: the hook is installed with mode 644, named hooks written by other tools survive the merge, and a malformed `hooks.json` fails closed without being overwritten.

- `make nix-format-check` — pass
- `make shell-check` — pass
- `make shell-test` — pass (2403 examples, 0 failures)

## Note

`config/pi/moshi-hooks.ts` carries an `Auto-generated by moshi-hook. Update with care.` header. The new extension is a separate file specifically to avoid that regeneration hazard.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires traces agent hooks for Antigravity and Pi, completing the hook coverage that was already added for grok and copilot.

**Antigravity**
- `activate.sh` now merges the managed `traces-share-to-traces` hook into the global `~/.gemini/config/hooks.json`, preserving named hooks written by `moshi-hook` and `orca-status`.
- The hook runs even when the `traces` CLI is missing, and invalid existing hooks JSON aborts without being overwritten.
- Adds three specs covering install, merge preservation, and fail-closed behavior.

**Pi**
- Installs `traces-hooks.ts` as a separate file next to `moshi-hooks.ts`, importing `ExtensionAPI` only as a type since `@earendil-works/pi-coding-agent` ships no `dist/`; keeping it separate also avoids `moshi-hook` regeneration overwriting it.
- Reports `agent-done` on `agent_settled` (once per prompt), keeping `agent_end` as the fallback for Pi older than 0.80.5.

<sup>Written for commit d0c2d0e65a095fdea4f93d524c33b3e8da831613. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

