### PR TITLE
fix(fzf): drop Ctrl-R so Atuin owns history search

### DIFF
--- a/home-manager/programs/fzf/default.nix
+++ b/home-manager/programs/fzf/default.nix
@@ -2,5 +2,6 @@
   programs.fzf = {
     enable = true;
     enableFishIntegration = false;
+    historyWidget.command = "";
   };
 }


### PR DESCRIPTION
## Summary
- SHUN-3582: Home Manager warns that `programs.fzf` and `programs.atuin` both bind Ctrl-R for bash and zsh.
- Set `programs.fzf.historyWidget.command = ""` so fzf yields Ctrl-R to Atuin, matching the home-manager warning's supported path.
- No Atuin flag change (`programs.atuin.flags` is untouched). Fish fzf integration stays off. Other fzf widgets are unchanged.

## Test plan
- [ ] `home-manager switch` (or equivalent eval) no longer emits the Ctrl-R warning for bash/zsh
- [ ] Atuin still owns Ctrl-R
- [ ] fzf file/dir search and other non-history widgets still work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `fzf` from binding Ctrl-R so Atuin owns history search in bash and zsh, resolving the Home Manager warning about both programs claiming the shortcut.

- Sets `programs.fzf.historyWidget.command = ""`; Atuin flags, Fish integration, and other fzf widgets are unchanged.

<sup>Written for commit ca836d29426ca30dc6bb9a2df082db751b3409f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

