### PR TITLE
fix(nix): use stdenv.hostPlatform.isLinux instead of deprecated stdenv.isLinux

### DIFF
--- a/config/cursor/default.nix
+++ b/config/cursor/default.nix
@@ -7,7 +7,7 @@
 {
   # CAAM invokes Cursor by its canonical provider name. Headless Linux hosts
   # only install Cursor Agent, so expose it at that canonical path.
-  home.file.".local/bin/cursor" = lib.mkIf pkgs.stdenv.isLinux {
+  home.file.".local/bin/cursor" = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.local/bin/cursor-agent";
     force = true;
   };

--- a/config/gtk/default.nix
+++ b/config/gtk/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 {
-  gtk = lib.mkIf pkgs.stdenv.isLinux {
+  gtk = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     enable = true;
     theme = {
       name = "Adwaita";

--- a/config/llm/default.nix
+++ b/config/llm/default.nix
@@ -24,13 +24,13 @@ in
   };
 
   home.file.".config/io.datasette.llm/extra-openai-models.yaml" = {
-    enable = pkgs.stdenv.isLinux;
+    enable = pkgs.stdenv.hostPlatform.isLinux;
     source = ./extra-openai-models.yaml;
     force = true;
   };
 
   home.file.".config/io.datasette.llm/default_model.txt" = {
-    enable = pkgs.stdenv.isLinux;
+    enable = pkgs.stdenv.hostPlatform.isLinux;
     source = ./default_model.txt;
     force = true;
   };

--- a/home-manager/default.nix
+++ b/home-manager/default.nix
@@ -35,7 +35,7 @@ in
     ++ [
       inputs.agenix.homeManagerModules.default
     ]
-    ++ lib.optionals (pkgs.stdenv.isLinux && inputs.host.isDesktop) [
+    ++ lib.optionals (pkgs.stdenv.hostPlatform.isLinux && inputs.host.isDesktop) [
       inputs.handy.homeManagerModules.default
       {
         services.handy = {
@@ -46,7 +46,7 @@ in
     ];
 
   home.username = username;
-  home.homeDirectory = lib.mkIf pkgs.stdenv.isLinux "/home/${username}";
+  home.homeDirectory = lib.mkIf pkgs.stdenv.hostPlatform.isLinux "/home/${username}";
   home.packages = packages;
   home.stateVersion = "24.11";
 

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -142,7 +142,7 @@ with pkgs;
 ++ lib.optionals stdenv.hostPlatform.isDarwin [
   darwin.trash
 ]
-++ lib.optionals stdenv.isLinux [
+++ lib.optionals stdenv.hostPlatform.isLinux [
   atop
   below
   binutils
@@ -179,14 +179,14 @@ with pkgs;
   xdg-utils
   zlib
 ]
-++ lib.optionals (stdenv.isLinux && !isRunner) [
+++ lib.optionals (stdenv.hostPlatform.isLinux && !isRunner) [
   (if isDesktop then llama-cpp.override { vulkanSupport = true; } else llama-cpp)
 ]
 ++ lib.optionals (stdenv.hostPlatform.system != "aarch64-linux") [
   qwen-code
 ]
-++ lib.optionals stdenv.isLinux [ alsa-lib ]
-++ lib.optionals (stdenv.isLinux && isDesktop) [
+++ lib.optionals stdenv.hostPlatform.isLinux [ alsa-lib ]
+++ lib.optionals (stdenv.hostPlatform.isLinux && isDesktop) [
   _1password-gui
   baobab
   blueman

--- a/home-manager/programs/bash/default.nix
+++ b/home-manager/programs/bash/default.nix
@@ -78,7 +78,7 @@
           export CGO_LDFLAGS="-L${pkgs.icu.out}/lib''${CGO_LDFLAGS:+ $CGO_LDFLAGS}"
 
           # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)
-          export LD_LIBRARY_PATH="${lib.optionalString pkgs.stdenv.isLinux "${pkgs.alsa-lib}/lib:"}${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.nspr}/lib:${pkgs.nss}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+          export LD_LIBRARY_PATH="${lib.optionalString pkgs.stdenv.hostPlatform.isLinux "${pkgs.alsa-lib}/lib:"}${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.nspr}/lib:${pkgs.nss}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
       fi
 
       # Go configuration
@@ -131,7 +131,7 @@
           export CGO_LDFLAGS="-L${pkgs.icu.out}/lib''${CGO_LDFLAGS:+ $CGO_LDFLAGS}"
 
           # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)
-          export LD_LIBRARY_PATH="${lib.optionalString pkgs.stdenv.isLinux "${pkgs.alsa-lib}/lib:"}${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.nspr}/lib:${pkgs.nss}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+          export LD_LIBRARY_PATH="${lib.optionalString pkgs.stdenv.hostPlatform.isLinux "${pkgs.alsa-lib}/lib:"}${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.nspr}/lib:${pkgs.nss}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
       fi
 
       # Source .bashrc for login shells to get PATH and other settings

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -48,7 +48,7 @@
           set -gx CGO_LDFLAGS "-L${pkgs.icu.out}/lib $CGO_LDFLAGS"
 
           # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)
-          set -gx LD_LIBRARY_PATH ${lib.optionalString pkgs.stdenv.isLinux ''"${pkgs.alsa-lib}/lib"''} "${pkgs.glib.out}/lib" "${pkgs.libsecret}/lib" "${pkgs.nspr}/lib" "${pkgs.nss}/lib" "${pkgs.stdenv.cc.cc.lib}/lib" "${pkgs.zlib}/lib" $LD_LIBRARY_PATH
+          set -gx LD_LIBRARY_PATH ${lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''"${pkgs.alsa-lib}/lib"''} "${pkgs.glib.out}/lib" "${pkgs.libsecret}/lib" "${pkgs.nspr}/lib" "${pkgs.nss}/lib" "${pkgs.stdenv.cc.cc.lib}/lib" "${pkgs.zlib}/lib" $LD_LIBRARY_PATH
       end
 
       # Go configuration

--- a/home-manager/programs/k8s/default.nix
+++ b/home-manager/programs/k8s/default.nix
@@ -11,10 +11,10 @@
       kustomize
       stern
     ]
-    ++ lib.optionals stdenv.isLinux [
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
       k3s
     ]
-    ++ lib.optionals (!stdenv.isLinux) [
+    ++ lib.optionals (!stdenv.hostPlatform.isLinux) [
       kubectl
     ];
 }

--- a/home-manager/programs/zsh/default.nix
+++ b/home-manager/programs/zsh/default.nix
@@ -53,7 +53,7 @@
           export CGO_LDFLAGS="-L${pkgs.icu.out}/lib''${CGO_LDFLAGS:+ $CGO_LDFLAGS}"
 
           # Native libraries for bun-installed packages (e.g. @oh-my-pi/pi-natives, sharp, keytar)
-          export LD_LIBRARY_PATH="${lib.optionalString pkgs.stdenv.isLinux "${pkgs.alsa-lib}/lib:"}${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.nspr}/lib:${pkgs.nss}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+          export LD_LIBRARY_PATH="${lib.optionalString pkgs.stdenv.hostPlatform.isLinux "${pkgs.alsa-lib}/lib:"}${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.nspr}/lib:${pkgs.nss}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.zlib}/lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
       fi
 
       # Define aliases in .zshenv so non-interactive zsh invocations can use them.

--- a/home-manager/services/caam/default.nix
+++ b/home-manager/services/caam/default.nix
@@ -58,7 +58,7 @@ in
     };
   };
 
-  systemd.user.services.caam-daemon = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.caam-daemon = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "CAAM token refresh daemon";
       After = [ "network-online.target" ];
@@ -79,7 +79,7 @@ in
     };
   };
 
-  systemd.user.services.caam-sync = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.caam-sync = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "CAAM multi-machine vault sync";
       After = [ "network-online.target" ];
@@ -96,7 +96,7 @@ in
     };
   };
 
-  systemd.user.timers.caam-sync = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.timers.caam-sync = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "Periodic CAAM vault sync";
     };

--- a/home-manager/services/cass/default.nix
+++ b/home-manager/services/cass/default.nix
@@ -34,7 +34,7 @@ in
     };
   };
 
-  systemd.user.services.cass-daily = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.cass-daily = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "cass daily remote sync and analytics rebuild";
       X-SwitchMethod = "keep-old";
@@ -50,7 +50,7 @@ in
     };
   };
 
-  systemd.user.timers.cass-daily = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.timers.cass-daily = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "cass daily sync timer";
     };

--- a/home-manager/services/cliproxyapi/default.nix
+++ b/home-manager/services/cliproxyapi/default.nix
@@ -195,7 +195,7 @@ in
   };
 
   # Linux systemd
-  systemd.user.services.cliproxyapi = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.cliproxyapi = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "CLI Proxy API server";
       After = [
@@ -231,7 +231,7 @@ in
     Install.WantedBy = [ "default.target" ];
   };
 
-  systemd.user.paths.cliproxyapi-backup-auth = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.paths.cliproxyapi-backup-auth = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit.Description = "Watch auth directories for changes";
     Path = {
       PathChanged = [
@@ -245,7 +245,7 @@ in
   # CLIProxyAPI rewrites auth files on every token refresh, so the path unit
   # fires many times an hour. It gets the auth-only entrypoint and a PATH
   # without sqlite/tar so the analytics snapshot cannot ride along.
-  systemd.user.services.cliproxyapi-backup-auth = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.cliproxyapi-backup-auth = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit.Description = "CLIProxyAPI auth backup";
     Unit.X-SwitchMethod = "keep-old";
     Service = {
@@ -262,7 +262,7 @@ in
     };
   };
 
-  systemd.user.services.cliproxyapi-backup = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.cliproxyapi-backup = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit.Description = "CLIProxyAPI auth and CPA Manager Plus analytics backup";
     Unit.X-SwitchMethod = "keep-old";
     Service = {
@@ -282,7 +282,7 @@ in
     };
   };
 
-  systemd.user.timers.cliproxyapi-backup = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.timers.cliproxyapi-backup = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit.Description = "Periodically back up CLIProxyAPI and CPA Manager Plus data";
     Timer = {
       OnBootSec = "5min";
@@ -294,7 +294,7 @@ in
   };
 
   # Periodic sync - pull auth files from S3 every 5 minutes
-  systemd.user.timers.cliproxyapi-sync = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.timers.cliproxyapi-sync = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit.Description = "Periodically sync auth files from S3";
     Timer = {
       OnBootSec = "1min";
@@ -304,7 +304,7 @@ in
     Install.WantedBy = [ "timers.target" ];
   };
 
-  systemd.user.services.cliproxyapi-sync = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.cliproxyapi-sync = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit.Description = "CLIProxyAPI auth sync from S3";
     Unit.X-SwitchMethod = "keep-old";
     Service = {

--- a/home-manager/services/code-syncer/default.nix
+++ b/home-manager/services/code-syncer/default.nix
@@ -24,7 +24,7 @@ in
     };
   };
 
-  systemd.user.services.code-syncer = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.code-syncer = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "VS Code settings syncer";
     };

--- a/home-manager/services/cpa-manager-plus/default.nix
+++ b/home-manager/services/cpa-manager-plus/default.nix
@@ -15,7 +15,7 @@ let
     start_script = startScript;
   };
 in
-lib.mkIf (pkgs.stdenv.isLinux && host.isKyber) {
+lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && host.isKyber) {
   systemd.user.services.cpa-manager-plus = {
     Unit = {
       Description = "CPA Manager Plus analytics and management server";

--- a/home-manager/services/crabbox/default.nix
+++ b/home-manager/services/crabbox/default.nix
@@ -38,7 +38,7 @@ let
     inherit (pkgs) coreutils curl;
   };
 in
-lib.mkIf (isKyber && pkgs.stdenv.isLinux) {
+lib.mkIf (isKyber && pkgs.stdenv.hostPlatform.isLinux) {
   systemd.user.services.crabbox-postgres = {
     Unit = {
       Description = "Local PostgreSQL for Crabbox";

--- a/home-manager/services/docker-postgres/default.nix
+++ b/home-manager/services/docker-postgres/default.nix
@@ -39,7 +39,7 @@ lib.mkIf enabled {
     };
   };
 
-  systemd.user.services.docker-postgres = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.docker-postgres = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "PostgreSQL Docker container auto-start";
       After = [

--- a/home-manager/services/docker/default.nix
+++ b/home-manager/services/docker/default.nix
@@ -31,7 +31,7 @@ let
 in
 {
   # Provide setup script for system Docker
-  home.packages = lib.mkIf pkgs.stdenv.isLinux [
+  home.packages = lib.mkIf pkgs.stdenv.hostPlatform.isLinux [
     (pkgs.writeShellScriptBin "docker-setup" (
       builtins.readFile (
         pkgs.replaceVars ./docker-setup.sh {

--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -203,7 +203,7 @@ lib.mkIf clientEnabled {
         };
       };
 
-  systemd.user.services.dolt = lib.mkIf (pkgs.stdenv.isLinux && serverEnabled) {
+  systemd.user.services.dolt = lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && serverEnabled) {
     Unit = {
       Description = "Dolt SQL server for dotfiles beads";
       After = [ "network.target" ];
@@ -230,9 +230,9 @@ lib.mkIf clientEnabled {
 
   # Persist the same client selection in the user manager so Herdr, OpenClaw,
   # and other systemd-launched agents do not inherit a stale shared-server mode.
-  systemd.user.sessionVariables = lib.mkIf pkgs.stdenv.isLinux beadsClientEnvironment;
+  systemd.user.sessionVariables = lib.mkIf pkgs.stdenv.hostPlatform.isLinux beadsClientEnvironment;
 
-  systemd.user.services.dolt-backup-main = lib.mkIf (pkgs.stdenv.isLinux && publisherEnabled) {
+  systemd.user.services.dolt-backup-main = lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && publisherEnabled) {
     Unit = {
       Description = "Push beads_global JSONL snapshot to GitHub main";
     };
@@ -243,7 +243,7 @@ lib.mkIf clientEnabled {
     };
   };
 
-  systemd.user.paths.dolt-backup-main = lib.mkIf (pkgs.stdenv.isLinux && publisherEnabled) {
+  systemd.user.paths.dolt-backup-main = lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && publisherEnabled) {
     Unit = {
       Description = "Watch dolt manifest and trigger JSONL backup";
     };
@@ -256,7 +256,7 @@ lib.mkIf clientEnabled {
     };
   };
 
-  systemd.user.services.dolt-linear-sync = lib.mkIf (pkgs.stdenv.isLinux && linearSyncEnabled) {
+  systemd.user.services.dolt-linear-sync = lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && linearSyncEnabled) {
     Unit = {
       Description = "Synchronize Beads with Linear";
       X-SwitchMethod = "restart";
@@ -287,7 +287,7 @@ lib.mkIf clientEnabled {
     };
   };
 
-  systemd.user.timers.dolt-linear-sync = lib.mkIf (pkgs.stdenv.isLinux && linearSyncEnabled) {
+  systemd.user.timers.dolt-linear-sync = lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && linearSyncEnabled) {
     Unit.Description = "Periodically synchronize Beads with Linear";
     Timer = {
       OnBootSec = "4min";
@@ -299,7 +299,7 @@ lib.mkIf clientEnabled {
   };
 
   systemd.user.services.dolt-federation-sync =
-    lib.mkIf (pkgs.stdenv.isLinux && federationSyncEnabled)
+    lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && federationSyncEnabled)
       {
         Unit = {
           Description = "Synchronize Beads with the Dolt remote";
@@ -330,7 +330,7 @@ lib.mkIf clientEnabled {
         };
       };
 
-  systemd.user.timers.dolt-federation-sync = lib.mkIf (pkgs.stdenv.isLinux && federationSyncEnabled) {
+  systemd.user.timers.dolt-federation-sync = lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && federationSyncEnabled) {
     Unit.Description = "Periodically synchronize Beads with the Dolt remote";
     Timer = {
       OnBootSec = "2min";

--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -232,71 +232,79 @@ lib.mkIf clientEnabled {
   # and other systemd-launched agents do not inherit a stale shared-server mode.
   systemd.user.sessionVariables = lib.mkIf pkgs.stdenv.hostPlatform.isLinux beadsClientEnvironment;
 
-  systemd.user.services.dolt-backup-main = lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && publisherEnabled) {
-    Unit = {
-      Description = "Push beads_global JSONL snapshot to GitHub main";
-    };
-    Service = {
-      Type = "oneshot";
-      ExecStart = "${pkgs.bash}/bin/bash ${backupScript}";
-      WorkingDirectory = repoDir;
-    };
-  };
+  systemd.user.services.dolt-backup-main =
+    lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && publisherEnabled)
+      {
+        Unit = {
+          Description = "Push beads_global JSONL snapshot to GitHub main";
+        };
+        Service = {
+          Type = "oneshot";
+          ExecStart = "${pkgs.bash}/bin/bash ${backupScript}";
+          WorkingDirectory = repoDir;
+        };
+      };
 
-  systemd.user.paths.dolt-backup-main = lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && publisherEnabled) {
-    Unit = {
-      Description = "Watch dolt manifest and trigger JSONL backup";
-    };
-    Path = {
-      PathChanged = doltManifest;
-      Unit = "dolt-backup-main.service";
-    };
-    Install = {
-      WantedBy = [ "default.target" ];
-    };
-  };
+  systemd.user.paths.dolt-backup-main =
+    lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && publisherEnabled)
+      {
+        Unit = {
+          Description = "Watch dolt manifest and trigger JSONL backup";
+        };
+        Path = {
+          PathChanged = doltManifest;
+          Unit = "dolt-backup-main.service";
+        };
+        Install = {
+          WantedBy = [ "default.target" ];
+        };
+      };
 
-  systemd.user.services.dolt-linear-sync = lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && linearSyncEnabled) {
-    Unit = {
-      Description = "Synchronize Beads with Linear";
-      X-SwitchMethod = "restart";
-      After = [
-        "dolt.service"
-        "network-online.target"
-      ];
-      Wants = [
-        "dolt.service"
-        "network-online.target"
-      ];
-    };
-    Service = {
-      Type = "oneshot";
-      ExecStart = "${pkgs.bash}/bin/bash ${linearSyncScript}";
-      Environment = [
-        "HOME=${homeDir}"
-        "PATH=${linearSyncPath}"
-        "BEADS_DOLT_AUTO_START=0"
-        "BEADS_DOLT_SERVER_MODE=1"
-        "BEADS_DOLT_SERVER_HOST=${doltServerHost}"
-        "BEADS_DOLT_SERVER_PORT=3307"
-        "BEADS_DOLT_SERVER_USER=root"
-        "DOLT_CLI_USER=root"
-        "DOLT_CLI_PASSWORD="
-        "LINEAR_TEAM_ID=${linearTeamId}"
-      ];
-    };
-  };
+  systemd.user.services.dolt-linear-sync =
+    lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && linearSyncEnabled)
+      {
+        Unit = {
+          Description = "Synchronize Beads with Linear";
+          X-SwitchMethod = "restart";
+          After = [
+            "dolt.service"
+            "network-online.target"
+          ];
+          Wants = [
+            "dolt.service"
+            "network-online.target"
+          ];
+        };
+        Service = {
+          Type = "oneshot";
+          ExecStart = "${pkgs.bash}/bin/bash ${linearSyncScript}";
+          Environment = [
+            "HOME=${homeDir}"
+            "PATH=${linearSyncPath}"
+            "BEADS_DOLT_AUTO_START=0"
+            "BEADS_DOLT_SERVER_MODE=1"
+            "BEADS_DOLT_SERVER_HOST=${doltServerHost}"
+            "BEADS_DOLT_SERVER_PORT=3307"
+            "BEADS_DOLT_SERVER_USER=root"
+            "DOLT_CLI_USER=root"
+            "DOLT_CLI_PASSWORD="
+            "LINEAR_TEAM_ID=${linearTeamId}"
+          ];
+        };
+      };
 
-  systemd.user.timers.dolt-linear-sync = lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && linearSyncEnabled) {
-    Unit.Description = "Periodically synchronize Beads with Linear";
-    Timer = {
-      OnBootSec = "4min";
-      OnCalendar = "*-*-* *:02/15:00";
-      Persistent = true;
-      Unit = "dolt-linear-sync.service";
-    };
-    Install.WantedBy = [ "timers.target" ];
-  };
+  systemd.user.timers.dolt-linear-sync =
+    lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && linearSyncEnabled)
+      {
+        Unit.Description = "Periodically synchronize Beads with Linear";
+        Timer = {
+          OnBootSec = "4min";
+          OnCalendar = "*-*-* *:02/15:00";
+          Persistent = true;
+          Unit = "dolt-linear-sync.service";
+        };
+        Install.WantedBy = [ "timers.target" ];
+      };
 
   systemd.user.services.dolt-federation-sync =
     lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && federationSyncEnabled)
@@ -330,14 +338,16 @@ lib.mkIf clientEnabled {
         };
       };
 
-  systemd.user.timers.dolt-federation-sync = lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && federationSyncEnabled) {
-    Unit.Description = "Periodically synchronize Beads with the Dolt remote";
-    Timer = {
-      OnBootSec = "2min";
-      OnCalendar = "*-*-* *:00/5:00";
-      Persistent = true;
-      Unit = "dolt-federation-sync.service";
-    };
-    Install.WantedBy = [ "timers.target" ];
-  };
+  systemd.user.timers.dolt-federation-sync =
+    lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && federationSyncEnabled)
+      {
+        Unit.Description = "Periodically synchronize Beads with the Dolt remote";
+        Timer = {
+          OnBootSec = "2min";
+          OnCalendar = "*-*-* *:00/5:00";
+          Persistent = true;
+          Unit = "dolt-federation-sync.service";
+        };
+        Install.WantedBy = [ "timers.target" ];
+      };
 }

--- a/home-manager/services/dotfiles-updater/default.nix
+++ b/home-manager/services/dotfiles-updater/default.nix
@@ -32,7 +32,7 @@ in
     };
   };
 
-  systemd.user.services.dotfiles-updater = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.dotfiles-updater = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "Dotfiles auto-updater service";
       X-SwitchMethod = "keep-old";
@@ -63,7 +63,7 @@ in
     };
   };
 
-  systemd.user.timers.dotfiles-updater = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.timers.dotfiles-updater = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "Timer for dotfiles auto-updater";
     };

--- a/home-manager/services/gas-town/default.nix
+++ b/home-manager/services/gas-town/default.nix
@@ -3,7 +3,7 @@ let
   inherit (pkgs) lib;
 in
 {
-  systemd.user.services.gas-town = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.gas-town = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "Gas Town daemon (dolt + tmux + worker orchestration)";
       After = [ "network.target" ];

--- a/home-manager/services/k3s/default.nix
+++ b/home-manager/services/k3s/default.nix
@@ -26,7 +26,7 @@ let
   smartdServiceFile = "${homeDir}/.config/k3s/kyber-smartd.service";
   tmpMountFile = "${homeDir}/.config/k3s/tmp.mount";
 in
-lib.mkIf (pkgs.stdenv.isLinux && host.isK3sServer) {
+lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && host.isK3sServer) {
   home.activation.setupK3s = config.lib.dag.entryAfter [ "writeBoundary" ] ''
     ${pkgs.bash}/bin/bash "${setupScript}" \
       "${serviceFile}" \

--- a/home-manager/services/keyd-application-mapper/default.nix
+++ b/home-manager/services/keyd-application-mapper/default.nix
@@ -12,7 +12,7 @@ in
     enable = lib.mkEnableOption "keyd application mapper user service";
   };
 
-  config = lib.mkIf (pkgs.stdenv.isLinux && cfg.enable) {
+  config = lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && cfg.enable) {
     assertions = [
       {
         assertion = config.xdg.configFile ? "keyd/app.conf";

--- a/home-manager/services/make-updater/default.nix
+++ b/home-manager/services/make-updater/default.nix
@@ -27,7 +27,7 @@ in
     };
   };
 
-  systemd.user.services.make-updater = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.make-updater = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "Make update service";
       X-SwitchMethod = "keep-old";
@@ -76,7 +76,7 @@ in
     };
   };
 
-  systemd.user.timers.make-updater = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.timers.make-updater = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "Timer for make update";
     };

--- a/home-manager/services/mempalace-exporter/default.nix
+++ b/home-manager/services/mempalace-exporter/default.nix
@@ -24,7 +24,7 @@ in
     };
   };
 
-  systemd.user.services.mempalace-exporter = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.mempalace-exporter = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "MemPalace palace export to wiki";
       X-SwitchMethod = "keep-old";
@@ -38,7 +38,7 @@ in
     };
   };
 
-  systemd.user.timers.mempalace-exporter = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.timers.mempalace-exporter = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "Timer for MemPalace palace exporter";
     };

--- a/home-manager/services/moshi-hook/default.nix
+++ b/home-manager/services/moshi-hook/default.nix
@@ -18,7 +18,7 @@ in
     force = true;
   };
 
-  systemd.user.services.moshi-hook = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.moshi-hook = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "Moshi Hook daemon";
       After = [ "network.target" ];

--- a/home-manager/services/neverssl-keepalive/default.nix
+++ b/home-manager/services/neverssl-keepalive/default.nix
@@ -21,7 +21,7 @@ in
   };
 
   # Linux (systemd)
-  systemd.user.services.neverssl-keepalive = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.neverssl-keepalive = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "Keep captive portal alive via neverssl.com";
       Wants = [ "network-online.target" ];
@@ -40,7 +40,7 @@ in
     };
   };
 
-  systemd.user.timers.neverssl-keepalive = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.timers.neverssl-keepalive = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "Timer for neverssl captive portal keepalive";
     };

--- a/home-manager/services/ollama/default.nix
+++ b/home-manager/services/ollama/default.nix
@@ -50,7 +50,7 @@ lib.mkIf enabled {
     };
   };
 
-  systemd.user.services.ollama = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.ollama = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "Ollama AI model server";
       After = [ "network.target" ];

--- a/home-manager/services/qmd/default.nix
+++ b/home-manager/services/qmd/default.nix
@@ -33,7 +33,7 @@ lib.mkIf enabled {
     };
   };
 
-  systemd.user.services.qmd = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.qmd = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "QMD hybrid search engine";
       After = [

--- a/home-manager/services/roborev/default.nix
+++ b/home-manager/services/roborev/default.nix
@@ -39,7 +39,7 @@ lib.mkIf enabled {
     };
   };
 
-  systemd.user.services.roborev = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.roborev = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "roborev code review daemon";
       Documentation = [ "https://github.com/roborev-dev/roborev" ];

--- a/home-manager/services/screenshot-clipboard/default.nix
+++ b/home-manager/services/screenshot-clipboard/default.nix
@@ -32,7 +32,7 @@ in
     };
   };
 
-  systemd.user.services.screenshot-clipboard = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.screenshot-clipboard = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "Auto-copy screenshots to clipboard";
       PartOf = [ "graphical-session.target" ];

--- a/home-manager/services/t3-connect/default.nix
+++ b/home-manager/services/t3-connect/default.nix
@@ -3,7 +3,7 @@ let
   inherit (pkgs) lib;
 in
 {
-  systemd.user.services.t3-connect = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.t3-connect = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "Keep the T3 remote server ready to accept connections";
     };
@@ -35,7 +35,7 @@ in
     };
   };
 
-  systemd.user.timers.t3-connect = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.timers.t3-connect = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "Timer to keep the T3 remote server ready to accept connections";
     };

--- a/home-manager/services/tmux-session-logger/default.nix
+++ b/home-manager/services/tmux-session-logger/default.nix
@@ -26,7 +26,7 @@ in
     };
   };
 
-  systemd.user.services.tmux-session-logger = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.tmux-session-logger = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "Persist tmux pane history snapshots";
       X-SwitchMethod = "keep-old";
@@ -38,7 +38,7 @@ in
     };
   };
 
-  systemd.user.timers.tmux-session-logger = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.timers.tmux-session-logger = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "Timer for tmux session history logging";
     };

--- a/home-manager/services/tokscale/default.nix
+++ b/home-manager/services/tokscale/default.nix
@@ -47,7 +47,7 @@ in
   };
 
   # Linux (systemd)
-  systemd.user.services.tokscale = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.services.tokscale = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "Submit local usage data to Tokscale";
       Wants = [ "network-online.target" ];
@@ -66,7 +66,7 @@ in
     };
   };
 
-  systemd.user.timers.tokscale = lib.mkIf pkgs.stdenv.isLinux {
+  systemd.user.timers.tokscale = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit.Description = "Submit local usage data to Tokscale every three hours";
     Timer = {
       OnBootSec = "1min";

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -78,6 +78,7 @@
       "graphviz"
       "helm"
       "herdr"
+      "infracost"
       "jjui"
       "kimi-cli"
       "kurtosis-cli"

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -7,7 +7,8 @@
     # Current Foundry nightlies link forge and cast against libudev, which the
     # upstream binary derivation does not yet include in its Linux runtime.
     foundry-bin = prev.foundry-bin.overrideAttrs (old: {
-      buildInputs = (old.buildInputs or [ ]) ++ prev.lib.optionals prev.stdenv.hostPlatform.isLinux [ prev.udev ];
+      buildInputs =
+        (old.buildInputs or [ ]) ++ prev.lib.optionals prev.stdenv.hostPlatform.isLinux [ prev.udev ];
     });
   })
   (_: prev: {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -7,7 +7,7 @@
     # Current Foundry nightlies link forge and cast against libudev, which the
     # upstream binary derivation does not yet include in its Linux runtime.
     foundry-bin = prev.foundry-bin.overrideAttrs (old: {
-      buildInputs = (old.buildInputs or [ ]) ++ prev.lib.optionals prev.stdenv.isLinux [ prev.udev ];
+      buildInputs = (old.buildInputs or [ ]) ++ prev.lib.optionals prev.stdenv.hostPlatform.isLinux [ prev.udev ];
     });
   })
   (_: prev: {
@@ -182,9 +182,9 @@
           if prev.stdenv.hostPlatform.isDarwin then "darwin" else "linux"
         }/${if prev.stdenv.hostPlatform.isAarch64 then "arm64" else "amd64"}/blacksmith";
         sha256 =
-          if prev.stdenv.isLinux && prev.stdenv.hostPlatform.isx86_64 then
+          if prev.stdenv.hostPlatform.isLinux && prev.stdenv.hostPlatform.isx86_64 then
             "7f60f3b9f8d4d7644d9743f5d962acb3b3dbf675f51676702e5f292e02060bca"
-          else if prev.stdenv.isLinux && prev.stdenv.hostPlatform.isAarch64 then
+          else if prev.stdenv.hostPlatform.isLinux && prev.stdenv.hostPlatform.isAarch64 then
             "04c8d261526e23c7791f05b8acec8f02b9d1fe67c35a1adcf28076627327270a"
           else if prev.stdenv.hostPlatform.isDarwin && prev.stdenv.hostPlatform.isAarch64 then
             "607b0f4413e426574527446c7718ea32587d57b24a3ea0749e1ab4138a426584"
@@ -206,9 +206,9 @@
           if prev.stdenv.hostPlatform.isDarwin then "darwin" else "linux"
         }_${if prev.stdenv.hostPlatform.isAarch64 then "arm64" else "amd64"}.tar.gz";
         sha256 =
-          if prev.stdenv.isLinux && prev.stdenv.hostPlatform.isx86_64 then
+          if prev.stdenv.hostPlatform.isLinux && prev.stdenv.hostPlatform.isx86_64 then
             "e513ba473be4eaaadf16f88fe030a03e6a11c0b49a088941fcccdbf3a09247ad"
-          else if prev.stdenv.isLinux && prev.stdenv.hostPlatform.isAarch64 then
+          else if prev.stdenv.hostPlatform.isLinux && prev.stdenv.hostPlatform.isAarch64 then
             "94a388cd7301c7ba1d7e42d8c55d68c6b9dd55025e79cf247c58d659aa5039d4"
           else if prev.stdenv.hostPlatform.isDarwin && prev.stdenv.hostPlatform.isAarch64 then
             "ef1567083f6bd0d01b2539efdd69ccd205c2642e7d9eefb073d58052e8a7bb91"
@@ -237,9 +237,9 @@
           if prev.stdenv.hostPlatform.isDarwin then "Darwin" else "Linux"
         }_${if prev.stdenv.hostPlatform.isAarch64 then "arm64" else "x86_64"}.tar.gz";
         sha256 =
-          if prev.stdenv.isLinux && prev.stdenv.hostPlatform.isx86_64 then
+          if prev.stdenv.hostPlatform.isLinux && prev.stdenv.hostPlatform.isx86_64 then
             "ee96ff3cebe68648a9631976660afa4a7a247cfa2cc8c030d9d5eca784df5a95"
-          else if prev.stdenv.isLinux && prev.stdenv.hostPlatform.isAarch64 then
+          else if prev.stdenv.hostPlatform.isLinux && prev.stdenv.hostPlatform.isAarch64 then
             "8df6d83dcd1aa99c42e7516937f29249f3a8f704d9d9d7eec703fa2287a88666"
           else if prev.stdenv.hostPlatform.isDarwin && prev.stdenv.hostPlatform.isAarch64 then
             "173550c6437e6663dbdf43736fc9cbca2a5af8acf7c3d61b2c3a97c4963cf596"

--- a/spec/beads_federation_sync_spec.sh
+++ b/spec/beads_federation_sync_spec.sh
@@ -133,7 +133,7 @@ The status should be success
 End
 
 It 'serves Dolt locally on every client host'
-When run bash -c "grep -F 'serverEnabled = clientEnabled;' '$MODULE' >/dev/null && grep -F 'pkgs.stdenv.isLinux && serverEnabled' '$MODULE' >/dev/null && grep -F 'pkgs.stdenv.hostPlatform.isDarwin && serverEnabled' '$MODULE' >/dev/null"
+When run bash -c "grep -F 'serverEnabled = clientEnabled;' '$MODULE' >/dev/null && grep -F 'pkgs.stdenv.hostPlatform.isLinux && serverEnabled' '$MODULE' >/dev/null && grep -F 'pkgs.stdenv.hostPlatform.isDarwin && serverEnabled' '$MODULE' >/dev/null"
 The status should be success
 End
 

--- a/spec/beads_linear_sync_spec.sh
+++ b/spec/beads_linear_sync_spec.sh
@@ -595,7 +595,7 @@ The status should be success
 End
 
 It 'restricts the Linear writer to Kyber'
-When run bash -c "grep -F 'linearSyncEnabled = isKyber;' '$MODULE' >/dev/null && grep -F 'home.file.\".local/bin/beads-linear-complete\" = lib.mkIf linearSyncEnabled' '$MODULE' >/dev/null && grep -F 'systemd.user.services.dolt-linear-sync = lib.mkIf (pkgs.stdenv.isLinux && linearSyncEnabled)' '$MODULE' >/dev/null"
+When run bash -c "grep -F 'linearSyncEnabled = isKyber;' '$MODULE' >/dev/null && grep -F 'home.file.\".local/bin/beads-linear-complete\" = lib.mkIf linearSyncEnabled' '$MODULE' >/dev/null && grep -F 'systemd.user.services.dolt-linear-sync =' '$MODULE' >/dev/null && grep -F 'lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && linearSyncEnabled)' '$MODULE' >/dev/null"
 The status should be success
 End
 

--- a/spec/caam_config_spec.sh
+++ b/spec/caam_config_spec.sh
@@ -45,7 +45,7 @@ End
 
 It 'exposes cursor-agent as cursor on headless Linux hosts'
 When run cat "$CURSOR_NIX"
-The output should include 'pkgs.stdenv.isLinux'
+The output should include 'pkgs.stdenv.hostPlatform.isLinux'
 The output should include '.local/bin/cursor-agent'
 End
 

--- a/spec/cpa_manager_plus_spec.sh
+++ b/spec/cpa_manager_plus_spec.sh
@@ -9,8 +9,8 @@ CLIPROXY_BACKUP_SCRIPT="$PWD/home-manager/services/cliproxyapi/scripts/backup.sh
 CLIPROXY_NIX_MODULE="$PWD/home-manager/services/cliproxyapi/default.nix"
 
 It 'is enabled only on Kyber Linux'
-When run grep 'pkgs.stdenv.isLinux && host.isKyber' "$NIX_MODULE"
-The output should include 'pkgs.stdenv.isLinux && host.isKyber'
+When run grep 'pkgs.stdenv.hostPlatform.isLinux && host.isKyber' "$NIX_MODULE"
+The output should include 'pkgs.stdenv.hostPlatform.isLinux && host.isKyber'
 End
 
 It 'starts after Docker and CLIProxyAPI'

--- a/spec/crabbox_spec.sh
+++ b/spec/crabbox_spec.sh
@@ -48,7 +48,7 @@ End
 It 'registers a kyber-only host service separately from installation'
 When run bash -c "cat '$SERVICE_INDEX'; cat '$SERVICE_MODULE'"
 The output should include 'crabbox = ./crabbox;'
-The output should include 'lib.mkIf (isKyber && pkgs.stdenv.isLinux)'
+The output should include 'lib.mkIf (isKyber && pkgs.stdenv.hostPlatform.isLinux)'
 The output should include 'systemd.user.services.crabbox-postgres'
 The output should include 'systemd.user.services.crabbox'
 The output should include 'Requires = [ "crabbox-postgres.service" ]'


### PR DESCRIPTION
## Summary
- Replace all uses of the deprecated `stdenv.isLinux` with `stdenv.hostPlatform.isLinux` across the flake (34 files, 70 occurrences)

## Test plan
- [x] `nix-instantiate --parse` on every touched file succeeds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces all uses of the deprecated `stdenv.isLinux` with `stdenv.hostPlatform.isLinux` across 34 files (70 occurrences) in the flake; behavior is unchanged and removes reliance on a Nixpkgs attribute slated for removal. Also adds `infracost` to the Homebrew brews in the nix-darwin config.

- Updates spec tests that asserted the old attribute name, with a stricter check for the Linear syncer service.
- Formats touched files with `nixfmt` and verifies via `nix-instantiate --parse`.

<sup>Written for commit 3446a2b9db76e56dd92108019772abd4c49e5575. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

