### PR TITLE
fix(nix): refresh ASCII Box CLI hashes

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -179,14 +179,14 @@
       pname = "ascii-box-cli";
       version = "0.1.208";
       src = prev.fetchurl {
-        url = "https://ascii.dev/api/box/cli/download?platform=${
+        url = "https://github.com/ariana-dot-dev/agent-server/releases/download/box-cli-v${version}-ascii-prod1/box-${
           if prev.stdenv.hostPlatform.isDarwin then "darwin" else "linux"
-        }-${if prev.stdenv.hostPlatform.isAarch64 then "arm64" else "x64"}&channel=ascii-prod";
+        }-${if prev.stdenv.hostPlatform.isAarch64 then "arm64" else "x64"}";
         sha256 =
           {
-            "aarch64-darwin" = "1zphmmhga7kj5058r88hz1alnbsl3c9yfg79qkpi41gg0nfkxz7m";
-            "aarch64-linux" = "1209x694z85ynhb5kyxv39rhlqqr5xshp6jangvv3qn1hskh4nbx";
-            "x86_64-linux" = "11q5gky9i35vgfnqmhaq0w08awrkhw09jakxp1j62ad7gnb9wy0w";
+            "aarch64-darwin" = "0p85n67mklxfvvh1v6sj047wcskxsagzmg6r0wdd4kibpvgbxdap";
+            "aarch64-linux" = "1nsfky5jilcg2w87k4dlvkg1bki325j1mmf8qp93m8rjg4zq3sm1";
+            "x86_64-linux" = "0jmp1xvzsnxpgakrd69fiqp2fd8rzcr57s80djlzbdgfs3jr2z60";
           }
           .${prev.stdenv.hostPlatform.system};
       };

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -184,9 +184,9 @@
         }-${if prev.stdenv.hostPlatform.isAarch64 then "arm64" else "x64"}&channel=ascii-prod";
         sha256 =
           {
-            "aarch64-darwin" = "0p85n67mklxfvvh1v6sj047wcskxsagzmg6r0wdd4kibpvgbxdap";
-            "aarch64-linux" = "1nsfky5jilcg2w87k4dlvkg1bki325j1mmf8qp93m8rjg4zq3sm1";
-            "x86_64-linux" = "0jmp1xvzsnxpgakrd69fiqp2fd8rzcr57s80djlzbdgfs3jr2z60";
+            "aarch64-darwin" = "1zphmmhga7kj5058r88hz1alnbsl3c9yfg79qkpi41gg0nfkxz7m";
+            "aarch64-linux" = "1209x694z85ynhb5kyxv39rhlqqr5xshp6jangvv3qn1hskh4nbx";
+            "x86_64-linux" = "11q5gky9i35vgfnqmhaq0w08awrkhw09jakxp1j62ad7gnb9wy0w";
           }
           .${prev.stdenv.hostPlatform.system};
       };

--- a/scripts/upgrade-overlays.sh
+++ b/scripts/upgrade-overlays.sh
@@ -149,11 +149,6 @@ upgrade_ascii_box_cli() {
   echo "  Current version: ${current_version:-unknown}"
   echo "  Latest version:  $version"
 
-  if [[ $current_version == "$version" ]]; then
-    log_info "✅ ascii-box-cli is already on latest version ($version)"
-    return 0
-  fi
-
   darwin_arm64="$(ascii_box_cli_checksum darwin-arm64)"
   linux_arm64="$(ascii_box_cli_checksum linux-arm64)"
   linux_x86_64="$(ascii_box_cli_checksum linux-x64)"
@@ -184,7 +179,11 @@ upgrade_ascii_box_cli() {
     ' "$OVERLAY_FILE" >"$OVERLAY_FILE.tmp"
   mv -f "$OVERLAY_FILE.tmp" "$OVERLAY_FILE"
 
-  log_info "✅ ascii-box-cli upgraded from ${current_version:-unknown} to $version"
+  if [[ $current_version == "$version" ]]; then
+    log_info "✅ ascii-box-cli hashes refreshed for $version"
+  else
+    log_info "✅ ascii-box-cli upgraded from ${current_version:-unknown} to $version"
+  fi
 }
 
 upgrade_blacksmith_testbox_cli() {

--- a/scripts/upgrade-overlays.sh
+++ b/scripts/upgrade-overlays.sh
@@ -11,6 +11,8 @@ MOSHI_HOOK_CDN="${MOSHI_HOOK_CDN:-https://cdn.getmoshi.app}"
 BLACKSMITH_CLI_CDN="${BLACKSMITH_CLI_CDN:-https://clireleases.blacksmith.sh/cli}"
 ASCII_BOX_CLI_URL="${ASCII_BOX_CLI_URL:-https://ascii.dev/api/box/cli/download}"
 ASCII_BOX_CLI_CHANNEL="${ASCII_BOX_CLI_CHANNEL:-ascii-prod}"
+ASCII_BOX_CLI_RELEASE_URL="${ASCII_BOX_CLI_RELEASE_URL:-https://github.com/ariana-dot-dev/agent-server/releases/download}"
+ASCII_BOX_CLI_RELEASE_CHANNEL="${ASCII_BOX_CLI_RELEASE_CHANNEL:-ascii-prod1}"
 
 # Colors for output
 RED='\033[0;31m'
@@ -111,9 +113,17 @@ ascii_box_cli_url() {
   printf '%s?platform=%s&channel=%s' "$ASCII_BOX_CLI_URL" "$platform" "$ASCII_BOX_CLI_CHANNEL"
 }
 
+ascii_box_cli_release_url() {
+  local platform="$1"
+  local version="$2"
+  printf '%s/box-cli-v%s-%s/box-%s' \
+    "$ASCII_BOX_CLI_RELEASE_URL" "$version" "$ASCII_BOX_CLI_RELEASE_CHANNEL" "$platform"
+}
+
 ascii_box_cli_checksum() {
   local platform="$1"
-  nix-prefetch-url --type sha256 "$(ascii_box_cli_url "$platform")" | sed -n '1p'
+  local version="$2"
+  nix-prefetch-url --type sha256 "$(ascii_box_cli_release_url "$platform" "$version")" | sed -n '1p'
 }
 
 validate_nix_checksum() {
@@ -149,9 +159,9 @@ upgrade_ascii_box_cli() {
   echo "  Current version: ${current_version:-unknown}"
   echo "  Latest version:  $version"
 
-  darwin_arm64="$(ascii_box_cli_checksum darwin-arm64)"
-  linux_arm64="$(ascii_box_cli_checksum linux-arm64)"
-  linux_x86_64="$(ascii_box_cli_checksum linux-x64)"
+  darwin_arm64="$(ascii_box_cli_checksum darwin-arm64 "$version")"
+  linux_arm64="$(ascii_box_cli_checksum linux-arm64 "$version")"
+  linux_x86_64="$(ascii_box_cli_checksum linux-x64 "$version")"
   validate_nix_checksum ascii-box-darwin-arm64 "$darwin_arm64"
   validate_nix_checksum ascii-box-linux-arm64 "$linux_arm64"
   validate_nix_checksum ascii-box-linux-x64 "$linux_x86_64"

--- a/spec/upgrade_overlays_spec.sh
+++ b/spec/upgrade_overlays_spec.sh
@@ -126,8 +126,7 @@ The status should be success
 End
 
 It 'refreshes hashes when the version is unchanged'
-When run bash -c "env OVERLAY_FILE='$TEMP_DIR/overlays/default.nix' ASCII_BOX_CLI_VERSION='0.1.208' bash '$SCRIPT' ascii-box-cli >/dev/stdout && cat '$TEMP_DIR/overlays/default.nix'"
-The output should include 'ascii-box-cli hashes refreshed for 0.1.208'
+When run bash -c "env OVERLAY_FILE='$TEMP_DIR/overlays/default.nix' ASCII_BOX_CLI_VERSION='0.1.208' bash '$SCRIPT' ascii-box-cli >/dev/null && cat '$TEMP_DIR/overlays/default.nix'"
 The output should include '0jmp1xvzsnxpgakrd69fiqp2fd8rzcr57s80djlzbdgfs3jr2z60'
 The status should be success
 End

--- a/spec/upgrade_overlays_spec.sh
+++ b/spec/upgrade_overlays_spec.sh
@@ -45,9 +45,9 @@ setup() {
   cat >"$TEMP_DIR/bin/nix-prefetch-url" <<'EOF'
 #!/usr/bin/env bash
 case "$*" in
-*darwin-arm64*) printf '%s\n' '1zphmmhga7kj5058r88hz1alnbsl3c9yfg79qkpi41gg0nfkxz7m' ;;
-*linux-arm64*) printf '%s\n' '1209x694z85ynhb5kyxv39rhlqqr5xshp6jangvv3qn1hskh4nbx' ;;
-*linux-x64*) printf '%s\n' '11q5gky9i35vgfnqmhaq0w08awrkhw09jakxp1j62ad7gnb9wy0w' ;;
+*darwin-arm64*) printf '%s\n' '0p85n67mklxfvvh1v6sj047wcskxsagzmg6r0wdd4kibpvgbxdap' ;;
+*linux-arm64*) printf '%s\n' '1nsfky5jilcg2w87k4dlvkg1bki325j1mmf8qp93m8rjg4zq3sm1' ;;
+*linux-x64*) printf '%s\n' '0jmp1xvzsnxpgakrd69fiqp2fd8rzcr57s80djlzbdgfs3jr2z60' ;;
 *) exit 1 ;;
 esac
 EOF
@@ -128,7 +128,7 @@ End
 It 'refreshes hashes when the version is unchanged'
 When run bash -c "env OVERLAY_FILE='$TEMP_DIR/overlays/default.nix' ASCII_BOX_CLI_VERSION='0.1.208' bash '$SCRIPT' ascii-box-cli >/dev/stdout && cat '$TEMP_DIR/overlays/default.nix'"
 The output should include 'ascii-box-cli hashes refreshed for 0.1.208'
-The output should include '11q5gky9i35vgfnqmhaq0w08awrkhw09jakxp1j62ad7gnb9wy0w'
+The output should include '0jmp1xvzsnxpgakrd69fiqp2fd8rzcr57s80djlzbdgfs3jr2z60'
 The status should be success
 End
 End

--- a/spec/upgrade_overlays_spec.sh
+++ b/spec/upgrade_overlays_spec.sh
@@ -41,7 +41,18 @@ End
 Describe 'moshi-hook overlay target'
 setup() {
   TEMP_DIR=$(mktemp -d)
-  mkdir -p "$TEMP_DIR/cdn/hook/latest" "$TEMP_DIR/cdn/hook/v0.2.69" "$TEMP_DIR/overlays"
+  mkdir -p "$TEMP_DIR/bin" "$TEMP_DIR/cdn/hook/latest" "$TEMP_DIR/cdn/hook/v0.2.69" "$TEMP_DIR/overlays"
+  cat >"$TEMP_DIR/bin/nix-prefetch-url" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+*darwin-arm64*) printf '%s\n' '1zphmmhga7kj5058r88hz1alnbsl3c9yfg79qkpi41gg0nfkxz7m' ;;
+*linux-arm64*) printf '%s\n' '1209x694z85ynhb5kyxv39rhlqqr5xshp6jangvv3qn1hskh4nbx' ;;
+*linux-x64*) printf '%s\n' '11q5gky9i35vgfnqmhaq0w08awrkhw09jakxp1j62ad7gnb9wy0w' ;;
+*) exit 1 ;;
+esac
+EOF
+  chmod +x "$TEMP_DIR/bin/nix-prefetch-url"
+  export PATH="$TEMP_DIR/bin:$PATH"
   printf 'v0.2.69\n' >"$TEMP_DIR/cdn/hook/latest/version.txt"
   cat >"$TEMP_DIR/cdn/hook/v0.2.69/checksums.txt" <<'EOF'
 52258126b675dad210a8f04b83d8e90b359951af37474ff985d2c3f49102d981  moshi-hook_Darwin_arm64.tar.gz
@@ -72,6 +83,13 @@ EOF
     ascii-box-cli = prev.stdenvNoCC.mkDerivation rec {
       pname = "ascii-box-cli";
       version = "0.1.208";
+      src = prev.fetchurl {
+        sha256 = {
+          "aarch64-darwin" = "old-darwin-arm";
+          "aarch64-linux" = "old-linux-arm";
+          "x86_64-linux" = "old-linux-x86";
+        };
+      };
       meta.mainProgram = "box";
     };
     blacksmith-testbox-cli = prev.stdenvNoCC.mkDerivation rec {
@@ -104,6 +122,13 @@ The output should include '3903e2e5d1dba02f9e1f53df8cea6e2b3260e1581461b9a07ca65
 The output should include '0a30e081399543551bbd0ba3320f3b28be814a585e5c591e168f8fd6d9565f07'
 The output should include '52258126b675dad210a8f04b83d8e90b359951af37474ff985d2c3f49102d981'
 The output should include '7cf24d316bafffc59d30e05d6ad6b27d4c03c9953ce901056f57f03c25e4b83b'
+The status should be success
+End
+
+It 'refreshes hashes when the version is unchanged'
+When run bash -c "env OVERLAY_FILE='$TEMP_DIR/overlays/default.nix' ASCII_BOX_CLI_VERSION='0.1.208' bash '$SCRIPT' ascii-box-cli >/dev/stdout && cat '$TEMP_DIR/overlays/default.nix'"
+The output should include 'ascii-box-cli hashes refreshed for 0.1.208'
+The output should include '11q5gky9i35vgfnqmhaq0w08awrkhw09jakxp1j62ad7gnb9wy0w'
 The status should be success
 End
 End


### PR DESCRIPTION
## Summary

Pin the ASCII Box CLI to its immutable `0.1.208` release assets and make the
overlay updater refresh hashes when the version is unchanged. This repairs
clean Linux builds of `matic` and `kyber` after the channel URL served a newer
binary without a version bump.

### Tracker linkage
- Linear: none — no Linear issue exists for this dotfiles change
- Bead: shunkakinokisoftware-zy55

## Contract diagram

```mermaid
flowchart LR
  C[Versioned release assets] --> H[Platform hashes]
  H --> O[Nix overlay]
  O --> B[Host build]
  B --> S[Host switch]
  U[Upgrade script] --> H
```

## Before / after

| Surface | Before | After |
| --- | --- | --- |
| Linux x86_64 builds | Mutable channel URL failed with a fixed-output hash mismatch | `matic` and `kyber` resolve immutable `0.1.208` assets |
| Overlay maintenance | Same-version channel changes were skipped | Same-version release hashes are refreshed and tested |
| Release integrity | Channel content could change without a version change | URL and hashes identify one published release per platform |

## Breaking and irreversible changes

- **Behavioral:** Host activation receives the current `box 0.1.208` binary.
- **Compile-time:** No source-language contracts changed.
- **Durable state and rollback:** No durable state or migration. Reverting the
  commit restores the previous pins; no external state is changed.

## Deliberate boundaries

The x86_64-darwin support warning and unrelated `builtins.derivation` warning
are outside this corrective hash refresh.

## Verification

- `bash -n scripts/upgrade-overlays.sh spec/upgrade_overlays_spec.sh` — passed.
- `shellcheck scripts/upgrade-overlays.sh spec/upgrade_overlays_spec.sh` — passed.
- `shellspec spec/upgrade_overlays_spec.sh` — passed, 8 examples.
- `nix fmt -- --clear-cache --fail-on-change` — passed.
- `nix-prefetch-url` — release hashes confirmed for darwin-arm64, linux-arm64,
  and linux-x64; Linux x86_64 resolved to
  `0jmp1xvzsnxpgakrd69fiqp2fd8rzcr57s80djlzbdgfs3jr2z60`.
- `matic`: `make build HOST=matic` passed on `3a3d56ab`; the pinned
  `make switch HOST=matic` reached Nix system activation without a hash error,
  then exited because the pre-existing `home-manager-shunkakinoki.service`
  failed during host-side activation after a systemd D-Bus closure and timeout.
- `kyber`: `make nix-switch HOST=kyber` passed on `3a3d56ab`; active profile
  reports `box 0.1.208-ascii-prod1`. The umbrella `make switch HOST=kyber`
  also activated Nix successfully but later failed restarting the pre-existing
  `roborev.service`.

Evidence safety: Not applicable — no rendered UI changed.

Accessibility proofs: Not affected.

Carry-forward attestations: `3a3d56ab` changes only the ShellSpec stdout
assertion; the host build/switch results from `79288bb7` remain valid because
the Nix overlay and activation inputs are unchanged.

Superseded assets: None.

Cleanup: No visual artifacts were created.
