### PR TITLE
fix(openclaw): constrain forwarded proxy attribution

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -379,11 +379,10 @@
       }
     },
     "trustedProxies": [
-      "10.0.0.0/8",
-      "172.16.0.0/12",
-      "192.168.0.0/16"
+      "127.0.0.1/32",
+      "::1/128"
     ],
-    "allowRealIpFallback": true
+    "allowRealIpFallback": false
   },
   "diagnostics": {
     "enabled": true,

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -379,11 +379,10 @@
       }
     },
     "trustedProxies": [
-      "10.0.0.0/8",
-      "172.16.0.0/12",
-      "192.168.0.0/16"
+      "127.0.0.1/32",
+      "::1/128"
     ],
-    "allowRealIpFallback": true
+    "allowRealIpFallback": false
   },
   "diagnostics": {
     "enabled": true,

--- a/spec/activate_openclaw_hermes_spec.sh
+++ b/spec/activate_openclaw_hermes_spec.sh
@@ -52,6 +52,11 @@ When run bash -c "jq -e '.gateway.tailscale.mode == \"off\"' '$PWD/config/opencl
 The status should be success
 End
 
+It 'trusts only the local forwarded-header proxies'
+When run bash -c "jq -e '.gateway.trustedProxies == [\"127.0.0.1/32\", \"::1/128\"] and .gateway.allowRealIpFallback == false' '$PWD/config/openclaw/openclaw.tpl.json' >/dev/null"
+The status should be success
+End
+
 It 'resolves the current k3s bridge address instead of pinning a pod subnet'
 When run bash -c "grep -q 'ip -4 -o address show dev' '$PWD/home-manager/services/openclaw/k3s-proxy.sh' && grep -q 'bind=\${listen_address}' '$PWD/home-manager/services/openclaw/k3s-proxy.sh' && ! grep -R -q 'bind=10.42.0.1' '$PWD/home-manager/services/openclaw'"
 The status should be success


### PR DESCRIPTION
## Summary
Fix Gateway-authenticated requests arriving through Kyber’s local Tailscale Serve proxy.

- Linear: none — no current Linear issue exists for this incident
- Bead: follow-up to shunkakinokisoftware-hqos

## Root cause

Tailscale Serve reaches OpenClaw from loopback and supplies forwarded client headers. The prior broad private-network allowlist did not include loopback, so OpenClaw rejected the request as unattributable proxy traffic.

## Change

- Trust only `127.0.0.1/32` and `::1/128`, the local proxy endpoints.
- Disable `X-Real-IP` fallback so client attribution relies on the proxy’s forwarded chain.
- Keep Tailscale Serve as the host-owned proxy that rebuilds forwarded headers.

## Verification

- `make llm-update`
- `shellspec spec/activate_openclaw_hermes_spec.sh` (32 examples, 0 failures)
- `shellcheck spec/activate_openclaw_hermes_spec.sh`
- `jq empty config/openclaw/openclaw.tpl.json config/openclaw/openclaw.template.json`
- `git diff --check`

Non-UI change; screenshots are not applicable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Gateway-authenticated requests arriving through Kyber's local Tailscale Serve proxy so they are no longer rejected as unattributable proxy traffic.

- Trusts only `127.0.0.1/32` and `::1/128` as forwarded-header proxies, replacing the previous broad private-network allowlist.
- Disables `X-Real-IP` fallback so client attribution relies on the proxy's forwarded chain.
- Adds a spec check for the trusted proxy configuration.

<sup>Written for commit 33480096879c5a3914793b498850b4def1a32bc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

