### PR TITLE
fix(hooks): scope block-gh-settings matching to invoked commands

### DIFF
--- a/config/shared/hooks/README.md
+++ b/config/shared/hooks/README.md
@@ -17,7 +17,7 @@ matcher for file writes with these shared guardrails.
 
 The push hook blocks explicit and implicit updates or deletions of `main`, `master`, and the cached remote default branch. It resolves upstream and push configuration, bulk pushes, force variants, and Git aliases without executing alias bodies. Direct pushes remain allowed for `shunkakinoki/wiki` and `shunkakinoki/gthq`.
 
-The settings hook blocks repository control-plane mutations through settings-oriented `gh` commands, REST or GraphQL API calls, and common direct HTTP clients. Read-only API calls and ordinary pull request, issue, review, and comment operations remain available.
+The settings hook blocks repository control-plane mutations through settings-oriented `gh` commands, REST or GraphQL API calls, and common direct HTTP clients. It splits the command line into individual invocations and judges each one by its own arguments, so quoted text that merely names a command is not matched. GraphQL is judged by the root mutation fields the document invokes, and a document the hook cannot read is treated as a settings mutation. Read-only API calls and ordinary pull request, issue, review, and comment operations remain available.
 
 ## Security boundary
 

--- a/config/shared/hooks/block-gh-settings.sh
+++ b/config/shared/hooks/block-gh-settings.sh
@@ -70,7 +70,7 @@ mutation_root_fields() {
 
     if [[ $char == '"' ]]; then
       while ((index < length)) && [[ ${rest:index:1} != '"' ]]; do
-        if [[ ${rest:index:1} == "\\" ]]; then
+        if [[ ${rest:index:1} == $'\\' ]]; then
           index=$((index + 1))
         fi
         index=$((index + 1))
@@ -399,7 +399,7 @@ scan_command_line() {
     if [[ $quote == '"' ]]; then
       case $char in
       '"') quote='' ;;
-      "\\")
+      $'\\')
         token+=${line:index:1}
         index=$((index + 1))
         ;;
@@ -432,7 +432,7 @@ scan_command_line() {
       quote='"'
       token_started=1
       ;;
-    "\\")
+    $'\\')
       token+=${line:index:1}
       index=$((index + 1))
       token_started=1

--- a/config/shared/hooks/block-gh-settings.sh
+++ b/config/shared/hooks/block-gh-settings.sh
@@ -18,96 +18,455 @@ block_settings() {
   exit 2
 }
 
-is_control_plane_target() {
-  local candidate="$1"
-  local repo_prefix="(api/v3/)?repos/[^/[:space:]\"']+/[^/?[:space:]\"']+"
-  local protected_suffix="(rulesets|branches/[^/?[:space:]\"']+/protection|collaborators|teams|hooks|deploy_keys|keys|actions/(permissions|access|secrets|variables|cache/retention-limit|cache/storage-limit)|environments|pages|topics|vulnerability-alerts|automated-security-fixes|private-vulnerability-reporting|security-and-analysis|interaction-limits)"
-
-  printf '%s\n' "$candidate" | grep -Eiq "${repo_prefix}([?[:space:]\"']|$)" && return 0
-  printf '%s\n' "$candidate" | grep -Eiq "${repo_prefix}/${protected_suffix}([/?[:space:]\"']|$)"
+mutating_method() {
+  local method=${1^^}
+  [[ $method =~ ^(POST|PATCH|PUT|DELETE)$ ]]
 }
 
-explicit_method() {
-  local candidate="$1"
-  local method
-  method=$(printf '%s\n' "$candidate" | sed -nE 's/.*(^|[[:space:]])(-X|--method)(=|[[:space:]]+)(GET|POST|PATCH|PUT|DELETE)([[:space:]]|$).*/\4/ip' | tail -1)
-  if [[ -z $method ]]; then
-    method=$(printf '%s\n' "$candidate" | sed -nE 's/.*(^|[[:space:]])-X(GET|POST|PATCH|PUT|DELETE)([[:space:]]|$).*/\2/ip' | tail -1)
+is_control_plane_endpoint() {
+  local path="$1"
+  if [[ $path == *://* ]]; then
+    path=${path#*://}
+    path=${path#*/}
   fi
-  printf '%s' "${method^^}"
+  path=${path%%\?*}
+  path=${path%%#*}
+  path=${path#/}
+  path=${path%/}
+
+  local repo='(api/v3/)?repos/[^/]+/[^/]+'
+  local protected='(rulesets|branches/[^/]+/protection|collaborators|teams|hooks|deploy_keys|keys|actions/(permissions|access|secrets|variables|cache/retention-limit|cache/storage-limit)|environments|pages|topics|vulnerability-alerts|automated-security-fixes|private-vulnerability-reporting|security-and-analysis|interaction-limits)'
+
+  [[ $path =~ ^${repo}$ ]] && return 0
+  [[ $path =~ ^${repo}/${protected}(/.*)?$ ]]
 }
 
-has_implicit_body() {
-  local candidate="$1"
-  printf '%s\n' "$candidate" | grep -Eiq '(^|[[:space:]])(-f|-F|--field|--raw-field|--input)(=|[[:space:]])'
+has_control_plane_argument() {
+  local arg
+  for arg in "$@"; do
+    if is_control_plane_endpoint "$arg"; then
+      return 0
+    fi
+  done
+  return 1
 }
 
-if printf '%s\n' "$command" | grep -Eiq '(^|[;&|[:space:]])gh[[:space:]]+repo[[:space:]]+(delete|rename|archive|transfer|edit)([[:space:]]|$)'; then
-  block_settings "A mutating 'gh repo' command was requested."
-fi
+# Root selection fields of a GraphQL mutation document, one per line. Argument
+# values and nested selections sit at a deeper depth, so a repository field
+# selected inside a pull request mutation never reads as a root field.
+mutation_root_fields() {
+  local rest=${1#*mutation}
+  rest=${rest#*\{}
 
-if printf '%s\n' "$command" | grep -Eiq '(^|[;&|[:space:]])gh[[:space:]]+(secret|variable)[[:space:]]+(set|delete)([[:space:]]|$)'; then
-  block_settings "A GitHub secret or variable mutation was requested."
-fi
+  local length=${#rest}
+  local index=0
+  local depth=0
+  local name=''
+  local char
 
-if printf '%s\n' "$command" | grep -Eiq '(^|[;&|[:space:]])gh[[:space:]]+repo[[:space:]]+deploy-key[[:space:]]+(add|delete)([[:space:]]|$)'; then
-  block_settings "A repository deploy-key mutation was requested."
-fi
+  while ((index < length)); do
+    char=${rest:index:1}
+    index=$((index + 1))
 
-if printf '%s\n' "$command" | grep -Eiq '(^|[;&|[:space:]])gh[[:space:]]+workflow[[:space:]]+(enable|disable)([[:space:]]|$)'; then
-  block_settings "A workflow settings mutation was requested."
-fi
+    if [[ $char == '"' ]]; then
+      while ((index < length)) && [[ ${rest:index:1} != '"' ]]; do
+        if [[ ${rest:index:1} == "\\" ]]; then
+          index=$((index + 1))
+        fi
+        index=$((index + 1))
+      done
+      index=$((index + 1))
+      continue
+    fi
 
-if printf '%s\n' "$command" | grep -Eiq '(^|[;&|[:space:]])gh[[:space:]]+api[[:space:]]+([^;&|]*[[:space:]])?graphql([[:space:]]|$)'; then
-  if printf '%s\n' "$command" | grep -Eiq '(^|[^[:alnum:]_])mutation([^[:alnum:]_]|$)' ||
-    printf '%s\n' "$command" | grep -Eiq '(^|[[:space:]])--input(=|[[:space:]])'; then
-    block_settings "A raw GraphQL mutation was requested."
+    if [[ $char == [A-Za-z0-9_] ]]; then
+      name+=$char
+      continue
+    fi
+
+    if [[ -n $name ]]; then
+      # A name followed by a colon is an alias, not the invoked field.
+      if ((depth == 0)) && [[ $char != ':' ]]; then
+        printf '%s\n' "$name"
+      fi
+      name=''
+    fi
+
+    case $char in
+    '(' | '{' | '[') depth=$((depth + 1)) ;;
+    ')' | '}' | ']')
+      depth=$((depth - 1))
+      if ((depth < 0)); then
+        return 0
+      fi
+      ;;
+    esac
+  done
+
+  if [[ -n $name ]] && ((depth == 0)); then
+    printf '%s\n' "$name"
   fi
-fi
+}
 
-if printf '%s\n' "$command" | grep -Eiq '(^|[;&|[:space:]])gh[[:space:]]+api([[:space:]]|$)' && is_control_plane_target "$command"; then
-  method=$(explicit_method "$command")
-  if [[ -z $method ]] && has_implicit_body "$command"; then
+is_settings_mutation() {
+  local name=${1,,}
+  [[ $name =~ (repository|organization|enterprise|team|collaborator|branchprotection|ruleset|ipallowlist|environment|deploykey|webhook|interactionlimit|verifiabledomain|topics|pages|secret|variable|actionspermission|securityanalysis|vulnerabilityalert) ]]
+}
+
+check_graphql() {
+  # A document read from a file, from stdin, or from a shell expansion cannot be
+  # inspected, so it is treated as a settings mutation.
+  if ((gql_opaque)) || [[ -z $gql_document || $gql_document == @* || $gql_document == '$'* ]]; then
+    block_settings "A GraphQL document that could not be inspected was requested."
+  fi
+
+  local operation='(^|[^[:alnum:]_])mutation[[:space:]]*([A-Za-z_({]|$)'
+  if [[ ! $gql_document =~ $operation ]]; then
+    return 0
+  fi
+
+  local field
+  while IFS= read -r field; do
+    if is_settings_mutation "$field"; then
+      block_settings "The GraphQL mutation '$field' changes repository or organization settings."
+    fi
+  done < <(mutation_root_fields "$gql_document")
+}
+
+gql_document=''
+gql_opaque=0
+
+record_gh_api_field() {
+  if [[ $1 == query=* ]]; then
+    gql_document=${1#query=}
+  fi
+}
+
+check_gh_api() {
+  while (($#)) && [[ $1 != api ]]; do
+    shift
+  done
+  if (($# == 0)); then
+    return 0
+  fi
+  shift
+
+  local endpoint='' method='' body=0 arg
+  gql_document=''
+  gql_opaque=0
+
+  while (($#)); do
+    arg=$1
+    case $arg in
+    -X | --method)
+      method=${2-}
+      shift $(($# > 1 ? 2 : 1))
+      ;;
+    --method=*)
+      method=${arg#--method=}
+      shift
+      ;;
+    -X?*)
+      method=${arg#-X}
+      shift
+      ;;
+    -f | -F | --field | --raw-field)
+      record_gh_api_field "${2-}"
+      body=1
+      shift $(($# > 1 ? 2 : 1))
+      ;;
+    --field=* | --raw-field=*)
+      record_gh_api_field "${arg#*=}"
+      body=1
+      shift
+      ;;
+    -f?* | -F?*)
+      record_gh_api_field "${arg:2}"
+      body=1
+      shift
+      ;;
+    --input)
+      gql_opaque=1
+      body=1
+      shift $(($# > 1 ? 2 : 1))
+      ;;
+    --input=*)
+      gql_opaque=1
+      body=1
+      shift
+      ;;
+    -H | --header | -q | --jq | -t | --template | --hostname | --cache | -p | --preview)
+      shift $(($# > 1 ? 2 : 1))
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      if [[ -z $endpoint ]]; then
+        endpoint=$arg
+      fi
+      shift
+      ;;
+    esac
+  done
+
+  if [[ $endpoint == graphql ]]; then
+    check_graphql
+    return 0
+  fi
+
+  if [[ -z $method ]] && ((body)); then
     method=POST
   fi
-  if [[ $method =~ ^(POST|PATCH|PUT|DELETE)$ ]]; then
-    block_settings "A $method request to a repository control-plane endpoint was requested."
+
+  if mutating_method "$method" && is_control_plane_endpoint "$endpoint"; then
+    block_settings "A ${method^^} request to a repository control-plane endpoint was requested."
   fi
-fi
+}
 
-if is_control_plane_target "$command"; then
-  http_method=$(explicit_method "$command")
+check_gh() {
+  local -a words=()
+  local arg
+  for arg in "$@"; do
+    if [[ $arg != -* ]]; then
+      words+=("$arg")
+    fi
+  done
 
-  if printf '%s\n' "$command" | grep -Eiq '(^|[;&|[:space:]])(http|https|xh)[[:space:]]+(POST|PATCH|PUT|DELETE)([[:space:]]|$)'; then
-    http_method=$(printf '%s\n' "$command" | sed -nE 's/.*(^|[;&|[:space:]])(http|https|xh)[[:space:]]+(POST|PATCH|PUT|DELETE)([[:space:]]|$).*/\3/ip' | tail -1)
+  case "${words[0]-} ${words[1]-}" in
+  'repo delete' | 'repo rename' | 'repo archive' | 'repo transfer' | 'repo edit')
+    block_settings "A mutating 'gh repo' command was requested."
+    ;;
+  'secret set' | 'secret delete' | 'variable set' | 'variable delete')
+    block_settings "A GitHub secret or variable mutation was requested."
+    ;;
+  'workflow enable' | 'workflow disable')
+    block_settings "A workflow settings mutation was requested."
+    ;;
+  esac
+
+  case "${words[0]-} ${words[1]-} ${words[2]-}" in
+  'repo deploy-key add' | 'repo deploy-key delete')
+    block_settings "A repository deploy-key mutation was requested."
+    ;;
+  esac
+
+  if [[ ${words[0]-} == api ]]; then
+    check_gh_api "$@"
+  fi
+}
+
+check_curl() {
+  if ! has_control_plane_argument "$@"; then
+    return 0
   fi
 
-  if [[ -z $http_method ]]; then
-    http_method=$(printf '%s\n' "$command" | sed -nE 's/.*(^|[[:space:]])--request(=|[[:space:]]+)(POST|PATCH|PUT|DELETE)([[:space:]]|$).*/\3/ip' | tail -1)
+  local method='' body=0 arg previous=''
+  for arg in "$@"; do
+    if [[ $previous == -X || $previous == --request ]]; then
+      method=$arg
+    fi
+    case $arg in
+    --request=*) method=${arg#--request=} ;;
+    -X?*) method=${arg#-X} ;;
+    -d | -F | -T | --data | --data-* | --form | --json | --upload-file) body=1 ;;
+    -d?* | --data=*) body=1 ;;
+    esac
+    previous=$arg
+  done
+
+  if [[ -z $method ]] && ((body)); then
+    method=POST
   fi
 
-  if [[ -z $http_method ]] &&
-    printf '%s\n' "$command" | grep -Eiq '(^|[;&|[:space:]])curl([[:space:]]|$)' &&
-    printf '%s\n' "$command" | grep -Eiq '(^|[[:space:]])(--data[^[:space:]]*|-d|--form|-F|--json|--upload-file|-T)(=|[[:space:]])'; then
-    http_method=POST
+  if mutating_method "$method"; then
+    block_settings "A direct ${method^^} request to a repository control-plane endpoint was requested."
+  fi
+}
+
+check_httpie() {
+  if ! has_control_plane_argument "$@"; then
+    return 0
   fi
 
-  if [[ -z $http_method ]] &&
-    printf '%s\n' "$command" | grep -Eiq '(^|[;&|[:space:]])(http|https|xh)([[:space:]]|$)' &&
-    printf '%s\n' "$command" | grep -Eq '(^|[[:space:]])[^-[:space:]=?:/][^[:space:]=?/]*(:=|=)[^[:space:]]+'; then
-    http_method=POST
+  local method='' arg positional=0
+  for arg in "$@"; do
+    if [[ $arg == -* ]]; then
+      continue
+    fi
+    positional=$((positional + 1))
+    if ((positional == 1)) && [[ ${arg,,} =~ ^(get|head|post|put|patch|delete|options)$ ]]; then
+      method=$arg
+      continue
+    fi
+    # A request item carries a body, which makes the implicit method a POST.
+    if [[ -z $method && $arg != *://* && $arg =~ ^[A-Za-z_][A-Za-z0-9_.-]*:?=. ]]; then
+      method=POST
+    fi
+  done
+
+  if mutating_method "$method"; then
+    block_settings "A direct ${method^^} request to a repository control-plane endpoint was requested."
+  fi
+}
+
+check_wget() {
+  if ! has_control_plane_argument "$@"; then
+    return 0
   fi
 
-  if [[ -z $http_method ]] &&
-    printf '%s\n' "$command" | grep -Eiq '(^|[;&|[:space:]])wget([[:space:]]|$)' &&
-    printf '%s\n' "$command" | grep -Eiq '(^|[[:space:]])(--post-data|--post-file|--body-data)(=|[[:space:]])'; then
-    http_method=POST
+  local method='' arg previous=''
+  for arg in "$@"; do
+    if [[ $previous == --method ]]; then
+      method=$arg
+    fi
+    case $arg in
+    --method=*) method=${arg#--method=} ;;
+    --post-data* | --post-file* | --body-data* | --body-file*)
+      if [[ -z $method ]]; then
+        method=POST
+      fi
+      ;;
+    esac
+    previous=$arg
+  done
+
+  if mutating_method "$method"; then
+    block_settings "A direct ${method^^} request to a repository control-plane endpoint was requested."
+  fi
+}
+
+evaluate_invocation() {
+  local -a words=("$@")
+  while ((${#words[@]})) && [[ ${words[0]} =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; do
+    words=("${words[@]:1}")
+  done
+  if ((${#words[@]} == 0)); then
+    return 0
   fi
 
-  http_method=${http_method^^}
-  if [[ $http_method =~ ^(POST|PATCH|PUT|DELETE)$ ]]; then
-    block_settings "A direct $http_method request to a repository control-plane endpoint was requested."
-  fi
-fi
+  case "${words[0]##*/}" in
+  gh) check_gh "${words[@]:1}" ;;
+  curl) check_curl "${words[@]:1}" ;;
+  http | https | xh | xhs) check_httpie "${words[@]:1}" ;;
+  wget) check_wget "${words[@]:1}" ;;
+  esac
+}
 
+argv=()
+token=''
+token_started=0
+
+end_token() {
+  if ((token_started)); then
+    argv+=("$token")
+  fi
+  token=''
+  token_started=0
+}
+
+end_invocation() {
+  end_token
+  if ((${#argv[@]})); then
+    evaluate_invocation "${argv[@]}"
+  fi
+  argv=()
+}
+
+# Split the command line the way the shell would and judge each invocation by
+# its own argument vector. Quoted text stays inside the token that carries it,
+# so prose that merely names a command never reads as running one.
+scan_command_line() {
+  local line="$1"
+  local length=${#line}
+  local index=0
+  local quote=''
+  local char
+
+  while ((index < length)); do
+    char=${line:index:1}
+    index=$((index + 1))
+
+    if [[ $quote == "'" ]]; then
+      if [[ $char == "'" ]]; then
+        quote=''
+      else
+        token+=$char
+      fi
+      continue
+    fi
+
+    if [[ $quote == '"' ]]; then
+      case $char in
+      '"') quote='' ;;
+      "\\")
+        token+=${line:index:1}
+        index=$((index + 1))
+        ;;
+      '$')
+        if [[ ${line:index:1} == '(' ]]; then
+          # A substitution runs its own commands, so leave the quoted state and
+          # tokenize what follows as an invocation of its own.
+          end_invocation
+          quote=''
+          index=$((index + 1))
+        else
+          token+=$char
+        fi
+        ;;
+      '`')
+        end_invocation
+        quote=''
+        ;;
+      *) token+=$char ;;
+      esac
+      continue
+    fi
+
+    case $char in
+    "'")
+      quote="'"
+      token_started=1
+      ;;
+    '"')
+      quote='"'
+      token_started=1
+      ;;
+    "\\")
+      token+=${line:index:1}
+      index=$((index + 1))
+      token_started=1
+      ;;
+    '$')
+      case ${line:index:1} in
+      "'")
+        quote="'"
+        token_started=1
+        index=$((index + 1))
+        ;;
+      '(')
+        end_invocation
+        index=$((index + 1))
+        ;;
+      *)
+        token+=$char
+        token_started=1
+        ;;
+      esac
+      ;;
+    '`') end_invocation ;;
+    ';' | '&' | '|' | '(' | ')' | $'\n') end_invocation ;;
+    '<' | '>') end_token ;;
+    ' ' | $'\t' | $'\r') end_token ;;
+    *)
+      token+=$char
+      token_started=1
+      ;;
+    esac
+  done
+
+  end_invocation
+}
+
+scan_command_line "$command"
 exit 0

--- a/spec/block_gh_settings_spec.sh
+++ b/spec/block_gh_settings_spec.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2329
+# shellcheck disable=SC2016,SC2329
 
 Describe 'block-gh-settings.sh'
 SCRIPT="$PWD/config/shared/hooks/block-gh-settings.sh"
@@ -176,11 +176,56 @@ The status should eq 2
 The stderr should include 'BLOCKED'
 End
 
+It 'blocks a ruleset mutation'
+Data '{"tool_input": {"command": "gh api graphql -f query=\"mutation { createRepositoryRuleset(input: {}) { ruleset { id } } }\""}}'
+When run bash "$SCRIPT"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
 It 'blocks a GraphQL input file because it may contain a mutation'
 Data '{"tool_input": {"command": "gh api graphql --input mutation.json"}}'
 When run bash "$SCRIPT"
 The status should eq 2
 The stderr should include 'BLOCKED'
+End
+
+It 'blocks a GraphQL document read from a file'
+Data '{"tool_input": {"command": "gh api graphql -F query=@mutation.graphql"}}'
+When run bash "$SCRIPT"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+It 'blocks a GraphQL document read from a shell expansion'
+Data '{"tool_input": {"command": "gh api graphql -f query=\"$(cat mutation.graphql)\""}}'
+When run bash "$SCRIPT"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+It 'allows resolving a pull request review thread'
+Data '{"tool_input": {"command": "gh api graphql -f threadId=PRRT_1 -f query=\"mutation ResolveThread($threadId: ID!) { resolveReviewThread(input: {threadId: $threadId}) { thread { id } } }\""}}'
+When run bash "$SCRIPT"
+The status should be success
+End
+
+It 'allows replying to a pull request review thread'
+Data '{"tool_input": {"command": "gh api graphql -f query=\"mutation Reply($threadId: ID!, $body: String!) { addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: $threadId, body: $body}) { comment { id } } }\""}}'
+When run bash "$SCRIPT"
+The status should be success
+End
+
+It 'allows a review mutation that selects repository fields'
+Data '{"tool_input": {"command": "gh api graphql -f query=\"mutation ResolveThread($threadId: ID!) { resolveReviewThread(input: {threadId: $threadId}) { thread { pullRequest { repository { name } } } } }\""}}'
+When run bash "$SCRIPT"
+The status should be success
+End
+
+It 'allows an aliased review mutation'
+Data '{"tool_input": {"command": "gh api graphql -f query=\"mutation ResolveThread($threadId: ID!) { resolved: resolveReviewThread(input: {threadId: $threadId}) { thread { id } } }\""}}'
+When run bash "$SCRIPT"
+The status should be success
 End
 End
 
@@ -316,6 +361,56 @@ End
 
 It 'blocks camel-case tool input'
 Data '{"toolInput": {"command": "gh repo edit --enable-wiki"}}'
+When run bash "$SCRIPT"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+End
+
+Describe 'prose that names commands'
+
+It 'allows an issue description quoting settings commands'
+Data '{"tool_input": {"command": "bd create -t \"guard false positive\" -d \"gh repo edit and gh api graphql -f query=mutation are refused\""}}'
+When run bash "$SCRIPT"
+The status should be success
+End
+
+It 'allows a commit message quoting a settings command'
+Data '{"tool_input": {"command": "git commit -m \"fix(gh): stop gh repo edit false positives\""}}'
+When run bash "$SCRIPT"
+The status should be success
+End
+
+It 'allows a note quoting a direct HTTP mutation'
+Data '{"tool_input": {"command": "bd note issue-1 \"curl -X PATCH https://api.github.com/repos/owner/repo is refused\""}}'
+When run bash "$SCRIPT"
+The status should be success
+End
+
+It 'blocks a real command chained after prose'
+Data '{"tool_input": {"command": "bd note issue-1 \"gh repo edit is refused\" && gh repo edit --visibility private"}}'
+When run bash "$SCRIPT"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+It 'blocks a command inside a substitution'
+Data '{"tool_input": {"command": "echo \"$(gh secret set TOKEN)\""}}'
+When run bash "$SCRIPT"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+It 'blocks a command on a later line'
+Data '{"tool_input": {"command": "gh pr list\ngh repo edit --enable-wiki"}}'
+When run bash "$SCRIPT"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+It 'blocks a command behind an environment assignment'
+Data '{"tool_input": {"command": "GH_TOKEN=x gh repo edit --visibility private"}}'
 When run bash "$SCRIPT"
 The status should eq 2
 The stderr should include 'BLOCKED'

--- a/spec/block_gh_settings_spec.sh
+++ b/spec/block_gh_settings_spec.sh
@@ -388,6 +388,12 @@ When run bash "$SCRIPT"
 The status should be success
 End
 
+It 'allows a note quoting a REST method override'
+Data '{"tool_input": {"command": "bd note issue-1 \"gh api -X PATCH /repos/owner/repo is refused\""}}'
+When run bash "$SCRIPT"
+The status should be success
+End
+
 It 'blocks a real command chained after prose'
 Data '{"tool_input": {"command": "bd note issue-1 \"gh repo edit is refused\" && gh repo edit --visibility private"}}'
 When run bash "$SCRIPT"


### PR DESCRIPTION
## Problem

`block-gh-settings.sh` matched its keywords against the raw command string, so anything that merely contained the text was refused:

1. **Pull-request review actions.** Any `gh api graphql` invocation containing the word `mutation` was blocked, including `resolveReviewThread` and `addPullRequestReviewThreadReply`. Those are ordinary review operations, not repository settings. Auto-merge readiness requires review threads to be replied to and resolved, so the hook could stall merges on any PR that accumulated a review thread.
2. **Prose.** A `bd create`, `bd note`, or `git commit -m` whose text quoted a settings command was refused even though no such command ran. The `bd create` that first filed this bug was itself blocked this way, and so was the first attempt at the bead note recording this fix.

## Change

The hook now splits the command line the way the shell would and judges each invocation by its own argument vector. Quoted text stays inside the token that carries it, so prose that names a command is never mistaken for running one. Command substitutions and later lines are still tokenized and evaluated, so chained or nested invocations remain covered.

GraphQL is judged by the root mutation fields the document invokes:

- Root fields naming a repository or organization settings entity (`updateRepositoryRuleset`, `updateOrganizationWebCommitSignoffSetting`, `createBranchProtectionRule`, ...) are blocked.
- Nested selections and argument values sit at a deeper depth, so `mutation { resolveReviewThread(...) { thread { pullRequest { repository { name } } } } }` is allowed.
- A document the hook cannot read (`--input`, `-F query=@file`, a shell expansion) is treated as a settings mutation and stays blocked.

REST, `curl`, HTTPie, `xh`, and `wget` paths keep their existing control-plane surface and method detection; the endpoint is now taken from the invocation's own arguments instead of from anywhere in the command text.

## Verification

- `shellspec spec/block_gh_settings_spec.sh` - 60 examples, 0 failures. All 45 pre-existing examples keep passing; 15 new ones cover review-thread mutations, settings mutations, unreadable documents, aliased mutations, prose, substitutions, later lines, and environment-assignment prefixes.
- Full `shellspec` suite: 2446 examples, 16 failures, 4 warnings - identical failure and warning counts to `origin/main` on this host (clipboard backends, tailscale, and DMI probes that need hardware this machine does not have).
- `make shell-check`, `make shell-inline-check`, and `nix fmt --fail-on-change` pass.
- The exact command from the report now exits 0:
  `gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "PRRT_..."}) { thread { id isResolved } } }'`
  while `updateRepositoryRuleset`, `updateOrganizationWebCommitSignoffSetting`, and a REST method override against `/repos/owner/repo` still exit 2.

## Not installed

This is a guardrail narrowing, so it is left for operator review and activation. Nothing was applied to the running host.

## Follow-up

`block-git-push.sh` still matches against the raw command string and has the same prose exposure. It is out of scope here and worth a separate change.
