### PR TITLE
fix(roborev): automate review triage

### DIFF
--- a/config/roborev/config.template.toml
+++ b/config/roborev/config.template.toml
@@ -54,9 +54,8 @@ batch_timeout = "0"
 repos = ["__ROBOREV_REPOS__"]
 
 [agent_hook]
-# Surface any open failed review without automatically invoking a fixer.
-# Keep turn and commit triggers explicitly disabled.
+# Surface failed reviews for autonomous triage without broad turn or commit triggers.
 turn_threshold = 0
 commit_threshold = 0
 failed_review_threshold = 1
-instruction = "Inspect open RoboRev findings read-only. Report proposed changes and ask the user for explicit approval. Do not edit files, run a fixer, commit, or close reviews before approval."
+instruction = "Inspect open RoboRev findings and triage them autonomously. Implement sound findings or decline incorrect, stale, duplicative, or out-of-scope findings; document the disposition, revalidate edits, and continue without asking for approval. Escalate only security-sensitive findings, scope expansion beyond PR intent, or operator-gated surfaces."

--- a/spec/roborev_hydrate_spec.sh
+++ b/spec/roborev_hydrate_spec.sh
@@ -85,7 +85,7 @@ repos = ["__ROBOREV_REPOS__"]
 turn_threshold = 0
 commit_threshold = 0
 failed_review_threshold = 1
-instruction = "Inspect open RoboRev findings read-only. Report proposed changes and ask the user for explicit approval. Do not edit files, run a fixer, commit, or close reviews before approval."
+instruction = "Inspect open RoboRev findings and triage them autonomously. Implement sound findings or decline incorrect, stale, duplicative, or out-of-scope findings; document the disposition, revalidate edits, and continue without asking for approval. Escalate only security-sensitive findings, scope expansion beyond PR intent, or operator-gated surfaces."
 TOML
 
   cat >"$TEMP_HOME/dotfiles/.env" <<'ENV'
@@ -144,16 +144,17 @@ The status should be success
 The output should include 'max_workers = 4'
 End
 
-It 'hydrates the complete approval gate'
+It 'hydrates the autonomous review triage contract'
 When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; cat "'"$TEMP_HOME"'/.roborev/config.toml"'
 The status should be success
 The output should include 'turn_threshold = 0'
 The output should include 'commit_threshold = 0'
 The output should include 'failed_review_threshold = 1'
-The output should include 'Inspect open RoboRev findings read-only.'
-The output should include 'ask the user for explicit approval.'
-The output should include 'Do not edit files, run a fixer, commit, or close reviews before approval.'
-The output should not include 'roborev-fix'
+The output should include 'triage them autonomously.'
+The output should include 'Implement sound findings or decline incorrect, stale, duplicative, or out-of-scope findings'
+The output should include 'continue without asking for approval.'
+The output should include 'Escalate only security-sensitive findings, scope expansion beyond PR intent, or operator-gated surfaces.'
+The output should not include 'ask the user for explicit approval'
 End
 
 It 'installs native hooks in each configured local checkout'


### PR DESCRIPTION
## Summary

- replace the failed-review approval pause with autonomous implement-or-decline triage
- retain escalation for security-sensitive, scope-expanding, and operator-gated findings
- update the hydration fixture and assertions to pin the generated hook contract

## Verification

- `shellspec spec/roborev_hydrate_spec.sh --format documentation` (17 examples, 0 failures)
- `git diff --check`

## Tracking

- Bead: `shunkakinokisoftware-04d8`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the failed-review approval pause with autonomous implement-or-decline triage while keeping escalation for security-sensitive, scope-expanding, or operator-gated findings.

- Updates the `agent_hook` instruction to triage findings autonomously instead of pausing for explicit approval.
- Pins the new hook contract in the hydration spec and fixture.

<sup>Written for commit b91c91fca4158eb6a774853e7799978f742ef3fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

