### PR TITLE
refactor(antigravity): drop the orca-status named hook

### DIFF
--- a/config/antigravity/hooks.json
+++ b/config/antigravity/hooks.json
@@ -16,42 +16,6 @@
       }
     ]
   },
-  "orca-status": {
-    "enabled": true,
-    "PreInvocation": [
-      {
-        "type": "command",
-        "command": "if [ -x \"$HOME/.orca/agent-hooks/antigravity-hook.sh\" ]; then ORCA_ANTIGRAVITY_EVENT='PreInvocation' /bin/sh \"$HOME/.orca/agent-hooks/antigravity-hook.sh\"; else { command -p cat 2>/dev/null || cat; } >/dev/null 2>&1 || :; fi",
-        "timeout": 10
-      }
-    ],
-    "PostInvocation": [
-      {
-        "type": "command",
-        "command": "if [ -x \"$HOME/.orca/agent-hooks/antigravity-hook.sh\" ]; then ORCA_ANTIGRAVITY_EVENT='PostInvocation' /bin/sh \"$HOME/.orca/agent-hooks/antigravity-hook.sh\"; else { command -p cat 2>/dev/null || cat; } >/dev/null 2>&1 || :; fi",
-        "timeout": 10
-      }
-    ],
-    "Stop": [
-      {
-        "type": "command",
-        "command": "if [ -x \"$HOME/.orca/agent-hooks/antigravity-hook.sh\" ]; then ORCA_ANTIGRAVITY_EVENT='Stop' /bin/sh \"$HOME/.orca/agent-hooks/antigravity-hook.sh\"; else { command -p cat 2>/dev/null || cat; } >/dev/null 2>&1 || :; fi",
-        "timeout": 10
-      }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "if [ -x \"$HOME/.orca/agent-hooks/antigravity-hook.sh\" ]; then ORCA_ANTIGRAVITY_EVENT='PostToolUse' /bin/sh \"$HOME/.orca/agent-hooks/antigravity-hook.sh\"; else { command -p cat 2>/dev/null || cat; } >/dev/null 2>&1 || :; fi",
-            "timeout": 10
-          }
-        ]
-      }
-    ]
-  },
   "traces-share-to-traces": {
     "enabled": true,
     "Stop": [

--- a/spec/antigravity_config_spec.sh
+++ b/spec/antigravity_config_spec.sh
@@ -48,7 +48,7 @@ The contents of file "$TEMP_HOME/.gemini/antigravity-cli/settings.json" should e
 End
 
 It 'installs every managed named hook into the global customization root'
-When run bash -c 'HOME="$1" bash "$2" "$3" "$4" jq && jq -e '\''(keys == ["moshi-hook", "orca-status", "traces-share-to-traces"]) and (.["traces-share-to-traces"].Stop[0].command | contains("traces hook agent agent-done --agent antigravity"))'\'' "$1/.gemini/config/hooks.json" >/dev/null && find "$1/.gemini/config/hooks.json" -prune -perm 644 -print -quit | grep -q .' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS" "$HOOKS"
+When run bash -c 'HOME="$1" bash "$2" "$3" "$4" jq && jq -e '\''(keys == ["moshi-hook", "traces-share-to-traces"]) and (.["traces-share-to-traces"].Stop[0].command | contains("traces hook agent agent-done --agent antigravity"))'\'' "$1/.gemini/config/hooks.json" >/dev/null && find "$1/.gemini/config/hooks.json" -prune -perm 644 -print -quit | grep -q .' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS" "$HOOKS"
 The status should be success
 The path "$TEMP_HOME/.gemini/config/hooks.json" should be file
 The path "$TEMP_HOME/.gemini/config/hooks.json" should be writable
@@ -68,12 +68,12 @@ cat >"$TEMP_HOME/.gemini/config/hooks.json" <<'JSON'
       }
     ]
   },
-  "some-other-tool": {
+  "orca-status": {
     "enabled": true
   }
 }
 JSON
-When run bash -c 'HOME="$1" bash "$2" "$3" "$4" jq && jq -e '\''(has("some-other-tool") | not) and (.["moshi-hook"].Stop[0].command == "moshi-hook antigravity-hook Stop")'\'' "$1/.gemini/config/hooks.json" >/dev/null' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS" "$HOOKS"
+When run bash -c 'HOME="$1" bash "$2" "$3" "$4" jq && jq -e '\''(has("orca-status") | not) and (.["moshi-hook"].Stop[0].command == "moshi-hook antigravity-hook Stop")'\'' "$1/.gemini/config/hooks.json" >/dev/null' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS" "$HOOKS"
 The status should be success
 End
 


### PR DESCRIPTION
Follow-up to #2553. Drops `orca-status` from the managed Antigravity hooks, leaving `moshi-hook` and `traces-share-to-traces`.

Because `activate.sh` replaces `~/.gemini/config/hooks.json` rather than merging into it, removing the entry here also removes it from the live file on the next switch. If orca reinstalls its hook, the following switch reverts it again.

`spec/antigravity_config_spec.sh` is updated to match: the managed-set assertion drops `orca-status`, and the revert test now seeds an `orca-status` entry and asserts activation removes it.

`make shell-test` passes (2403 examples, 0 failures).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the `orca-status` named hook from the managed Antigravity hooks, leaving `moshi-hook` and `traces-share-to-traces`. Because `activate.sh` replaces `~/.gemini/config/hooks.json` instead of merging, the next activation also removes `orca-status` from the live config; if orca reinstalls its hook, the following activation removes it again.

**Refactors**
- Updates the spec's managed-set assertion to drop `orca-status` and seeds an `orca-status` entry in the revert test to verify activation removes it.

<sup>Written for commit d8a19b48112f1bae7e76ba21786fade67c4dd1a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

