### PR TITLE
fix(openclaw): remove legacy default marker

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -229,8 +229,7 @@
     },
     "list": [
       {
-        "id": "main",
-        "default": true
+        "id": "main"
       },
       {
         "id": "amp",

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -229,8 +229,7 @@
     },
     "list": [
       {
-        "id": "main",
-        "default": true
+        "id": "main"
       },
       {
         "id": "amp",

--- a/spec/activate_openclaw_hermes_spec.sh
+++ b/spec/activate_openclaw_hermes_spec.sh
@@ -58,7 +58,7 @@ The status should be success
 End
 
 It 'enables the experimental OpenClaw feature set with explicit agent ownership'
-When run bash -c "jq -e '.agents.ownership == \"explicit\" and .agents.defaults.systemAgent.agentId == \"main\" and .agents.defaults.experimental.localModelLean == true and .tools.codeMode == true and .tools.toolSearch == true and .tools.loopDetection.enabled == true and .tools.swarm == {enabled: true, maxConcurrent: 8, maxChildrenPerGroup: 50, maxTotalPerGroup: 200, waitTimeoutSecondsMax: 600, defaultAgentId: \"\"} and .gateway.cliAgents.enabled == true and .logging.audit.messages == \"all\" and .desktop.host.enabled == true and .cloudWorkers.desktop == true' '$PWD/config/openclaw/openclaw.tpl.json' >/dev/null"
+When run bash -c "jq -e '.agents.ownership == \"explicit\" and (.agents.list | any(.default == true) | not) and .agents.defaults.systemAgent.agentId == \"main\" and .agents.defaults.experimental.localModelLean == true and .tools.codeMode == true and .tools.toolSearch == true and .tools.loopDetection.enabled == true and .tools.swarm == {enabled: true, maxConcurrent: 8, maxChildrenPerGroup: 50, maxTotalPerGroup: 200, waitTimeoutSecondsMax: 600, defaultAgentId: \"\"} and .gateway.cliAgents.enabled == true and .logging.audit.messages == \"all\" and .desktop.host.enabled == true and .cloudWorkers.desktop == true' '$PWD/config/openclaw/openclaw.tpl.json' >/dev/null"
 The status should be success
 End
 


### PR DESCRIPTION
## Summary

Remove the obsolete `agents.list[].default` marker now that OpenClaw uses explicit agent ownership. This resolves config validation and gateway startup failures after enabling the experimental feature set.

### Tracker linkage
- Linear: none — no current Linear issue exists for this operational configuration change
- Bead: shunkakinisoftware-jqvx

## Verification

- `make llm-update`
- `shellspec spec/activate_openclaw_hermes_spec.sh`
- `shellcheck spec/activate_openclaw_hermes_spec.sh`
- `jq empty config/openclaw/openclaw.tpl.json`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the obsolete `agents.list[].default` marker from OpenClaw configs so gateway startup and config validation succeed with explicit agent ownership enabled.

- Updates the test spec to assert no agent entry carries a `default` marker.

<sup>Written for commit dabb926a9d5021f5165b45a0bb2ae333a2159c19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

