### PR TITLE
fix(fzf): drop Ctrl-R so Atuin owns history search

### DIFF
--- a/home-manager/programs/fzf/default.nix
+++ b/home-manager/programs/fzf/default.nix
@@ -2,5 +2,6 @@
   programs.fzf = {
     enable = true;
     enableFishIntegration = false;
+    historyWidget.command = "";
   };
 }


### PR DESCRIPTION
Sets programs.fzf.historyWidget.command to empty so Atuin keeps Ctrl-R. SHUN-3582. Does not change atuin flags.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets `fzf`'s history widget command to an empty string so Atuin owns Ctrl-R for history search, fixing the conflict from SHUN-3582. Does not change any `atuin` flags.

<sup>Written for commit ca836d29426ca30dc6bb9a2df082db751b3409f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

