### PR TITLE
fix(roborev): use default hook policy

### DIFF
--- a/config/roborev/config.template.toml
+++ b/config/roborev/config.template.toml
@@ -54,8 +54,8 @@ batch_timeout = "0"
 repos = ["__ROBOREV_REPOS__"]
 
 [agent_hook]
-# Surface failed reviews for autonomous triage without broad turn or commit triggers.
+# Surface failed reviews without broad turn or commit triggers. RoboRev owns the
+# continuation instruction so its hook behavior stays aligned with the CLI.
 turn_threshold = 0
 commit_threshold = 0
 failed_review_threshold = 1
-instruction = "Inspect open RoboRev findings and triage them autonomously. Implement sound findings or decline incorrect, stale, duplicative, or out-of-scope findings; document the disposition, revalidate edits, and continue without asking for approval. Escalate only security-sensitive findings, scope expansion beyond PR intent, or operator-gated surfaces."

--- a/spec/beads_federation_sync_spec.sh
+++ b/spec/beads_federation_sync_spec.sh
@@ -133,7 +133,7 @@ The status should be success
 End
 
 It 'serves Dolt locally on every client host'
-When run bash -c "grep -F 'serverEnabled = clientEnabled;' '$MODULE' >/dev/null && grep -F 'pkgs.stdenv.isLinux && serverEnabled' '$MODULE' >/dev/null && grep -F 'pkgs.stdenv.isDarwin && serverEnabled' '$MODULE' >/dev/null"
+When run bash -c "grep -F 'serverEnabled = clientEnabled;' '$MODULE' >/dev/null && grep -F 'pkgs.stdenv.isLinux && serverEnabled' '$MODULE' >/dev/null && grep -F 'pkgs.stdenv.hostPlatform.isDarwin && serverEnabled' '$MODULE' >/dev/null"
 The status should be success
 End
 

--- a/spec/moshi_hook_spec.sh
+++ b/spec/moshi_hook_spec.sh
@@ -20,7 +20,7 @@ End
 
 It 'uses Homebrew moshi-hook on Darwin'
 When run cat "$MODULE"
-The output should include 'pkgs.stdenv.isDarwin'
+The output should include 'pkgs.stdenv.hostPlatform.isDarwin'
 The output should include '/opt/homebrew/bin/moshi-hook'
 End
 

--- a/spec/roborev_hydrate_spec.sh
+++ b/spec/roborev_hydrate_spec.sh
@@ -85,7 +85,6 @@ repos = ["__ROBOREV_REPOS__"]
 turn_threshold = 0
 commit_threshold = 0
 failed_review_threshold = 1
-instruction = "Inspect open RoboRev findings and triage them autonomously. Implement sound findings or decline incorrect, stale, duplicative, or out-of-scope findings; document the disposition, revalidate edits, and continue without asking for approval. Escalate only security-sensitive findings, scope expansion beyond PR intent, or operator-gated surfaces."
 TOML
 
   cat >"$TEMP_HOME/dotfiles/.env" <<'ENV'
@@ -144,17 +143,13 @@ The status should be success
 The output should include 'max_workers = 4'
 End
 
-It 'hydrates the autonomous review triage contract'
+It 'hydrates the review trigger without overriding RoboRev instructions'
 When run bash -c 'HOME="'"$TEMP_HOME"'" bash "'"$PREPROCESSED_SCRIPT"'" >/dev/null 2>&1; cat "'"$TEMP_HOME"'/.roborev/config.toml"'
 The status should be success
 The output should include 'turn_threshold = 0'
 The output should include 'commit_threshold = 0'
 The output should include 'failed_review_threshold = 1'
-The output should include 'triage them autonomously.'
-The output should include 'Implement sound findings or decline incorrect, stale, duplicative, or out-of-scope findings'
-The output should include 'continue without asking for approval.'
-The output should include 'Escalate only security-sensitive findings, scope expansion beyond PR intent, or operator-gated surfaces.'
-The output should not include 'ask the user for explicit approval'
+The output should not include 'instruction ='
 End
 
 It 'installs native hooks in each configured local checkout'


### PR DESCRIPTION
## Summary

- remove the custom RoboRev agent-hook instruction and retain the failed-review trigger
- let the installed RoboRev CLI own its continuation policy so developer instructions do not drift from the tool
- update Dolt and Moshi Hook ShellSpec assertions for the current `hostPlatform.isDarwin` predicates

## CI failure addressed

- [Shell run 33464187128](https://github.com/shunkakinoki/dotfiles/actions/runs/33464187128) failed on the two stale platform assertions now updated in this batch

## Verification

- `shellspec spec/roborev_hydrate_spec.sh spec/beads_federation_sync_spec.sh spec/moshi_hook_spec.sh --format documentation --jobs 1` — 37 examples, 0 failures
- `env -u AMP_API_KEY shellspec --format progress --jobs 1` — 2,447 examples, 0 failures
- `git diff --check`

## Tracking

- Bead: `shunkakinokisoftware-gvlc`
- Follow-up to #2572

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the custom RoboRev agent-hook instruction so the CLI owns its continuation policy, and updates stale platform assertions in Dolt and Moshi hook specs to fix a failing CI run.

<sup>Written for commit c2c641eccefe7f9e37648fddd83ad38a94a43988. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

