### PR TITLE
fix(hyprland): isolate compositor library path

### DIFF
--- a/config/hyprland/default.nix
+++ b/config/hyprland/default.nix
@@ -17,6 +17,14 @@
     + builtins.readFile ./hyprland.conf;
   };
 
+  # Shells expose native addon dependencies through LD_LIBRARY_PATH. UWSM
+  # sources the login profile before starting Hyprland, so keep that broad
+  # loader override out of the graphical session and let Nix RUNPATHs select
+  # the matching C++ runtime for the compositor closure.
+  xdg.configFile."uwsm/env".text = ''
+    unset LD_LIBRARY_PATH
+  '';
+
   xdg.configFile."hypr/scripts/toggle-terminal.sh" = {
     source = ./scripts/toggle-terminal.sh;
     executable = true;

--- a/spec/hyprland_uwsm_env_spec.sh
+++ b/spec/hyprland_uwsm_env_spec.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'Hyprland UWSM environment isolation'
+MODULE="$PWD/config/hyprland/default.nix"
+
+It 'removes the shell-wide library override before starting Hyprland'
+When run bash -c "grep -F 'xdg.configFile.\"uwsm/env\".text' '$MODULE' && grep -F 'unset LD_LIBRARY_PATH' '$MODULE'"
+The output should include 'xdg.configFile."uwsm/env".text'
+The output should include 'unset LD_LIBRARY_PATH'
+End
+
+End


### PR DESCRIPTION
## Summary
- keep shell-wide native addon libraries out of UWSM graphical sessions
- let Hyprland use the C++ runtime from its Nix closure
- add regression coverage for the UWSM environment file

## Validation
- `make nix-format-check`
- `shellspec spec/hyprland_uwsm_env_spec.sh`
- full ShellSpec suite: 2455 examples, 0 failures
- live Matic recovery: Hyprland and graphical-session targets active

## Known unrelated failures
- full Matic build is blocked by the existing ASCII Box fixed-output hash mismatch
- aggregate `make shell-test` reaches unrelated CAAM Fish expectations (2 failures); this change does not touch those files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Hyprland from inheriting shell-wide `LD_LIBRARY_PATH` libraries, which could load mismatched native addons into the compositor. UWSM now unsets `LD_LIBRARY_PATH` before starting Hyprland, letting the Nix closure's RUNPATH select the correct C++ runtime. Adds a ShellSpec regression check for the UWSM environment file.

<sup>Written for commit d7bf33c8377367174611f14d68c0ec311222dd74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

