### PR TITLE
fix(nix): remove deprecated Gemini CLI and platform access

### DIFF
--- a/home-manager/modules/bin-shells/default.nix
+++ b/home-manager/modules/bin-shells/default.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  inherit (pkgs.stdenv) isLinux;
+  inherit (pkgs.stdenv.hostPlatform) isLinux;
 in
 {
   config = lib.mkIf isLinux {

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -157,7 +157,6 @@ with pkgs;
   collectd
   fwupd
   gcc
-  gemini-cli
   glib
   pkgs.llm-agents.grok
   keychain

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -72,7 +72,6 @@
       "coreutils"
       "crabbox"
       "ffmpeg"
-      "gemini-cli"
       "geth"
       "grafana"
       "graphviz"

--- a/spec/upgrade_overlays_spec.sh
+++ b/spec/upgrade_overlays_spec.sh
@@ -69,9 +69,9 @@ EOF
       version = "0.2.55";
       src = prev.fetchurl {
         sha256 =
-          if prev.stdenv.isLinux && prev.stdenv.hostPlatform.isx86_64 then
+          if prev.stdenv.hostPlatform.isLinux && prev.stdenv.hostPlatform.isx86_64 then
             "old-linux-x86"
-          else if prev.stdenv.isLinux && prev.stdenv.hostPlatform.isAarch64 then
+          else if prev.stdenv.hostPlatform.isLinux && prev.stdenv.hostPlatform.isAarch64 then
             "old-linux-arm"
           else if prev.stdenv.isDarwin && prev.stdenv.hostPlatform.isAarch64 then
             "old-darwin-arm"
@@ -154,9 +154,9 @@ setup() {
       version = "0.4.57";
       src = prev.fetchurl {
         sha256 =
-          if prev.stdenv.isLinux && prev.stdenv.hostPlatform.isx86_64 then
+          if prev.stdenv.hostPlatform.isLinux && prev.stdenv.hostPlatform.isx86_64 then
             "old-linux-x86"
-          else if prev.stdenv.isLinux && prev.stdenv.hostPlatform.isAarch64 then
+          else if prev.stdenv.hostPlatform.isLinux && prev.stdenv.hostPlatform.isAarch64 then
             "old-linux-arm"
           else if prev.stdenv.isDarwin && prev.stdenv.hostPlatform.isAarch64 then
             "old-darwin-arm"


### PR DESCRIPTION
## Summary

- use stdenv.hostPlatform.isLinux in the bin-shells module
- remove the removed Nixpkgs and Homebrew gemini-cli packages in favor of the existing Antigravity CLI
- update overlay test fixtures to use the non-deprecated platform predicate

## Validation

- shellspec spec/activate_bin_shells_spec.sh spec/upgrade_overlays_spec.sh: 17 examples, 0 failures
- Nix warning-as-error evaluation of the affected home configuration emitted no deprecation or package-removal warnings
- the exact kamino1 Linux-target evaluation also emitted no requested warnings, then hit the expected local foreign-system derivation/build limitation
- the all-systems flake check was started and showed no requested warnings before being stopped because the matrix did not complete on this Darwin host