### PR TITLE
fix(openclaw): declare OpenAI runtime plugins

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -453,6 +453,12 @@
           "nonInteractivePermissions": "deny"
         }
       },
+      "codex": {
+        "enabled": true
+      },
+      "openai": {
+        "enabled": true
+      },
       "telegram": {
         "enabled": true
       },

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -453,6 +453,12 @@
           "nonInteractivePermissions": "deny"
         }
       },
+      "codex": {
+        "enabled": true
+      },
+      "openai": {
+        "enabled": true
+      },
       "telegram": {
         "enabled": true
       },


### PR DESCRIPTION
## Summary

Declare the bundled OpenAI and Codex runtime plugins in the managed OpenClaw template so the Codex-authenticated Luna route remains activatable after Home Manager activation.

### Tracker linkage
- Linear: none — no current Linear issue exists for this operational configuration change
- Bead: shunkakinisoftware-jqvx

## Verification

- `make llm-update`
- `shellspec spec/activate_openclaw_hermes_spec.sh`
- `shellcheck spec/activate_openclaw_hermes_spec.sh`
- `jq empty config/openclaw/openclaw.tpl.json`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `codex` and `openai` runtime plugins to the OpenClaw config templates so the Codex-authenticated Luna route stays activatable after Home Manager activation.

- Enables `codex` and `openai` plugins in `config/openclaw/openclaw.template.json` and `config/openclaw/openclaw.tpl.json`.

<sup>Written for commit 3b2d3880f3d3c4e4285fd4f80dc402adb893c5f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

