### PR TITLE
fix(matic): match lock clock metrics

### DIFF
--- a/config/noctalia/default.nix
+++ b/config/noctalia/default.nix
@@ -56,10 +56,12 @@ in
 
     label {
         monitor =
-        text = $TIME
+        # Match Eww's 156px Inter 700 clock at 96 DPI. Hyprlock's Pango size is
+        # point-based; 4096 Pango units reproduce Eww's 4px letter spacing.
+        text = <span weight="700" letter_spacing="4096">$TIME</span>
         color = rgb(f8f8f2)
-        font_family = Noto Sans
-        font_size = 156
+        font_family = Inter
+        font_size = 117
         position = 0, 120
         halign = center
         valign = center

--- a/spec/hyprlock_spec.sh
+++ b/spec/hyprlock_spec.sh
@@ -48,11 +48,14 @@ The output should include 'blur_size = 8'
 The output should include 'brightness = 0.8'
 End
 
-It 'matches the home clock font family and size'
-When run bash -c "grep -A10 'label {' '$MODULE' && grep -F 'font-size: 156px;' '$EWW_STYLE'"
-The output should include 'font_family = Noto Sans'
-The output should include 'font_size = 156'
+It 'matches the home clock rendered type metrics'
+When run bash -c "grep -A13 'label {' '$MODULE' && grep -A6 '.clock-time {' '$EWW_STYLE'"
+The output should include 'text = <span weight="700" letter_spacing="4096">$TIME</span>'
+The output should include 'font_family = Inter'
+The output should include 'font_size = 117'
 The output should include 'font-size: 156px;'
+The output should include 'font-weight: 700;'
+The output should include 'letter-spacing: 4px;'
 End
 
 It 'disables the crashing Noctalia lockscreen and routes idle locking to hyprlock'


### PR DESCRIPTION
## Root cause
Hyprlock interprets `font_size` as Pango points, while the Eww home clock declares CSS pixels. The prior 156-point lock clock rendered 534px wide. It also omitted Eww's weight 700 and 4px tracking.

## Fix
- use explicit Inter, the Matic sans-serif resolution
- convert 156 CSS pixels to 117 Pango points at the 96 DPI render context
- reproduce weight 700 and 4px tracking using Pango markup
- strengthen the focused cross-check against all home-clock metrics

## Validation
- measured home model: 439x190
- measured corrected Hyprlock model: 439x190
- `nix shell nixpkgs#shellspec nixpkgs#ripgrep --command shellspec --format documentation spec/hyprlock_spec.sh`
- `make nix-format-check`

Bead: shunkakinokisoftware-gv3u

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Hyprlock clock so its rendered type matches the Eww home clock. Hyprlock reads `font_size` as Pango points, so the previous 156-point setting rendered 534px wide; the lock clock now uses 117 points (the 96 DPI equivalent of 156px), Inter, weight 700, and 4px letter spacing. The spec now cross-checks the lock clock against all home-clock font metrics.

<sup>Written for commit 840c9e4ec68afbb066b0b4bc288de0ab2679acb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

