### PR TITLE
fix(matic): replace Noctalia lock with hyprlock

### DIFF
--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -423,8 +423,10 @@ binde = CTRL ALT SHIFT SUPER, minus, exec, hyprctl -j monitors | jq -r '.[0].sca
 # =============================================================================
 # Lock Screen
 # =============================================================================
-bind = CTRL ALT SHIFT SUPER, L, exec, noctalia msg session lock
-bindl = , switch:on:Lid Switch, exec, noctalia msg session lock
+$lock = systemctl --user start hyprlock.service
+bind = CTRL ALT SHIFT SUPER, L, exec, $lock
+bindl = , switch:on:Lid Switch, exec, $lock
+bindl = , XF86PowerOff, exec, $lock
 
 # =============================================================================
 # Notification Toggle

--- a/config/noctalia/ac-idle-inhibit.sh
+++ b/config/noctalia/ac-idle-inhibit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # On battery: run swayidle for screen-off (5 min) and suspend (10 min).
-# On AC: stop swayidle so only noctalia's lock fires.
+# On AC: stop swayidle so only the configured hyprlock idle trigger fires.
 set -euo pipefail
 
 AC=/sys/class/power_supply/ACAD/online

--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -6,8 +6,9 @@
 let
   # v5 renamed the binary noctalia-shell -> noctalia (pname/mainProgram = "noctalia").
   noctalia = inputs.noctalia-shell.packages.${pkgs.system}.default;
-  noctaliaLockBeforeSleep = pkgs.replaceVars ./lock-before-sleep.sh {
-    noctalia = "${noctalia}/bin/noctalia";
+  lockCommand = "${pkgs.systemd}/bin/systemctl --user start hyprlock.service";
+  lockBeforeSleep = pkgs.replaceVars ./lock-before-sleep.sh {
+    systemctl = "${pkgs.systemd}/bin/systemctl";
     sleep = "${pkgs.coreutils}/bin/sleep";
   };
   quitAllAppsScript = pkgs.replaceVars ./quit-all-apps-launcher.sh {
@@ -16,6 +17,66 @@ let
   };
 in
 {
+  home.packages = [ pkgs.hyprlock ];
+
+  systemd.user.services.hyprlock = {
+    Unit = {
+      Description = "Hyprland screen locker";
+      After = [ "graphical-session.target" ];
+      PartOf = [ "graphical-session.target" ];
+    };
+    Service = {
+      Type = "simple";
+      ExecStart = "${pkgs.hyprlock}/bin/hyprlock --immediate-render";
+      Restart = "no";
+    };
+  };
+
+  xdg.configFile."hypr/hyprlock.conf".text = ''
+    general {
+        hide_cursor = true
+        immediate_render = true
+    }
+
+    auth {
+        pam:enabled = true
+        pam:module = hyprlock
+        fingerprint:enabled = true
+    }
+
+    background {
+        monitor =
+        color = rgb(282a36)
+    }
+
+    label {
+        monitor =
+        text = $TIME
+        color = rgb(f8f8f2)
+        font_size = 64
+        position = 0, 120
+        halign = center
+        valign = center
+    }
+
+    input-field {
+        monitor =
+        size = 360, 64
+        outline_thickness = 3
+        dots_size = 0.2
+        dots_spacing = 0.3
+        outer_color = rgb(bd93f9)
+        inner_color = rgb(44475a)
+        font_color = rgb(f8f8f2)
+        check_color = rgb(8be9fd)
+        fail_color = rgb(ff5555)
+        placeholder_text = <i>Password</i>
+        position = 0, -30
+        halign = center
+        valign = center
+    }
+  '';
+
   # NOTE: v4 shipped a Dracula-Custom colorscheme at noctalia/colorschemes/...
   # v5 replaced colorschemes with a palette/theme system (noctalia/palettes/*.json,
   # different format), so the old file is no longer wired up. Recreate the palette
@@ -45,14 +106,14 @@ in
     Install.WantedBy = [ "graphical-session.target" ];
   };
 
-  systemd.user.services.noctalia-lock-before-sleep = {
+  systemd.user.services.hyprlock-before-sleep = {
     Unit = {
-      Description = "Lock Noctalia before system sleep";
+      Description = "Start hyprlock before system sleep";
       Before = [ "sleep.target" ];
     };
     Service = {
       Type = "oneshot";
-      ExecStart = "${pkgs.bash}/bin/bash ${noctaliaLockBeforeSleep}";
+      ExecStart = "${pkgs.bash}/bin/bash ${lockBeforeSleep}";
     };
     Install.WantedBy = [ "sleep.target" ];
   };
@@ -126,7 +187,7 @@ in
   xdg.desktopEntries.lock-screen = {
     name = "Lock Screen";
     comment = "Lock the session";
-    exec = "${noctalia}/bin/noctalia msg session lock";
+    exec = lockCommand;
     terminal = false;
     categories = [ "System" ];
     icon = "system-lock-screen";
@@ -259,20 +320,20 @@ in
       osd.position = "right";
 
       lockscreen = {
-        enabled = true;
+        enabled = false;
         fingerprint = true;
         blurred_desktop = true;
         blur_intensity = 0.4;
         tint_intensity = 0.2;
       };
 
-      lockscreen_widgets.enabled = true;
+      lockscreen_widgets.enabled = false;
 
       idle = {
         behavior.lock = {
           enabled = true;
           timeout = 300;
-          command = "noctalia msg session lock";
+          command = lockCommand;
         };
         behavior.screen-off.enabled = false;
         behavior.suspend.enabled = false;

--- a/config/noctalia/lock-before-sleep.sh
+++ b/config/noctalia/lock-before-sleep.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
-# Lock through Noctalia before systemd lets suspend continue.
+# Start hyprlock before systemd lets suspend continue.
 set -euo pipefail
 
-NOCTALIA="@noctalia@"
+SYSTEMCTL="@systemctl@"
 SLEEP="@sleep@"
 
-# v5 IPC surface: `noctalia msg session <lock|...>` (was `ipc call lockScreen lock`).
-if ! "$NOCTALIA" msg session lock; then
+if ! "$SYSTEMCTL" --user start hyprlock.service; then
   exit 0
 fi
 

--- a/config/walker/config.toml
+++ b/config/walker/config.toml
@@ -58,8 +58,8 @@ provider = "providerlist"
 # Custom Commands (searchable system actions)
 # =============================================================================
 [customcommands]
-"Lock Screen" = "hyprlock"
-"Start Screen Saver" = "hyprlock"
+"Lock Screen" = "systemctl --user start hyprlock.service"
+"Start Screen Saver" = "systemctl --user start hyprlock.service"
 "Suspend" = "systemctl suspend"
 "Reboot" = "systemctl reboot"
 "Shutdown" = "systemctl poweroff"

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -240,6 +240,9 @@ import ../../hosts/nixos {
             timeout = -1;
           };
         };
+        security.pam.services.hyprlock = {
+          fprintAuth = true;
+        };
         security.pam.services.sudo = {
           fprintAuth = true;
         };

--- a/spec/hyprland_lid_lock_spec.sh
+++ b/spec/hyprland_lid_lock_spec.sh
@@ -1,13 +1,23 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2329
 
-Describe 'config/hyprland/hyprland.conf lid lock binding'
+Describe 'config/hyprland/hyprland.conf hyprlock bindings'
 CONFIG="$PWD/config/hyprland/hyprland.conf"
 
-It 'locks Noctalia when Hyprland reports the lid switch closing'
-When run bash -c "grep -F 'bindl = , switch:on:Lid Switch, exec, noctalia msg session lock' '$CONFIG'"
+It 'defines the managed hyprlock command'
+When run bash -c "grep -F '\$lock = systemctl --user start hyprlock.service' '$CONFIG'"
+The output should include 'hyprlock.service'
+End
+
+It 'locks through hyprlock when Hyprland reports the lid switch closing'
+When run bash -c "grep -F 'bindl = , switch:on:Lid Switch, exec, \$lock' '$CONFIG'"
 The output should include 'switch:on:Lid Switch'
-The output should include 'msg session lock'
+The output should include 'exec, $lock'
+End
+
+It 'routes the power key through hyprlock'
+When run bash -c "grep -F 'bindl = , XF86PowerOff, exec, \$lock' '$CONFIG'"
+The output should include 'XF86PowerOff'
 End
 
 End

--- a/spec/hyprlock_spec.sh
+++ b/spec/hyprlock_spec.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016,SC2329
+
+Describe 'managed hyprlock integration'
+MODULE="$PWD/config/noctalia/default.nix"
+MATIC="$PWD/named-hosts/matic/default.nix"
+WALKER="$PWD/config/walker/config.toml"
+
+It 'installs and manages hyprlock as a graphical-session service'
+When run bash -c "grep -F 'systemd.user.services.hyprlock' '$MODULE' && grep -F 'ExecStart = \"\${pkgs.hyprlock}/bin/hyprlock --immediate-render\";' '$MODULE'"
+The output should include 'systemd.user.services.hyprlock'
+The output should include 'hyprlock --immediate-render'
+End
+
+It 'starts hyprlock before system sleep'
+When run bash -c "grep -F 'systemd.user.services.hyprlock-before-sleep' '$MODULE' && grep -F 'ExecStart = \"\${pkgs.bash}/bin/bash \${lockBeforeSleep}\";' '$MODULE'"
+The output should include 'hyprlock-before-sleep'
+The output should include 'lockBeforeSleep'
+End
+
+It 'provides an authenticated visible lock configuration'
+When run bash -c "grep -F 'xdg.configFile.\"hypr/hyprlock.conf\"' '$MODULE' && grep -F 'fingerprint:enabled = true' '$MODULE' && grep -F 'input-field {' '$MODULE'"
+The output should include 'hypr/hyprlock.conf'
+The output should include 'fingerprint:enabled = true'
+The output should include 'input-field {'
+End
+
+It 'disables the crashing Noctalia lockscreen and routes idle locking to hyprlock'
+When run bash -c "grep -A4 'lockscreen = {' '$MODULE' && grep -A5 'behavior.lock = {' '$MODULE'"
+The output should include 'enabled = false'
+The output should include 'command = lockCommand'
+End
+
+It 'configures fingerprint PAM authentication on Matic'
+When run bash -c "grep -A2 'security.pam.services.hyprlock' '$MATIC'"
+The output should include 'fprintAuth = true'
+End
+
+It 'routes Walker lock actions through the managed service'
+When run bash -c "grep -F '\"Lock Screen\" = \"systemctl --user start hyprlock.service\"' '$WALKER' && grep -F '\"Start Screen Saver\" = \"systemctl --user start hyprlock.service\"' '$WALKER'"
+The output should include 'Lock Screen'
+The output should include 'Start Screen Saver'
+End
+
+End

--- a/spec/noctalia_lock_before_sleep_spec.sh
+++ b/spec/noctalia_lock_before_sleep_spec.sh
@@ -11,13 +11,13 @@ End
 
 It 'uses injected command paths'
 When run bash -c "cat '$SCRIPT'"
-The output should include '@noctalia@'
+The output should include '@systemctl@'
 The output should include '@sleep@'
 End
 
-It 'calls Noctalia lock IPC before sleeping'
+It 'starts the managed hyprlock service before sleeping'
 When run bash -c "cat '$SCRIPT'"
-The output should include 'msg session lock'
+The output should include 'start hyprlock.service'
 The output should include '"$SLEEP" 1'
 End
 


### PR DESCRIPTION
## Summary
- replace the crashing Noctalia v5 session lock with a managed Hyprlock user service
- route manual, lid, power-key, idle, Walker, and pre-suspend lock entrypoints through Hyprlock
- enable Matic fingerprint PAM and add focused regression specs

## Validation
- `shellspec spec/hyprlock_spec.sh spec/hyprland_lid_lock_spec.sh spec/noctalia_lock_before_sleep_spec.sh` (12 examples, 0 failures)
- `nixfmt --check config/noctalia/default.nix named-hosts/matic/default.nix`
- `shellcheck config/noctalia/lock-before-sleep.sh config/noctalia/ac-idle-inhibit.sh`
- Matic eval: `/nix/store/q69xs03zqz4z11az2fba7ra2bd3r5lvq-nixos-system-matic-26.11.20260829.e8be781.drv`
- exact patch built successfully on Matic

Closes shunkakinokisoftware-knwb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the crashing Noctalia v5 session lock with a managed `hyprlock` user service on Matic.

- Routes manual, lid, power-key, Walker, idle, and pre-suspend lock entrypoints through `hyprlock`.
- Disables Noctalia's lockscreen and lockscreen widgets.
- Enables fingerprint PAM for `hyprlock` on Matic.

<sup>Written for commit fa5bfb1b2720fdbc942406040cddeb98f97500a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

