### PR TITLE
fix(openclaw): run the gateway through the explicit command

### DIFF
--- a/home-manager/services/openclaw/default.nix
+++ b/home-manager/services/openclaw/default.nix
@@ -41,7 +41,7 @@ lib.mkIf host.isKyber {
     };
     Service = {
       Type = "simple";
-      ExecStart = "${homeDir}/.bun/bin/openclaw gateway --port 18789 --bind loopback";
+      ExecStart = "${homeDir}/.bun/bin/openclaw gateway run --port 18789 --bind loopback";
       Restart = "always";
       RestartSec = "5s";
       Environment = [

--- a/spec/activate_openclaw_hermes_spec.sh
+++ b/spec/activate_openclaw_hermes_spec.sh
@@ -37,6 +37,11 @@ When run bash -c "grep -- '--bind loopback' '$PWD/home-manager/services/openclaw
 The output should include '--bind loopback'
 End
 
+It 'runs the explicit foreground gateway command'
+When run bash -c "grep -F 'gateway run --port 18789 --bind loopback' '$PWD/home-manager/services/openclaw/default.nix'"
+The output should include 'gateway run --port 18789 --bind loopback'
+End
+
 It 'resolves the current k3s bridge address instead of pinning a pod subnet'
 When run bash -c "grep -q 'ip -4 -o address show dev' '$PWD/home-manager/services/openclaw/k3s-proxy.sh' && grep -q 'bind=\${listen_address}' '$PWD/home-manager/services/openclaw/k3s-proxy.sh' && ! grep -R -q 'bind=10.42.0.1' '$PWD/home-manager/services/openclaw'"
 The status should be success


### PR DESCRIPTION
## Summary
Align the Kyber Home Manager OpenClaw service with the supported foreground command so the managed gateway runs through `openclaw gateway run`. Add a focused ShellSpec regression for the service command.

### Tracker linkage
- Linear: none — no current Linear issue exists for this incident
- Bead: shunkakinokisoftware-hqos

## Before / after

| Surface | Before | After |
| --- | --- | --- |
| Kyber `openclaw-gateway.service` | Invoked the gateway parent command | Invokes the explicit foreground `gateway run` command |

## Breaking and irreversible changes

- Behavioral: service invocation is aligned with the documented foreground gateway command; reversible by reverting this commit.
- Compile-time: none.
- Durable state and rollback: none; no persisted state or migration is introduced.

## Deliberate boundaries

This change does not alter OpenClaw state, credentials, model routing, ingress ports, or the k3s proxy.

## Verification

- `shellspec spec/activate_openclaw_hermes_spec.sh` — 29 examples, 0 failures
- `shellcheck spec/activate_openclaw_hermes_spec.sh` — passed
- `git diff --check` — passed
- Kyber diagnosis: SQLite quick/integrity checks passed; direct read-only worker returned `ok`; isolated `openclaw gateway run` reached ready.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the Kyber OpenClaw gateway service with the supported foreground command so it runs `openclaw gateway run` instead of `openclaw gateway`. No state, credentials, or routing changes; the service now matches the documented invocation.

- Adds a ShellSpec regression asserting the service command includes `gateway run --port 18789 --bind loopback`.

<sup>Written for commit 4f164b50eef3a9259dad71bdab992d5b824c5106. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

