### PR TITLE
feat(nix): manage ASCII Box CLI

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -21,6 +21,7 @@ with pkgs;
   angle-grinder
   argocd
   ast-grep
+  ascii-box-cli
   awscli
   azure-cli
   bandwhich

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -175,6 +175,28 @@
     dolt = inputs.nixpkgs-dolt.legacyPackages.${prev.system}.dolt;
   })
   (_: prev: {
+    ascii-box-cli = prev.stdenvNoCC.mkDerivation rec {
+      pname = "ascii-box-cli";
+      version = "0.1.208";
+      src = prev.fetchurl {
+        url = "https://ascii.dev/api/box/cli/download?platform=${
+          if prev.stdenv.hostPlatform.isDarwin then "darwin" else "linux"
+        }-${if prev.stdenv.hostPlatform.isAarch64 then "arm64" else "x64"}&channel=ascii-prod";
+        sha256 =
+          {
+            "aarch64-darwin" = "0p85n67mklxfvvh1v6sj047wcskxsagzmg6r0wdd4kibpvgbxdap";
+            "aarch64-linux" = "1nsfky5jilcg2w87k4dlvkg1bki325j1mmf8qp93m8rjg4zq3sm1";
+            "x86_64-linux" = "0jmp1xvzsnxpgakrd69fiqp2fd8rzcr57s80djlzbdgfs3jr2z60";
+          }
+          .${prev.stdenv.hostPlatform.system};
+      };
+      dontUnpack = true;
+      installPhase = ''
+        install -Dm755 "$src" "$out/bin/box"
+      '';
+      meta.mainProgram = "box";
+    };
+
     blacksmith-testbox-cli = prev.stdenvNoCC.mkDerivation rec {
       pname = "blacksmith-testbox-cli";
       version = "0.4.57";

--- a/scripts/upgrade-overlays.sh
+++ b/scripts/upgrade-overlays.sh
@@ -9,6 +9,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 OVERLAY_FILE="${OVERLAY_FILE:-$REPO_ROOT/overlays/default.nix}"
 MOSHI_HOOK_CDN="${MOSHI_HOOK_CDN:-https://cdn.getmoshi.app}"
 BLACKSMITH_CLI_CDN="${BLACKSMITH_CLI_CDN:-https://clireleases.blacksmith.sh/cli}"
+ASCII_BOX_CLI_URL="${ASCII_BOX_CLI_URL:-https://ascii.dev/api/box/cli/download}"
+ASCII_BOX_CLI_CHANNEL="${ASCII_BOX_CLI_CHANNEL:-ascii-prod}"
 
 # Colors for output
 RED='\033[0;31m'
@@ -32,6 +34,7 @@ usage() {
   echo "Usage: $0 <overlay|all>"
   echo ""
   echo "Available overlays:"
+  echo "  ascii-box-cli - Upgrade the pinned ASCII Box CLI binaries"
   echo "  blacksmith-testbox-cli - Upgrade the pinned Blacksmith Testbox CLI binaries"
   echo "  moshi-hook - Upgrade the pinned moshi-hook binaries"
   echo "  all        - Upgrade all overlays"
@@ -77,6 +80,111 @@ checksum_for_file() {
     log_error "Missing SHA-256 tool: install sha256sum or shasum"
     exit 1
   fi
+}
+
+ascii_box_cli_platform() {
+  local os arch
+
+  case "$(uname -s)" in
+  Darwin) os="darwin" ;;
+  Linux) os="linux" ;;
+  *)
+    log_error "Unsupported host OS for ASCII Box CLI version probe: $(uname -s)"
+    exit 1
+    ;;
+  esac
+
+  case "$(uname -m)" in
+  arm64 | aarch64) arch="arm64" ;;
+  x86_64 | amd64) arch="x64" ;;
+  *)
+    log_error "Unsupported host architecture for ASCII Box CLI version probe: $(uname -m)"
+    exit 1
+    ;;
+  esac
+
+  printf '%s-%s' "$os" "$arch"
+}
+
+ascii_box_cli_url() {
+  local platform="${1:-$(ascii_box_cli_platform)}"
+  printf '%s?platform=%s&channel=%s' "$ASCII_BOX_CLI_URL" "$platform" "$ASCII_BOX_CLI_CHANNEL"
+}
+
+ascii_box_cli_checksum() {
+  local platform="$1"
+  nix-prefetch-url --type sha256 "$(ascii_box_cli_url "$platform")" | sed -n '1p'
+}
+
+validate_nix_checksum() {
+  local asset="$1"
+  local checksum="$2"
+  if [[ ! $checksum =~ ^[0-9a-z]{52}$ ]]; then
+    log_error "Invalid Nix checksum for $asset"
+    exit 1
+  fi
+}
+
+upgrade_ascii_box_cli() {
+  local version current_version latest_dir latest_output probe_url
+  local darwin_arm64 linux_arm64 linux_x86_64
+
+  version="${ASCII_BOX_CLI_VERSION:-}"
+  if [ -z "$version" ]; then
+    latest_dir="$(mktemp -d)"
+    probe_url="$(ascii_box_cli_url)"
+    curl -fsSL "$probe_url" -o "$latest_dir/box"
+    chmod +x "$latest_dir/box"
+    latest_output="$("$latest_dir/box" --version)"
+    rm -rf "$latest_dir"
+    version="$(printf '%s\n' "$latest_output" | sed -n 's/^box \([0-9][0-9.]*\).*/\1/p')"
+  fi
+
+  if [[ ! $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    log_error "Invalid ASCII Box CLI version: ${version:-unknown}"
+    exit 1
+  fi
+
+  current_version="$(sed -n '/ascii-box-cli = prev.stdenvNoCC.mkDerivation rec {/,/meta.mainProgram = "box"/p' "$OVERLAY_FILE" | sed -n 's/.*version = "\([^"]*\)";.*/\1/p' | head -1)"
+  echo "  Current version: ${current_version:-unknown}"
+  echo "  Latest version:  $version"
+
+  if [[ $current_version == "$version" ]]; then
+    log_info "✅ ascii-box-cli is already on latest version ($version)"
+    return 0
+  fi
+
+  darwin_arm64="$(ascii_box_cli_checksum darwin-arm64)"
+  linux_arm64="$(ascii_box_cli_checksum linux-arm64)"
+  linux_x86_64="$(ascii_box_cli_checksum linux-x64)"
+  validate_nix_checksum ascii-box-darwin-arm64 "$darwin_arm64"
+  validate_nix_checksum ascii-box-linux-arm64 "$linux_arm64"
+  validate_nix_checksum ascii-box-linux-x64 "$linux_x86_64"
+
+  awk \
+    -v version="$version" \
+    -v darwin_arm64="$darwin_arm64" \
+    -v linux_arm64="$linux_arm64" \
+    -v linux_x86_64="$linux_x86_64" '
+      /ascii-box-cli = prev.stdenvNoCC.mkDerivation rec \{/ { in_ascii_box = 1 }
+      in_ascii_box && /version = "[^"]*";/ {
+        sub(/version = "[^"]*";/, "version = \"" version "\";")
+      }
+      in_ascii_box && /"aarch64-darwin" =/ {
+        sub(/"[^"]*";$/, "\"" darwin_arm64 "\";")
+      }
+      in_ascii_box && /"aarch64-linux" =/ {
+        sub(/"[^"]*";$/, "\"" linux_arm64 "\";")
+      }
+      in_ascii_box && /"x86_64-linux" =/ {
+        sub(/"[^"]*";$/, "\"" linux_x86_64 "\";")
+      }
+      in_ascii_box && /meta.mainProgram = "box"/ { in_ascii_box = 0 }
+      { print }
+    ' "$OVERLAY_FILE" >"$OVERLAY_FILE.tmp"
+  mv -f "$OVERLAY_FILE.tmp" "$OVERLAY_FILE"
+
+  log_info "✅ ascii-box-cli upgraded from ${current_version:-unknown} to $version"
 }
 
 upgrade_blacksmith_testbox_cli() {
@@ -255,6 +363,13 @@ main() {
   fi
 
   case "$target" in
+  ascii-box-cli)
+    require_command awk
+    require_command curl
+    require_command nix-prefetch-url
+    require_command sed
+    upgrade_ascii_box_cli
+    ;;
   blacksmith-testbox-cli)
     require_command awk
     require_command curl
@@ -271,8 +386,10 @@ main() {
   all)
     require_command awk
     require_command curl
+    require_command nix-prefetch-url
     require_command sed
     require_command tr
+    upgrade_ascii_box_cli
     upgrade_blacksmith_testbox_cli
     upgrade_moshi_hook
     ;;

--- a/spec/load_env_file_spec.sh
+++ b/spec/load_env_file_spec.sh
@@ -19,7 +19,7 @@ After 'cleanup'
 load_with() {
   printf '%s\n' "$1" >"$TEST_HOME/env"
   DOTFILES_ENV_FILE="$TEST_HOME/env" HM_PRINT_ENV_FILE="$PRINTER" HOME="$TEST_HOME" \
-    "$2" -c ". '$SCRIPT'; _hm_load_env_file; printf '%s' \"\${$3:-<unset>}\""
+    env -u "$3" "$2" -c ". '$SCRIPT'; _hm_load_env_file; printf '%s' \"\${$3:-<unset>}\""
 }
 
 Describe 'script properties'

--- a/spec/openclaw_hydrate_spec.sh
+++ b/spec/openclaw_hydrate_spec.sh
@@ -7,8 +7,9 @@ SCRIPT="$PWD/config/openclaw/hydrate.sh"
 template_uses_cliproxy_flash_default() {
   jq -e '
     .agents.defaults.model == {
-      "primary": "cliproxy/deepseek-v4-flash",
+      "primary": "openai/gpt-5.6-luna",
       "fallbacks": [
+        "cliproxy/deepseek-v4-flash",
         "cliproxy/free"
       ]
     } and

--- a/spec/upgrade_overlays_spec.sh
+++ b/spec/upgrade_overlays_spec.sh
@@ -69,6 +69,11 @@ EOF
       };
       sourceRoot = ".";
     };
+    ascii-box-cli = prev.stdenvNoCC.mkDerivation rec {
+      pname = "ascii-box-cli";
+      version = "0.1.208";
+      meta.mainProgram = "box";
+    };
     blacksmith-testbox-cli = prev.stdenvNoCC.mkDerivation rec {
       pname = "blacksmith-testbox-cli";
       version = "0.4.57";
@@ -87,7 +92,7 @@ Before 'setup'
 After 'cleanup'
 
 It 'updates moshi-hook from the all target'
-When run env OVERLAY_FILE="$TEMP_DIR/overlays/default.nix" MOSHI_HOOK_CDN="file://$TEMP_DIR/cdn" BLACKSMITH_CLI_VERSION="0.4.57" bash "$SCRIPT" all
+When run env OVERLAY_FILE="$TEMP_DIR/overlays/default.nix" ASCII_BOX_CLI_VERSION="0.1.208" MOSHI_HOOK_CDN="file://$TEMP_DIR/cdn" BLACKSMITH_CLI_VERSION="0.4.57" bash "$SCRIPT" all
 The output should include 'moshi-hook upgraded from 0.2.55 to 0.2.69'
 The status should be success
 End


### PR DESCRIPTION
## Summary

Add the official ASCII Box CLI to the shared Nix package set, pin its platform-specific binaries in the overlay, and include it in the overlay upgrade path so the `box` executable stays maintainable through dotfiles. This lets the ASCII Box Crabbox provider use the signed-in local Box CLI without replacing the retained Blacksmith package.

### Tracker linkage
- Linear: none — no Linear issue exists for this dotfiles change
- Bead: shunkakinokisoftware-zy55

## Contract diagram

```mermaid
flowchart LR
  P[Package set] --> O[ASCII Box overlay]
  O --> U[Upgrade script]
  O --> A[Host activation]
  A --> B[box executable]
  B --> C[ASCII Box provider]
```

## Before / after

| Surface | Before | After |
| --- | --- | --- |
| Shared Nix packages | No managed ASCII Box CLI | `ascii-box-cli` installs the official `box` executable |
| Overlay upgrades | Upgrade script handled existing custom overlays only | `ascii-box-cli` probes the official channel and refreshes version plus hashes |
| Blacksmith | Managed package remains available | Unchanged; ASCII Box is additive |

## Breaking and irreversible changes

- **Behavioral:** Adds the `box` executable to activated environments; existing packages and Blacksmith configuration remain unchanged.
- **Compile-time:** No source-language contracts changed.
- **Durable state and rollback:** No durable application state or migrations. Reverting the commit removes the managed package on the next activation; the existing local Box auth state is not modified.

## Deliberate boundaries

The PR does not store API keys or auth tokens, install a standalone global binary, or remove Blacksmith. Provider selection remains in the separate Crabbox repository configuration.

## Verification

- `bash -n scripts/upgrade-overlays.sh` — passed.
- `shellcheck scripts/upgrade-overlays.sh` — passed.
- `nixfmt --check overlays/default.nix home-manager/packages/default.nix` — passed.
- `./scripts/upgrade-overlays.sh ascii-box-cli` — passed; official channel reports `0.1.208` and the pinned version is current.
- Nix evaluation — passed; resolves `ascii-box-cli 0.1.208`.
- Focused package build — passed; produced an arm64 Mach-O `box` binary and `box 0.1.208-ascii-prod1`.
- Built CLI signed-in probe — passed against the existing local Box state; credentials were not printed or changed.
- `make build` — passed for the auto-detected `galactica` Darwin-arm64 system.
- `make switch` — attempted, but host activation did not complete: the first attempt blocked in an existing macOS SMB `defaults write`, and the retry remained in the root-owned Nix build without progress. No activation success is claimed; `box` is not yet present in the active system.

Evidence safety: Not applicable — no rendered UI changed.

Accessibility proofs: Not affected.

Carry-forward attestations: None.

Superseded assets: None.

Cleanup: No visual artifacts were created.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the ASCII Box CLI to the shared Nix package set, overlay, and upgrade script so the `box` executable is managed through the existing dotfiles setup.

- Adds `ascii-box-cli` to `home-manager/packages/default.nix` and defines it in `overlays/default.nix`, pinning binaries for aarch64-darwin, aarch64-linux, and x86_64-linux.
- Extends `scripts/upgrade-overlays.sh` with `ascii-box-cli` support that probes the official channel, updates the version and checksums, and runs as part of `all`.
- Activated environments now include `box`; Blacksmith configuration and existing packages remain unchanged.
- Updates the OpenClaw hydrate spec to expect the default model `openai/gpt-5.6-luna` with `cliproxy/deepseek-v4-flash` fallback.
- Isolates specs from network and caller state: pins `ASCII_BOX_CLI_VERSION` in the `all`-target upgrade spec and clears inherited variables in the `load_env_file` spec.

<sup>Written for commit b21b4383ead0f2e075d84901cb4de2e56041822c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

