### PR TITLE
feat(orchestration): declare durable wake schedulers

### DIFF
--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -31,6 +31,7 @@ let
   ollama = ./ollama;
   qmd = ./qmd;
   openclaw = ./openclaw;
+  orchestratorWake = ./orchestrator-wake;
   roborev = ./roborev;
   screenshotClipboard = import ./screenshot-clipboard { inherit pkgs; };
   sshAgent = ./ssh-agent;
@@ -64,6 +65,7 @@ in
   ollama
   qmd
   openclaw
+  orchestratorWake
   roborev
   screenshotClipboard
   sshAgent

--- a/home-manager/services/orchestrator-wake/default.nix
+++ b/home-manager/services/orchestrator-wake/default.nix
@@ -1,0 +1,73 @@
+{
+  config,
+  inputs,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (inputs.host) isGalactica isMatic;
+  homeDir = config.home.homeDirectory;
+  enabled = isGalactica || isMatic;
+  lane = if isMatic then "matic_orchestrator" else "galactica_orchestrator";
+  wakeScript = "${homeDir}/ghq/github.com/shunkakinokisoftware/shunkakinokisoftware/scripts/herdr-orchestrator-wake.ts";
+  servicePath = lib.makeBinPath [
+    pkgs.bun
+    pkgs.coreutils
+  ];
+in
+lib.mkIf enabled {
+  launchd.agents.orchestrator-wake = lib.mkIf isGalactica {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "${pkgs.bun}/bin/bun"
+        "run"
+        wakeScript
+        lane
+        "--tag"
+        "via-home-manager"
+      ];
+      EnvironmentVariables = {
+        HOME = homeDir;
+        PATH = "${servicePath}:${homeDir}/.local/bin:${homeDir}/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
+      };
+      RunAtLoad = true;
+      StartInterval = 600;
+      StandardOutPath = "/tmp/orchestrator-wake.log";
+      StandardErrorPath = "/tmp/orchestrator-wake.error.log";
+    };
+  };
+
+  systemd.user.services.orchestrator-wake = lib.mkIf isMatic {
+    Unit = {
+      Description = "Wake the local Herdr orchestrator";
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
+      X-SwitchMethod = "keep-old";
+    };
+    Service = {
+      Type = "oneshot";
+      Environment = [
+        "HOME=${homeDir}"
+        "PATH=${servicePath}:${homeDir}/.local/bin:${homeDir}/.bun/bin:/run/current-system/sw/bin:/usr/bin:/bin"
+      ];
+      ExecStart = "${pkgs.bun}/bin/bun run ${wakeScript} ${lane} --tag via-home-manager";
+    };
+  };
+
+  systemd.user.timers.orchestrator-wake = lib.mkIf isMatic {
+    Unit = {
+      Description = "Wake the local Herdr orchestrator every ten minutes";
+    };
+    Timer = {
+      OnBootSec = "1min";
+      OnUnitActiveSec = "10min";
+      AccuracySec = "1min";
+      Unit = "orchestrator-wake.service";
+    };
+    Install = {
+      WantedBy = [ "timers.target" ];
+    };
+  };
+}

--- a/named-hosts/galactica/default.nix
+++ b/named-hosts/galactica/default.nix
@@ -4,8 +4,14 @@
   ...
 }:
 let
+  host = (import ../../lib/host.nix) // {
+    isGalactica = true;
+  };
   darwin-modules = import ../../hosts/darwin {
-    inherit inputs username;
+    inherit username;
+    inputs = inputs // {
+      inherit host;
+    };
     hostname = "galactica";
   };
 in
@@ -17,9 +23,7 @@ inputs.nix-darwin.lib.darwinSystem {
       home-manager.extraSpecialArgs = {
         isRunner = false;
         inputs = inputs // {
-          host = (import ../../lib/host.nix) // {
-            isGalactica = true;
-          };
+          inherit host;
         };
       };
       age.identityPaths = [ "/Users/${username}/.ssh/id_ed25519" ];


### PR DESCRIPTION
## Summary
- Declare the local orchestrator wake scheduler through Home Manager.
- Configure a ten-minute systemd user timer/service for Matic.
- Configure a ten-minute launchd agent for Galactica.
- Pass the Galactica host flag into its Home Manager import so host-gated services are included.

## Validation
- make nix-format-check
- Matic Nix configuration evaluation
- Galactica Home Manager launchd configuration evaluation

No host activation or service-manager mutation was performed. This PR remains draft for operator review and application.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declares a durable ten-minute wake scheduler on Matic and Galactica that runs the Herdr orchestrator wake script via Home Manager.

- Matic uses a systemd user timer and oneshot service; Galactica uses a launchd agent with a 600-second `StartInterval`.
- Galactica now passes its host flag into its Home Manager import so host-gated services are enabled.
- No host activation or service-manager mutation is performed; the PR stays draft for operator review.

<sup>Written for commit 72296a22cf2934292fc22a34e9f57884ffa91690. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

