### PR TITLE
fix(kyber): contain orchestration under I/O pressure

### DIFF
--- a/config/k3s/default.nix
+++ b/config/k3s/default.nix
@@ -55,6 +55,7 @@ let
       pkgs.k3s
       pkgs.procps
       pkgs.smartmontools
+      pkgs.sysstat
       pkgs.systemd
       pkgs.util-linux
     ];

--- a/config/k3s/kyber-host-health.sh
+++ b/config/k3s/kyber-host-health.sh
@@ -3,7 +3,10 @@ set -euo pipefail
 
 readonly EXPECTED_CONTAINERD_UUID="90f29a7b-38ff-460b-b534-92a02f1412ec"
 readonly CONTAINERD_MOUNT="/var/lib/rancher/k3s/agent/containerd"
-readonly STATE_DIR="/run/kyber-host-health"
+readonly STATE_DIR="${KYBER_HOST_HEALTH_STATE_DIR:-/run/kyber-host-health}"
+readonly ORCHESTRATION_USER="${KYBER_ORCHESTRATION_USER:-ubuntu}"
+readonly ORCHESTRATION_SLICE="orchestration.slice"
+readonly ORCHESTRATION_RECOVERY_SAMPLES=5
 readonly D_STATE_THRESHOLD=3
 readonly D_STATE_SUSTAINED_SAMPLES=5
 readonly IO_SOME_AVG300_THRESHOLD=20
@@ -17,6 +20,10 @@ readonly CRI_LATENCY_THRESHOLD_SECONDS=5
 readonly CRI_ERROR_THRESHOLD=5
 readonly DISK_WEAR_WARNING_PERCENT=10
 readonly DISK_WEAR_CHECK_INTERVAL_SECONDS=21600
+
+IO_PRESSURE_UNHEALTHY=0
+D_STATE_UNHEALTHY=0
+CRI_UNHEALTHY=0
 
 set_alert() {
   local key="$1"
@@ -48,8 +55,10 @@ check_io_pressure() {
   full_avg300="$(awk '$1 == "full" { for (i = 1; i <= NF; i++) if ($i ~ /^avg300=/) { sub(/^avg300=/, "", $i); print $i } }' /proc/pressure/io)"
 
   if awk -v some="$some_avg300" -v full="$full_avg300" -v some_limit="$IO_SOME_AVG300_THRESHOLD" -v full_limit="$IO_FULL_AVG300_THRESHOLD" 'BEGIN { exit !(some >= some_limit || full >= full_limit) }'; then
+    IO_PRESSURE_UNHEALTHY=1
     set_alert "io-pressure" "sustained I/O PSI is elevated (some avg300=${some_avg300}, full avg300=${full_avg300})"
   else
+    IO_PRESSURE_UNHEALTHY=0
     clear_alert "io-pressure"
   fi
 }
@@ -69,8 +78,12 @@ check_d_state() {
   printf '%s\n' "$samples" >"$count_file"
 
   if [ "$samples" -ge "$D_STATE_SUSTAINED_SAMPLES" ]; then
+    D_STATE_UNHEALTHY=1
     set_alert "d-state" "${d_state_count} processes have remained in uninterruptible sleep for ${samples} consecutive samples"
-  elif [ "$samples" -eq 0 ]; then
+  else
+    D_STATE_UNHEALTHY=0
+  fi
+  if [ "$samples" -eq 0 ]; then
     clear_alert "d-state"
   fi
 }
@@ -154,6 +167,7 @@ check_cri() {
 
   started_at="$(date +%s)"
   if ! timeout 15 k3s crictl info >/dev/null 2>&1; then
+    CRI_UNHEALTHY=1
     set_alert "cri-health" "k3s crictl info failed or exceeded 15 seconds"
     return
   fi
@@ -164,9 +178,85 @@ check_cri() {
     grep -Eci 'DeadlineExceeded|deadline exceeded|FailedPrecondition|failed precondition|reserved (container )?name|failed to (create|stop|remove).*(sandbox|container)|cgroup.*(busy|failed)' || true)"
 
   if [ "$latency_seconds" -ge "$CRI_LATENCY_THRESHOLD_SECONDS" ] || [ "$error_count" -ge "$CRI_ERROR_THRESHOLD" ]; then
+    CRI_UNHEALTHY=1
     set_alert "cri-health" "CRI latency was ${latency_seconds}s with ${error_count} lifecycle errors in the last five minutes"
   else
+    CRI_UNHEALTHY=0
     clear_alert "cri-health"
+  fi
+}
+
+capture_orchestration_evidence() {
+  local evidence_dir timestamp
+
+  timestamp="$(date --utc +%Y%m%dT%H%M%SZ)"
+  evidence_dir="$STATE_DIR/evidence/$timestamp"
+  install -d --mode 0700 "$evidence_dir"
+
+  cat /proc/pressure/io >"$evidence_dir/io-pressure.txt"
+  ps -eo state,pid,ppid,uid,unit,cgroup,wchan:32,comm,args >"$evidence_dir/processes.txt"
+  pidstat -d -p ALL 1 1 >"$evidence_dir/process-io.txt" 2>&1 || true
+  systemd-cgtop --batch --iterations=1 --depth=6 --order=io >"$evidence_dir/cgroup-io.txt" 2>&1 || true
+  journalctl --unit k3s --since '10 minutes ago' --no-pager --quiet >"$evidence_dir/k3s-journal.txt" 2>&1 || true
+
+  printf '%s\n' "$evidence_dir"
+}
+
+orchestration_control() {
+  local action="$1"
+
+  systemctl --user --machine="${ORCHESTRATION_USER}@.host" "$action" "$ORCHESTRATION_SLICE"
+}
+
+manage_orchestration_circuit_breaker() {
+  local capture_file="$STATE_DIR/orchestration.capture"
+  local frozen_file="$STATE_DIR/orchestration.frozen"
+  local recovery_file="$STATE_DIR/orchestration.recovery-samples"
+  local evidence_dir recovery_samples=0
+
+  if [ "$IO_PRESSURE_UNHEALTHY" -eq 1 ] || [ "$D_STATE_UNHEALTHY" -eq 1 ]; then
+    printf '0\n' >"$recovery_file"
+    if [ ! -s "$capture_file" ]; then
+      evidence_dir="$(capture_orchestration_evidence)"
+      printf '%s\n' "$evidence_dir" >"$capture_file"
+    else
+      read -r evidence_dir <"$capture_file"
+    fi
+
+    if orchestration_control freeze; then
+      : >"$frozen_file"
+      set_alert "orchestration-circuit-breaker" "froze $ORCHESTRATION_SLICE after sustained host I/O pressure; evidence: $evidence_dir"
+    else
+      set_alert "orchestration-circuit-breaker" "failed to freeze $ORCHESTRATION_SLICE after sustained host I/O pressure; evidence: $evidence_dir"
+    fi
+    return
+  fi
+
+  if [ ! -e "$frozen_file" ]; then
+    rm -f "$capture_file" "$recovery_file"
+    clear_alert "orchestration-circuit-breaker"
+    return
+  fi
+
+  if [ "$CRI_UNHEALTHY" -eq 1 ]; then
+    printf '0\n' >"$recovery_file"
+    return
+  fi
+
+  if [ -r "$recovery_file" ]; then
+    read -r recovery_samples <"$recovery_file" || recovery_samples=0
+  fi
+  recovery_samples=$((recovery_samples + 1))
+  printf '%s\n' "$recovery_samples" >"$recovery_file"
+  if [ "$recovery_samples" -lt "$ORCHESTRATION_RECOVERY_SAMPLES" ]; then
+    return
+  fi
+
+  if orchestration_control thaw; then
+    rm -f "$capture_file" "$frozen_file" "$recovery_file"
+    clear_alert "orchestration-circuit-breaker"
+  else
+    set_alert "orchestration-circuit-breaker" "failed to thaw $ORCHESTRATION_SLICE after $recovery_samples healthy samples"
   fi
 }
 
@@ -213,6 +303,7 @@ main() {
   check_image_filesystem
   check_disk_wear
   check_cri
+  manage_orchestration_circuit_breaker
   check_dns
 }
 

--- a/config/k3s/kyber-host-health.sh
+++ b/config/k3s/kyber-host-health.sh
@@ -7,6 +7,7 @@ readonly STATE_DIR="${KYBER_HOST_HEALTH_STATE_DIR:-/run/kyber-host-health}"
 readonly ORCHESTRATION_USER="${KYBER_ORCHESTRATION_USER:-ubuntu}"
 readonly ORCHESTRATION_SLICE="orchestration.slice"
 readonly ORCHESTRATION_RECOVERY_SAMPLES=5
+readonly ORCHESTRATION_EVIDENCE_RETENTION=5
 readonly D_STATE_THRESHOLD=3
 readonly D_STATE_SUSTAINED_SAMPLES=5
 readonly IO_SOME_AVG300_THRESHOLD=20
@@ -186,12 +187,36 @@ check_cri() {
   fi
 }
 
+prune_orchestration_evidence() {
+  local evidence_root="$STATE_DIR/evidence"
+  local evidence_name evidence_path retained=0
+
+  [ -d "$evidence_root" ] || return
+  while IFS= read -r evidence_name; do
+    [[ $evidence_name =~ ^[0-9]{8}T[0-9]{6}Z$ ]] || continue
+    retained=$((retained + 1))
+    if [ "$retained" -le "$ORCHESTRATION_EVIDENCE_RETENTION" ]; then
+      continue
+    fi
+
+    evidence_path="$evidence_root/$evidence_name"
+    [ -d "$evidence_path" ] || continue
+    find "$evidence_path" -depth -delete
+  done < <(
+    for evidence_path in "$evidence_root"/*; do
+      [ -d "$evidence_path" ] || continue
+      basename "$evidence_path"
+    done | sort -r
+  )
+}
+
 capture_orchestration_evidence() {
-  local evidence_dir timestamp
+  local evidence_dir evidence_root timestamp
 
   timestamp="$(date --utc +%Y%m%dT%H%M%SZ)"
-  evidence_dir="$STATE_DIR/evidence/$timestamp"
-  install -d --mode 0700 "$evidence_dir"
+  evidence_root="$STATE_DIR/evidence"
+  evidence_dir="$evidence_root/$timestamp"
+  install -d --mode 0700 "$evidence_root" "$evidence_dir"
 
   cat /proc/pressure/io >"$evidence_dir/io-pressure.txt"
   ps -eo state,pid,ppid,uid,unit,cgroup,wchan:32,comm,args >"$evidence_dir/processes.txt"
@@ -199,19 +224,27 @@ capture_orchestration_evidence() {
   systemd-cgtop --batch --iterations=1 --depth=6 --order=io >"$evidence_dir/cgroup-io.txt" 2>&1 || true
   journalctl --unit k3s --since '10 minutes ago' --no-pager --quiet >"$evidence_dir/k3s-journal.txt" 2>&1 || true
 
+  prune_orchestration_evidence
   printf '%s\n' "$evidence_dir"
 }
 
 orchestration_control() {
   local action="$1"
+  local orchestration_uid
 
-  systemctl --user --machine="${ORCHESTRATION_USER}@.host" "$action" "$ORCHESTRATION_SLICE"
+  orchestration_uid="$(id --user "$ORCHESTRATION_USER")"
+  runuser --user "$ORCHESTRATION_USER" -- env \
+    XDG_RUNTIME_DIR="/run/user/$orchestration_uid" \
+    systemctl --user "$action" "$ORCHESTRATION_SLICE"
 }
 
 manage_orchestration_circuit_breaker() {
   local capture_file="$STATE_DIR/orchestration.capture"
   local frozen_file="$STATE_DIR/orchestration.frozen"
   local recovery_file="$STATE_DIR/orchestration.recovery-samples"
+  local freeze_failure_alert="orchestration-freeze-failed"
+  local state_failure_alert="orchestration-state-persist-failed"
+  local thaw_failure_alert="orchestration-thaw-failed"
   local evidence_dir recovery_samples=0
 
   if [ "$IO_PRESSURE_UNHEALTHY" -eq 1 ] || [ "$D_STATE_UNHEALTHY" -eq 1 ]; then
@@ -223,11 +256,18 @@ manage_orchestration_circuit_breaker() {
       read -r evidence_dir <"$capture_file"
     fi
 
-    if orchestration_control freeze; then
-      : >"$frozen_file"
+    if ! : >"$frozen_file"; then
+      clear_alert "orchestration-circuit-breaker"
+      set_alert "$state_failure_alert" "failed to persist frozen state for $ORCHESTRATION_SLICE; evidence: $evidence_dir"
+    elif orchestration_control freeze; then
+      clear_alert "$state_failure_alert"
+      clear_alert "$freeze_failure_alert"
+      clear_alert "$thaw_failure_alert"
       set_alert "orchestration-circuit-breaker" "froze $ORCHESTRATION_SLICE after sustained host I/O pressure; evidence: $evidence_dir"
     else
-      set_alert "orchestration-circuit-breaker" "failed to freeze $ORCHESTRATION_SLICE after sustained host I/O pressure; evidence: $evidence_dir"
+      rm -f "$frozen_file"
+      clear_alert "orchestration-circuit-breaker"
+      set_alert "$freeze_failure_alert" "failed to freeze $ORCHESTRATION_SLICE after sustained host I/O pressure; evidence: $evidence_dir"
     fi
     return
   fi
@@ -235,6 +275,9 @@ manage_orchestration_circuit_breaker() {
   if [ ! -e "$frozen_file" ]; then
     rm -f "$capture_file" "$recovery_file"
     clear_alert "orchestration-circuit-breaker"
+    clear_alert "$state_failure_alert"
+    clear_alert "$freeze_failure_alert"
+    clear_alert "$thaw_failure_alert"
     return
   fi
 
@@ -255,8 +298,11 @@ manage_orchestration_circuit_breaker() {
   if orchestration_control thaw; then
     rm -f "$capture_file" "$frozen_file" "$recovery_file"
     clear_alert "orchestration-circuit-breaker"
+    clear_alert "$state_failure_alert"
+    clear_alert "$freeze_failure_alert"
+    clear_alert "$thaw_failure_alert"
   else
-    set_alert "orchestration-circuit-breaker" "failed to thaw $ORCHESTRATION_SLICE after $recovery_samples healthy samples"
+    set_alert "$thaw_failure_alert" "failed to thaw $ORCHESTRATION_SLICE after $recovery_samples healthy samples"
   fi
 }
 

--- a/config/roborev/config.template.toml
+++ b/config/roborev/config.template.toml
@@ -1,5 +1,5 @@
-# Kyber uses eight workers during hydration to match its host capacity while
-# keeping desktop hosts at the upstream default.
+# Keep review concurrency bounded on every host. Kyber's orchestration slice
+# provides an additional host-level containment boundary.
 max_workers = 4
 
 # Upstream falls back to codex when no workflow agent is set; codex is not

--- a/config/roborev/default.nix
+++ b/config/roborev/default.nix
@@ -6,12 +6,11 @@
   ...
 }:
 let
-  ciEnabled = if inputs.host.isKyber then "true" else "false";
   hydrateScript =
     let
       vars = {
         ciEnabled = if inputs.host.isKyber then "true" else "false";
-        maxWorkers = if inputs.host.isKyber then "8" else "4";
+        maxWorkers = "4";
         sed = "${pkgs.gnused}/bin/sed";
         template = "${./config.template.toml}";
       };

--- a/home-manager/services/dolt/linear-sync.sh
+++ b/home-manager/services/dolt/linear-sync.sh
@@ -202,9 +202,9 @@ push_issue_batches() {
 
     if run_linear @coreutils@/bin/timeout 120 "$bd_cli" -C "$repo_dir" linear sync --push --issues "$batch_ids" --no-wait; then
       if [ -n "$progress_file" ] && [ -n "$progress_entries" ]; then
-        printf '%s\n' "$progress_entries" \
-          | @coreutils@/bin/tail -n +"$((batch_start + 1))" \
-          | @coreutils@/bin/head -n "$batch_size" >>"$progress_file"
+        printf '%s\n' "$progress_entries" |
+          @coreutils@/bin/tail -n +"$((batch_start + 1))" |
+          @coreutils@/bin/head -n "$batch_size" >>"$progress_file"
       fi
     else
       status=$?

--- a/home-manager/services/openclaw/default.nix
+++ b/home-manager/services/openclaw/default.nix
@@ -8,6 +8,15 @@
 let
   inherit (inputs) host;
   homeDir = config.home.homeDirectory;
+  k3sProxy = pkgs.writeShellApplication {
+    name = "openclaw-k3s-proxy";
+    runtimeInputs = [
+      pkgs.gawk
+      pkgs.iproute2
+      pkgs.socat
+    ];
+    text = builtins.readFile ./k3s-proxy.sh;
+  };
 in
 # Only enable on kyber (gateway host)
 lib.mkIf host.isKyber {
@@ -56,12 +65,14 @@ lib.mkIf host.isKyber {
       After = [ "openclaw-gateway.service" ];
       Requires = [ "openclaw-gateway.service" ];
       X-SwitchMethod = "restart";
+      StartLimitIntervalSec = 300;
+      StartLimitBurst = 3;
     };
     Service = {
       Type = "simple";
-      ExecStart = "${pkgs.socat}/bin/socat TCP4-LISTEN:18789,bind=10.42.0.1,reuseaddr,fork TCP4:127.0.0.1:18789";
-      Restart = "always";
-      RestartSec = "5s";
+      ExecStart = "${k3sProxy}/bin/openclaw-k3s-proxy";
+      Restart = "on-failure";
+      RestartSec = "30s";
       NoNewPrivileges = true;
     };
     Install = {

--- a/home-manager/services/openclaw/default.nix
+++ b/home-manager/services/openclaw/default.nix
@@ -11,6 +11,7 @@ let
   k3sProxy = pkgs.writeShellApplication {
     name = "openclaw-k3s-proxy";
     runtimeInputs = [
+      pkgs.coreutils
       pkgs.gawk
       pkgs.iproute2
       pkgs.socat

--- a/home-manager/services/openclaw/k3s-proxy.sh
+++ b/home-manager/services/openclaw/k3s-proxy.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 readonly BRIDGE_INTERFACE="${OPENCLAW_K3S_BRIDGE_INTERFACE:-cni0}"
 readonly LISTEN_PORT=18789
 readonly ADDRESS_RETRY_SECONDS=30
+readonly ADDRESS_LOG_EVERY_RETRIES=10
 
 resolve_listen_address() {
   local address
@@ -16,13 +17,13 @@ resolve_listen_address() {
   printf '%s\n' "$address"
 }
 
-reported_missing_address=0
+missing_address_retries=0
 until listen_address="$(resolve_listen_address)"; do
-  if [ "$reported_missing_address" -eq 0 ]; then
+  if [ $((missing_address_retries % ADDRESS_LOG_EVERY_RETRIES)) -eq 0 ]; then
     printf 'OpenClaw k3s proxy: %s has no global IPv4 address; retrying every %ss\n' \
       "$BRIDGE_INTERFACE" "$ADDRESS_RETRY_SECONDS" >&2
-    reported_missing_address=1
   fi
+  missing_address_retries=$((missing_address_retries + 1))
   sleep "$ADDRESS_RETRY_SECONDS"
 done
 

--- a/home-manager/services/openclaw/k3s-proxy.sh
+++ b/home-manager/services/openclaw/k3s-proxy.sh
@@ -2,15 +2,29 @@
 set -euo pipefail
 
 readonly BRIDGE_INTERFACE="${OPENCLAW_K3S_BRIDGE_INTERFACE:-cni0}"
-readonly LISTEN_PORT="${OPENCLAW_K3S_PROXY_PORT:-18789}"
+readonly LISTEN_PORT=18789
+readonly ADDRESS_RETRY_SECONDS=30
 
-listen_address="$(ip -4 -o address show dev "$BRIDGE_INTERFACE" scope global 2>/dev/null |
-  awk 'NR == 1 { split($4, address, "/"); print address[1] }')"
+resolve_listen_address() {
+  local address
 
-if [ -z "$listen_address" ]; then
-  echo "OpenClaw k3s proxy: $BRIDGE_INTERFACE has no global IPv4 address" >&2
-  exit 75
-fi
+  if ! address="$(ip -4 -o address show dev "$BRIDGE_INTERFACE" scope global 2>/dev/null |
+    awk 'NR == 1 { split($4, parts, "/"); print parts[1] }')"; then
+    return 1
+  fi
+  [ -n "$address" ] || return 1
+  printf '%s\n' "$address"
+}
+
+reported_missing_address=0
+until listen_address="$(resolve_listen_address)"; do
+  if [ "$reported_missing_address" -eq 0 ]; then
+    printf 'OpenClaw k3s proxy: %s has no global IPv4 address; retrying every %ss\n' \
+      "$BRIDGE_INTERFACE" "$ADDRESS_RETRY_SECONDS" >&2
+    reported_missing_address=1
+  fi
+  sleep "$ADDRESS_RETRY_SECONDS"
+done
 
 exec socat \
   "TCP4-LISTEN:${LISTEN_PORT},bind=${listen_address},reuseaddr,fork" \

--- a/home-manager/services/openclaw/k3s-proxy.sh
+++ b/home-manager/services/openclaw/k3s-proxy.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly BRIDGE_INTERFACE="${OPENCLAW_K3S_BRIDGE_INTERFACE:-cni0}"
+readonly LISTEN_PORT="${OPENCLAW_K3S_PROXY_PORT:-18789}"
+
+listen_address="$(ip -4 -o address show dev "$BRIDGE_INTERFACE" scope global 2>/dev/null |
+  awk 'NR == 1 { split($4, address, "/"); print address[1] }')"
+
+if [ -z "$listen_address" ]; then
+  echo "OpenClaw k3s proxy: $BRIDGE_INTERFACE has no global IPv4 address" >&2
+  exit 75
+fi
+
+exec socat \
+  "TCP4-LISTEN:${LISTEN_PORT},bind=${listen_address},reuseaddr,fork" \
+  "TCP4:127.0.0.1:${LISTEN_PORT}"

--- a/named-hosts/kyber/README.md
+++ b/named-hosts/kyber/README.md
@@ -195,6 +195,20 @@ cleaner:
   probe latency, recent CRI lifecycle errors, and host DNS (Tailscale must not
   own `/etc/resolv.conf`).
 
+Herdr and RoboRev run inside `orchestration.slice`, which caps aggregate writes
+to 20 MB/s and aggregate tasks to 2,048. When sustained I/O PSI or D-state
+pressure crosses the health threshold, the host-health check records PSI,
+process/`wchan`, per-process I/O, cgroup I/O, and recent k3s logs under
+`/run/kyber-host-health/evidence`, then freezes only that disposable slice. It
+never freezes or restarts k3s, containerd, or storage services. The slice thaws
+after five consecutive pressure-free samples with a healthy CRI probe.
+
+This containment does not isolate ext4 journals. Kyber has two physical SSDs:
+the root/PVC filesystem and the dedicated containerd filesystem. Moving k3s
+server state therefore requires a third durable filesystem plus an attended
+backup, integrity check, migration, and rollback exercise; do not simulate that
+boundary with a bind mount on the root filesystem.
+
 Alerts are deduplicated until recovery. They are written to the journal at
 `daemon.alert` priority without interrupting logged-in terminals; a recovery
 notice is written when a condition clears. These checks never remove containers,

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -111,10 +111,25 @@ home-manager.lib.homeManagerConfiguration {
         # Review daemons own disposable work and may be frozen by the host
         # health circuit breaker without interrupting production services.
         home.file.".config/systemd/user/orchestration.slice".source = ./orchestration.slice;
-        home.file.".config/systemd/user/herdr-server.service.d/10-orchestration.conf".source =
-          ./orchestration-service.conf;
         home.file.".config/systemd/user/roborev.service.d/10-orchestration.conf".source =
           ./orchestration-service.conf;
+        xdg.configFile."systemd/user/herdr-server.service".force = true;
+        systemd.user.services.herdr-server = {
+          Unit = {
+            Description = "Herdr headless server (coding-agent multiplexer)";
+            After = [ "install-npm-globals.service" ];
+            X-SwitchMethod = "restart";
+          };
+          Service = {
+            Type = "simple";
+            ExecStart = "${config.home.homeDirectory}/.local/bin/herdr server";
+            Restart = "on-failure";
+            RestartSec = "30s";
+            Slice = "orchestration.slice";
+            Environment = [ "HERDR_ENV=1" ];
+          };
+          Install.WantedBy = [ "default.target" ];
+        };
 
         # GPG configuration for commit signing
         programs.gpg = {

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -123,7 +123,7 @@ home-manager.lib.homeManagerConfiguration {
           };
           Service = {
             Type = "simple";
-            ExecStart = "${config.home.homeDirectory}/.local/bin/herdr server";
+            ExecStart = "${pkgs.llm-agents.herdr}/bin/herdr server";
             Restart = "on-failure";
             RestartSec = "30s";
             Slice = "orchestration.slice";

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -114,6 +114,7 @@ home-manager.lib.homeManagerConfiguration {
         home.file.".config/systemd/user/roborev.service.d/10-orchestration.conf".source =
           ./orchestration-service.conf;
         xdg.configFile."systemd/user/herdr-server.service".force = true;
+        xdg.configFile."systemd/user/default.target.wants/herdr-server.service".force = true;
         systemd.user.services.herdr-server = {
           Unit = {
             Description = "Herdr headless server (coding-agent multiplexer)";

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -108,6 +108,14 @@ home-manager.lib.homeManagerConfiguration {
 
         programs.home-manager.enable = true;
 
+        # Review daemons own disposable work and may be frozen by the host
+        # health circuit breaker without interrupting production services.
+        home.file.".config/systemd/user/orchestration.slice".source = ./orchestration.slice;
+        home.file.".config/systemd/user/herdr-server.service.d/10-orchestration.conf".source =
+          ./orchestration-service.conf;
+        home.file.".config/systemd/user/roborev.service.d/10-orchestration.conf".source =
+          ./orchestration-service.conf;
+
         # GPG configuration for commit signing
         programs.gpg = {
           enable = true;

--- a/named-hosts/kyber/orchestration-service.conf
+++ b/named-hosts/kyber/orchestration-service.conf
@@ -1,0 +1,2 @@
+[Service]
+Slice=orchestration.slice

--- a/named-hosts/kyber/orchestration.slice
+++ b/named-hosts/kyber/orchestration.slice
@@ -1,0 +1,10 @@
+[Unit]
+Description=Disposable Kyber review and orchestration workloads
+
+[Slice]
+CPUWeight=100
+IOWeight=10
+IOWriteBandwidthMax=/ 20M
+IOAccounting=yes
+TasksAccounting=yes
+TasksMax=2048

--- a/spec/activate_kyber_spec.sh
+++ b/spec/activate_kyber_spec.sh
@@ -110,7 +110,7 @@ The output should include 'activate-user-service-priority.sh'
 End
 
 It 'declaratively owns Herdr and places review daemons in the orchestration slice'
-When run bash -c "unit=\$(sed -n '/systemd.user.services.herdr-server =/,/Install.WantedBy/p' '$PWD/named-hosts/kyber/default.nix'); grep -q 'xdg.configFile.\"systemd/user/herdr-server.service\".force = true' '$PWD/named-hosts/kyber/default.nix' && grep -q 'xdg.configFile.\"systemd/user/default.target.wants/herdr-server.service\".force = true' '$PWD/named-hosts/kyber/default.nix' && grep -q 'Slice = \"orchestration.slice\"' <<<\"\$unit\" && grep -q 'roborev.service.d/10-orchestration.conf' '$PWD/named-hosts/kyber/default.nix' && grep -qxF 'Slice=orchestration.slice' '$PWD/named-hosts/kyber/orchestration-service.conf'"
+When run bash -c "unit=\$(sed -n '/systemd.user.services.herdr-server =/,/Install.WantedBy/p' '$PWD/named-hosts/kyber/default.nix'); grep -q 'xdg.configFile.\"systemd/user/herdr-server.service\".force = true' '$PWD/named-hosts/kyber/default.nix' && grep -q 'xdg.configFile.\"systemd/user/default.target.wants/herdr-server.service\".force = true' '$PWD/named-hosts/kyber/default.nix' && grep -q 'ExecStart = \"\${pkgs.llm-agents.herdr}/bin/herdr server\"' <<<\"\$unit\" && grep -q 'Slice = \"orchestration.slice\"' <<<\"\$unit\" && grep -q 'roborev.service.d/10-orchestration.conf' '$PWD/named-hosts/kyber/default.nix' && grep -qxF 'Slice=orchestration.slice' '$PWD/named-hosts/kyber/orchestration-service.conf'"
 The status should be success
 End
 

--- a/spec/activate_kyber_spec.sh
+++ b/spec/activate_kyber_spec.sh
@@ -110,7 +110,7 @@ The output should include 'activate-user-service-priority.sh'
 End
 
 It 'declaratively owns Herdr and places review daemons in the orchestration slice'
-When run bash -c "unit=\$(sed -n '/systemd.user.services.herdr-server =/,/Install.WantedBy/p' '$PWD/named-hosts/kyber/default.nix'); grep -q 'xdg.configFile.\"systemd/user/herdr-server.service\".force = true' '$PWD/named-hosts/kyber/default.nix' && grep -q 'Slice = \"orchestration.slice\"' <<<\"\$unit\" && grep -q 'roborev.service.d/10-orchestration.conf' '$PWD/named-hosts/kyber/default.nix' && grep -qxF 'Slice=orchestration.slice' '$PWD/named-hosts/kyber/orchestration-service.conf'"
+When run bash -c "unit=\$(sed -n '/systemd.user.services.herdr-server =/,/Install.WantedBy/p' '$PWD/named-hosts/kyber/default.nix'); grep -q 'xdg.configFile.\"systemd/user/herdr-server.service\".force = true' '$PWD/named-hosts/kyber/default.nix' && grep -q 'xdg.configFile.\"systemd/user/default.target.wants/herdr-server.service\".force = true' '$PWD/named-hosts/kyber/default.nix' && grep -q 'Slice = \"orchestration.slice\"' <<<\"\$unit\" && grep -q 'roborev.service.d/10-orchestration.conf' '$PWD/named-hosts/kyber/default.nix' && grep -qxF 'Slice=orchestration.slice' '$PWD/named-hosts/kyber/orchestration-service.conf'"
 The status should be success
 End
 

--- a/spec/activate_kyber_spec.sh
+++ b/spec/activate_kyber_spec.sh
@@ -109,8 +109,8 @@ When run bash -c "grep 'activate-user-service-priority.sh' '$PWD/named-hosts/kyb
 The output should include 'activate-user-service-priority.sh'
 End
 
-It 'places Herdr and RoboRev in the disposable orchestration slice'
-When run bash -c "grep -q 'herdr-server.service.d/10-orchestration.conf' '$PWD/named-hosts/kyber/default.nix' && grep -q 'roborev.service.d/10-orchestration.conf' '$PWD/named-hosts/kyber/default.nix' && grep -qxF 'Slice=orchestration.slice' '$PWD/named-hosts/kyber/orchestration-service.conf'"
+It 'declaratively owns Herdr and places review daemons in the orchestration slice'
+When run bash -c "unit=\$(sed -n '/systemd.user.services.herdr-server =/,/Install.WantedBy/p' '$PWD/named-hosts/kyber/default.nix'); grep -q 'xdg.configFile.\"systemd/user/herdr-server.service\".force = true' '$PWD/named-hosts/kyber/default.nix' && grep -q 'Slice = \"orchestration.slice\"' <<<\"\$unit\" && grep -q 'roborev.service.d/10-orchestration.conf' '$PWD/named-hosts/kyber/default.nix' && grep -qxF 'Slice=orchestration.slice' '$PWD/named-hosts/kyber/orchestration-service.conf'"
 The status should be success
 End
 

--- a/spec/activate_kyber_spec.sh
+++ b/spec/activate_kyber_spec.sh
@@ -109,6 +109,16 @@ When run bash -c "grep 'activate-user-service-priority.sh' '$PWD/named-hosts/kyb
 The output should include 'activate-user-service-priority.sh'
 End
 
+It 'places Herdr and RoboRev in the disposable orchestration slice'
+When run bash -c "grep -q 'herdr-server.service.d/10-orchestration.conf' '$PWD/named-hosts/kyber/default.nix' && grep -q 'roborev.service.d/10-orchestration.conf' '$PWD/named-hosts/kyber/default.nix' && grep -qxF 'Slice=orchestration.slice' '$PWD/named-hosts/kyber/orchestration-service.conf'"
+The status should be success
+End
+
+It 'bounds orchestration write bandwidth and task count'
+When run bash -c "grep -qxF 'IOWriteBandwidthMax=/ 20M' '$PWD/named-hosts/kyber/orchestration.slice' && grep -qxF 'TasksMax=2048' '$PWD/named-hosts/kyber/orchestration.slice' && grep -qxF 'IOAccounting=yes' '$PWD/named-hosts/kyber/orchestration.slice'"
+The status should be success
+End
+
 It 'keeps a long gpg-agent cache ttl'
 When run bash -c "grep 'defaultCacheTtl = 94608000' '$PWD/named-hosts/kyber/default.nix'"
 The output should include 'defaultCacheTtl = 94608000'

--- a/spec/activate_openclaw_hermes_spec.sh
+++ b/spec/activate_openclaw_hermes_spec.sh
@@ -37,10 +37,30 @@ When run bash -c "grep -- '--bind loopback' '$PWD/home-manager/services/openclaw
 The output should include '--bind loopback'
 End
 
-It 'proxies the loopback gateway only through the k3s bridge'
-When run bash -c "grep -F 'TCP4-LISTEN:18789,bind=10.42.0.1' '$PWD/home-manager/services/openclaw/default.nix'"
-The output should include 'TCP4-LISTEN:18789,bind=10.42.0.1'
+It 'resolves the current k3s bridge address instead of pinning a pod subnet'
+When run bash -c "grep -q 'ip -4 -o address show dev' '$PWD/home-manager/services/openclaw/k3s-proxy.sh' && grep -q 'bind=\${listen_address}' '$PWD/home-manager/services/openclaw/k3s-proxy.sh' && ! grep -R -q 'bind=10.42.0.1' '$PWD/home-manager/services/openclaw'"
+The status should be success
+End
+
+It 'does not restart forever when the k3s bridge is unavailable'
+When run bash -c "grep -q 'Restart = \"on-failure\"' '$PWD/home-manager/services/openclaw/default.nix' && grep -q 'RestartSec = \"30s\"' '$PWD/home-manager/services/openclaw/default.nix' && grep -q 'StartLimitBurst = 3' '$PWD/home-manager/services/openclaw/default.nix' && grep -q 'exit 75' '$PWD/home-manager/services/openclaw/k3s-proxy.sh'"
+The status should be success
+End
+
+It 'binds the proxy to the live cni0 address'
+When run env SCRIPT="$PWD/home-manager/services/openclaw/k3s-proxy.sh" bash -c '
+  tools="$(mktemp -d)"
+  printf "%s\n" "#!/usr/bin/env bash" "printf \"%s\\n\" \"2: cni0 inet 10.42.1.1/24 scope global cni0\"" >"$tools/ip"
+  printf "%s\n" "#!/usr/bin/env bash" "printf \"%s\\n\" \"\$*\"" >"$tools/socat"
+  chmod +x "$tools/ip" "$tools/socat"
+  PATH="$tools:$PATH" "$SCRIPT"
+  status=$?
+  rm -rf "$tools"
+  exit "$status"
+'
+The output should include 'TCP4-LISTEN:18789,bind=10.42.1.1,reuseaddr,fork'
 The output should not include 'bind=0.0.0.0'
+The status should be success
 End
 
 It 'orders the k3s bridge proxy after the loopback gateway'

--- a/spec/activate_openclaw_hermes_spec.sh
+++ b/spec/activate_openclaw_hermes_spec.sh
@@ -43,7 +43,7 @@ The status should be success
 End
 
 It 'rate-limits process failures inside the k3s proxy unit'
-When run bash -c "unit=\$(sed -n '/systemd.user.services.openclaw-k3s-proxy =/,/Install = {/p' '$PWD/home-manager/services/openclaw/default.nix'); grep -q 'pkgs.coreutils' '$PWD/home-manager/services/openclaw/default.nix' && grep -q 'Restart = \"on-failure\"' <<<\"\$unit\" && grep -q 'RestartSec = \"30s\"' <<<\"\$unit\" && grep -q 'StartLimitBurst = 3' <<<\"\$unit\""
+When run bash -c "proxy=\$(sed -n '/k3sProxy = pkgs.writeShellApplication/,/};/p' '$PWD/home-manager/services/openclaw/default.nix'); unit=\$(sed -n '/systemd.user.services.openclaw-k3s-proxy =/,/Install = {/p' '$PWD/home-manager/services/openclaw/default.nix'); grep -q 'pkgs.coreutils' <<<\"\$proxy\" && grep -q 'Restart = \"on-failure\"' <<<\"\$unit\" && grep -q 'RestartSec = \"30s\"' <<<\"\$unit\" && grep -q 'StartLimitBurst = 3' <<<\"\$unit\""
 The status should be success
 End
 

--- a/spec/activate_openclaw_hermes_spec.sh
+++ b/spec/activate_openclaw_hermes_spec.sh
@@ -42,8 +42,42 @@ When run bash -c "grep -q 'ip -4 -o address show dev' '$PWD/home-manager/service
 The status should be success
 End
 
-It 'does not restart forever when the k3s bridge is unavailable'
-When run bash -c "grep -q 'Restart = \"on-failure\"' '$PWD/home-manager/services/openclaw/default.nix' && grep -q 'RestartSec = \"30s\"' '$PWD/home-manager/services/openclaw/default.nix' && grep -q 'StartLimitBurst = 3' '$PWD/home-manager/services/openclaw/default.nix' && grep -q 'exit 75' '$PWD/home-manager/services/openclaw/k3s-proxy.sh'"
+It 'rate-limits process failures inside the k3s proxy unit'
+When run bash -c "unit=\$(sed -n '/systemd.user.services.openclaw-k3s-proxy =/,/Install = {/p' '$PWD/home-manager/services/openclaw/default.nix'); grep -q 'Restart = \"on-failure\"' <<<\"\$unit\" && grep -q 'RestartSec = \"30s\"' <<<\"\$unit\" && grep -q 'StartLimitBurst = 3' <<<\"\$unit\""
+The status should be success
+End
+
+It 'waits in one process until the k3s bridge address appears'
+When run env SCRIPT="$PWD/home-manager/services/openclaw/k3s-proxy.sh" bash -c '
+  tools="$(mktemp -d)"
+  count_file="$tools/ip-count"
+  printf "%s\n" "#!/usr/bin/env bash" "count=0" "[ ! -r \"$count_file\" ] || read -r count <\"$count_file\"" "count=\$((count + 1))" "printf \"%s\\n\" \"\$count\" >\"$count_file\"" "[ \"\$count\" -gt 1 ] || exit 1" "printf \"%s\\n\" \"2: cni0 inet 10.42.1.1/24 scope global cni0\"" >"$tools/ip"
+  printf "%s\n" "#!/usr/bin/env bash" "exit 0" >"$tools/sleep"
+  printf "%s\n" "#!/usr/bin/env bash" "printf \"%s\\n\" \"\$*\"" >"$tools/socat"
+  chmod +x "$tools/ip" "$tools/sleep" "$tools/socat"
+  PATH="$tools:$PATH" "$SCRIPT"
+  status=$?
+  rm -rf "$tools"
+  exit "$status"
+'
+The stderr should include 'has no global IPv4 address; retrying every 30s'
+The output should include 'TCP4-LISTEN:18789,bind=10.42.1.1,reuseaddr,fork'
+The status should be success
+End
+
+It 'keeps the proxy and gateway on their shared fixed port'
+When run env SCRIPT="$PWD/home-manager/services/openclaw/k3s-proxy.sh" OPENCLAW_K3S_PROXY_PORT=19999 bash -c '
+  tools="$(mktemp -d)"
+  printf "%s\n" "#!/usr/bin/env bash" "printf \"%s\\n\" \"2: cni0 inet 10.42.1.1/24 scope global cni0\"" >"$tools/ip"
+  printf "%s\n" "#!/usr/bin/env bash" "printf \"%s\\n\" \"\$*\"" >"$tools/socat"
+  chmod +x "$tools/ip" "$tools/socat"
+  PATH="$tools:$PATH" "$SCRIPT"
+  status=$?
+  rm -rf "$tools"
+  exit "$status"
+'
+The output should include 'TCP4-LISTEN:18789,bind=10.42.1.1,reuseaddr,fork'
+The output should not include '19999'
 The status should be success
 End
 

--- a/spec/activate_openclaw_hermes_spec.sh
+++ b/spec/activate_openclaw_hermes_spec.sh
@@ -43,7 +43,7 @@ The status should be success
 End
 
 It 'rate-limits process failures inside the k3s proxy unit'
-When run bash -c "unit=\$(sed -n '/systemd.user.services.openclaw-k3s-proxy =/,/Install = {/p' '$PWD/home-manager/services/openclaw/default.nix'); grep -q 'Restart = \"on-failure\"' <<<\"\$unit\" && grep -q 'RestartSec = \"30s\"' <<<\"\$unit\" && grep -q 'StartLimitBurst = 3' <<<\"\$unit\""
+When run bash -c "unit=\$(sed -n '/systemd.user.services.openclaw-k3s-proxy =/,/Install = {/p' '$PWD/home-manager/services/openclaw/default.nix'); grep -q 'pkgs.coreutils' '$PWD/home-manager/services/openclaw/default.nix' && grep -q 'Restart = \"on-failure\"' <<<\"\$unit\" && grep -q 'RestartSec = \"30s\"' <<<\"\$unit\" && grep -q 'StartLimitBurst = 3' <<<\"\$unit\""
 The status should be success
 End
 
@@ -62,6 +62,25 @@ When run env SCRIPT="$PWD/home-manager/services/openclaw/k3s-proxy.sh" bash -c '
 '
 The stderr should include 'has no global IPv4 address; retrying every 30s'
 The output should include 'TCP4-LISTEN:18789,bind=10.42.1.1,reuseaddr,fork'
+The status should be success
+End
+
+It 'repeats missing bridge evidence every five minutes'
+When run env SCRIPT="$PWD/home-manager/services/openclaw/k3s-proxy.sh" bash -c '
+  tools="$(mktemp -d)"
+  count_file="$tools/ip-count"
+  stderr_file="$tools/stderr"
+  printf "%s\n" "#!/usr/bin/env bash" "count=0" "[ ! -r \"$count_file\" ] || read -r count <\"$count_file\"" "count=\$((count + 1))" "printf \"%s\\n\" \"\$count\" >\"$count_file\"" "[ \"\$count\" -gt 11 ] || exit 1" "printf \"%s\\n\" \"2: cni0 inet 10.42.1.1/24 scope global cni0\"" >"$tools/ip"
+  printf "%s\n" "#!/usr/bin/env bash" "exit 0" >"$tools/sleep"
+  printf "%s\n" "#!/usr/bin/env bash" "exit 0" >"$tools/socat"
+  chmod +x "$tools/ip" "$tools/sleep" "$tools/socat"
+  PATH="$tools:$PATH" "$SCRIPT" 2>"$stderr_file"
+  status=$?
+  grep -c "has no global IPv4 address; retrying every 30s" "$stderr_file"
+  rm -rf "$tools"
+  exit "$status"
+'
+The output should equal '2'
 The status should be success
 End
 

--- a/spec/activate_roborev_spec.sh
+++ b/spec/activate_roborev_spec.sh
@@ -57,9 +57,9 @@ When run bash -c "grep 'ciEnabled = if inputs.host.isKyber then \"true\" else \"
 The output should include 'ciEnabled = if inputs.host.isKyber then "true" else "false";'
 End
 
-It 'sizes Kyber reviews for host capacity while retaining desktop concurrency'
-When run bash -c "grep 'maxWorkers = if inputs.host.isKyber then \"8\" else \"4\";' '$PWD/config/roborev/default.nix'"
-The output should include 'maxWorkers = if inputs.host.isKyber then "8" else "4";'
+It 'keeps review concurrency bounded on every host'
+When run bash -c "grep 'maxWorkers = \"4\";' '$PWD/config/roborev/default.nix'"
+The output should include 'maxWorkers = "4";'
 End
 
 It 'runs roborev daemon run'

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -563,6 +563,7 @@ home-manager/services/hermes/activate.sh
 home-manager/services/obsidian/obsidian-git-trigger.sh
 home-manager/services/obsidian/obsidian-headless.sh
 home-manager/services/openclaw/activate.sh
+home-manager/services/openclaw/k3s-proxy.sh
 home-manager/services/qmd/activate.sh
 home-manager/services/roborev/activate.sh
 home-manager/services/roborev/start.sh

--- a/spec/k3s_service_activate_spec.sh
+++ b/spec/k3s_service_activate_spec.sh
@@ -108,6 +108,65 @@ When run bash -c "grep -q '/proc/pressure/io' '$HEALTH_CHECK' && grep -q 'D_STAT
 The status should be success
 End
 
+It 'captures incident attribution before freezing only the orchestration slice'
+When run bash -c "grep -q 'pidstat -d -p ALL 1 1' '$HEALTH_CHECK' && grep -q 'systemd-cgtop.*--order=io' '$HEALTH_CHECK' && grep -q 'wchan:32' '$HEALTH_CHECK' && grep -q 'orchestration_control freeze' '$HEALTH_CHECK' && ! grep -Eq 'systemctl .* (stop|freeze) (k3s|containerd)' '$HEALTH_CHECK'"
+The status should be success
+End
+
+It 'freezes orchestration after sustained pressure'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  state="$(mktemp -d)"
+  export KYBER_HOST_HEALTH_STATE_DIR="$state"
+  source "$HEALTH_CHECK"
+  IO_PRESSURE_UNHEALTHY=1
+  capture_orchestration_evidence() { printf "%s/evidence/test\n" "$STATE_DIR"; }
+  orchestration_control() { printf "control:%s\n" "$1"; }
+  set_alert() { printf "alert:%s:%s\n" "$1" "$2"; }
+  manage_orchestration_circuit_breaker
+  test -e "$state/orchestration.frozen"
+  rm -rf "$state"
+'
+The output should include 'control:freeze'
+The output should include 'alert:orchestration-circuit-breaker:froze orchestration.slice'
+The status should be success
+End
+
+It 'thaws orchestration only after five healthy samples'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  state="$(mktemp -d)"
+  export KYBER_HOST_HEALTH_STATE_DIR="$state"
+  source "$HEALTH_CHECK"
+  : >"$state/orchestration.frozen"
+  printf "4\n" >"$state/orchestration.recovery-samples"
+  orchestration_control() { printf "control:%s\n" "$1"; }
+  clear_alert() { printf "clear:%s\n" "$1"; }
+  manage_orchestration_circuit_breaker
+  test ! -e "$state/orchestration.frozen"
+  rm -rf "$state"
+'
+The output should include 'control:thaw'
+The output should include 'clear:orchestration-circuit-breaker'
+The status should be success
+End
+
+It 'keeps orchestration frozen while CRI remains unhealthy'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  state="$(mktemp -d)"
+  export KYBER_HOST_HEALTH_STATE_DIR="$state"
+  source "$HEALTH_CHECK"
+  CRI_UNHEALTHY=1
+  : >"$state/orchestration.frozen"
+  printf "4\n" >"$state/orchestration.recovery-samples"
+  orchestration_control() { printf "unexpected:%s\n" "$1"; }
+  manage_orchestration_circuit_breaker
+  test "$(cat "$state/orchestration.recovery-samples")" = 0
+  test -e "$state/orchestration.frozen"
+  rm -rf "$state"
+'
+The output should equal ''
+The status should be success
+End
+
 It 'runs the read-only reliability check every minute'
 When run bash -c "grep -qxF 'OnUnitActiveSec=1min' '$HEALTH_TIMER' && grep -qxF 'Persistent=true' '$HEALTH_TIMER'"
 The status should be success

--- a/spec/k3s_service_activate_spec.sh
+++ b/spec/k3s_service_activate_spec.sh
@@ -113,6 +113,11 @@ When run bash -c "grep -q 'pidstat -d -p ALL 1 1' '$HEALTH_CHECK' && grep -q 'sy
 The status should be success
 End
 
+It 'controls the user slice through the target users runtime directory'
+When run bash -c "grep -q 'runuser --user \"\$ORCHESTRATION_USER\"' '$HEALTH_CHECK' && grep -q 'XDG_RUNTIME_DIR=\"/run/user/\$orchestration_uid\"' '$HEALTH_CHECK' && ! grep -q -- '--machine=' '$HEALTH_CHECK'"
+The status should be success
+End
+
 It 'freezes orchestration after sustained pressure'
 When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   state="$(mktemp -d)"
@@ -120,14 +125,52 @@ When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   source "$HEALTH_CHECK"
   IO_PRESSURE_UNHEALTHY=1
   capture_orchestration_evidence() { printf "%s/evidence/test\n" "$STATE_DIR"; }
-  orchestration_control() { printf "control:%s\n" "$1"; }
+  orchestration_control() { test -e "$STATE_DIR/orchestration.frozen"; printf "control:%s\n" "$1"; }
   set_alert() { printf "alert:%s:%s\n" "$1" "$2"; }
+  clear_alert() { printf "clear:%s\n" "$1"; }
   manage_orchestration_circuit_breaker
   test -e "$state/orchestration.frozen"
   rm -rf "$state"
 '
 The output should include 'control:freeze'
 The output should include 'alert:orchestration-circuit-breaker:froze orchestration.slice'
+The output should include 'clear:orchestration-freeze-failed'
+The status should be success
+End
+
+It 'removes the frozen marker when the freeze command fails'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  state="$(mktemp -d)"
+  export KYBER_HOST_HEALTH_STATE_DIR="$state"
+  source "$HEALTH_CHECK"
+  IO_PRESSURE_UNHEALTHY=1
+  capture_orchestration_evidence() { printf "%s/evidence/test\n" "$STATE_DIR"; }
+  orchestration_control() { return 1; }
+  set_alert() { printf "alert:%s:%s\n" "$1" "$2"; }
+  manage_orchestration_circuit_breaker
+  test ! -e "$state/orchestration.frozen"
+  rm -rf "$state"
+'
+The output should include 'alert:orchestration-freeze-failed:failed to freeze orchestration.slice'
+The status should be success
+End
+
+It 'retains only the five newest orchestration evidence captures'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  state="$(mktemp -d)"
+  export KYBER_HOST_HEALTH_STATE_DIR="$state"
+  source "$HEALTH_CHECK"
+  mkdir -p "$state/evidence"
+  for stamp in 20260829T000001Z 20260829T000002Z 20260829T000003Z 20260829T000004Z 20260829T000005Z 20260829T000006Z 20260829T000007Z; do
+    mkdir "$state/evidence/$stamp"
+    : >"$state/evidence/$stamp/processes.txt"
+  done
+  prune_orchestration_evidence
+  test "$(find "$state/evidence" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d " ")" = 5
+  test ! -e "$state/evidence/20260829T000001Z"
+  test -e "$state/evidence/20260829T000007Z"
+  rm -rf "$state"
+'
 The status should be success
 End
 
@@ -146,6 +189,23 @@ When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
 '
 The output should include 'control:thaw'
 The output should include 'clear:orchestration-circuit-breaker'
+The status should be success
+End
+
+It 'keeps orchestration frozen through the fourth healthy sample'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  state="$(mktemp -d)"
+  export KYBER_HOST_HEALTH_STATE_DIR="$state"
+  source "$HEALTH_CHECK"
+  : >"$state/orchestration.frozen"
+  printf "3\n" >"$state/orchestration.recovery-samples"
+  orchestration_control() { printf "unexpected:%s\n" "$1"; }
+  manage_orchestration_circuit_breaker
+  test "$(cat "$state/orchestration.recovery-samples")" = 4
+  test -e "$state/orchestration.frozen"
+  rm -rf "$state"
+'
+The output should equal ''
 The status should be success
 End
 


### PR DESCRIPTION
## Summary

- Put Herdr and RoboRev in a bounded `orchestration.slice`, cap root-device writes at 20 MB/s, cap tasks at 2048, and reduce Kyber RoboRev workers from 8 to 4.
- Turn Kyber host-health detection into an evidence-first circuit breaker: capture I/O PSI, D-state processes, cgroups, wait channels, per-process I/O, cgroup usage, and the k3s journal before freezing only disposable orchestration work.
- Require five consecutive healthy samples, including healthy CRI, before thawing orchestration work.
- Keep the OpenClaw k3s bridge proxy alive while `cni0` is unavailable, resolve its live address when it appears, and keep the proxy and gateway on the same fixed port.
- Declaratively own the Herdr service and enablement link so containment is reproducible from Home Manager.

### Tracker linkage

- Linear: none — operator-requested incident mitigation has no Linear issue
- Bead: `shunkakinokisoftware-x7vw`

## Contract diagram

```mermaid
flowchart TD
  A[Kyber host health] --> B{I/O PSI or sustained D state}
  B -->|healthy| C[Keep orchestration running]
  B -->|unhealthy| D[Capture PSI process cgroup and k3s evidence]
  D --> E[Freeze orchestration slice]
  E --> F{Five healthy samples and CRI healthy}
  F -->|no| E
  F -->|yes| G[Thaw orchestration slice]
```

## Before and after

| Surface | Before | After |
| --- | --- | --- |
| Review workloads | Herdr and RoboRev shared the generic user slice; RoboRev allowed 8 workers | Dedicated 20 MB/s, 2048-task orchestration slice; RoboRev allows 4 workers |
| Host pressure | Health detection alerted but left disposable work running | Captures bounded evidence, freezes only orchestration, and requires five CRI-aware healthy samples to thaw |
| OpenClaw bridge | Hardcoded bridge address and a restart path that could stop permanently before `cni0` appeared | Resolves the live `cni0` address and waits safely until the bridge exists |
| Herdr ownership | Writable host-local unit outside repository ownership | Declarative service and enablement link owned by the Home Manager generation |

## Breaking and irreversible changes

- Behavioral: Kyber review and orchestration jobs can pause during host I/O pressure; RoboRev concurrency is reduced to 4. Reverting the commits restores the prior behavior.
- Compile-time: none.
- Durable state: none. Evidence is stored under `/run/kyber-host-health/evidence` with five-capture retention; no datastore migration is included.
- Rollback: revert these commits and apply the resulting Kyber Home Manager generation.

## Deliberate boundaries

- The operator does not currently have a separate SSD. This PR does not move, repartition, or rewrite the k3s/containerd datastore; it remains on the shared disk.
- A separate durable SSD remains the required follow-up for physical datastore journal isolation.
- The circuit breaker never freezes or stops k3s, containerd, storage, or customer-serving services.

## Verification

- `env -u AMP_API_KEY shellspec` — 2,420 examples, 0 failures
- focused Kyber pressure/proxy suite — 137 examples, 0 failures
- focused Kyber activation suite — 53 examples, 0 failures
- `shellcheck` on changed shell scripts and specs
- `bash scripts/check-nix-inline-scripts.sh`
- `git diff --check`
- `make nix-format-check` — 614 files, 0 changes
- `nix eval .#homeConfigurations.kyber.config.systemd.user.services.herdr-server --json`
- `statix check .` — completed with existing repository warnings
- `deadnix --fail .`
- `gh signoff local-ci` on exact head `18b6aebeef38298f2e9568a830bf7ba704515b70`

## Live Kyber acceptance

- Exact head `18b6aebeef38298f2e9568a830bf7ba704515b70` built on Kyber as `/nix/store/kmnr4hibfax1d128gv35qhnq34m91wvm-home-manager-generation` and activated successfully.
- The active Home Manager profile resolves to that exact generation.
- Herdr's service and `default.target.wants` link resolve through the generation into the same immutable Nix-store unit, and the live `ExecStart` resolves directly to the packaged Herdr binary.
- The live OpenClaw proxy wrapper includes Nix-provided coreutils and re-emits missing-bridge evidence every five minutes while waiting for `cni0`.
- Herdr, RoboRev, the OpenClaw gateway, and its k3s proxy are active/running; the proxy listens on the live bridge at `10.42.1.1:18789`.
- `orchestration.slice` reports `IOWeight=10`, a 20 MB/s write cap on root device `8:16`, and `TasksMax=2048`.
- The host-health timer is active and its post-switch run completed successfully. Current sustained I/O PSI is below the freeze threshold, so the slice is correctly thawed.
- The Kyber k3s node is `Ready`; OpenFactor API, router, platform, and status endpoints returned HTTP 200, while the authenticated website returned the expected HTTP 401.
