### PR TITLE
feat(matic): restore blurred Hyprlock background

### DIFF
--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -44,7 +44,14 @@ in
 
     background {
         monitor =
+        path = screenshot
         color = rgb(282a36)
+        blur_passes = 3
+        blur_size = 8
+        noise = 0.0117
+        contrast = 0.9
+        brightness = 0.8
+        vibrancy = 0.15
     }
 
     label {

--- a/spec/hyprlock_spec.sh
+++ b/spec/hyprlock_spec.sh
@@ -38,6 +38,15 @@ The output should include 'fingerprint:enabled = true'
 The output should include 'input-field {'
 End
 
+It 'renders the desktop screenshot with a bounded blur treatment'
+When run bash -c "grep -A9 'background {' '$MODULE'"
+The output should include 'path = screenshot'
+The output should include 'color = rgb(282a36)'
+The output should include 'blur_passes = 3'
+The output should include 'blur_size = 8'
+The output should include 'brightness = 0.8'
+End
+
 It 'disables the crashing Noctalia lockscreen and routes idle locking to hyprlock'
 When run bash -c "grep -A4 'lockscreen = {' '$MODULE' && grep -A5 'behavior.lock = {' '$MODULE'"
 The output should include 'enabled = false'


### PR DESCRIPTION
## Summary
- render the current desktop screenshot behind Hyprlock
- apply bounded blur and Dracula-compatible tone adjustments
- retain the solid fallback used during immediate rendering
- cover the managed visual settings in the focused Hyprlock spec

## Validation
- `nix shell nixpkgs#shellspec nixpkgs#ripgrep --command shellspec --format documentation spec/hyprlock_spec.sh`
- `make nix-format-check`

Bead: shunkakinokisoftware-t7q0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the blurred Hyprlock background by rendering the current desktop screenshot behind the lock screen with a bounded blur and Dracula-compatible tone adjustments. The solid color fallback remains for immediate rendering, and the Hyprlock spec now covers these visual settings.

<sup>Written for commit 82c41cf5036c5645fbaf711176c6f7238cb5a879. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

