### PR TITLE
fix(antigravity): install Traces Git hooks for CLI

### DIFF
--- a/config/antigravity/agy.sh
+++ b/config/antigravity/agy.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -u
+
+ANTIGRAVITY_CLI_BIN="${ANTIGRAVITY_CLI_BIN:-${HOME}/.local/libexec/antigravity-cli/agy}"
+
+if command -v git >/dev/null 2>&1 &&
+  command -v traces >/dev/null 2>&1 &&
+  git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  if ! traces setup git >/dev/null; then
+    printf '%s\n' 'warning: unable to install Traces Git hooks; continuing with Antigravity CLI' >&2
+  fi
+fi
+
+exec "$ANTIGRAVITY_CLI_BIN" "$@"

--- a/config/antigravity/agy.sh
+++ b/config/antigravity/agy.sh
@@ -3,10 +3,28 @@ set -u
 
 ANTIGRAVITY_CLI_BIN="${ANTIGRAVITY_CLI_BIN:-${HOME}/.local/libexec/antigravity-cli/agy}"
 
+traces_hooks_installed() {
+  hooks_dir="$1/hooks"
+  for hook in \
+    post-commit \
+    post-merge \
+    pre-merge-commit \
+    pre-push \
+    traces-post-commit \
+    traces-post-merge \
+    traces-pre-merge-commit \
+    traces-pre-push; do
+    [ -x "$hooks_dir/$hook" ] || return 1
+  done
+}
+
 if command -v git >/dev/null 2>&1 &&
   command -v traces >/dev/null 2>&1 &&
-  git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  if ! traces setup git >/dev/null; then
+  [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]; then
+  git_common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"
+  if [ -n "$git_common_dir" ] &&
+    ! traces_hooks_installed "$git_common_dir" &&
+    ! traces setup git >/dev/null; then
     printf '%s\n' 'warning: unable to install Traces Git hooks; continuing with Antigravity CLI' >&2
   fi
 fi

--- a/config/antigravity/default.nix
+++ b/config/antigravity/default.nix
@@ -12,4 +12,13 @@
       "${./hooks.json}" \
       "${pkgs.jq}/bin/jq"
   '';
+
+  # Bootstrap Traces' repository-local Git dispatchers before each CLI session
+  # so the Stop hook's captured trace can be attributed and shared on push.
+  home.file.".local/bin/agy" = {
+    source = ./agy.sh;
+    executable = true;
+  };
+  home.file.".local/libexec/antigravity-cli/agy".source =
+    "${pkgs.llm-agents.antigravity-cli}/bin/agy";
 }

--- a/config/antigravity/default.nix
+++ b/config/antigravity/default.nix
@@ -13,8 +13,8 @@
       "${pkgs.jq}/bin/jq"
   '';
 
-  # Bootstrap Traces' repository-local Git dispatchers before each CLI session
-  # so the Stop hook's captured trace can be attributed and shared on push.
+  # Install Traces' repository-local Git dispatchers before each CLI session;
+  # reporting itself remains owned by the official hook in hooks.json.
   home.file.".local/bin/agy" = {
     source = ./agy.sh;
     executable = true;

--- a/config/antigravity/hooks.json
+++ b/config/antigravity/hooks.json
@@ -21,7 +21,7 @@
     "Stop": [
       {
         "type": "command",
-        "command": "command -v traces >/dev/null 2>&1 && traces hook agent agent-done --agent antigravity >/dev/null 2>&1; printf %s '{\"decision\":\"\"}'",
+        "command": "traces hook agent agent-done --agent antigravity >/dev/null 2>&1; printf %s '{\"decision\":\"\"}'",
         "timeout": 30
       }
     ]

--- a/config/antigravity/hooks.json
+++ b/config/antigravity/hooks.json
@@ -21,7 +21,7 @@
     "Stop": [
       {
         "type": "command",
-        "command": "traces hook agent agent-done --agent antigravity >/dev/null 2>&1; printf %s '{\"decision\":\"\"}'",
+        "command": "command -v traces >/dev/null 2>&1 && traces hook agent agent-done --agent antigravity >/dev/null 2>&1; printf %s '{\"decision\":\"\"}'",
         "timeout": 30
       }
     ]

--- a/spec/antigravity_config_spec.sh
+++ b/spec/antigravity_config_spec.sh
@@ -72,9 +72,9 @@ The path "$TEMP_HOME/.gemini/config/hooks.json" should be file
 The path "$TEMP_HOME/.gemini/config/hooks.json" should be writable
 End
 
-It 'uses the official Traces Antigravity Stop hook verbatim'
+It 'uses the official Traces Antigravity Stop hook with an availability guard'
 When run jq -r '.["traces-share-to-traces"].Stop[0].command' "$HOOKS"
-The output should equal "traces hook agent agent-done --agent antigravity >/dev/null 2>&1; printf %s '{\"decision\":\"\"}'"
+The output should equal "command -v traces >/dev/null 2>&1 && traces hook agent agent-done --agent antigravity >/dev/null 2>&1; printf %s '{\"decision\":\"\"}'"
 End
 
 It 'reverts named hooks written by other tools'

--- a/spec/antigravity_config_spec.sh
+++ b/spec/antigravity_config_spec.sh
@@ -5,9 +5,27 @@ Describe 'config/antigravity'
 SCRIPT="$PWD/config/antigravity/activate.sh"
 SETTINGS="$PWD/config/antigravity/settings.json"
 HOOKS="$PWD/config/antigravity/hooks.json"
+WRAPPER="$PWD/config/antigravity/agy.sh"
 
 setup() {
   TEMP_HOME=$(mktemp -d)
+  TEMP_BIN="$TEMP_HOME/bin"
+  TRACES_LOG="$TEMP_HOME/traces.log"
+  AGY_LOG="$TEMP_HOME/agy.log"
+  mkdir -p "$TEMP_BIN"
+  : >"$TRACES_LOG"
+  : >"$AGY_LOG"
+  cat >"$TEMP_BIN/traces" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$TRACES_LOG"
+STUB
+  cat >"$TEMP_BIN/agy-real" <<'STUB'
+#!/usr/bin/env bash
+printf '<%s>\n' "$@" >>"$AGY_LOG"
+printf '%s\n' 'agy-ok'
+STUB
+  chmod +x "$TEMP_BIN/traces" "$TEMP_BIN/agy-real"
+  export TEMP_BIN TRACES_LOG AGY_LOG
 }
 
 cleanup() {
@@ -80,6 +98,26 @@ End
 It 'pins no absolute Nix store paths or home directories in managed hooks'
 When run bash -c 'grep -qE "/nix/store|/Users/" "$1" && exit 1 || exit 0' _ "$HOOKS"
 The status should be success
+End
+
+Describe 'CLI wrapper'
+It 'installs Traces Git hooks before starting Antigravity in a worktree'
+mkdir -p "$TEMP_HOME/repo"
+git -C "$TEMP_HOME/repo" init -q
+When run bash -c 'cd "$1" && PATH="$2:$PATH" TRACES_LOG="$3" AGY_LOG="$4" ANTIGRAVITY_CLI_BIN="$2/agy-real" bash "$5" --print hello' _ "$TEMP_HOME/repo" "$TEMP_BIN" "$TRACES_LOG" "$AGY_LOG" "$WRAPPER"
+The status should be success
+The output should equal 'agy-ok'
+The contents of file "$TRACES_LOG" should equal 'setup git'
+The contents of file "$AGY_LOG" should equal '<--print>
+<hello>'
+End
+
+It 'does not run Traces setup outside a Git worktree'
+When run bash -c 'cd "$1" && PATH="$2:$PATH" TRACES_LOG="$3" AGY_LOG="$4" ANTIGRAVITY_CLI_BIN="$2/agy-real" bash "$5" --version && test ! -s "$3"' _ "$TEMP_HOME" "$TEMP_BIN" "$TRACES_LOG" "$AGY_LOG" "$WRAPPER"
+The status should be success
+The output should equal 'agy-ok'
+The contents of file "$AGY_LOG" should equal '<--version>'
+End
 End
 
 It 'contains no remaining CCS integration outside this regression check'

--- a/spec/antigravity_config_spec.sh
+++ b/spec/antigravity_config_spec.sh
@@ -66,10 +66,15 @@ The contents of file "$TEMP_HOME/.gemini/antigravity-cli/settings.json" should e
 End
 
 It 'installs every managed named hook into the global customization root'
-When run bash -c 'HOME="$1" bash "$2" "$3" "$4" jq && jq -e '\''(keys == ["moshi-hook", "traces-share-to-traces"]) and (.["traces-share-to-traces"].Stop[0].command | contains("traces hook agent agent-done --agent antigravity"))'\'' "$1/.gemini/config/hooks.json" >/dev/null && find "$1/.gemini/config/hooks.json" -prune -perm 644 -print -quit | grep -q .' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS" "$HOOKS"
+When run bash -c 'HOME="$1" bash "$2" "$3" "$4" jq && jq -e '\''(keys == ["moshi-hook", "traces-share-to-traces"]) and (.["traces-share-to-traces"].Stop | length == 1)'\'' "$1/.gemini/config/hooks.json" >/dev/null && find "$1/.gemini/config/hooks.json" -prune -perm 644 -print -quit | grep -q .' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS" "$HOOKS"
 The status should be success
 The path "$TEMP_HOME/.gemini/config/hooks.json" should be file
 The path "$TEMP_HOME/.gemini/config/hooks.json" should be writable
+End
+
+It 'uses the official Traces Antigravity Stop hook verbatim'
+When run jq -r '.["traces-share-to-traces"].Stop[0].command' "$HOOKS"
+The output should equal "traces hook agent agent-done --agent antigravity >/dev/null 2>&1; printf %s '{\"decision\":\"\"}'"
 End
 
 It 'reverts named hooks written by other tools'
@@ -101,7 +106,7 @@ The status should be success
 End
 
 Describe 'CLI wrapper'
-It 'installs Traces Git hooks before starting Antigravity in a worktree'
+It 'installs official Traces Git hooks before starting Antigravity in a worktree'
 mkdir -p "$TEMP_HOME/repo"
 git -C "$TEMP_HOME/repo" init -q
 When run bash -c 'cd "$1" && PATH="$2:$PATH" TRACES_LOG="$3" AGY_LOG="$4" ANTIGRAVITY_CLI_BIN="$2/agy-real" bash "$5" --print hello' _ "$TEMP_HOME/repo" "$TEMP_BIN" "$TRACES_LOG" "$AGY_LOG" "$WRAPPER"

--- a/spec/antigravity_config_spec.sh
+++ b/spec/antigravity_config_spec.sh
@@ -18,6 +18,7 @@ setup() {
   cat >"$TEMP_BIN/traces" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$TRACES_LOG"
+exit "${TRACES_EXIT:-0}"
 STUB
   cat >"$TEMP_BIN/agy-real" <<'STUB'
 #!/usr/bin/env bash
@@ -115,6 +116,38 @@ The output should equal 'agy-ok'
 The contents of file "$TRACES_LOG" should equal 'setup git'
 The contents of file "$AGY_LOG" should equal '<--print>
 <hello>'
+End
+
+It 'skips setup when every official Traces Git hook is executable'
+mkdir -p "$TEMP_HOME/repo"
+git -C "$TEMP_HOME/repo" init -q
+hooks_dir="$(git -C "$TEMP_HOME/repo" rev-parse --path-format=absolute --git-common-dir)/hooks"
+for hook in post-commit post-merge pre-merge-commit pre-push traces-post-commit traces-post-merge traces-pre-merge-commit traces-pre-push; do
+  printf '%s\n' '#!/bin/sh' >"$hooks_dir/$hook"
+  chmod +x "$hooks_dir/$hook"
+done
+When run bash -c 'cd "$1" && PATH="$2:$PATH" TRACES_LOG="$3" AGY_LOG="$4" ANTIGRAVITY_CLI_BIN="$2/agy-real" bash "$5" --version' _ "$TEMP_HOME/repo" "$TEMP_BIN" "$TRACES_LOG" "$AGY_LOG" "$WRAPPER"
+The status should be success
+The output should equal 'agy-ok'
+The contents of file "$TRACES_LOG" should equal ''
+End
+
+It 'continues to Antigravity when Traces setup fails'
+mkdir -p "$TEMP_HOME/repo"
+git -C "$TEMP_HOME/repo" init -q
+When run bash -c 'cd "$1" && PATH="$2:$PATH" TRACES_LOG="$3" AGY_LOG="$4" TRACES_EXIT=17 ANTIGRAVITY_CLI_BIN="$2/agy-real" bash "$5" --version' _ "$TEMP_HOME/repo" "$TEMP_BIN" "$TRACES_LOG" "$AGY_LOG" "$WRAPPER"
+The status should be success
+The output should equal 'agy-ok'
+The error should include 'continuing with Antigravity CLI'
+The contents of file "$AGY_LOG" should equal '<--version>'
+End
+
+It 'does not run Traces setup in a bare repository'
+git -C "$TEMP_HOME" init --bare -q bare.git
+When run bash -c 'cd "$1" && PATH="$2:$PATH" TRACES_LOG="$3" AGY_LOG="$4" ANTIGRAVITY_CLI_BIN="$2/agy-real" bash "$5" --version' _ "$TEMP_HOME/bare.git" "$TEMP_BIN" "$TRACES_LOG" "$AGY_LOG" "$WRAPPER"
+The status should be success
+The output should equal 'agy-ok'
+The contents of file "$TRACES_LOG" should equal ''
 End
 
 It 'does not run Traces setup outside a Git worktree'

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -486,6 +486,7 @@ It 'covers all non-spec shell scripts in the repository'
 # List of all shell scripts that should have tests
 # Update this list when adding new shell scripts
 covered_scripts="config/antigravity/activate.sh
+config/antigravity/agy.sh
 config/caam/hydrate.sh
 config/factory/activate-settings.sh
 config/claude/activate.sh


### PR DESCRIPTION
## Summary

- use the official Traces Antigravity Stop hook with a non-blocking `command -v traces` availability guard
- bootstrap the official `traces setup git` integration when `agy` starts inside a Git worktree
- preserve the Nix-packaged Antigravity binary as the final exec target and pass CLI arguments unchanged

## Root cause

The Antigravity hook captured completed sessions, but Traces Git integration is a separate repository-local setup. Repositories without those hooks never ran commit attribution or the pre-push publishing path.

## Validation

- `shellcheck config/antigravity/agy.sh config/antigravity/activate.sh`
- `nix fmt -- --fail-on-change`
- full ShellSpec on the parent exact head — 2,429 examples, 0 failures
- focused Antigravity ShellSpec after the guard change — 10 examples, 0 failures
- missing-`traces` acceptance confirms the hook still emits `{"decision":""}`
- real `traces setup git` acceptance reports post-commit, pre-merge-commit, post-merge, and pre-push installed