### PR TITLE
fix(fish): skip grr when git index is locked

### DIFF
--- a/home-manager/programs/fish/functions/_grr_function.fish
+++ b/home-manager/programs/fish/functions/_grr_function.fish
@@ -26,6 +26,18 @@ function _grr_function --description "Refresh to origin default branch every 3 m
     set -l default_branch (git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
     set -l ts (date '+%Y-%m-%d %H:%M:%S')
     set -l ok 0
+    set -l index_lock (git rev-parse --git-path index.lock 2>/dev/null)
+
+    # Another Git process owns the index. Do not race it or remove its lock;
+    # retry on the next cycle instead.
+    if test -n "$index_lock"; and test -e "$index_lock"
+      echo "[$ts] grr: git index is locked, skipping" >&2
+      if test $once -eq 1
+        return 1
+      end
+      sleep $interval
+      continue
+    end
 
     if not git fetch origin $default_branch
       echo "[$ts] grr: fetch failed, will retry" >&2
@@ -40,10 +52,15 @@ function _grr_function --description "Refresh to origin default branch every 3 m
         # On default branch, clean tree: pull if fast-forwardable (no conflicts)
         if git merge-base --is-ancestor HEAD origin/$default_branch
           echo "[$ts] grr: pull --ff-only origin/$default_branch"
-          if git pull --ff-only origin $default_branch
+          set -l pull_output (git pull --ff-only origin $default_branch 2>&1)
+          set -l pull_status $status
+          if test $pull_status -eq 0
             set ok 1
             echo "[$ts] grr: ok (pulled origin/$default_branch)"
+          else if string match -q '*index.lock*' -- $pull_output
+            echo "[$ts] grr: git index became locked, will retry" >&2
           else
+            printf '%s\n' $pull_output >&2
             echo "[$ts] grr: pull failed, will retry" >&2
           end
         else

--- a/spec/fish/_grr_function_test.fish
+++ b/spec/fish/_grr_function_test.fish
@@ -195,3 +195,41 @@ set exit_code $status
 @test "fail: prints warning" (grep -c "fetch failed" $err_log) -ge 1
 
 rm -f $call_log $err_log
+
+# --- Test: an existing Git index lock skips the cycle ---
+
+set call_log (mktemp)
+set err_log (mktemp)
+set lock_path (mktemp)
+
+function git
+    echo $argv >> $call_log
+    switch $argv[1]
+        case symbolic-ref
+            echo "refs/remotes/origin/main"
+        case rev-parse
+            if contains -- '--git-path' $argv
+                echo $lock_path
+            else
+                echo "main"
+            end
+    end
+end
+
+function sed
+    echo "main"
+end
+
+function date
+    echo "2026-07-16 12:00:00"
+end
+
+_grr_function --once 2>$err_log
+set exit_code $status
+
+@test "locked: non-zero exit" $exit_code -ne 0
+@test "locked: skips fetch" (grep -c "fetch" $call_log) -eq 0
+@test "locked: skips pull" (grep -c "pull" $call_log) -eq 0
+@test "locked: prints warning" (grep -c "git index is locked" $err_log) -eq 1
+
+rm -f $call_log $err_log $lock_path


### PR DESCRIPTION
Summary:
- skip a grr cycle while another Git process owns index.lock
- suppress and retry index-lock races during pull
- add focused lock handling coverage

Tests:
- focused grr fishtape test: 25/25 passed
- full fish suite: 466/468 passed; 2 pre-existing CAAM profile expectation failures in _caam_exec_function_test.fish

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the `grr` refresh cycle from racing the Git index lock: it now checks for `index.lock` before fetching and skips the cycle when another Git process holds it. Pull failures caused by a transient index lock are retried instead of reported as failures.

- Detects the lock with `git rev-parse --git-path index.lock` and skips only that cycle.
- Pull output matching `index.lock` is suppressed and retried on the next cycle.
- Adds focused fishtape tests covering the locked-skip and lock-race paths.

<sup>Written for commit e8bc4a6f7413b3022a5955087e5ca3def59cdec9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

