### PR TITLE
fix(matic): isolate hyprlock runtime libraries

### DIFF
--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -28,6 +28,7 @@ in
     Service = {
       Type = "simple";
       ExecStart = "${pkgs.hyprlock}/bin/hyprlock --immediate-render";
+      UnsetEnvironment = "LD_LIBRARY_PATH";
       Restart = "no";
     };
   };

--- a/spec/hyprlock_spec.sh
+++ b/spec/hyprlock_spec.sh
@@ -7,9 +7,10 @@ MATIC="$PWD/named-hosts/matic/default.nix"
 WALKER="$PWD/config/walker/config.toml"
 
 It 'installs and manages hyprlock as a graphical-session service'
-When run bash -c "grep -F 'systemd.user.services.hyprlock' '$MODULE' && grep -F 'ExecStart = \"\${pkgs.hyprlock}/bin/hyprlock --immediate-render\";' '$MODULE'"
+When run bash -c "grep -F 'systemd.user.services.hyprlock' '$MODULE' && grep -F 'ExecStart = \"\${pkgs.hyprlock}/bin/hyprlock --immediate-render\";' '$MODULE' && grep -F 'UnsetEnvironment = \"LD_LIBRARY_PATH\";' '$MODULE'"
 The output should include 'systemd.user.services.hyprlock'
 The output should include 'hyprlock --immediate-render'
+The output should include 'UnsetEnvironment = "LD_LIBRARY_PATH";'
 End
 
 It 'starts hyprlock before system sleep'


### PR DESCRIPTION
## Summary
- clear the polluted `LD_LIBRARY_PATH` only for the managed Hyprlock service
- keep all other desktop processes and environment settings unchanged
- assert the runtime isolation in the Hyprlock regression spec

## Evidence
- direct `hyprlock --help` failed on Matic with missing `GLIBCXX_3.4.36`
- `env -u LD_LIBRARY_PATH hyprlock --help` succeeds
- focused ShellSpec: 12 examples, 0 failures
- `nixfmt --check config/noctalia/default.nix`

Follow-up to #2594 and shunkakinokisoftware-knwb.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hyprlock failing on Matic with `GLIBCXX_3.4.36` not found by clearing the inherited `LD_LIBRARY_PATH` only for the managed Hyprlock service.

- Sets `UnsetEnvironment = "LD_LIBRARY_PATH"` on the Hyprlock systemd unit in `config/noctalia/default.nix`.
- Extends the regression spec to assert the new environment isolation.

<sup>Written for commit 0eacc26d721d0bd17233c542787f4dda4385ebc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

