### PR TITLE
refactor(antigravity): manage every named hook declaratively

### DIFF
--- a/config/antigravity/activate.sh
+++ b/config/antigravity/activate.sh
@@ -3,9 +3,10 @@
 # The explicit Gemini provider requires GEMINI_API_KEY and bypasses Antigravity's
 # authenticated default backend, so remove that legacy managed key on upgrade.
 #
-# Also merges the managed named hooks into the global customization root at
-# ~/.gemini/config/hooks.json. That file is a shared merge point -- moshi-hook
-# and orca write their own named hooks into it -- so merge rather than replace.
+# Also installs the managed named hooks into the global customization root at
+# ~/.gemini/config/hooks.json. Every hook there is declared here, including the
+# ones moshi-hook and orca install themselves, so this replaces the file rather
+# than merging into whatever those installers last wrote.
 # Usage: activate.sh <managed-settings-json> <managed-hooks-json> [jq]
 set -euo pipefail
 
@@ -39,20 +40,8 @@ trap - EXIT
 
 mkdir -p "$HOOKS_DIR"
 
-if [ -f "$HOOKS_FILE" ] && ! "$JQ" -e 'type == "object"' "$HOOKS_FILE" >/dev/null; then
-  echo "ERROR: refusing to replace invalid Antigravity hooks: $HOOKS_FILE" >&2
-  exit 1
-fi
-
-hooks_tmp="$(mktemp "$HOOKS_DIR/hooks.json.XXXXXX")"
-trap 'rm -f "$hooks_tmp"' EXIT
-
-if [ -f "$HOOKS_FILE" ]; then
-  "$JQ" -s '.[0] * .[1]' "$HOOKS_FILE" "$MANAGED_HOOKS" >"$hooks_tmp"
-else
-  "$JQ" '.' "$MANAGED_HOOKS" >"$hooks_tmp"
-fi
-
-chmod 644 "$hooks_tmp"
-mv -f "$hooks_tmp" "$HOOKS_FILE"
-trap - EXIT
+# Copied rather than symlinked: moshi-hook and orca rewrite this file on their
+# own install, and a store symlink would make them fail instead of simply being
+# reverted on the next switch.
+cp -f "$MANAGED_HOOKS" "$HOOKS_FILE"
+chmod 644 "$HOOKS_FILE"

--- a/config/antigravity/hooks.json
+++ b/config/antigravity/hooks.json
@@ -1,4 +1,57 @@
 {
+  "moshi-hook": {
+    "enabled": true,
+    "PreInvocation": [
+      {
+        "type": "command",
+        "command": "moshi-hook antigravity-hook PreInvocation",
+        "timeout": 5
+      }
+    ],
+    "Stop": [
+      {
+        "type": "command",
+        "command": "moshi-hook antigravity-hook Stop",
+        "timeout": 5
+      }
+    ]
+  },
+  "orca-status": {
+    "enabled": true,
+    "PreInvocation": [
+      {
+        "type": "command",
+        "command": "if [ -x \"$HOME/.orca/agent-hooks/antigravity-hook.sh\" ]; then ORCA_ANTIGRAVITY_EVENT='PreInvocation' /bin/sh \"$HOME/.orca/agent-hooks/antigravity-hook.sh\"; else { command -p cat 2>/dev/null || cat; } >/dev/null 2>&1 || :; fi",
+        "timeout": 10
+      }
+    ],
+    "PostInvocation": [
+      {
+        "type": "command",
+        "command": "if [ -x \"$HOME/.orca/agent-hooks/antigravity-hook.sh\" ]; then ORCA_ANTIGRAVITY_EVENT='PostInvocation' /bin/sh \"$HOME/.orca/agent-hooks/antigravity-hook.sh\"; else { command -p cat 2>/dev/null || cat; } >/dev/null 2>&1 || :; fi",
+        "timeout": 10
+      }
+    ],
+    "Stop": [
+      {
+        "type": "command",
+        "command": "if [ -x \"$HOME/.orca/agent-hooks/antigravity-hook.sh\" ]; then ORCA_ANTIGRAVITY_EVENT='Stop' /bin/sh \"$HOME/.orca/agent-hooks/antigravity-hook.sh\"; else { command -p cat 2>/dev/null || cat; } >/dev/null 2>&1 || :; fi",
+        "timeout": 10
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if [ -x \"$HOME/.orca/agent-hooks/antigravity-hook.sh\" ]; then ORCA_ANTIGRAVITY_EVENT='PostToolUse' /bin/sh \"$HOME/.orca/agent-hooks/antigravity-hook.sh\"; else { command -p cat 2>/dev/null || cat; } >/dev/null 2>&1 || :; fi",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  },
   "traces-share-to-traces": {
     "enabled": true,
     "Stop": [

--- a/spec/antigravity_config_spec.sh
+++ b/spec/antigravity_config_spec.sh
@@ -47,13 +47,14 @@ The error should include 'refusing to replace invalid Antigravity settings'
 The contents of file "$TEMP_HOME/.gemini/antigravity-cli/settings.json" should equal '{broken'
 End
 
-It 'installs the traces hook into the global customization root'
-When run bash -c 'HOME="$1" bash "$2" "$3" "$4" jq && jq -e '\''.["traces-share-to-traces"].enabled == true and (.["traces-share-to-traces"].Stop[0].command | contains("traces hook agent agent-done --agent antigravity"))'\'' "$1/.gemini/config/hooks.json" >/dev/null && find "$1/.gemini/config/hooks.json" -prune -perm 644 -print -quit | grep -q .' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS" "$HOOKS"
+It 'installs every managed named hook into the global customization root'
+When run bash -c 'HOME="$1" bash "$2" "$3" "$4" jq && jq -e '\''(keys == ["moshi-hook", "orca-status", "traces-share-to-traces"]) and (.["traces-share-to-traces"].Stop[0].command | contains("traces hook agent agent-done --agent antigravity"))'\'' "$1/.gemini/config/hooks.json" >/dev/null && find "$1/.gemini/config/hooks.json" -prune -perm 644 -print -quit | grep -q .' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS" "$HOOKS"
 The status should be success
 The path "$TEMP_HOME/.gemini/config/hooks.json" should be file
+The path "$TEMP_HOME/.gemini/config/hooks.json" should be writable
 End
 
-It 'keeps named hooks written by other tools'
+It 'reverts named hooks written by other tools'
 mkdir -p "$TEMP_HOME/.gemini/config"
 cat >"$TEMP_HOME/.gemini/config/hooks.json" <<'JSON'
 {
@@ -62,24 +63,23 @@ cat >"$TEMP_HOME/.gemini/config/hooks.json" <<'JSON'
     "Stop": [
       {
         "type": "command",
-        "command": "moshi-hook antigravity-hook Stop",
+        "command": "/nix/store/stale-moshi-hook/bin/moshi-hook antigravity-hook Stop",
         "timeout": 5
       }
     ]
+  },
+  "some-other-tool": {
+    "enabled": true
   }
 }
 JSON
-When run bash -c 'HOME="$1" bash "$2" "$3" "$4" jq && jq -e '\''.["moshi-hook"].Stop[0].command == "moshi-hook antigravity-hook Stop" and has("traces-share-to-traces")'\'' "$1/.gemini/config/hooks.json" >/dev/null' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS" "$HOOKS"
+When run bash -c 'HOME="$1" bash "$2" "$3" "$4" jq && jq -e '\''(has("some-other-tool") | not) and (.["moshi-hook"].Stop[0].command == "moshi-hook antigravity-hook Stop")'\'' "$1/.gemini/config/hooks.json" >/dev/null' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS" "$HOOKS"
 The status should be success
 End
 
-It 'fails closed without overwriting malformed hooks'
-mkdir -p "$TEMP_HOME/.gemini/config"
-printf '%s\n' '{broken' >"$TEMP_HOME/.gemini/config/hooks.json"
-When run bash -c 'HOME="$1" bash "$2" "$3" "$4" jq' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS" "$HOOKS"
-The status should be failure
-The error should include 'refusing to replace invalid Antigravity hooks'
-The contents of file "$TEMP_HOME/.gemini/config/hooks.json" should equal '{broken'
+It 'pins no absolute Nix store paths or home directories in managed hooks'
+When run bash -c 'grep -qE "/nix/store|/Users/" "$1" && exit 1 || exit 0' _ "$HOOKS"
+The status should be success
 End
 
 It 'contains no remaining CCS integration outside this regression check'


### PR DESCRIPTION
Follow-up to #2552. That change merged the traces hook into `~/.gemini/config/hooks.json` and left `moshi-hook` and `orca-status` as whatever their own installers had written. This declares all three here instead, so the file is managed the same way as every other agent config.

## What was in the unmanaged entries

- `moshi-hook` pinned `/nix/store/f3py5wgy...-moshi-hook-0.2.69/bin/moshi-hook`, which goes stale on the next moshi-hook bump.
- `orca-status` hardcoded `/Users/shunkakinoki/.orca/agent-hooks/antigravity-hook.sh`.

Both now use the same forms `config/grok/plugin/hooks/hooks.json` already uses: bare `moshi-hook` on `PATH`, and `$HOME` for the orca script. `moshi-hook` keeps its `PreInvocation` and `Stop` hooks; `orca-status` keeps `PreInvocation`, `PostInvocation`, `Stop`, and `PostToolUse`.

## Install method

`activate.sh` replaces the file rather than jq-merging into it. It copies rather than symlinking, matching `config/grok`: moshi-hook and orca still rewrite this file when they install, and a read-only store symlink would make them fail instead of simply being reverted on the next switch.

## Tests

`spec/antigravity_config_spec.sh`:
- all three named hooks are installed, mode 644, writable
- a foreign hook and a stale store path written by another tool are both reverted
- the managed file pins no `/nix/store` or `/Users/` path

`make shell-test` passes (2403 examples, 0 failures); `make shell-check` passes.

`make nix-format-check` fails on an unrelated pre-existing formatting drift in `home-manager/services/dolt/linear-sync.sh`, which is the same failure `nix-format` shows on `main`. Left untouched here to keep this diff scoped.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declares every named hook (`moshi-hook`, `orca-status`, `traces-share-to-traces`) in the managed `~/.gemini/config/hooks.json` and replaces the file on switch instead of merging into whatever installers last wrote. Previously `moshi-hook` and `orca-status` wrote their own hooks pinning a Nix store path and an absolute home directory; they now use the same bare-command and `$HOME` forms as `config/grok`. The file is copied rather than symlinked, matching `config/grok`, so installer rewrites are simply reverted on the next switch instead of breaking.

<sup>Written for commit 4eb71b4ed9f5e2d43969a747ba5f76f3088c6b34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

