### PR TITLE
feat(kyber): add bounded Incus Crabbox pilot

### DIFF
--- a/named-hosts/kyber/README.md
+++ b/named-hosts/kyber/README.md
@@ -2,6 +2,9 @@
 
 Ubuntu Linux server managed via home-manager with Tailscale VPN.
 
+The [Incus Crabbox pilot](incus/README.md) provisions bounded local containers
+on Kyber without changing other hosts or the Crabbox coordinator.
+
 ## Initial Setup
 
 On the Kyber server, run:

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -34,6 +34,7 @@ home-manager.lib.homeManagerConfiguration {
   modules = [
     agenix.homeManagerModules.default
     ../../home-manager/default.nix
+    ./incus
     (
       { config, lib, ... }:
       {

--- a/named-hosts/kyber/incus/README.md
+++ b/named-hosts/kyber/incus/README.md
@@ -1,0 +1,107 @@
+# Incus pilot on Kyber
+
+Kyber's Home Manager profile installs `~/.config/crabbox/config.yaml` with
+`provider: incus` and a `kyber-incus-setup` command. Other hosts are unchanged.
+Incus is a direct CLI provider, not a backend for the Crabbox Node coordinator
+or its browser portal. This does not change any repository's `ci:ship` routing.
+Repo configuration, environment variables, and explicit flags override these
+user defaults; pass `--provider incus` when the repo selects another provider.
+
+## Install and activate
+
+On Kyber, from the reviewed dotfiles revision:
+
+```sh
+cd ~/dotfiles
+HOST=kyber make build
+HOST=kyber make nix-switch
+kyber-incus-setup
+```
+
+The setup command requires non-interactive sudo and refuses other hosts or
+users. It installs Ubuntu's native `incus`, `incus-client`, and `btrfs-progs`
+packages without adding a package repository. Ubuntu APT owns their security
+updates. It enables Incus and applies the checked-in `preseed.yaml`; subsequent
+runs reapply the same named resources, refusing unmarked name collisions.
+It does not delete existing instances or modify the default Incus profile.
+
+Setup adds `ubuntu` to `incus-admin`, which grants **root-equivalent host
+authority**. Only the host operator gets this access; guests do not receive the
+Incus socket. Reconnect with `ssh kyber` after setup to acquire the new group.
+Existing long-lived Herdr sessions must be restarted separately before they
+inherit group membership; setup does not interrupt those sessions.
+
+## Pilot boundaries
+
+| Setting | Value |
+| --- | --- |
+| Project / profile | `crabbox` / `crabbox` |
+| Maximum existing instances | 2, including stopped instances |
+| Per container | 4 CPUs, 8 GiB RAM, 1,024 processes |
+| Project CPU / memory budget | 8 CPUs / 16 GiB RAM |
+| Storage | 64 GiB Btrfs loop-backed pool; 24 GiB root quota per container |
+| Per-container write limit | 10 MiB/s |
+| Network | `incus-crabbox`, `10.203.0.1/24`, IPv4 NAT |
+| Management | Local Unix socket only; no HTTPS listener configured |
+| Guest image | Ubuntu 24.04 cloud image |
+
+The pool is a file under Incus storage, **not a physical disk to format**. The
+64 GiB pool bounds its guest/image storage, not all Incus logs, backups, or host
+usage. Btrfs per-container quotas are not a hostile-tenant security boundary.
+Containers share Kyber's kernel and can reach host services: use trusted work
+only. Privileged containers, nesting, host bind mounts, and VMs are not enabled;
+Docker-in-Docker validation is outside this first pilot.
+
+The bridge is separate from K3s and Docker networks. A systemd oneshot permits
+only bridge-to-uplink forwarding and established return traffic through
+`DOCKER-USER`, including after Docker/Incus restarts. It does not open public
+ports or change Docker's global forwarding policy. Incus handles bridge NAT,
+DHCP, and DNS. Verify connectivity before treating the pilot as ready.
+
+## Verify and try two concurrent boxes
+
+In the new SSH session, from the repository you intend to sync:
+
+```sh
+id -nG
+systemctl is-active incus kyber-incus-network
+incus project show crabbox
+incus profile show crabbox
+crabbox config show --provider incus
+crabbox doctor --provider incus
+```
+
+After doctor passes, create two separate leases. Each command prints a lease
+ID; retain both IDs for explicit cleanup, including if bootstrap fails:
+
+```sh
+crabbox warmup --provider incus --slug kyber-smoke-1
+crabbox warmup --provider incus --slug kyber-smoke-2
+incus list --project crabbox
+```
+
+Use each printed ID in a separate terminal to verify sync and execution:
+
+```sh
+crabbox run --provider incus --id <lease-id> -- sh -c 'hostname; id; getent hosts github.com; test -d .git'
+```
+
+The containers use separate bridge IPs with port 22; there is no shared host
+proxy port to collide. They are not automatically named Tailscale machines.
+Release only the two IDs created by this smoke test:
+
+```sh
+crabbox stop --provider incus <first-lease-id>
+crabbox stop --provider incus <second-lease-id>
+incus list --project crabbox
+```
+
+Default release deletes the instance and frees its slot. There is no daily
+start quota configured here, but the two-instance cap still applies. Raise it
+in `preseed.yaml` only after measuring CPU, memory, disk, and I/O contention.
+Removing the Home Manager import alone does not uninstall Incus or destroy its
+data; retirement requires an explicit inventory and cleanup operation.
+
+References: [Crabbox Incus provider](https://crabbox.sh/providers/incus.html),
+[Incus initialization](https://linuxcontainers.org/incus/docs/main/howto/initialize/),
+[Docker coexistence](https://linuxcontainers.org/incus/docs/main/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-incus-and-docker).

--- a/named-hosts/kyber/incus/crabbox.yaml
+++ b/named-hosts/kyber/incus/crabbox.yaml
@@ -1,0 +1,16 @@
+# User defaults on Kyber only; explicit repo configuration and flags still win.
+provider: incus
+target: linux
+os: ubuntu:24.04
+incus:
+  socket: /var/lib/incus/unix.socket
+  project: crabbox
+  instanceType: container
+  image: images:ubuntu/24.04/cloud
+  profile: crabbox
+  user: crabbox
+  workRoot: /work/crabbox
+  deleteOnRelease: true
+  startTimeout: 10m
+  launchPort: "22"
+# Reach each guest directly on its bridge IP; a shared proxy port would collide.

--- a/named-hosts/kyber/incus/default.nix
+++ b/named-hosts/kyber/incus/default.nix
@@ -1,0 +1,23 @@
+{ pkgs, ... }:
+let
+  setup = pkgs.replaceVars ./setup.sh {
+    preseed = ./preseed.yaml;
+    networkScript = ./network.sh;
+    networkService = ./kyber-incus-network.service;
+  };
+in
+{
+  xdg.configFile."crabbox/config.yaml".source = ./crabbox.yaml;
+
+  # Ubuntu owns the privileged daemon and its security updates. A normal
+  # Home Manager switch installs the setup command without changing the host.
+  home.packages = [
+    (pkgs.writeShellApplication {
+      name = "kyber-incus-setup";
+      runtimeInputs = [ pkgs.jq ];
+      text = ''
+        exec ${pkgs.bash}/bin/bash ${setup}
+      '';
+    })
+  ];
+}

--- a/named-hosts/kyber/incus/default.nix
+++ b/named-hosts/kyber/incus/default.nix
@@ -1,9 +1,9 @@
 { pkgs, ... }:
 let
   setup = pkgs.replaceVars ./setup.sh {
-    preseed = ./preseed.yaml;
-    networkScript = ./network.sh;
-    networkService = ./kyber-incus-network.service;
+    preseed = "${./preseed.yaml}";
+    networkScript = "${./network.sh}";
+    networkService = "${./kyber-incus-network.service}";
   };
 in
 {

--- a/named-hosts/kyber/incus/kyber-incus-network.service
+++ b/named-hosts/kyber/incus/kyber-incus-network.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Kyber Incus bridge egress through Docker firewall
+Requires=incus.service docker.service
+After=incus.service docker.service network-online.target
+Wants=network-online.target
+PartOf=docker.service incus.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/kyber-incus-network
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/named-hosts/kyber/incus/network.sh
+++ b/named-hosts/kyber/incus/network.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Docker's FORWARD policy otherwise drops Incus egress. Permit only traffic
+# from this bridge to the default uplink and its established return traffic.
+uplink="$(ip -4 route show default | awk '/default/ { for (i=1; i<=NF; i++) if ($i == "dev") { print $(i+1); exit } }')"
+if [ -z "$uplink" ] || [ "$uplink" = incus-crabbox ]; then
+  echo "Cannot determine the Incus egress uplink." >&2
+  exit 1
+fi
+iptables -w -S DOCKER-USER >/dev/null
+if ! iptables -w -C DOCKER-USER -i incus-crabbox -o "$uplink" -j ACCEPT 2>/dev/null; then
+  iptables -w -I DOCKER-USER -i incus-crabbox -o "$uplink" -j ACCEPT
+fi
+if ! iptables -w -C DOCKER-USER -i "$uplink" -o incus-crabbox -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2>/dev/null; then
+  iptables -w -I DOCKER-USER -i "$uplink" -o incus-crabbox -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+fi

--- a/named-hosts/kyber/incus/preseed.yaml
+++ b/named-hosts/kyber/incus/preseed.yaml
@@ -1,0 +1,49 @@
+# Owned pilot resources only. Do not modify the default profile or expose HTTPS.
+storage_pools:
+  - name: crabbox
+    driver: btrfs
+    config:
+      user.dotfiles: kyber-crabbox
+      size: 64GiB
+networks:
+  - name: incus-crabbox
+    type: bridge
+    config:
+      user.dotfiles: kyber-crabbox
+      ipv4.address: 10.203.0.1/24
+      ipv4.nat: "true"
+      ipv6.address: none
+projects:
+  - name: crabbox
+    config:
+      user.dotfiles: kyber-crabbox
+      features.images: "true"
+      features.profiles: "false"
+      features.networks: "false"
+      limits.instances: "2"
+      limits.virtual-machines: "0"
+      limits.cpu: "8"
+      limits.memory: 16GiB
+      restricted: "true"
+      restricted.networks.access: incus-crabbox
+profiles:
+  - name: crabbox
+    config:
+      user.dotfiles: kyber-crabbox
+      limits.cpu: "4"
+      limits.memory: 8GiB
+      limits.memory.swap: "false"
+      limits.processes: "1024"
+      security.privileged: "false"
+      security.nesting: "false"
+    devices:
+      eth0:
+        name: eth0
+        network: incus-crabbox
+        type: nic
+      root:
+        path: /
+        pool: crabbox
+        size: 24GiB
+        limits.write: 10MiB
+        type: disk

--- a/named-hosts/kyber/incus/setup.sh
+++ b/named-hosts/kyber/incus/setup.sh
@@ -40,7 +40,7 @@ if printf '%s\n' "$routes" | grep -v ' dev incus-crabbox ' | grep -q .; then
   exit 1
 fi
 
-incus_local admin init --preseed < '@preseed@'
+incus_local admin init --preseed <'@preseed@'
 
 sudo -n install -m 0755 '@networkScript@' /usr/local/sbin/kyber-incus-network
 sudo -n install -m 0644 '@networkService@' /etc/systemd/system/kyber-incus-network.service

--- a/named-hosts/kyber/incus/setup.sh
+++ b/named-hosts/kyber/incus/setup.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$(uname -s)" != Linux ] || [ "$(hostname -s)" != kyber ] || [ "$(id -un)" != ubuntu ]; then
+  echo "Run kyber-incus-setup as ubuntu on Kyber only." >&2
+  exit 1
+fi
+
+sudo -n true
+if ! command -v incus >/dev/null 2>&1 || ! command -v mkfs.btrfs >/dev/null 2>&1; then
+  sudo -n apt-get update
+  sudo -n env DEBIAN_FRONTEND=noninteractive apt-get install -y incus incus-client btrfs-progs
+fi
+sudo -n systemctl enable --now incus.service
+
+# Always address the local daemon, regardless of the invoking user's remotes.
+incus_local() {
+  sudo -n env INCUS_SOCKET=/var/lib/incus/unix.socket incus --force-local --project default "$@"
+}
+
+# Preseed can update resources. Refuse to adopt an unrelated resource with a
+# matching name, or hide its API error by treating it as a missing resource.
+for kind in storage network project profile; do
+  name=crabbox
+  [ "$kind" != network ] || name=incus-crabbox
+  inventory="$(incus_local "$kind" list --format=json)"
+  if ! jq -e --arg name "$name" '
+    all(.[]; .name != $name or .config["user.dotfiles"] == "kyber-crabbox")
+  ' <<<"$inventory" >/dev/null; then
+    echo "Refusing unmanaged Incus $kind $name." >&2
+    exit 1
+  fi
+done
+
+# Refuse to take over an existing route on another interface. The native
+# preseed owns the address, and reapplying it to our own bridge is allowed.
+routes="$(ip -4 route show 10.203.0.0/24)"
+if printf '%s\n' "$routes" | grep -v ' dev incus-crabbox ' | grep -q .; then
+  echo "10.203.0.0/24 is already routed outside incus-crabbox." >&2
+  exit 1
+fi
+
+incus_local admin init --preseed < '@preseed@'
+
+sudo -n install -m 0755 '@networkScript@' /usr/local/sbin/kyber-incus-network
+sudo -n install -m 0644 '@networkService@' /etc/systemd/system/kyber-incus-network.service
+sudo -n systemctl daemon-reload
+sudo -n systemctl enable kyber-incus-network.service
+sudo -n systemctl restart kyber-incus-network.service
+
+# This is root-equivalent Incus administration, for the existing host operator
+# only. New SSH sessions acquire the group; no daemon or user-manager restart.
+if ! id -nG ubuntu | tr ' ' '\n' | grep -qx incus-admin; then
+  sudo -n usermod -aG incus-admin ubuntu
+fi
+echo "Incus pilot configured. Open a new SSH session, then run crabbox doctor --provider incus."

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -396,6 +396,10 @@ It 'has behavior tests for named-hosts/kamino/activate.sh'
 The path "tests/test_kamino_activation.py" should be exist
 End
 
+It 'has behavior tests for named-hosts/kyber/incus/setup.sh and network.sh'
+The path "tests/test_kyber_incus.py" should be exist
+End
+
 It 'has spec file for named-hosts/kyber/activate-ip-forwarding.sh'
 The path "spec/activate_kyber_spec.sh" should be exist
 End
@@ -640,6 +644,8 @@ named-hosts/kyber/activate-fish-ssh-compat.sh
 named-hosts/kyber/activate-ip-forwarding.sh
 named-hosts/kyber/activate-sshd.sh
 named-hosts/kyber/activate-user-service-priority.sh
+named-hosts/kyber/incus/network.sh
+named-hosts/kyber/incus/setup.sh
 named-hosts/kyber/prepare-containerd-disk.sh
 named-hosts/kyber/rekey-galactica.sh
 named-hosts/kyber/setup.sh

--- a/tests/test_kyber_incus.py
+++ b/tests/test_kyber_incus.py
@@ -1,0 +1,209 @@
+"""Exercise the Kyber setup and firewall scripts without privileged operations."""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INCUS = ROOT / "named-hosts/kyber/incus"
+MOCK = r"""#!/usr/bin/env bash
+set -eu
+cmd="${0##*/}"
+printf '%s %s\n' "$cmd" "$*" >> "$MOCK_LOG"
+case "$cmd" in
+  uname) echo "${MOCK_OS:-Linux}" ;;
+  hostname) echo "${MOCK_HOST:-kyber}" ;;
+  id)
+    if [ "$1" = -un ]; then echo "${MOCK_USER:-ubuntu}"
+    else echo "${MOCK_GROUPS:-ubuntu incus-admin}"; fi ;;
+  sudo)
+    [ "$1" != -n ] || shift
+    [ "${MOCK_DENY_SUDO:-0}" = 0 ] || exit 1
+    exec "$@" ;;
+  incus)
+    [ "$1 $2 $3" = '--force-local --project default' ] || exit 1
+    shift 3
+    [ "${MOCK_API_ERROR:-0}" = 0 ] || exit 1
+    if [ "$1" = admin ]; then
+      cat > "$MOCK_PRESEED"
+    else
+      case "${MOCK_INVENTORY:-empty}" in
+        empty) echo '[]' ;;
+        owned) echo '[{"name":"crabbox","config":{"user.dotfiles":"kyber-crabbox"}}]' ;;
+        foreign) echo '[{"name":"crabbox","config":{}}]' ;;
+        invalid) echo 'invalid' ;;
+      esac
+    fi ;;
+  ip)
+    [ "${MOCK_ROUTE_ERROR:-0}" = 0 ] || exit 1
+    if [ "${4:-}" = default ]; then
+      echo "${MOCK_DEFAULT_ROUTE-default via 192.0.2.1 dev eno1}"
+    else echo "${MOCK_ROUTE:-}"; fi ;;
+  iptables)
+    [ "${MOCK_CHAIN_ERROR:-0}" = 0 ] || exit 1
+    if [ "$2" = -C ]; then
+      [ "${MOCK_RULES_EXIST:-0}" = 1 ] || exit 1
+    fi ;;
+esac
+"""
+
+
+class KyberIncusTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.directory = Path(self.temp.name)
+        self.log = self.directory / "calls.log"
+        self.seed = self.directory / "preseed.yaml"
+        for command in [
+            "uname",
+            "hostname",
+            "id",
+            "sudo",
+            "incus",
+            "ip",
+            "iptables",
+            "systemctl",
+            "install",
+            "usermod",
+            "apt-get",
+            "mkfs.btrfs",
+        ]:
+            path = self.directory / command
+            path.write_text(MOCK)
+            path.chmod(0o755)
+        setup = (INCUS / "setup.sh").read_text()
+        for placeholder, filename in [
+            ("preseed", "preseed.yaml"),
+            ("networkScript", "network.sh"),
+            ("networkService", "kyber-incus-network.service"),
+        ]:
+            setup = setup.replace(f"@{placeholder}@", str(INCUS / filename))
+        self.setup_script = self.directory / "setup.sh"
+        self.setup_script.write_text(setup)
+        self.env = {
+            **os.environ,
+            "PATH": f"{self.directory}:{os.environ['PATH']}",
+            "MOCK_LOG": str(self.log),
+            "MOCK_PRESEED": str(self.seed),
+        }
+
+    def run_script(self, script=None, **env):
+        return subprocess.run(
+            [shutil.which("bash"), str(script or self.setup_script)],
+            env={**self.env, **env},
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_reapply_owned_setup_and_keep_default_profile(self):
+        for _ in range(2):
+            result = self.run_script(MOCK_INVENTORY="owned")
+            self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.seed.read_text(), (INCUS / "preseed.yaml").read_text())
+        calls = self.log.read_text()
+        self.assertEqual(
+            calls.splitlines().count(
+                "incus --force-local --project default admin init --preseed"
+            ),
+            2,
+        )
+        self.assertNotIn("usermod ", calls)
+        self.assertNotIn("delete", calls)
+        self.assertNotIn("apt-get ", calls)
+        self.assertIn("restart kyber-incus-network.service", calls)
+        self.assertNotIn("name: default", self.seed.read_text())
+
+    def test_fresh_setup_grants_only_operator_access(self):
+        result = self.run_script(MOCK_GROUPS="ubuntu docker")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = self.log.read_text()
+        self.assertIn("usermod -aG incus-admin ubuntu", calls)
+        self.assertNotIn("restart incus.service", calls)
+
+    def test_missing_packages_use_native_apt_before_configuration(self):
+        (self.directory / "incus").unlink()
+        (self.directory / "mkfs.btrfs").unlink()
+        for command in ["bash", "env", "cat", "jq", "grep", "tr", "true"]:
+            (self.directory / command).symlink_to(shutil.which(command))
+        installer = self.directory / "apt-get"
+        installer.write_text(
+            MOCK
+            + '\nif [ "$1" = install ]; then\n'
+            + '  cp "$0" "${0%/*}/incus"\n'
+            + '  cp "$0" "${0%/*}/mkfs.btrfs"\nfi\n'
+        )
+        (self.directory / "cp").symlink_to(shutil.which("cp"))
+        result = self.run_script(PATH=str(self.directory))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = self.log.read_text()
+        self.assertIn("apt-get update", calls)
+        self.assertIn("apt-get install -y incus incus-client btrfs-progs", calls)
+        self.assertLess(calls.index("apt-get install"), calls.index("admin init"))
+
+    def test_wrong_host_os_or_user_never_attempts_privileges(self):
+        for env in [
+            {"MOCK_HOST": "matic"},
+            {"MOCK_HOST": "kamino"},
+            {"MOCK_OS": "Darwin"},
+            {"MOCK_USER": "root"},
+        ]:
+            with self.subTest(env=env):
+                self.log.write_text("")
+                result = self.run_script(**env)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("Kyber only", result.stderr)
+                self.assertNotIn("sudo ", self.log.read_text())
+
+    def test_permission_inventory_and_route_errors_abort_before_preseed(self):
+        for env in [
+            {"MOCK_DENY_SUDO": "1"},
+            {"MOCK_API_ERROR": "1"},
+            {"MOCK_INVENTORY": "foreign"},
+            {"MOCK_INVENTORY": "invalid"},
+            {"MOCK_ROUTE_ERROR": "1"},
+            {"MOCK_ROUTE": "10.203.0.0/24 dev another-bridge proto kernel"},
+        ]:
+            with self.subTest(env=env):
+                result = self.run_script(**env)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertFalse(self.seed.exists())
+
+    def test_own_bridge_route_is_safe_to_reapply(self):
+        result = self.run_script(
+            MOCK_ROUTE="10.203.0.0/24 dev incus-crabbox proto kernel"
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_network_rules_are_narrow_and_idempotent(self):
+        result = self.run_script(INCUS / "network.sh")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        inserts = [line for line in self.log.read_text().splitlines() if "-I " in line]
+        self.assertEqual(len(inserts), 2)
+        self.assertIn("-i incus-crabbox -o eno1 -j ACCEPT", inserts[0])
+        self.assertIn("-i eno1 -o incus-crabbox", inserts[1])
+        self.assertIn("--ctstate RELATED,ESTABLISHED", inserts[1])
+        self.log.write_text("")
+        result = self.run_script(INCUS / "network.sh", MOCK_RULES_EXIST="1")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("-I ", self.log.read_text())
+
+    def test_no_firewall_mutation_without_route_or_docker_chain(self):
+        for env in [
+            {"MOCK_DEFAULT_ROUTE": ""},
+            {"MOCK_ROUTE_ERROR": "1"},
+            {"MOCK_CHAIN_ERROR": "1"},
+        ]:
+            with self.subTest(env=env):
+                self.log.write_text("")
+                result = self.run_script(INCUS / "network.sh", **env)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertNotIn("-I ", self.log.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add a Kyber-only direct Incus pilot for Crabbox. Home Manager installs the CLI defaults and an explicit `kyber-incus-setup` command; switching does not install or start Incus automatically.

### Tracker linkage

- Linear: none — operator-requested infrastructure pilot.
- Bead: qpt1h — repository scope kept in the internal task tracker per repository privacy guidance.

## Contract

```mermaid
flowchart LR
  HM[Kyber Home Manager] --> Config[Crabbox user defaults]
  HM --> Setup[Explicit setup command]
  Setup --> Incus[Local Incus daemon and bounded project]
  Config --> CLI[Crabbox CLI]
  CLI --> Incus
  Incus --> Guests[Up to two container leases]
```

## Before / after

| Surface | Before | After |
| --- | --- | --- |
| Kyber CLI defaults | No managed user config | Direct Incus over a local Unix socket |
| Provisioning | No Incus setup | Ubuntu packages and owned preseed resources |
| Capacity | No pilot project | Two instances; 4 CPUs / 8 GiB each; 64 GiB loop-backed storage pool |
| Other hosts and coordinator | Existing behavior | Unchanged |

## Breaking and irreversible changes

- Behavioral: Kyber user defaults become Incus; repo configuration and explicit overrides still take precedence.
- Compile-time: no upstream Crabbox or public API changes.
- Durable state and rollback: explicit setup installs Ubuntu packages, creates named Incus resources, installs a narrow Docker egress oneshot, and grants the existing operator root-equivalent `incus-admin` membership. No physical device is formatted. Reverting the Nix import does not remove daemon data or group membership; retirement needs an explicit inventory and cleanup.

## Deliberate boundaries

No Matic/Kamino changes, public Incus API, Tailscale guest enrollment, coordinator support, or repository CI routing changes. Trusted Linux containers only; no privileged containers, host socket mounts, nesting, or VMs.

## Verification

- Eight behavioral Python tests passed, including wrong-host refusal, native package installation, ownership collisions, API/route failures, repeat setup, and narrow/idempotent firewall rules.
- 200 Crabbox/Kyber/coverage ShellSpec examples passed.
- ShellCheck, Ruff, Nixfmt, inline-shell policy, whitespace checks, YAML relationships, and actual Crabbox config parsing passed.
- Nix config evaluation: Kyber receives the config; Matic and Kamino do not.
- Native setup-wrapper build passed; its Nix closure retains the preseed, network script, and systemd unit. Wrong-host execution refuses before privileges.
- Full Linux Home Manager build is not certified from the macOS author host.
- Read-only Kyber doctor confirms the provider exists but the Incus socket is absent. Session policy blocks privileged installation. No live containers were created; provisioning, concurrent execution, release, and host activation remain unverified.

Keep draft until an authorized operator runs the documented setup and bounded two-lease smoke on Kyber. No merge requested in this iteration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Kyber-only Incus pilot for Crabbox, making Kyber's CLI use Incus directly while leaving other hosts and the coordinator unchanged. It includes an explicit setup command that provisions a bounded two-instance project, but does not start Incus until that command is run.

**New Features**
- Kyber user defaults now point Crabbox at a local Incus socket via `~/.config/crabbox/config.yaml`.
- The new `kyber-incus-setup` command installs Ubuntu packages, applies a checked-in preseed, and configures a two-instance `crabbox` project with per-container CPU/memory/disk limits.
- A systemd oneshot installs narrow firewall rules to allow bridge egress through Docker's `DOCKER-USER` chain.
- Behavior tests cover wrong-host refusal, package installation, ownership collisions, repeat setup, and idempotent firewall rules.

**Breaking Changes**
- Setup grants the `ubuntu` user `incus-admin` membership, which is root-equivalent; a new SSH session is required to use it.
- Reverting the Home Manager import does not uninstall Incus or remove its data; retirement requires explicit cleanup.

<sup>Written for commit 78d0e04e160c899397109a7ff4b0b8782317ae5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

