### PR TITLE
fix(openclaw): route Telegram to main agent

### DIFF
--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -204,6 +204,16 @@
       ]
     }
   },
+  "bindings": [
+    {
+      "type": "route",
+      "agentId": "main",
+      "match": {
+        "channel": "telegram",
+        "accountId": "default"
+      }
+    }
+  ],
   "agents": {
     "ownership": "explicit",
     "defaults": {

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -204,6 +204,16 @@
       ]
     }
   },
+  "bindings": [
+    {
+      "type": "route",
+      "agentId": "main",
+      "match": {
+        "channel": "telegram",
+        "accountId": "default"
+      }
+    }
+  ],
   "agents": {
     "ownership": "explicit",
     "defaults": {

--- a/spec/openclaw_hydrate_spec.sh
+++ b/spec/openclaw_hydrate_spec.sh
@@ -28,7 +28,6 @@ template_uses_cliproxy_flash_default() {
 
 template_disables_groups() {
   jq -e '
-    (.bindings? == null) and
     (.broadcast? == null) and
     (.channels.telegram.groups? == null) and
     (.channels.telegram.groupPolicy == "disabled") and
@@ -41,6 +40,28 @@ template_disables_groups() {
     ))
   ' "$PWD/config/openclaw/openclaw.template.json" >/dev/null
 }
+
+template_routes_telegram_to_main() {
+  jq -e '
+    .bindings == [
+      {
+        "type": "route",
+        "agentId": "main",
+        "match": {
+          "channel": "telegram",
+          "accountId": "default"
+        }
+      }
+    ]
+  ' "$PWD/config/openclaw/openclaw.template.json" >/dev/null
+}
+
+Describe 'channel routing'
+It 'routes the Telegram default account to the main agent'
+When call template_routes_telegram_to_main
+The status should be success
+End
+End
 
 Describe 'script properties'
 It 'uses bash shebang'


### PR DESCRIPTION
## Summary
- add an explicit route for the Telegram default account to the main agent
- cover the routing contract with the OpenClaw hydration spec

## Validation
- `shellspec spec/openclaw_hydrate_spec.sh`
- `jq empty config/openclaw/openclaw.tpl.json config/openclaw/openclaw.template.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Telegram's default account to the main agent in OpenClaw config templates, so Telegram messages now reach the main agent instead of remaining unrouted.

- Adds a `bindings` route in `config/openclaw/openclaw.template.json` and `config/openclaw/openclaw.tpl.json`.
- Updates the OpenClaw hydration spec to assert the new route and drops the old expectation that `bindings` was null.

<sup>Written for commit a2b568857b03d401725c1b41d7171862c6acf5f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

