### PR TITLE
feat(openclaw): enable experimental features and Codex primary

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -222,6 +222,9 @@
       },
       "experimental": {
         "localModelLean": true
+      },
+      "systemAgent": {
+        "agentId": "main"
       }
     },
     "list": [

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -205,10 +205,12 @@
     }
   },
   "agents": {
+    "ownership": "explicit",
     "defaults": {
       "model": {
-        "primary": "cliproxy/deepseek-v4-flash",
+        "primary": "openai/gpt-5.6-sol",
         "fallbacks": [
+          "cliproxy/deepseek-v4-flash",
           "cliproxy/free"
         ]
       },
@@ -217,6 +219,9 @@
       "maxConcurrent": 4,
       "subagents": {
         "maxConcurrent": 8
+      },
+      "experimental": {
+        "localModelLean": true
       }
     },
     "list": [
@@ -279,10 +284,28 @@
     }
   },
   "tools": {
+    "codeMode": true,
+    "toolSearch": true,
+    "loopDetection": {
+      "enabled": true
+    },
+    "swarm": {
+      "enabled": true,
+      "maxConcurrent": 8,
+      "maxChildrenPerGroup": 50,
+      "maxTotalPerGroup": 200,
+      "waitTimeoutSecondsMax": 600,
+      "defaultAgentId": ""
+    },
     "web": {
       "search": {
         "enabled": true
       }
+    }
+  },
+  "logging": {
+    "audit": {
+      "messages": "all"
     }
   },
   "commands": {
@@ -382,7 +405,18 @@
       "127.0.0.1/32",
       "::1/128"
     ],
-    "allowRealIpFallback": false
+    "allowRealIpFallback": false,
+    "cliAgents": {
+      "enabled": true
+    }
+  },
+  "desktop": {
+    "host": {
+      "enabled": true
+    }
+  },
+  "cloudWorkers": {
+    "desktop": true
   },
   "diagnostics": {
     "enabled": true,

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -208,7 +208,7 @@
     "ownership": "explicit",
     "defaults": {
       "model": {
-        "primary": "openai/gpt-5.6-sol",
+        "primary": "openai/gpt-5.6-luna",
         "fallbacks": [
           "cliproxy/deepseek-v4-flash",
           "cliproxy/free"

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -208,7 +208,7 @@
     "ownership": "explicit",
     "defaults": {
       "model": {
-        "primary": "openai/gpt-5.6-sol",
+        "primary": "openai/__GPT_LUNA__",
         "fallbacks": [
           "cliproxy/__DEEPSEEK_FLASH__",
           "cliproxy/free"

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -205,10 +205,12 @@
     }
   },
   "agents": {
+    "ownership": "explicit",
     "defaults": {
       "model": {
-        "primary": "cliproxy/__DEEPSEEK_FLASH__",
+        "primary": "openai/gpt-5.6-sol",
         "fallbacks": [
+          "cliproxy/__DEEPSEEK_FLASH__",
           "cliproxy/free"
         ]
       },
@@ -217,6 +219,9 @@
       "maxConcurrent": 4,
       "subagents": {
         "maxConcurrent": 8
+      },
+      "experimental": {
+        "localModelLean": true
       }
     },
     "list": [
@@ -279,10 +284,28 @@
     }
   },
   "tools": {
+    "codeMode": true,
+    "toolSearch": true,
+    "loopDetection": {
+      "enabled": true
+    },
+    "swarm": {
+      "enabled": true,
+      "maxConcurrent": 8,
+      "maxChildrenPerGroup": 50,
+      "maxTotalPerGroup": 200,
+      "waitTimeoutSecondsMax": 600,
+      "defaultAgentId": ""
+    },
     "web": {
       "search": {
         "enabled": true
       }
+    }
+  },
+  "logging": {
+    "audit": {
+      "messages": "all"
     }
   },
   "commands": {
@@ -382,7 +405,18 @@
       "127.0.0.1/32",
       "::1/128"
     ],
-    "allowRealIpFallback": false
+    "allowRealIpFallback": false,
+    "cliAgents": {
+      "enabled": true
+    }
+  },
+  "desktop": {
+    "host": {
+      "enabled": true
+    }
+  },
+  "cloudWorkers": {
+    "desktop": true
   },
   "diagnostics": {
     "enabled": true,

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -222,6 +222,9 @@
       },
       "experimental": {
         "localModelLean": true
+      },
+      "systemAgent": {
+        "agentId": "main"
       }
     },
     "list": [

--- a/spec/activate_openclaw_hermes_spec.sh
+++ b/spec/activate_openclaw_hermes_spec.sh
@@ -62,8 +62,8 @@ When run bash -c "jq -e '.agents.ownership == \"explicit\" and .agents.defaults.
 The status should be success
 End
 
-It 'prefers OpenAI Codex over the DeepSeek fallback'
-When run bash -c "jq -e '.agents.defaults.model.primary == \"openai/gpt-5.6-sol\" and .agents.defaults.model.fallbacks == [\"cliproxy/__DEEPSEEK_FLASH__\", \"cliproxy/free\"]' '$PWD/config/openclaw/openclaw.tpl.json' >/dev/null"
+It 'prefers OpenAI Codex Luna over the DeepSeek fallback'
+When run bash -c "jq -e '.agents.defaults.model.primary == \"openai/__GPT_LUNA__\" and .agents.defaults.model.fallbacks == [\"cliproxy/__DEEPSEEK_FLASH__\", \"cliproxy/free\"]' '$PWD/config/openclaw/openclaw.tpl.json' >/dev/null"
 The status should be success
 End
 

--- a/spec/activate_openclaw_hermes_spec.sh
+++ b/spec/activate_openclaw_hermes_spec.sh
@@ -58,7 +58,7 @@ The status should be success
 End
 
 It 'enables the experimental OpenClaw feature set with explicit agent ownership'
-When run bash -c "jq -e '.agents.ownership == \"explicit\" and .agents.defaults.experimental.localModelLean == true and .tools.codeMode == true and .tools.toolSearch == true and .tools.loopDetection.enabled == true and .tools.swarm == {enabled: true, maxConcurrent: 8, maxChildrenPerGroup: 50, maxTotalPerGroup: 200, waitTimeoutSecondsMax: 600, defaultAgentId: \"\"} and .gateway.cliAgents.enabled == true and .logging.audit.messages == \"all\" and .desktop.host.enabled == true and .cloudWorkers.desktop == true' '$PWD/config/openclaw/openclaw.tpl.json' >/dev/null"
+When run bash -c "jq -e '.agents.ownership == \"explicit\" and .agents.defaults.systemAgent.agentId == \"main\" and .agents.defaults.experimental.localModelLean == true and .tools.codeMode == true and .tools.toolSearch == true and .tools.loopDetection.enabled == true and .tools.swarm == {enabled: true, maxConcurrent: 8, maxChildrenPerGroup: 50, maxTotalPerGroup: 200, waitTimeoutSecondsMax: 600, defaultAgentId: \"\"} and .gateway.cliAgents.enabled == true and .logging.audit.messages == \"all\" and .desktop.host.enabled == true and .cloudWorkers.desktop == true' '$PWD/config/openclaw/openclaw.tpl.json' >/dev/null"
 The status should be success
 End
 

--- a/spec/activate_openclaw_hermes_spec.sh
+++ b/spec/activate_openclaw_hermes_spec.sh
@@ -57,6 +57,16 @@ When run bash -c "jq -e '.gateway.trustedProxies == [\"127.0.0.1/32\", \"::1/128
 The status should be success
 End
 
+It 'enables the experimental OpenClaw feature set with explicit agent ownership'
+When run bash -c "jq -e '.agents.ownership == \"explicit\" and .agents.defaults.experimental.localModelLean == true and .tools.codeMode == true and .tools.toolSearch == true and .tools.loopDetection.enabled == true and .tools.swarm == {enabled: true, maxConcurrent: 8, maxChildrenPerGroup: 50, maxTotalPerGroup: 200, waitTimeoutSecondsMax: 600, defaultAgentId: \"\"} and .gateway.cliAgents.enabled == true and .logging.audit.messages == \"all\" and .desktop.host.enabled == true and .cloudWorkers.desktop == true' '$PWD/config/openclaw/openclaw.tpl.json' >/dev/null"
+The status should be success
+End
+
+It 'prefers OpenAI Codex over the DeepSeek fallback'
+When run bash -c "jq -e '.agents.defaults.model.primary == \"openai/gpt-5.6-sol\" and .agents.defaults.model.fallbacks == [\"cliproxy/__DEEPSEEK_FLASH__\", \"cliproxy/free\"]' '$PWD/config/openclaw/openclaw.tpl.json' >/dev/null"
+The status should be success
+End
+
 It 'resolves the current k3s bridge address instead of pinning a pod subnet'
 When run bash -c "grep -q 'ip -4 -o address show dev' '$PWD/home-manager/services/openclaw/k3s-proxy.sh' && grep -q 'bind=\${listen_address}' '$PWD/home-manager/services/openclaw/k3s-proxy.sh' && ! grep -R -q 'bind=10.42.0.1' '$PWD/home-manager/services/openclaw'"
 The status should be success


### PR DESCRIPTION
### Summary
- Enable all experimental Control UI feature toggles represented in the Kyber screenshot.
- Mark the multi-agent roster as explicitly owned and bind the system-agent owner to `main` for scoped administrative operations.
- Use the canonical OpenAI Codex Luna route (`openai/gpt-5.6-luna`) as primary, then DeepSeek V4 Flash and the existing free fallback.

### Tracker linkage
- Linear: none — no current Linear issue exists for this operational configuration change
- Bead: shunkakinisoftware-jqvx

### Verification
- `shellspec spec/activate_openclaw_hermes_spec.sh` — 34 examples, 0 failures
- `shellcheck spec/activate_openclaw_hermes_spec.sh`
- `jq empty config/openclaw/openclaw.tpl.json`
- `make check` started the repo-wide Nix flake check but was interrupted after roughly six minutes with no failure output; the focused checks above passed.

### OpenClaw auth
The installed Kyber OpenClaw 2026.8.1 does not accept the legacy `openai-codex` auth-choice. The supported current equivalent is `openai-device-code`; the declarative model route is `openai/gpt-5.6-luna`, matching `models.json` (`gpt-luna` → `gpt-5.6-luna`).

Evidence safety: Not applicable — configuration/service change only.

Accessibility proofs: Not affected.

Carry-forward attestations: None.

Superseded assets: None.

Cleanup: None.