### PR TITLE
fix(matic): keep screen lock across activation

### DIFF
--- a/config/hyprland/hyprland.conf
+++ b/config/hyprland/hyprland.conf
@@ -423,7 +423,7 @@ binde = CTRL ALT SHIFT SUPER, minus, exec, hyprctl -j monitors | jq -r '.[0].sca
 # =============================================================================
 # Lock Screen
 # =============================================================================
-$lock = systemctl --user start hyprlock.service
+$lock = lock-screen
 bind = CTRL ALT SHIFT SUPER, L, exec, $lock
 bindl = , switch:on:Lid Switch, exec, $lock
 bindl = , XF86PowerOff, exec, $lock

--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -6,9 +6,17 @@
 let
   # v5 renamed the binary noctalia-shell -> noctalia (pname/mainProgram = "noctalia").
   noctalia = inputs.noctalia-shell.packages.${pkgs.system}.default;
-  lockCommand = "${pkgs.systemd}/bin/systemctl --user start hyprlock.service";
+  lockScreen = pkgs.writeShellApplication {
+    name = "lock-screen";
+    runtimeInputs = [
+      pkgs.hyprlock
+      pkgs.systemd
+    ];
+    text = builtins.readFile ./lock-screen.sh;
+  };
+  lockCommand = "${lockScreen}/bin/lock-screen";
   lockBeforeSleep = pkgs.replaceVars ./lock-before-sleep.sh {
-    systemctl = "${pkgs.systemd}/bin/systemctl";
+    lockScreen = lockCommand;
     sleep = "${pkgs.coreutils}/bin/sleep";
   };
   quitAllAppsScript = pkgs.replaceVars ./quit-all-apps-launcher.sh {
@@ -17,21 +25,10 @@ let
   };
 in
 {
-  home.packages = [ pkgs.hyprlock ];
-
-  systemd.user.services.hyprlock = {
-    Unit = {
-      Description = "Hyprland screen locker";
-      After = [ "graphical-session.target" ];
-      PartOf = [ "graphical-session.target" ];
-    };
-    Service = {
-      Type = "simple";
-      ExecStart = "${pkgs.hyprlock}/bin/hyprlock --immediate-render";
-      UnsetEnvironment = "LD_LIBRARY_PATH";
-      Restart = "no";
-    };
-  };
+  home.packages = [
+    pkgs.hyprlock
+    lockScreen
+  ];
 
   xdg.configFile."hypr/hyprlock.conf".text = ''
     general {

--- a/config/noctalia/lock-before-sleep.sh
+++ b/config/noctalia/lock-before-sleep.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Start hyprlock before systemd lets suspend continue.
+# Start the transient hyprlock unit before systemd lets suspend continue.
 set -euo pipefail
 
-SYSTEMCTL="@systemctl@"
+LOCK_SCREEN="@lockScreen@"
 SLEEP="@sleep@"
 
-if ! "$SYSTEMCTL" --user start hyprlock.service; then
+if ! "$LOCK_SCREEN"; then
   exit 0
 fi
 

--- a/config/noctalia/lock-screen.sh
+++ b/config/noctalia/lock-screen.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Start hyprlock outside Home Manager's managed unit set so activation cannot
+# restart an active locker and orphan Hyprland's secure session lock.
+set -euo pipefail
+
+if systemctl --user is-active --quiet hyprlock.service; then
+  exit 0
+fi
+
+HYPRLOCK="$(command -v hyprlock)"
+
+if systemd-run \
+  --user \
+  --quiet \
+  --collect \
+  --unit=hyprlock.service \
+  --property='Description=Hyprland screen locker' \
+  --property=PartOf=graphical-session.target \
+  --property=UnsetEnvironment=LD_LIBRARY_PATH \
+  "$HYPRLOCK" --immediate-render; then
+  exit 0
+fi
+
+# Treat a concurrent lock request as success if it won the unit creation race.
+systemctl --user is-active --quiet hyprlock.service

--- a/config/walker/config.toml
+++ b/config/walker/config.toml
@@ -58,8 +58,8 @@ provider = "providerlist"
 # Custom Commands (searchable system actions)
 # =============================================================================
 [customcommands]
-"Lock Screen" = "systemctl --user start hyprlock.service"
-"Start Screen Saver" = "systemctl --user start hyprlock.service"
+"Lock Screen" = "lock-screen"
+"Start Screen Saver" = "lock-screen"
 "Suspend" = "systemctl suspend"
 "Reboot" = "systemctl reboot"
 "Shutdown" = "systemctl poweroff"

--- a/spec/hyprland_lid_lock_spec.sh
+++ b/spec/hyprland_lid_lock_spec.sh
@@ -4,9 +4,9 @@
 Describe 'config/hyprland/hyprland.conf hyprlock bindings'
 CONFIG="$PWD/config/hyprland/hyprland.conf"
 
-It 'defines the managed hyprlock command'
-When run bash -c "grep -F '\$lock = systemctl --user start hyprlock.service' '$CONFIG'"
-The output should include 'hyprlock.service'
+It 'defines the transient hyprlock command'
+When run bash -c "grep -F '\$lock = lock-screen' '$CONFIG'"
+The output should include 'lock-screen'
 End
 
 It 'locks through hyprlock when Hyprland reports the lid switch closing'

--- a/spec/hyprlock_spec.sh
+++ b/spec/hyprlock_spec.sh
@@ -5,12 +5,24 @@ Describe 'managed hyprlock integration'
 MODULE="$PWD/config/noctalia/default.nix"
 MATIC="$PWD/named-hosts/matic/default.nix"
 WALKER="$PWD/config/walker/config.toml"
+LOCK_SCRIPT="$PWD/config/noctalia/lock-screen.sh"
 
-It 'installs and manages hyprlock as a graphical-session service'
-When run bash -c "grep -F 'systemd.user.services.hyprlock' '$MODULE' && grep -F 'ExecStart = \"\${pkgs.hyprlock}/bin/hyprlock --immediate-render\";' '$MODULE' && grep -F 'UnsetEnvironment = \"LD_LIBRARY_PATH\";' '$MODULE'"
-The output should include 'systemd.user.services.hyprlock'
-The output should include 'hyprlock --immediate-render'
-The output should include 'UnsetEnvironment = "LD_LIBRARY_PATH";'
+It 'installs a stable lock-screen command without a Home Manager service'
+When run bash -c "grep -F 'name = \"lock-screen\";' '$MODULE' && ! grep -F 'systemd.user.services.hyprlock = {' '$MODULE'"
+The output should include 'name = "lock-screen";'
+The output should not include 'systemd.user.services.hyprlock'
+End
+
+It 'runs hyprlock as a transient unit with a clean library environment'
+When run bash -c "grep -F -- '--unit=hyprlock.service' '$LOCK_SCRIPT' && grep -F -- '--collect' '$LOCK_SCRIPT' && grep -F -- '--property=UnsetEnvironment=LD_LIBRARY_PATH' '$LOCK_SCRIPT'"
+The output should include '--unit=hyprlock.service'
+The output should include '--collect'
+The output should include 'UnsetEnvironment=LD_LIBRARY_PATH'
+End
+
+It 'makes repeated and concurrent lock requests idempotent'
+When run bash -c "grep -Fc 'systemctl --user is-active --quiet hyprlock.service' '$LOCK_SCRIPT'"
+The output should eq '2'
 End
 
 It 'starts hyprlock before system sleep'
@@ -37,8 +49,8 @@ When run bash -c "grep -A2 'security.pam.services.hyprlock' '$MATIC'"
 The output should include 'fprintAuth = true'
 End
 
-It 'routes Walker lock actions through the managed service'
-When run bash -c "grep -F '\"Lock Screen\" = \"systemctl --user start hyprlock.service\"' '$WALKER' && grep -F '\"Start Screen Saver\" = \"systemctl --user start hyprlock.service\"' '$WALKER'"
+It 'routes Walker lock actions through the transient command'
+When run bash -c "grep -F '\"Lock Screen\" = \"lock-screen\"' '$WALKER' && grep -F '\"Start Screen Saver\" = \"lock-screen\"' '$WALKER'"
 The output should include 'Lock Screen'
 The output should include 'Start Screen Saver'
 End

--- a/spec/noctalia_lock_before_sleep_spec.sh
+++ b/spec/noctalia_lock_before_sleep_spec.sh
@@ -11,13 +11,13 @@ End
 
 It 'uses injected command paths'
 When run bash -c "cat '$SCRIPT'"
-The output should include '@systemctl@'
+The output should include '@lockScreen@'
 The output should include '@sleep@'
 End
 
-It 'starts the managed hyprlock service before sleeping'
+It 'starts the transient hyprlock unit before sleeping'
 When run bash -c "cat '$SCRIPT'"
-The output should include 'start hyprlock.service'
+The output should include '"$LOCK_SCREEN"'
 The output should include '"$SLEEP" 1'
 End
 


### PR DESCRIPTION
## Summary
- replace the Home Manager-owned static Hyprlock service with a collected transient user unit
- route manual, lid, power, idle, Walker, desktop, and pre-sleep locking through an idempotent `lock-screen` command
- preserve the clean `LD_LIBRARY_PATH` runtime fix while preventing activation from restarting an active locker

## Root cause
A NixOS/Home Manager switch stopped a running Hyprlock service. Hyprland securely retained the session lock, while the restarted process could not reacquire it, leaving a black locked session until the compositor exited.

## Validation
- focused ShellSpec: 14 examples, 0 failures
- `nixfmt --check config/noctalia/default.nix`
- `shellcheck` for all lock scripts

Closes shunkakinokisoftware-37lm.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes screen lock surviving a NixOS/Home Manager switch by moving `hyprlock` from a managed service to a transient unit. Previously, a config switch stopped the running `hyprlock` service, leaving the session locked with a black screen until the compositor exited.

- Replaces the Home Manager–owned `hyprlock` service with a `lock-screen` command that starts a transient unit via `systemd-run`.
- Routes all lock triggers (keyboard, lid, power, idle, Walker, pre-sleep) through `lock-screen`, which is idempotent and preserves the `LD_LIBRARY_PATH` fix.

Closes shunkakinokisoftware-37lm.

<sup>Written for commit 60bdef54c30326e41887155f70eddad1f8a71bed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

