### PR TITLE
fix(openclaw): align Kyber config with current schema

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -7,9 +7,6 @@
   },
   "models": {
     "mode": "merge",
-    "pricing": {
-      "enabled": true
-    },
     "providers": {
       "cliproxy": {
         "baseUrl": "https://cliproxy.shunkakinoki.com/v1",
@@ -195,17 +192,13 @@
     }
   },
   "memory": {
-    "backend": "qmd",
-    "qmd": {
-      "update": {
-        "startup": "immediate"
-      },
-      "scope": {
-        "default": "allow"
-      },
-      "paths": [
+    "search": {
+      "enabled": true,
+      "sources": [
+        "memory"
+      ],
+      "extraPaths": [
         {
-          "name": "wiki-memory",
           "path": "__HOME__/ghq/github.com/shunkakinoki/wiki/MEMORY.md"
         }
       ]
@@ -275,14 +268,7 @@
   "acp": {
     "enabled": true,
     "backend": "acpx",
-    "defaultAgent": "codex",
-    "maxConcurrentSessions": 4,
-    "runtime": {
-      "ttlMinutes": 120
-    }
-  },
-  "commitments": {
-    "enabled": true
+    "defaultAgent": "codex"
   },
   "session": {
     "dmScope": "per-channel-peer"
@@ -372,8 +358,7 @@
       "enabled": true
     },
     "tailscale": {
-      "mode": "serve",
-      "resetOnExit": false
+      "mode": "serve"
     },
     "controlUi": {
       "allowedOrigins": [
@@ -413,10 +398,7 @@
       "sampleRate": 1
     },
     "cacheTrace": {
-      "enabled": true,
-      "includeMessages": true,
-      "includePrompt": true,
-      "includeSystem": true
+      "enabled": true
     }
   },
   "plugins": {

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -7,9 +7,6 @@
   },
   "models": {
     "mode": "merge",
-    "pricing": {
-      "enabled": true
-    },
     "providers": {
       "cliproxy": {
         "baseUrl": "https://cliproxy.shunkakinoki.com/v1",
@@ -195,17 +192,13 @@
     }
   },
   "memory": {
-    "backend": "qmd",
-    "qmd": {
-      "update": {
-        "startup": "immediate"
-      },
-      "scope": {
-        "default": "allow"
-      },
-      "paths": [
+    "search": {
+      "enabled": true,
+      "sources": [
+        "memory"
+      ],
+      "extraPaths": [
         {
-          "name": "wiki-memory",
           "path": "__HOME__/ghq/github.com/shunkakinoki/wiki/MEMORY.md"
         }
       ]
@@ -275,14 +268,7 @@
   "acp": {
     "enabled": true,
     "backend": "acpx",
-    "defaultAgent": "codex",
-    "maxConcurrentSessions": 4,
-    "runtime": {
-      "ttlMinutes": 120
-    }
-  },
-  "commitments": {
-    "enabled": true
+    "defaultAgent": "codex"
   },
   "session": {
     "dmScope": "per-channel-peer"
@@ -372,8 +358,7 @@
       "enabled": true
     },
     "tailscale": {
-      "mode": "serve",
-      "resetOnExit": false
+      "mode": "serve"
     },
     "controlUi": {
       "allowedOrigins": [
@@ -413,10 +398,7 @@
       "sampleRate": 1
     },
     "cacheTrace": {
-      "enabled": true,
-      "includeMessages": true,
-      "includePrompt": true,
-      "includeSystem": true
+      "enabled": true
     }
   },
   "plugins": {

--- a/spec/activate_openclaw_hermes_spec.sh
+++ b/spec/activate_openclaw_hermes_spec.sh
@@ -42,6 +42,11 @@ When run bash -c "grep -F 'gateway run --port 18789 --bind loopback' '$PWD/home-
 The output should include 'gateway run --port 18789 --bind loopback'
 End
 
+It 'uses the current OpenClaw configuration schema'
+When run bash -c "jq -e '(.models | has(\"pricing\") | not) and (.memory.search.enabled == true) and (.acp | has(\"maxConcurrentSessions\") | not) and (.gateway.tailscale | has(\"resetOnExit\") | not) and (.diagnostics.cacheTrace | (has(\"includeMessages\") or has(\"includePrompt\") or has(\"includeSystem\")) | not) and (has(\"commitments\") | not)' '$PWD/config/openclaw/openclaw.tpl.json' >/dev/null"
+The status should be success
+End
+
 It 'resolves the current k3s bridge address instead of pinning a pod subnet'
 When run bash -c "grep -q 'ip -4 -o address show dev' '$PWD/home-manager/services/openclaw/k3s-proxy.sh' && grep -q 'bind=\${listen_address}' '$PWD/home-manager/services/openclaw/k3s-proxy.sh' && ! grep -R -q 'bind=10.42.0.1' '$PWD/home-manager/services/openclaw'"
 The status should be success


### PR DESCRIPTION
## Summary
Align the generated Kyber OpenClaw config with the installed 2026.8.1 schema so `gateway run` can start after activation.

- Linear: none — no current Linear issue exists for this incident
- Bead: shunkakinokisoftware-hqos

## Before / after

| Area | Before | After |
| --- | --- | --- |
| Memory | legacy `backend`/`qmd` fields | supported `memory.search` configuration |
| Diagnostics | removed cache trace fields | supported `cacheTrace.enabled` only |
| ACP, Tailscale, models | unsupported legacy keys | current schema keys only |
| Root config | unsupported `commitments` block | block removed |

## Breaking tiers

- No persisted database migration.
- The memory configuration shape changes to the current OpenClaw contract; the configured wiki memory path remains present.

## Deliberate boundaries

- No unrelated service or runtime changes.
- No secrets or generated runtime state committed.

## Verification

- `make llm-update`
- `shellspec spec/activate_openclaw_hermes_spec.sh` (30 examples, 0 failures)
- `shellcheck spec/activate_openclaw_hermes_spec.sh`
- `jq empty config/openclaw/openclaw.tpl.json config/openclaw/openclaw.template.json`
- `git diff --check`

Non-UI change; screenshots are not applicable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the OpenClaw config with the installed 2026.8.1 schema so `gateway run` can start after activation. The config previously used legacy keys the newer schema rejects.

**Refactors**
- Swapped the legacy memory `backend`/`qmd` block for the supported `memory.search` config; the wiki memory path still points to the same file.
- Removed unsupported keys: model `pricing`, ACP `maxConcurrentSessions` and `runtime`, tailscale `resetOnExit`, cache trace message/prompt includes, and the `commitments` block.
- Added a spec that asserts the template no longer contains those legacy keys.

No database migration is required; only the config shape changes.

<sup>Written for commit 9bf12ce0c8c03b989f5cba85f049decdb49ac480. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

