### PR TITLE
fix(openclaw): disable conflicting Tailscale management

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -358,7 +358,7 @@
       "enabled": true
     },
     "tailscale": {
-      "mode": "serve"
+      "mode": "off"
     },
     "controlUi": {
       "allowedOrigins": [

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -358,7 +358,7 @@
       "enabled": true
     },
     "tailscale": {
-      "mode": "serve"
+      "mode": "off"
     },
     "controlUi": {
       "allowedOrigins": [

--- a/spec/activate_openclaw_hermes_spec.sh
+++ b/spec/activate_openclaw_hermes_spec.sh
@@ -47,6 +47,11 @@ When run bash -c "jq -e '(.models | has(\"pricing\") | not) and (.memory.search.
 The status should be success
 End
 
+It 'leaves Tailscale Serve ownership with the host activation'
+When run bash -c "jq -e '.gateway.tailscale.mode == \"off\"' '$PWD/config/openclaw/openclaw.tpl.json' >/dev/null"
+The status should be success
+End
+
 It 'resolves the current k3s bridge address instead of pinning a pod subnet'
 When run bash -c "grep -q 'ip -4 -o address show dev' '$PWD/home-manager/services/openclaw/k3s-proxy.sh' && grep -q 'bind=\${listen_address}' '$PWD/home-manager/services/openclaw/k3s-proxy.sh' && ! grep -R -q 'bind=10.42.0.1' '$PWD/home-manager/services/openclaw'"
 The status should be success


### PR DESCRIPTION
## Summary
Prevent OpenClaw from competing with Kyber’s declarative Tailscale Serve activation.

- Linear: none — no current Linear issue exists for this incident
- Bead: shunkakinokisoftware-hqos

## Change

Kyber’s Home Manager activation owns the Tailscale Serve routes, including OpenClaw on `:443`. OpenClaw now uses `gateway.tailscale.mode = "off"` so it does not reject the existing route or terminate the gateway during startup.

## Deliberate boundaries

- Host-level Tailscale Serve publication remains unchanged.
- No secrets, service state, or unrelated units changed.

## Verification

- `make llm-update`
- `shellspec spec/activate_openclaw_hermes_spec.sh` (31 examples, 0 failures)
- `shellcheck spec/activate_openclaw_hermes_spec.sh`
- `jq empty config/openclaw/openclaw.tpl.json config/openclaw/openclaw.template.json`
- `git diff --check`

Non-UI change; screenshots are not applicable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops OpenClaw’s Tailscale Serve mode from conflicting with Kyber’s host-level Tailscale route management. OpenClaw now uses `gateway.tailscale.mode = "off"` so it won’t reject the existing `:443` route or bring down the gateway during startup.

- Adds a spec assertion confirming the Tailscale Serve ownership stays with the host activation.

<sup>Written for commit 54d2e30c6908b081d9eb7ceb5f5f5c3a1c45bdff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

