### PR TITLE
style(matic): match lock and home clock type

### DIFF
--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -58,7 +58,8 @@ in
         monitor =
         text = $TIME
         color = rgb(f8f8f2)
-        font_size = 64
+        font_family = Noto Sans
+        font_size = 156
         position = 0, 120
         halign = center
         valign = center

--- a/spec/hyprlock_spec.sh
+++ b/spec/hyprlock_spec.sh
@@ -6,6 +6,7 @@ MODULE="$PWD/config/noctalia/default.nix"
 MATIC="$PWD/named-hosts/matic/default.nix"
 WALKER="$PWD/config/walker/config.toml"
 LOCK_SCRIPT="$PWD/config/noctalia/lock-screen.sh"
+EWW_STYLE="$PWD/config/eww/eww.scss"
 
 It 'installs a stable lock-screen command without a Home Manager service'
 When run bash -c "grep -F 'name = \"lock-screen\";' '$MODULE' && ! grep -F 'systemd.user.services.hyprlock = {' '$MODULE'"
@@ -45,6 +46,13 @@ The output should include 'color = rgb(282a36)'
 The output should include 'blur_passes = 3'
 The output should include 'blur_size = 8'
 The output should include 'brightness = 0.8'
+End
+
+It 'matches the home clock font family and size'
+When run bash -c "grep -A10 'label {' '$MODULE' && grep -F 'font-size: 156px;' '$EWW_STYLE'"
+The output should include 'font_family = Noto Sans'
+The output should include 'font_size = 156'
+The output should include 'font-size: 156px;'
 End
 
 It 'disables the crashing Noctalia lockscreen and routes idle locking to hyprlock'


### PR DESCRIPTION
## Summary
- set the Hyprlock time label to the home shell font, Noto Sans
- match the Eww home-clock size at 156
- add a focused cross-check against the home clock stylesheet

## Validation
- `nix shell nixpkgs#shellspec nixpkgs#ripgrep --command shellspec --format documentation spec/hyprlock_spec.sh`
- `make nix-format-check`

Bead: shunkakinokisoftware-do3o

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Matches the Hyprlock time label to the home clock typography so both screens show the same clock style.

- Sets the lock screen clock to Noto Sans at 156px, up from 64px.
- Adds a spec check that fails if the lock and home clock styles drift apart.

<sup>Written for commit dd7b48a87a6a127d3b562205207d159b285719f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

