### PR TITLE
fix(darwin): remove unsupported SMB defaults activation

### DIFF
--- a/nix-darwin/config/system.nix
+++ b/nix-darwin/config/system.nix
@@ -180,10 +180,6 @@
         askForPassword = true;
         askForPasswordDelay = 0;
       };
-      smb = {
-        NetBIOSName = "MAC";
-        ServerDescription = config.networking.hostName;
-      };
       spaces.spans-displays = null;
       trackpad = {
         ActuateDetents = true;


### PR DESCRIPTION
## Summary
- remove the nix-darwin SMB defaults block
- avoid macOS 26 cfprefsd rejecting the generated activation write

## Verification
- `make build` passes
- live `make switch` passed the former SMB failure and continued through Home Manager activation
- `git diff --check` passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unsupported SMB defaults block in `nix-darwin/config/system.nix` so macOS 26 no longer rejects the generated activation write. This fixes a failure where `cfprefsd` rejected the unsupported settings during activation.

<sup>Written for commit 53036bcc2c39f56935c2e77721e0428a91b96248. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

