### PR TITLE
Reconcile Tailscale preferences on every host switch

### DIFF
--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -3,6 +3,7 @@
   username,
   hostname ? "aarch64-darwin",
   isRunner ? false,
+  tailscaleSetFlags ? [ "--accept-dns=false" ],
 }:
 let
   inherit (inputs)
@@ -27,7 +28,12 @@ let
 in
 {
   specialArgs = {
-    inherit inputs username isRunner;
+    inherit
+      inputs
+      username
+      isRunner
+      tailscaleSetFlags
+      ;
   };
   modules = [
     configuration

--- a/named-hosts/andor/default.nix
+++ b/named-hosts/andor/default.nix
@@ -15,6 +15,11 @@ let
     config = nixpkgsConfig;
   };
   baseHost = import ../../lib/host.nix;
+  tailscaleUpArgs = [
+    "--reset"
+    "--accept-dns=false"
+    "--ssh"
+  ];
 in
 home-manager.lib.homeManagerConfiguration {
   inherit pkgs;
@@ -54,11 +59,7 @@ home-manager.lib.homeManagerConfiguration {
         modules.tailscale = {
           enable = true;
           installSystemService = true;
-          extraUpArgs = [
-            "--reset"
-            "--accept-dns=false"
-            "--ssh"
-          ];
+          extraUpArgs = tailscaleUpArgs;
         };
       }
     )

--- a/named-hosts/galactica/default.nix
+++ b/named-hosts/galactica/default.nix
@@ -4,8 +4,13 @@
   ...
 }:
 let
+  tailscaleSetFlags = [
+    "--accept-dns=false"
+    "--accept-routes=true"
+    "--ssh=false"
+  ];
   darwin-modules = import ../../hosts/darwin {
-    inherit inputs username;
+    inherit inputs username tailscaleSetFlags;
     hostname = "galactica";
   };
 in

--- a/named-hosts/kamino/README.md
+++ b/named-hosts/kamino/README.md
@@ -21,12 +21,16 @@ and keeps its named profile in the automatic dotfiles upgrade path. Reinstallati
 refuses to change an already-installed Kamino identity. Plain Docker containers
 without systemd are rejected; this is not a container deployment command.
 
-The installer starts Tailscale and sets the node name without waiting for login.
-On a fresh machine, enroll it once (or provision authentication separately):
+The installer runs the host-specific Tailscale enrollment command during its
+`make nix-switch` phase:
 
 ```sh
 tailscale up --hostname=kamino1 --accept-dns=false --ssh=false
 ```
+
+On a fresh machine, follow the login URL printed during activation and choose
+the intended tailnet. On an enrolled machine, the command reapplies the declared
+name and preferences without creating a new device.
 
 This keeps the existing OpenSSH server/login policy, not Tailscale SSH. Provision
 your root authorized key separately. Never put authentication keys in this command
@@ -117,8 +121,9 @@ Run switch only after build succeeds, on the intended root/systemd Linux machine
 For an existing checkout, preserve its local changes and untracked dotenv.
 Fresh minimal Ubuntu also needs `dbus-user-session`; the installer bootstraps it.
 Activation sets the hostname, enables root lingering, starts the user manager
-and applies the named service configuration. It configures Tailscale without
-interactive enrollment; a fresh node still needs authentication.
+and applies the named service configuration. Its Tailscale phase runs
+`tailscale up` directly, so a fresh node prompts for authentication as part of
+`make nix-switch` instead of requiring a separate command afterward.
 
 MagicDNS must be enabled in the tailnet and client access rules must permit TCP
 22. Server-side `--accept-dns=false` does not prevent publishing the node name.
@@ -127,7 +132,8 @@ controls the whole VPS, not an isolated worker.
 
 ## Join the tailnet and publish the machine name
 
-After installation, use the provider console on **kamino1**, not a client:
+During installation, use the provider console on **kamino1**, not a client.
+The final command below is run automatically by `make nix-switch`:
 
 ```sh
 hostname                          # must print kamino1
@@ -135,7 +141,8 @@ systemctl is-active tailscaled    # must print active
 tailscale up --hostname=kamino1 --accept-dns=false --ssh=false
 ```
 
-Open the login URL in your browser and choose the intended tailnet. If device
+Open the login URL printed by the switch in your browser and choose the intended
+tailnet. If device
 approval is enabled, approve this device in the Tailscale admin console. Check
 its name and device ID there; the name must be exactly `kamino1`, not a suffixed
 duplicate. Do not remove another machine to clear a collision: investigate which
@@ -156,9 +163,9 @@ tailscale status --json | jq '{BackendState, Self: (.Self | {ID, DNSName, Online
 
 Expect `Running`, `Online: true` and `kamino1.tail950b36.ts.net.` with this fleet
 declaration. Record the device ID and public SSH host-key fingerprint in your
-private machine inventory. Subsequent dotfiles activation reapplies the name
-and preferences to the same persisted Tailscale state; it does not enroll a new
-device. If authentication expires, reauthenticate this machine instead of
+private machine inventory. Subsequent dotfiles activation runs the same command
+against the persisted Tailscale state and does not create a second device. If
+authentication expires, reauthenticate this machine instead of
 deleting its state. Do not use `--reset` or `--force-reauth` as routine sync steps.
 
 ## Connect from another client

--- a/named-hosts/kamino/activate.sh
+++ b/named-hosts/kamino/activate.sh
@@ -26,8 +26,9 @@ user-manager)
 tailscale)
   name="${2:?name required}"
   tailscale_bin="${3:?tailscale binary required}"
-  "$tailscale_bin" set --hostname="$name" --accept-dns=false --ssh=false
-  echo "Tailscale installed. If not enrolled, run: tailscale up --hostname=$name --accept-dns=false --ssh=false"
+  shift 3
+  "$tailscale_bin" up "$@"
+  echo "Tailscale enrollment and preferences applied for $name."
   ;;
 *)
   echo "Unknown Kamino activation phase" >&2

--- a/named-hosts/kamino/default.nix
+++ b/named-hosts/kamino/default.nix
@@ -23,6 +23,11 @@ let
     k3s = null;
     nodeName = name;
   };
+  tailscaleUpArgs = [
+    "--hostname=${name}"
+    "--accept-dns=false"
+    "--ssh=false"
+  ];
 in
 inputs.home-manager.lib.homeManagerConfiguration {
   inherit pkgs;
@@ -76,7 +81,7 @@ inputs.home-manager.lib.homeManagerConfiguration {
         home.activation.configureKaminoTailscale =
           config.lib.dag.entryAfter [ "installTailscaleService" "startKaminoUserManager" ]
             ''
-              $DRY_RUN_CMD ${pkgs.bash}/bin/bash ${./activate.sh} tailscale ${lib.escapeShellArg name} ${pkgs.tailscale}/bin/tailscale
+              $DRY_RUN_CMD ${pkgs.bash}/bin/bash ${./activate.sh} tailscale ${lib.escapeShellArg name} ${pkgs.tailscale}/bin/tailscale ${lib.escapeShellArgs tailscaleUpArgs}
             '';
 
         systemd.user.services.herdr-server = {

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -15,6 +15,12 @@ let
     config = nixpkgsConfig;
   };
   baseHost = import ../../lib/host.nix;
+  tailscaleUpArgs = [
+    "--reset"
+    "--ssh=false"
+    "--accept-dns=false"
+    "--advertise-exit-node"
+  ];
 in
 home-manager.lib.homeManagerConfiguration {
   inherit pkgs;
@@ -195,12 +201,7 @@ home-manager.lib.homeManagerConfiguration {
           # authKeyFile = config.age.secrets."keys/tailscale-auth.age".path;
           # Exit node kept; explicitly disable Tailscale SSH so long-lived Codex
           # tunnels use OpenSSH over Tailscale instead of the Tailscale SSH proxy.
-          extraUpArgs = [
-            "--reset"
-            "--ssh=false"
-            "--accept-dns=false"
-            "--advertise-exit-node"
-          ];
+          extraUpArgs = tailscaleUpArgs;
         };
       }
     )

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -32,6 +32,15 @@ import ../../hosts/nixos {
         pkgs,
         ...
       }:
+      let
+        tailscaleSetFlags = [
+          "--hostname=matic"
+          "--accept-dns=true"
+          "--accept-routes=false"
+          "--operator=${username}"
+          "--ssh"
+        ];
+      in
       {
         # Boot loader (EFI/systemd-boot)
         boot.loader.systemd-boot.enable = true;
@@ -98,12 +107,16 @@ import ../../hosts/nixos {
         services.tailscale = {
           enable = true;
           useRoutingFeatures = "client";
-          extraSetFlags = [
-            "--accept-dns=true"
-            "--operator=${username}"
-            "--ssh"
-          ];
+          extraSetFlags = tailscaleSetFlags;
         };
+
+        # nixos-rebuild starts tailscaled-set at boot or when its unit changes.
+        # Reapply the same declared preferences during every switch as well.
+        system.activationScripts.tailscalePreferences.text = ''
+          if ${pkgs.tailscale}/bin/tailscale status >/dev/null 2>&1; then
+            ${pkgs.tailscale}/bin/tailscale set ${lib.escapeShellArgs tailscaleSetFlags}
+          fi
+        '';
 
         # Audit logging
         security.auditd.enable = true;

--- a/nix-darwin/config/networking.nix
+++ b/nix-darwin/config/networking.nix
@@ -1,4 +1,9 @@
-{ pkgs, ... }:
+{
+  lib,
+  pkgs,
+  tailscaleSetFlags,
+  ...
+}:
 {
   networking = {
     applicationFirewall = {
@@ -28,7 +33,7 @@
   # DNS preference aligned with this declarative split-DNS configuration.
   system.activationScripts.tailscaleDns.text = ''
     if ${pkgs.tailscale}/bin/tailscale status >/dev/null 2>&1; then
-      ${pkgs.tailscale}/bin/tailscale set --accept-dns=false || true
+      ${pkgs.tailscale}/bin/tailscale set ${lib.escapeShellArgs tailscaleSetFlags}
     fi
   '';
 }

--- a/nix-darwin/default.nix
+++ b/nix-darwin/default.nix
@@ -4,6 +4,7 @@
   lib,
   isRunner,
   username,
+  tailscaleSetFlags,
   ...
 }:
 let
@@ -11,7 +12,9 @@ let
   fonts = import ./config/fonts.nix { inherit pkgs; };
   homebrew = import ./config/homebrew.nix { inherit isRunner lib; };
   keyboard = import ./config/keyboard { inherit lib pkgs; };
-  networking = import ./config/networking.nix { inherit pkgs; };
+  networking = import ./config/networking.nix {
+    inherit lib pkgs tailscaleSetFlags;
+  };
   nix = import ./config/nix.nix;
   security = import ./config/security.nix { inherit username; };
   serviceModules = import ./services { inherit lib isRunner pkgs; };

--- a/spec/activate_tailscale_spec.sh
+++ b/spec/activate_tailscale_spec.sh
@@ -131,7 +131,6 @@ The output should include 'set -euo pipefail'
 End
 End
 
-
 Describe 'nix-darwin/config/networking.nix'
 DARWIN_CONFIG="$PWD/nix-darwin/config/networking.nix"
 

--- a/spec/activate_tailscale_spec.sh
+++ b/spec/activate_tailscale_spec.sh
@@ -131,6 +131,25 @@ The output should include 'set -euo pipefail'
 End
 End
 
+
+Describe 'nix-darwin/config/networking.nix'
+DARWIN_CONFIG="$PWD/nix-darwin/config/networking.nix"
+
+It 'reapplies Galactica DNS preferences during every system activation'
+When run bash -c "grep -F 'system.activationScripts.tailscaleDns.text' '$DARWIN_CONFIG' && grep -F 'tailscale set \${lib.escapeShellArgs tailscaleSetFlags}' '$DARWIN_CONFIG'"
+The output should include 'tailscaleDns'
+The output should include 'tailscaleSetFlags'
+End
+
+It 'sources Galactica preferences from its named host definition'
+When run bash -c "grep -F '\"--accept-dns=false\"' '$PWD/named-hosts/galactica/default.nix' && grep -F '\"--accept-routes=true\"' '$PWD/named-hosts/galactica/default.nix' && grep -F '\"--ssh=false\"' '$PWD/named-hosts/galactica/default.nix' && grep -F 'inherit inputs username tailscaleSetFlags;' '$PWD/named-hosts/galactica/default.nix'"
+The output should include '--accept-dns=false'
+The output should include '--accept-routes=true'
+The output should include '--ssh=false'
+The output should include 'tailscaleSetFlags'
+End
+End
+
 Describe 'flag application'
 It 'requires a tailscale binary argument'
 When run bash -c "grep 'tailscale binary required' '$SCRIPT'"

--- a/spec/matic_tailscale_spec.sh
+++ b/spec/matic_tailscale_spec.sh
@@ -24,6 +24,18 @@ When run bash -c "grep -F '\"--accept-dns=true\"' '$CONFIG'"
 The output should include '--accept-dns=true'
 End
 
+It 'preserves its live hostname and route policy'
+When run bash -c "grep -F '\"--hostname=matic\"' '$CONFIG' && grep -F '\"--accept-routes=false\"' '$CONFIG'"
+The output should include '--hostname=matic'
+The output should include '--accept-routes=false'
+End
+
+It 'reapplies the declared preferences during every system activation'
+When run bash -c "grep -F 'system.activationScripts.tailscalePreferences.text' '$CONFIG' && grep -F 'tailscale set \${lib.escapeShellArgs tailscaleSetFlags}' '$CONFIG'"
+The output should include 'tailscalePreferences'
+The output should include 'tailscaleSetFlags'
+End
+
 It 'uses systemd-resolved for Tailscale MagicDNS'
 When run bash -c "grep -F 'services.resolved.enable = true;' '$CONFIG'"
 The output should include 'services.resolved.enable = true'

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -43,11 +43,17 @@ let
         }).system;
 
     eval-darwin-galactica =
-      mkEvalCheck "darwin-galactica"
-        (import ../named-hosts/galactica {
+      let
+        galactica = import ../named-hosts/galactica {
           inherit inputs;
           username = "shunkakinoki";
-        }).system;
+        };
+        activation = galactica.config.system.activationScripts.tailscaleDns.text;
+      in
+      assert lib.hasInfix "--accept-dns=false" activation;
+      assert lib.hasInfix "--accept-routes=true" activation;
+      assert lib.hasInfix "--ssh=false" activation;
+      mkEvalCheck "darwin-galactica" galactica.system;
   };
 
   # --- NixOS configurations (x86_64-linux only) ---
@@ -78,11 +84,23 @@ let
       mkEvalCheck "nixos-runner" nixosRunner.config.system.build.toplevel;
 
     eval-nixos-matic =
-      mkEvalCheck "nixos-matic"
-        (import ../named-hosts/matic {
+      let
+        matic = import ../named-hosts/matic {
           inherit inputs;
           username = "shunkakinoki";
-        }).config.system.build.toplevel;
+        };
+        cfg = matic.config;
+      in
+      assert
+        cfg.services.tailscale.extraSetFlags == [
+          "--hostname=matic"
+          "--accept-dns=true"
+          "--accept-routes=false"
+          "--operator=shunkakinoki"
+          "--ssh"
+        ];
+      assert lib.hasInfix "tailscale set" cfg.system.activationScripts.tailscalePreferences.text;
+      mkEvalCheck "nixos-matic" cfg.system.build.toplevel;
 
     eval-nixos-viper =
       mkEvalCheck "nixos-viper"
@@ -192,21 +210,41 @@ let
         assert cfg.programs.ssh.settings.kamino100.data.User == "root";
         assert cfg.programs.ssh.settings.kamino100.data.HostName == "kamino100.tail950b36.ts.net";
         assert lib.hasInfix "tailscale kamino100" cfg.home.activation.configureKaminoTailscale.data;
+        assert lib.hasInfix "--hostname=kamino100" cfg.home.activation.configureKaminoTailscale.data;
+        assert lib.hasInfix "--accept-dns=false" cfg.home.activation.configureKaminoTailscale.data;
+        assert lib.hasInfix "--ssh=false" cfg.home.activation.configureKaminoTailscale.data;
         mkEvalCheck "home-kamino100" kamino.activationPackage;
       eval-home-andor =
-        mkEvalCheck "home-andor"
-          (import ../named-hosts/andor {
+        let
+          andor = import ../named-hosts/andor {
             inherit inputs;
             username = "ubuntu";
             system = "x86_64-linux";
-          }).activationPackage;
+          };
+        in
+        assert
+          andor.config.modules.tailscale.extraUpArgs == [
+            "--reset"
+            "--accept-dns=false"
+            "--ssh"
+          ];
+        mkEvalCheck "home-andor" andor.activationPackage;
       eval-home-kyber =
-        mkEvalCheck "home-kyber"
-          (import ../named-hosts/kyber {
+        let
+          kyber = import ../named-hosts/kyber {
             inherit inputs;
             username = "ubuntu";
             system = "x86_64-linux";
-          }).activationPackage;
+          };
+        in
+        assert
+          kyber.config.modules.tailscale.extraUpArgs == [
+            "--reset"
+            "--ssh=false"
+            "--accept-dns=false"
+            "--advertise-exit-node"
+          ];
+        mkEvalCheck "home-kyber" kyber.activationPackage;
     };
 in
 darwinChecks // nixosChecks // homeChecks

--- a/tests/test_kamino_activation.py
+++ b/tests/test_kamino_activation.py
@@ -35,6 +35,13 @@ class ActivationTests(unittest.TestCase):
                 arguments.append(str(identity))
             if phase == "tailscale":
                 arguments.append(str(root / "tailscale"))
+                arguments.extend(
+                    [
+                        "--hostname=kamino100",
+                        "--accept-dns=false",
+                        "--ssh=false",
+                    ]
+                )
             result = subprocess.run(
                 ["/bin/bash", str(SCRIPT), *arguments],
                 capture_output=True,
@@ -72,11 +79,11 @@ class ActivationTests(unittest.TestCase):
         self.assertEqual(result.returncode, 3)
         self.assertEqual(len(log), 1)
 
-    def test_tailscale_sets_preferences_without_login_or_state_reset(self):
+    def test_tailscale_enrolls_and_sets_preferences_without_state_reset(self):
         result, log = self.run_phase("tailscale")
         self.assertEqual(result.returncode, 0)
         self.assertEqual(
-            log, ["tailscale set --hostname=kamino100 --accept-dns=false --ssh=false"]
+            log, ["tailscale up --hostname=kamino100 --accept-dns=false --ssh=false"]
         )
         result, _ = self.run_phase("tailscale", fail="tailscale")
         self.assertEqual(result.returncode, 3)


### PR DESCRIPTION
## Summary
- define host-specific Tailscale arguments in each host module
- run Kamino enrollment from host activation using its configured hostname
- reapply Galactica and Matic preferences on every activation while preserving Kyber and Andor behavior
- document first-time Kamino login and add focused tests/evaluation assertions

## Validation
- `python3 -m unittest discover -s tests -p 'test_kamino*.py'` (15 tests)
- focused ShellSpec suite (141 examples)
- shellcheck/bash syntax, nixfmt, and diff checks
- Nix evaluation for Galactica, Kamino100, Kyber, Andor, plus focused Matic activation evaluation
- exact-commit remote build/switch on Matic; live policy verified
- exact-commit remote Kyber activation reached `installTailscaleService` and live exit-node policy verified; the overall switch later hit an unrelated existing `roborev.service` timeout
- local Galactica activation applied and live policy verified; Home Manager then entered its existing `~/.codex` backup cleanup scan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tailscale preferences are now reapplied on every host switch instead of only at initial setup, and Kamino enrolls during `make nix-switch` rather than needing a separate manual `tailscale up` afterward.

- Each host defines its Tailscale flags once in its Nix module and reuses them from activation.
- Galactica's darwin activation now reapplies its declared DNS, route, and SSH preferences on every switch.
- Matic now declares its hostname and route policy in Nix and reapplies its set flags on every activation.
- Kamino now runs `tailscale up` during activation; enrolled machines just reapply the declared name and preferences without creating a new device.
- Andor and Kyber keep their existing behavior; only the flag definitions moved.

**Migration**
- First-time Kamino setup prints a login URL during `make nix-switch`; follow it to choose the intended tailnet.

<sup>Written for commit 98db6305968b6c457aa3d4e65b88f3b8b100fef7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

