### PR TITLE
test(matic): cover transient lock wrapper

### DIFF
--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -537,6 +537,7 @@ config/k3s/kyber-host-health.sh
 config/llm/hydrate.sh
 config/noctalia/ac-idle-inhibit.sh
 config/noctalia/lock-before-sleep.sh
+config/noctalia/lock-screen.sh
 config/noctalia/quit-active-app.sh
 config/noctalia/quit-all-apps-launcher.sh
 config/noctalia/quit-all-apps.sh

--- a/spec/hyprland_lid_lock_spec.sh
+++ b/spec/hyprland_lid_lock_spec.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2329
+# shellcheck disable=SC2016,SC2329
 
 Describe 'config/hyprland/hyprland.conf hyprlock bindings'
 CONFIG="$PWD/config/hyprland/hyprland.conf"


### PR DESCRIPTION
## Summary
- register the new `lock-screen.sh` wrapper in the repository shell coverage inventory
- suppress the intentional literal `$lock` ShellSpec assertion from ShellCheck

## Validation
- `make shell-check`
- focused ShellSpec plus coverage: 132 examples, 0 failures

Follow-up to #2596 and shunkakinokisoftware-37lm.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `lock-screen.sh` wrapper to the shell coverage inventory and suppresses a ShellCheck warning (SC2016) for a literal `$lock` in the hyprland lid lock spec.

<sup>Written for commit 3b9c4e62589134c231fd8a2c8b992f9743e52c8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

