### PR TITLE
fix(openclaw): load dotenv in gateway service

### DIFF
--- a/home-manager/services/openclaw/default.nix
+++ b/home-manager/services/openclaw/default.nix
@@ -44,6 +44,7 @@ lib.mkIf host.isKyber {
       ExecStart = "${homeDir}/.bun/bin/openclaw gateway run --port 18789 --bind loopback";
       Restart = "always";
       RestartSec = "5s";
+      EnvironmentFile = [ "-${homeDir}/dotfiles/.env" ];
       Environment = [
         "HOME=${homeDir}"
         "PATH=${homeDir}/.local/bin:${homeDir}/.bun/bin:${homeDir}/.nix-profile/bin:${homeDir}/.local/share/pnpm:${homeDir}/.local/share/fnm/current/bin:${homeDir}/.npm-global/bin:/usr/local/bin:/usr/bin:/bin"

--- a/spec/activate_openclaw_hermes_spec.sh
+++ b/spec/activate_openclaw_hermes_spec.sh
@@ -42,6 +42,16 @@ When run bash -c "grep -F 'gateway run --port 18789 --bind loopback' '$PWD/home-
 The output should include 'gateway run --port 18789 --bind loopback'
 End
 
+It 'loads the optional dotenv only into the gateway service'
+When run bash -c "gateway=\$(sed -n '/systemd.user.services.openclaw-gateway =/,/Install = {/p' '$PWD/home-manager/services/openclaw/default.nix'); proxy=\$(sed -n '/systemd.user.services.openclaw-k3s-proxy =/,/Install = {/p' '$PWD/home-manager/services/openclaw/default.nix'); grep -qF 'EnvironmentFile = [ \"-\${homeDir}/dotfiles/.env\" ];' <<<\"\$gateway\" && ! grep -qF 'EnvironmentFile' <<<\"\$proxy\" && ! grep -R -q 'ASCII_BOX_API_KEY=' '$PWD/config/openclaw'"
+The status should be success
+End
+
+It 'starts the gateway directly through systemd'
+When run bash -c "sed -n '/systemd.user.services.openclaw-gateway =/,/Install = {/p' '$PWD/home-manager/services/openclaw/default.nix' | grep -qF 'ExecStart = \"\${homeDir}/.bun/bin/openclaw gateway run --port 18789 --bind loopback\";'"
+The status should be success
+End
+
 It 'uses the current OpenClaw configuration schema'
 When run bash -c "jq -e '(.models | has(\"pricing\") | not) and (.memory.search.enabled == true) and (.acp | has(\"maxConcurrentSessions\") | not) and (.gateway.tailscale | has(\"resetOnExit\") | not) and (.diagnostics.cacheTrace | (has(\"includeMessages\") or has(\"includePrompt\") or has(\"includeSystem\")) | not) and (has(\"commitments\") | not)' '$PWD/config/openclaw/openclaw.tpl.json' >/dev/null"
 The status should be success


### PR DESCRIPTION
## Summary
Load the optional ~/dotfiles/.env through the OpenClaw gateway systemd unit while retaining direct foreground execution. The proxy and unrelated services do not receive this environment.

### Tracker linkage
- Linear: none — direct operator request tracked in Beads; no linked Linear issue.
- Bead: shunkakinokisoftware-l4iu

## Validation
- 36 focused ShellSpec examples passed.
- Nix parsing, formatting, and diff checks passed.
- Galactica Darwin and Kyber Home Manager builds passed for candidate 704b606286ce1536411ea80f2bd90ac91d3cfc14.
- Admin merged as 79e48b4b4f649e96945c06e45e6f013635d56d23. Kyber built and switched that merged revision: gateway active/running, liveness OK, optional EnvironmentFile present, process API key matches hydrated dotenv without revealing values; proxy remains active and does not inherit that file.
- Matic intentionally has no gateway. Its Box provider key is valid: Crabbox doctor and the public limits API pass. Native Box login state is separate. Blacksmith authentication is still absent on both Linux hosts.

The unsupported ASCII Box cloud-worker profile is excluded. No credentials or dotenv contents are committed.