### PR TITLE
fix(nix): repair platform and PAM evaluation

### DIFF
--- a/config/codex/default.nix
+++ b/config/codex/default.nix
@@ -26,7 +26,7 @@ in
   # the complete global-state file after activation. Restore managed atom-state
   # keys after each app-owned rewrite; the synchronizer exits without writing
   # once the values already match.
-  launchd.agents.codex-desktop-settings-sync = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.codex-desktop-settings-sync = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [
@@ -47,7 +47,7 @@ in
   # Home Manager normally installs and bootstraps launchd.agents during
   # setupLaunchAgents. Self-heal after that phase so a missed registration
   # cannot leave the app free to replace the managed settings permanently.
-  home.activation.codexDesktopSettingsAgent = lib.mkIf pkgs.stdenv.isDarwin (
+  home.activation.codexDesktopSettingsAgent = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin (
     config.lib.dag.entryAfter [ "setupLaunchAgents" ] ''
       $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${ensureDesktopSettingsAgent}" \
         "${desktopSettingsAgentLabel}" \

--- a/config/ghostty/default.nix
+++ b/config/ghostty/default.nix
@@ -18,17 +18,17 @@ in
 
   # macOS GUI app reads from ~/Library/Application Support/com.mitchellh.ghostty/
   home.file."Library/Application Support/com.mitchellh.ghostty/config" =
-    lib.mkIf pkgs.stdenv.isDarwin
+    lib.mkIf pkgs.stdenv.hostPlatform.isDarwin
       {
         source = configFile;
       };
   home.file."Library/Application Support/com.mitchellh.ghostty/themes/Dracula Custom" =
-    lib.mkIf pkgs.stdenv.isDarwin
+    lib.mkIf pkgs.stdenv.hostPlatform.isDarwin
       {
         source = ./themes + "/Dracula Custom";
       };
   home.file."Library/Application Support/com.mitchellh.ghostty/themes/Catppuccin Latte Custom" =
-    lib.mkIf pkgs.stdenv.isDarwin
+    lib.mkIf pkgs.stdenv.hostPlatform.isDarwin
       {
         source = ./themes + "/Catppuccin Latte Custom";
       };

--- a/config/iterm2/default.nix
+++ b/config/iterm2/default.nix
@@ -1,7 +1,7 @@
 { pkgs, ... }:
 {
   home.file."Library/Application Support/iTerm2/DynamicProfiles/dotfiles.json" = {
-    enable = pkgs.stdenv.isDarwin;
+    enable = pkgs.stdenv.hostPlatform.isDarwin;
     source = ./profile.json;
     force = true;
   };

--- a/config/llm/default.nix
+++ b/config/llm/default.nix
@@ -12,13 +12,13 @@ let
 in
 {
   home.file."Library/Application Support/io.datasette.llm/extra-openai-models.yaml" = {
-    enable = pkgs.stdenv.isDarwin;
+    enable = pkgs.stdenv.hostPlatform.isDarwin;
     source = ./extra-openai-models.yaml;
     force = true;
   };
 
   home.file."Library/Application Support/io.datasette.llm/default_model.txt" = {
-    enable = pkgs.stdenv.isDarwin;
+    enable = pkgs.stdenv.hostPlatform.isDarwin;
     source = ./default_model.txt;
     force = true;
   };

--- a/home-manager/modules/cargo-globals/default.nix
+++ b/home-manager/modules/cargo-globals/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (pkgs.stdenv) isDarwin;
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
   libiconvPkgConfigPath = lib.optionalString isDarwin ":${pkgs.libiconv.dev}/lib/pkgconfig";
   libiconvLibraryPath = lib.optionalString isDarwin "${pkgs.libiconv.out}/lib";
   libiconvCPath = lib.optionalString isDarwin "${pkgs.libiconv.dev}/include";

--- a/home-manager/modules/dotenv/default.nix
+++ b/home-manager/modules/dotenv/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (pkgs.stdenv) isDarwin;
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
   exportGuiEnv = pkgs.replaceVars ./export-gui-env.sh {
     launchctl = "/bin/launchctl";
     printer = "${./print-env-file.sh}";

--- a/home-manager/modules/npm-globals/default.nix
+++ b/home-manager/modules/npm-globals/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (pkgs.stdenv) isDarwin;
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
 in
 {
   # Install npm global packages from package.json using home-manager activation

--- a/home-manager/modules/uv-globals/default.nix
+++ b/home-manager/modules/uv-globals/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 let
-  inherit (pkgs.stdenv) isDarwin;
+  inherit (pkgs.stdenv.hostPlatform) isDarwin;
 in
 {
   # Install uv global tools from pyproject.toml using home-manager activation

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -139,7 +139,7 @@ with pkgs;
   pkgs.llm-agents.prime-agent
   vector
 ]
-++ lib.optionals stdenv.isDarwin [
+++ lib.optionals stdenv.hostPlatform.isDarwin [
   darwin.trash
 ]
 ++ lib.optionals stdenv.isLinux [

--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -34,7 +34,10 @@
 
       # FNM (Fast Node Manager) configuration
       FNM_DIR =
-        if pkgs.stdenv.isDarwin then "$HOME/Library/Application Support/fnm" else "$HOME/.local/share/fnm";
+        if pkgs.stdenv.hostPlatform.isDarwin then
+          "$HOME/Library/Application Support/fnm"
+        else
+          "$HOME/.local/share/fnm";
       FNM_COREPACK_ENABLED = "false";
       FNM_ARCH = if pkgs.stdenv.hostPlatform.isAarch64 then "arm64" else "x64";
       FNM_RESOLVE_ENGINES = "false";
@@ -46,7 +49,7 @@
     shellAliases = {
       copy = "clipboard-copy";
       paste = "clipboard-paste";
-      rm = if pkgs.stdenv.isDarwin then "trash" else "gomi";
+      rm = if pkgs.stdenv.hostPlatform.isDarwin then "trash" else "gomi";
     };
 
     bashrcExtra = ''

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -125,7 +125,7 @@
       lzg = "lazygit";
       ompc = "omp commit";
       ompcp = "omp commit --push";
-      rm = if pkgs.stdenv.isDarwin then "trash" else "gomi";
+      rm = if pkgs.stdenv.hostPlatform.isDarwin then "trash" else "gomi";
       v = "nvim";
 
       # Function-based abbreviations

--- a/home-manager/programs/fnm/default.nix
+++ b/home-manager/programs/fnm/default.nix
@@ -7,7 +7,7 @@
 let
   homeDir = config.home.homeDirectory;
   fnmDir =
-    if pkgs.stdenv.isDarwin then
+    if pkgs.stdenv.hostPlatform.isDarwin then
       "${homeDir}/Library/Application Support/fnm"
     else
       "${homeDir}/.local/share/fnm";

--- a/home-manager/programs/gpg/default.nix
+++ b/home-manager/programs/gpg/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 let
-  inherit (pkgs.stdenv) isLinux isDarwin;
+  inherit (pkgs.stdenv.hostPlatform) isLinux isDarwin;
 in
 {
   programs.gpg = {

--- a/home-manager/programs/neovim/default.nix
+++ b/home-manager/programs/neovim/default.nix
@@ -9,7 +9,7 @@ let
   nvimPackLockJson = ./nvim-pack-lock.json;
   packDir = "$HOME/.local/share/nvim/site/pack";
   buildTools =
-    if pkgs.stdenv.isDarwin then
+    if pkgs.stdenv.hostPlatform.isDarwin then
       [
         pkgs.gnumake
         pkgs.clang
@@ -19,7 +19,7 @@ let
         pkgs.gnumake
         pkgs.gcc
       ];
-  libExt = if pkgs.stdenv.isDarwin then "dylib" else "so";
+  libExt = if pkgs.stdenv.hostPlatform.isDarwin then "dylib" else "so";
 in
 {
   programs.neovim = {

--- a/home-manager/programs/nvtop/default.nix
+++ b/home-manager/programs/nvtop/default.nix
@@ -1,6 +1,6 @@
 { pkgs, ... }:
 {
   home.packages = [
-    (if pkgs.stdenv.isDarwin then pkgs.nvtopPackages.apple else pkgs.nvtopPackages.full)
+    (if pkgs.stdenv.hostPlatform.isDarwin then pkgs.nvtopPackages.apple else pkgs.nvtopPackages.full)
   ];
 }

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -59,7 +59,7 @@
       # Define aliases in .zshenv so non-interactive zsh invocations can use them.
       alias copy='clipboard-copy'
       alias paste='clipboard-paste'
-      alias rm='${if pkgs.stdenv.isDarwin then "trash" else "gomi"}'
+      alias rm='${if pkgs.stdenv.hostPlatform.isDarwin then "trash" else "gomi"}'
     '';
 
     initContent = ''
@@ -85,7 +85,7 @@
 
       # FNM (Fast Node Manager) configuration
       ${
-        if pkgs.stdenv.isDarwin then
+        if pkgs.stdenv.hostPlatform.isDarwin then
           ''export FNM_DIR="$HOME/Library/Application Support/fnm"''
         else
           ''export FNM_DIR="$HOME/.local/share/fnm"''

--- a/home-manager/services/brew-upgrader/default.nix
+++ b/home-manager/services/brew-upgrader/default.nix
@@ -1,6 +1,6 @@
 { pkgs, ... }:
 {
-  launchd.agents.brew-upgrader = pkgs.lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.brew-upgrader = pkgs.lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [

--- a/home-manager/services/caam/default.nix
+++ b/home-manager/services/caam/default.nix
@@ -19,7 +19,7 @@ in
   '';
 
   # Persistent token-refresh daemon (foreground under launchd/systemd supervision).
-  launchd.agents.caam-daemon = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.caam-daemon = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [
@@ -40,7 +40,7 @@ in
   };
 
   # Periodic peer sync (freshness-based push/pull).
-  launchd.agents.caam-sync = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.caam-sync = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [

--- a/home-manager/services/cass/default.nix
+++ b/home-manager/services/cass/default.nix
@@ -11,7 +11,7 @@ in
   # blocks the TUI's otherwise usable lexical search path.
 
   # Daily remote sync + analytics rebuild (runs at 4am)
-  launchd.agents.cass-daily = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.cass-daily = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [

--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -6,8 +6,12 @@
 }:
 let
   homeDir =
-    config.home.homeDirectory
-      or (if pkgs.stdenv.isDarwin then builtins.getEnv "HOME" else "/home/${config.home.username}");
+    config.home.homeDirectory or (
+      if pkgs.stdenv.hostPlatform.isDarwin then
+        builtins.getEnv "HOME"
+      else
+        "/home/${config.home.username}"
+    );
 
   commonScript = pkgs.replaceVars ./scripts/common.sh {
     aws = "${pkgs.awscli2}/bin/aws";
@@ -60,10 +64,10 @@ in
     ${pkgs.bash}/bin/bash ${hydrateScript} || true
   '';
 
-  home.packages = lib.mkIf pkgs.stdenv.isDarwin [ cliWrapper ];
+  home.packages = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin [ cliWrapper ];
 
   # Main service
-  launchd.agents.cliproxyapi = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.cliproxyapi = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [
@@ -88,7 +92,7 @@ in
 
   # Auth backup - watches auth dir for changes. CLIProxyAPI rewrites auth files
   # on every token refresh, so this fires many times an hour and must stay cheap.
-  launchd.agents.cliproxyapi-backup-auth = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.cliproxyapi-backup-auth = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [
@@ -116,7 +120,7 @@ in
 
   # Full backup - auth files plus the multi-hundred-megabyte CPA Manager Plus
   # analytics snapshot. Wall clock only; never wire this to a file watch.
-  launchd.agents.cliproxyapi-backup = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.cliproxyapi-backup = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [
@@ -144,7 +148,7 @@ in
   };
 
   # Keychain sync - extract Claude/Codex OAuth from local stores into auth dir
-  launchd.agents.cliproxyapi-keychain-sync = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.cliproxyapi-keychain-sync = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [
@@ -168,7 +172,7 @@ in
   };
 
   # Periodic sync - pull auth files from S3 every 5 minutes
-  launchd.agents.cliproxyapi-sync = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.cliproxyapi-sync = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [

--- a/home-manager/services/code-syncer/default.nix
+++ b/home-manager/services/code-syncer/default.nix
@@ -3,7 +3,7 @@ let
   inherit (pkgs) lib;
 in
 {
-  launchd.agents.code-syncer = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.code-syncer = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [

--- a/home-manager/services/docker-postgres/default.nix
+++ b/home-manager/services/docker-postgres/default.nix
@@ -23,7 +23,7 @@ let
   );
 in
 lib.mkIf enabled {
-  launchd.agents.docker-postgres = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.docker-postgres = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [

--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -91,7 +91,7 @@ lib.mkIf clientEnabled {
 
   # GUI applications do not source shell session variables. Seed launchd's
   # per-user environment so newly launched agent daemons use Kyber directly.
-  launchd.agents.beads-dolt-client-environment = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.beads-dolt-client-environment = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [
@@ -108,7 +108,7 @@ lib.mkIf clientEnabled {
     executable = true;
   };
 
-  launchd.agents.dolt = lib.mkIf (pkgs.stdenv.isDarwin && serverEnabled) {
+  launchd.agents.dolt = lib.mkIf (pkgs.stdenv.hostPlatform.isDarwin && serverEnabled) {
     enable = true;
     config = {
       ProgramArguments = [
@@ -127,7 +127,7 @@ lib.mkIf clientEnabled {
   # is visible in the GitHub UI (Dolt's native push only writes refs/dolt/data).
   # Triggered by manifest changes inside dolt's noms store; throttled to avoid
   # hammering on rapid writes.
-  launchd.agents.dolt-backup-main = lib.mkIf (pkgs.stdenv.isDarwin && publisherEnabled) {
+  launchd.agents.dolt-backup-main = lib.mkIf (pkgs.stdenv.hostPlatform.isDarwin && publisherEnabled) {
     enable = true;
     config = {
       ProgramArguments = [
@@ -144,60 +144,64 @@ lib.mkIf clientEnabled {
     };
   };
 
-  launchd.agents.dolt-linear-sync = lib.mkIf (pkgs.stdenv.isDarwin && linearSyncEnabled) {
-    enable = true;
-    config = {
-      ProgramArguments = [
-        "${pkgs.bash}/bin/bash"
-        "${linearSyncScript}"
-      ];
-      StartInterval = linearSyncIntervalSeconds;
-      ThrottleInterval = linearSyncIntervalSeconds;
-      RunAtLoad = true;
-      WorkingDirectory = homeDir;
-      EnvironmentVariables = {
-        HOME = homeDir;
-        PATH = linearSyncPath;
-        BEADS_DOLT_AUTO_START = "0";
-        BEADS_DOLT_SERVER_MODE = "1";
-        BEADS_DOLT_SERVER_HOST = doltServerHost;
-        BEADS_DOLT_SERVER_PORT = "3307";
-        BEADS_DOLT_SERVER_USER = "root";
-        DOLT_CLI_USER = "root";
-        DOLT_CLI_PASSWORD = "";
-        LINEAR_TEAM_ID = linearTeamId;
+  launchd.agents.dolt-linear-sync =
+    lib.mkIf (pkgs.stdenv.hostPlatform.isDarwin && linearSyncEnabled)
+      {
+        enable = true;
+        config = {
+          ProgramArguments = [
+            "${pkgs.bash}/bin/bash"
+            "${linearSyncScript}"
+          ];
+          StartInterval = linearSyncIntervalSeconds;
+          ThrottleInterval = linearSyncIntervalSeconds;
+          RunAtLoad = true;
+          WorkingDirectory = homeDir;
+          EnvironmentVariables = {
+            HOME = homeDir;
+            PATH = linearSyncPath;
+            BEADS_DOLT_AUTO_START = "0";
+            BEADS_DOLT_SERVER_MODE = "1";
+            BEADS_DOLT_SERVER_HOST = doltServerHost;
+            BEADS_DOLT_SERVER_PORT = "3307";
+            BEADS_DOLT_SERVER_USER = "root";
+            DOLT_CLI_USER = "root";
+            DOLT_CLI_PASSWORD = "";
+            LINEAR_TEAM_ID = linearTeamId;
+          };
+          StandardOutPath = "/tmp/dolt-linear-sync.log";
+          StandardErrorPath = "/tmp/dolt-linear-sync.error.log";
+        };
       };
-      StandardOutPath = "/tmp/dolt-linear-sync.log";
-      StandardErrorPath = "/tmp/dolt-linear-sync.error.log";
-    };
-  };
 
-  launchd.agents.dolt-federation-sync = lib.mkIf (pkgs.stdenv.isDarwin && federationSyncEnabled) {
-    enable = true;
-    config = {
-      ProgramArguments = [
-        "${pkgs.bash}/bin/bash"
-        "${federationSyncScript}"
-      ];
-      StartInterval = federationSyncIntervalSeconds;
-      ThrottleInterval = federationSyncIntervalSeconds;
-      RunAtLoad = true;
-      WorkingDirectory = homeDir;
-      EnvironmentVariables = {
-        HOME = homeDir;
-        PATH = linearSyncPath;
-        BEADS_DOLT_AUTO_START = "0";
-        BEADS_DOLT_SERVER_MODE = "1";
-        BEADS_DOLT_SERVER_HOST = doltServerHost;
-        BEADS_DOLT_SERVER_PORT = "3307";
-        BEADS_DOLT_SERVER_USER = "root";
-        DOLT_CLI_USER = "root";
-        DOLT_CLI_PASSWORD = "";
+  launchd.agents.dolt-federation-sync =
+    lib.mkIf (pkgs.stdenv.hostPlatform.isDarwin && federationSyncEnabled)
+      {
+        enable = true;
+        config = {
+          ProgramArguments = [
+            "${pkgs.bash}/bin/bash"
+            "${federationSyncScript}"
+          ];
+          StartInterval = federationSyncIntervalSeconds;
+          ThrottleInterval = federationSyncIntervalSeconds;
+          RunAtLoad = true;
+          WorkingDirectory = homeDir;
+          EnvironmentVariables = {
+            HOME = homeDir;
+            PATH = linearSyncPath;
+            BEADS_DOLT_AUTO_START = "0";
+            BEADS_DOLT_SERVER_MODE = "1";
+            BEADS_DOLT_SERVER_HOST = doltServerHost;
+            BEADS_DOLT_SERVER_PORT = "3307";
+            BEADS_DOLT_SERVER_USER = "root";
+            DOLT_CLI_USER = "root";
+            DOLT_CLI_PASSWORD = "";
+          };
+          StandardOutPath = "/tmp/dolt-federation-sync.log";
+          StandardErrorPath = "/tmp/dolt-federation-sync.error.log";
+        };
       };
-      StandardOutPath = "/tmp/dolt-federation-sync.log";
-      StandardErrorPath = "/tmp/dolt-federation-sync.error.log";
-    };
-  };
 
   systemd.user.services.dolt = lib.mkIf (pkgs.stdenv.isLinux && serverEnabled) {
     Unit = {

--- a/home-manager/services/dotfiles-updater/default.nix
+++ b/home-manager/services/dotfiles-updater/default.nix
@@ -10,7 +10,7 @@ let
       null;
 in
 {
-  launchd.agents.dotfiles-updater = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.dotfiles-updater = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [

--- a/home-manager/services/make-updater/default.nix
+++ b/home-manager/services/make-updater/default.nix
@@ -3,7 +3,7 @@ let
   inherit (pkgs) lib;
 in
 {
-  launchd.agents.make-updater = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.make-updater = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [

--- a/home-manager/services/mempalace-exporter/default.nix
+++ b/home-manager/services/mempalace-exporter/default.nix
@@ -8,7 +8,7 @@ let
   ];
 in
 {
-  launchd.agents.mempalace-exporter = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.mempalace-exporter = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [

--- a/home-manager/services/moshi-hook/default.nix
+++ b/home-manager/services/moshi-hook/default.nix
@@ -6,7 +6,7 @@
 let
   inherit (pkgs) lib;
   moshiHookBin =
-    if pkgs.stdenv.isDarwin then
+    if pkgs.stdenv.hostPlatform.isDarwin then
       config.lib.file.mkOutOfStoreSymlink "/opt/homebrew/bin/moshi-hook"
     else
       "${pkgs.moshi-hook}/bin/moshi-hook";

--- a/home-manager/services/neverssl-keepalive/default.nix
+++ b/home-manager/services/neverssl-keepalive/default.nix
@@ -4,7 +4,7 @@ let
 in
 {
   # macOS (launchd)
-  launchd.agents.neverssl-keepalive = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.neverssl-keepalive = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [

--- a/home-manager/services/night-shift/default.nix
+++ b/home-manager/services/night-shift/default.nix
@@ -15,7 +15,7 @@ in
   #
   # RunAtLoad without a StartInterval deliberately makes this a default rather
   # than an enforcement: a manual toggle sticks until the next login.
-  launchd.agents.night-shift = pkgs.lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.night-shift = pkgs.lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [

--- a/home-manager/services/ollama/default.nix
+++ b/home-manager/services/ollama/default.nix
@@ -35,7 +35,7 @@ in
 lib.mkIf enabled {
   home.packages = [ ollamaPackage ];
 
-  launchd.agents.ollama = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.ollama = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [

--- a/home-manager/services/qmd/default.nix
+++ b/home-manager/services/qmd/default.nix
@@ -18,7 +18,7 @@ lib.mkIf enabled {
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${qmdBin}" "${wikiDir}"
   '';
 
-  launchd.agents.qmd = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.qmd = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [

--- a/home-manager/services/roborev/default.nix
+++ b/home-manager/services/roborev/default.nix
@@ -18,7 +18,7 @@ lib.mkIf enabled {
     $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate.sh}" "${dataDir}"
   '';
 
-  launchd.agents.roborev = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.roborev = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [

--- a/home-manager/services/screenshot-clipboard/default.nix
+++ b/home-manager/services/screenshot-clipboard/default.nix
@@ -5,7 +5,7 @@ let
   logDir = "${config.home.homeDirectory}/Library/Logs";
 in
 {
-  launchd.agents.screenshot-clipboard = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.screenshot-clipboard = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [

--- a/home-manager/services/tmux-session-logger/default.nix
+++ b/home-manager/services/tmux-session-logger/default.nix
@@ -9,7 +9,7 @@ let
   ];
 in
 {
-  launchd.agents.tmux-session-logger = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.tmux-session-logger = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [

--- a/home-manager/services/tokscale/default.nix
+++ b/home-manager/services/tokscale/default.nix
@@ -26,7 +26,7 @@ let
 in
 {
   # macOS (launchd)
-  launchd.agents.tokscale = lib.mkIf pkgs.stdenv.isDarwin {
+  launchd.agents.tokscale = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
     enable = true;
     config = {
       ProgramArguments = [

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -182,8 +182,9 @@ import ../../hosts/nixos {
           fprintAuth = true;
           enableGnomeKeyring = true;
           rules.session = {
-            # Run after pam_gnome_keyring (which starts the daemon but can't unlock
-            # on fingerprint login). Decrypts the TPM2 credential and sends the
+            # Run after greetd's login include, whose session stack runs
+            # pam_gnome_keyring (which starts the daemon but can't unlock on
+            # fingerprint login). Decrypts the TPM2 credential and sends the
             # password to the running daemon via the control socket protocol.
             gnome_keyring_tpm_unlock =
               let
@@ -222,7 +223,7 @@ import ../../hosts/nixos {
                 );
               in
               {
-                order = config.security.pam.services.greetd.rules.session.gnome_keyring.order + 10;
+                order = config.security.pam.services.greetd.rules.session.login.order + 10;
                 control = "optional";
                 modulePath = "${pkgs.pam}/lib/security/pam_exec.so";
                 args = [

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -158,7 +158,7 @@
         nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ prev.cmake ];
       });
     }
-    // prev.lib.optionalAttrs (prev ? vector && prev.stdenv.isDarwin) {
+    // prev.lib.optionalAttrs (prev ? vector && prev.stdenv.hostPlatform.isDarwin) {
       # Vector 0.58.0's timing-sensitive check suite is unstable under the
       # Darwin Nix sandbox (exec shutdown, file rotation, and adaptive
       # concurrency tests failed across otherwise-green 2,400+ test runs).
@@ -179,14 +179,14 @@
       version = "0.4.57";
       src = prev.fetchurl {
         url = "https://clireleases.blacksmith.sh/cli/v${version}/${
-          if prev.stdenv.isDarwin then "darwin" else "linux"
+          if prev.stdenv.hostPlatform.isDarwin then "darwin" else "linux"
         }/${if prev.stdenv.hostPlatform.isAarch64 then "arm64" else "amd64"}/blacksmith";
         sha256 =
           if prev.stdenv.isLinux && prev.stdenv.hostPlatform.isx86_64 then
             "7f60f3b9f8d4d7644d9743f5d962acb3b3dbf675f51676702e5f292e02060bca"
           else if prev.stdenv.isLinux && prev.stdenv.hostPlatform.isAarch64 then
             "04c8d261526e23c7791f05b8acec8f02b9d1fe67c35a1adcf28076627327270a"
-          else if prev.stdenv.isDarwin && prev.stdenv.hostPlatform.isAarch64 then
+          else if prev.stdenv.hostPlatform.isDarwin && prev.stdenv.hostPlatform.isAarch64 then
             "607b0f4413e426574527446c7718ea32587d57b24a3ea0749e1ab4138a426584"
           else
             "47281f402ff223f85e5165ea9018cd0281a727f19c69af8121ae4b09658ad313";
@@ -203,14 +203,14 @@
       version = "0.47.0";
       src = prev.fetchurl {
         url = "https://github.com/openclaw/crabbox/releases/download/v${version}/crabbox_${version}_${
-          if prev.stdenv.isDarwin then "darwin" else "linux"
+          if prev.stdenv.hostPlatform.isDarwin then "darwin" else "linux"
         }_${if prev.stdenv.hostPlatform.isAarch64 then "arm64" else "amd64"}.tar.gz";
         sha256 =
           if prev.stdenv.isLinux && prev.stdenv.hostPlatform.isx86_64 then
             "e513ba473be4eaaadf16f88fe030a03e6a11c0b49a088941fcccdbf3a09247ad"
           else if prev.stdenv.isLinux && prev.stdenv.hostPlatform.isAarch64 then
             "94a388cd7301c7ba1d7e42d8c55d68c6b9dd55025e79cf247c58d659aa5039d4"
-          else if prev.stdenv.isDarwin && prev.stdenv.hostPlatform.isAarch64 then
+          else if prev.stdenv.hostPlatform.isDarwin && prev.stdenv.hostPlatform.isAarch64 then
             "ef1567083f6bd0d01b2539efdd69ccd205c2642e7d9eefb073d58052e8a7bb91"
           else
             "642995363f7d6c367859e77f80eb66468ef2ed380d1e7ea4ae737f7deeb986d4";
@@ -220,9 +220,11 @@
       dontBuild = true;
       installPhase = ''
         install -Dm755 crabbox $out/bin/crabbox
-        ${prev.lib.optionalString (prev.stdenv.isDarwin && prev.stdenv.hostPlatform.isAarch64) ''
-          install -Dm755 crabbox-apple-vm-helper $out/bin/crabbox-apple-vm-helper
-        ''}
+        ${prev.lib.optionalString (prev.stdenv.hostPlatform.isDarwin && prev.stdenv.hostPlatform.isAarch64)
+          ''
+            install -Dm755 crabbox-apple-vm-helper $out/bin/crabbox-apple-vm-helper
+          ''
+        }
       '';
       meta.mainProgram = "crabbox";
     };
@@ -232,14 +234,14 @@
       version = "0.3.16";
       src = prev.fetchurl {
         url = "https://cdn.getmoshi.app/hook/v${version}/moshi-hook_${
-          if prev.stdenv.isDarwin then "Darwin" else "Linux"
+          if prev.stdenv.hostPlatform.isDarwin then "Darwin" else "Linux"
         }_${if prev.stdenv.hostPlatform.isAarch64 then "arm64" else "x86_64"}.tar.gz";
         sha256 =
           if prev.stdenv.isLinux && prev.stdenv.hostPlatform.isx86_64 then
             "ee96ff3cebe68648a9631976660afa4a7a247cfa2cc8c030d9d5eca784df5a95"
           else if prev.stdenv.isLinux && prev.stdenv.hostPlatform.isAarch64 then
             "8df6d83dcd1aa99c42e7516937f29249f3a8f704d9d9d7eec703fa2287a88666"
-          else if prev.stdenv.isDarwin && prev.stdenv.hostPlatform.isAarch64 then
+          else if prev.stdenv.hostPlatform.isDarwin && prev.stdenv.hostPlatform.isAarch64 then
             "173550c6437e6663dbdf43736fc9cbca2a5af8acf7c3d61b2c3a97c4963cf596"
           else
             "608c8af54a5d7add4e6d58ce2d1b5b3ea0ba536fd8b7e57d947b5f9f244e8311";


### PR DESCRIPTION
## Summary

- migrate repository-owned deprecated `stdenv.isDarwin` checks to `stdenv.hostPlatform.isDarwin`
- order the Matic GNOME Keyring TPM unlock hook after greetd's `login` PAM include, which owns the keyring session rule
- preserve the existing TPM unlock behavior while matching the current nixpkgs PAM contract

## Verification

- `make nix-format-check`
- `git diff --check`
- no tracked Nix source references `stdenv.isDarwin`
- rendered greetd PAM order: `login` 10100, TPM unlock 10110
- full `nix build .#nixosConfigurations.matic.config.system.build.toplevel --impure --no-link`

Bead: shunkakinokisoftware-8htj

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates all repository-owned `stdenv.isDarwin` checks to `stdenv.hostPlatform.isDarwin` so Nix evaluation succeeds on current nixpkgs, and fixes the Matic GNOME Keyring TPM unlock PAM hook ordering.

The platform migration is mechanical and behavior-preserving across 38 files, covering launchd agents, home packages, shell configs, and overlays. The PAM fix is the one behavioral change: the TPM unlock hook now orders after greetd's `login` session include (order 10110) instead of the `gnome_keyring` rule, since `login` owns the keyring session rule in current nixpkgs. TPM unlock on fingerprint login is preserved.

<sup>Written for commit bdf455218716fea8fe745f223b2d661540408b85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

