### PR TITLE
fix(home-manager): drop fzf Ctrl-R so Atuin owns history

### DIFF
--- a/home-manager/programs/fzf/default.nix
+++ b/home-manager/programs/fzf/default.nix
@@ -2,5 +2,6 @@
   programs.fzf = {
     enable = true;
     enableFishIntegration = false;
+    historyWidget.command = "";
   };
 }


### PR DESCRIPTION
## Summary
- Home Manager warns that `programs.fzf` and `programs.atuin` both bind Ctrl-R on bash and zsh. Atuin is sourced after fzf and already owns history search.
- Set `programs.fzf.historyWidget.command = ""` so fzf yields Ctrl-R. Atuin config is unchanged. fzf fish integration stays off.

SHUN-3582

## Test plan
- [ ] Home Manager eval no longer warns about fzf/Atuin Ctrl-R conflict
- [ ] Atuin still owns Ctrl-R on bash and zsh
- [ ] fzf non-history widgets (Ctrl-T, Alt-C) still work
- [ ] fzf fish integration remains disabled

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables fzf's Ctrl-R history widget in Home Manager so Atuin owns history search, resolving the keybinding conflict warning (SHUN-3582).

- fzf's Ctrl-T and Alt-C widgets and fish integration remain unchanged.

<sup>Written for commit ea8cb1125b62f0f78138a6623892a4fb0d8ece8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

