### PR TITLE
fix(gh): pin preview build with attach support

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -29,6 +29,26 @@
     inherit (prev.stdenv.hostPlatform) system;
   })
   (_: prev: {
+    # Use the immutable GitHub CLI preview commit that adds --attach to issue and PR
+    # commands. Remove this override once the feature is released in a tagged version.
+    gh = prev.gh.overrideAttrs (_: {
+      pname = "gh";
+      version = "2.95.0-unstable-20260825";
+      src = prev.fetchFromGitHub {
+        owner = "cli";
+        repo = "cli";
+        rev = "cc831722b71c3fc1603e6473bd1d9da27c0605e5";
+        hash = "sha256-8rnqM7jApjMYhUv2m/vrfSGu9i1eGLtmc/h/JUuipWs=";
+      };
+      vendorHash = "sha256-fhFsu/LjLNFwexSfUsd4X74UD+AQojLcdxU5IqOi3GY=";
+      buildPhase = ''
+        runHook preBuild
+        make GO_LDFLAGS="-s -w -X github.com/cli/cli/v2/internal/build.Date=nixpkgs" GH_VERSION=2.95.0-unstable-20260825 bin/gh manpages
+        runHook postBuild
+      '';
+    });
+  })
+  (_: prev: {
     # Fix shellspec wrapper script that breaks when called via symlinks
     shellspec = prev.shellspec.overrideAttrs (oldAttrs: {
       postInstall = (oldAttrs.postInstall or "") + ''


### PR DESCRIPTION
## Summary

Pin the GitHub CLI preview commit that adds `--attach` to issue and pull request commands.

The overlay is intentionally scoped to `pkgs.gh` and uses immutable source and vendor hashes. It should be removed once the feature is released in a tagged GitHub CLI version and available in nixpkgs.

## Validation

- `nix flake check --no-build`
- Local source and vendor hash verification
- Full `pkgs.gh` build is running locally against the pinned commit


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the GitHub CLI to a preview commit that adds `--attach` to issue and pull request commands. The overlay is scoped to `pkgs.gh` and uses immutable source and vendor hashes, so it should be removed once the feature is released in a tagged version and lands in nixpkgs.

<sup>Written for commit 868752a01fc3d865b0c3692f6afe532b29b4a312. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

