### PR TITLE
fix(nix): keep network-backed packages optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,11 @@ NIX_USERNAME := $(shell \
 		echo "$(shell whoami)"; \
 	fi)
 NIX_ENV := $(shell . ~/.nix-profile/etc/profile.d/nix.sh 2>/dev/null || . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh 2>/dev/null || command -v nix >/dev/null 2>&1 || echo "not_found")
-NIX_FLAGS := --extra-experimental-features 'flakes nix-command' --no-pure-eval --impure --fallback
+NIX_FLAGS := --extra-experimental-features 'flakes nix-command' --no-pure-eval --impure --fallback --option download-attempts 5 --option connect-timeout 10
+# Optional packages are omitted by default because their fixed-output builders
+# may require registry access during the build. Opt in with
+# NIX_INCLUDE_OPTIONAL_PACKAGES=1 when network-backed packages are desired.
+export NIX_INCLUDE_OPTIONAL_PACKAGES
 # Only add cache options when user is trusted or on Darwin/CI (avoids "ignoring untrusted substituter" warnings)
 ifeq ($(OS),Darwin)
 NIX_FLAGS += --option substituters "$(NIX_SUBSTITUTERS)" --option trusted-public-keys "$(NIX_TRUSTED_KEYS)"

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -5,6 +5,7 @@
 }:
 let
   inherit (inputs.host) isDesktop isDev;
+  includeOptionalPackages = builtins.getEnv "NIX_INCLUDE_OPTIONAL_PACKAGES" == "1";
   pkgs-nightly = import inputs.nixpkgs-nightly {
     inherit (pkgs) system;
     config.allowUnfree = true;
@@ -134,8 +135,9 @@ with pkgs;
   zellij
   zoxide
 ]
-# Heavy packages: skip on CI runners (disk pressure / LTO OOM on macos-latest).
-++ lib.optionals (!isRunner) [
+# Optional packages: skip on CI runners (disk pressure / LTO OOM on macos-latest)
+# and by default to keep builds independent of registry availability.
+++ lib.optionals (!isRunner && includeOptionalPackages) [
   pkgs.llm-agents.antigravity-cli
   pkgs.llm-agents.prime-agent
   vector

--- a/spec/optional_network_packages_spec.sh
+++ b/spec/optional_network_packages_spec.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+Describe 'Optional network-backed packages'
+
+PACKAGES="$PWD/home-manager/packages/default.nix"
+
+It 'keeps network-backed packages opt-in for resilient builds'
+When run grep -F 'NIX_INCLUDE_OPTIONAL_PACKAGES' "$PACKAGES"
+The output should include 'NIX_INCLUDE_OPTIONAL_PACKAGES'
+End
+
+It 'documents the group as optional registry-backed dependencies'
+When run sed -n '/includeOptionalPackages/,/++ lib.optionals stdenv.hostPlatform.isDarwin/p' "$PACKAGES"
+The output should include 'by default to keep builds independent of registry availability'
+The output should include 'pkgs.llm-agents.antigravity-cli'
+The output should include 'pkgs.llm-agents.prime-agent'
+The output should include 'vector'
+End
+
+End


### PR DESCRIPTION
## Summary
- make registry-backed optional packages opt-in for resilient builds
- add Nix download attempts and connection timeout
- preserve explicit opt-in via `NIX_INCLUDE_OPTIONAL_PACKAGES=1`

## Validation
- `shellspec spec/optional_network_packages_spec.sh spec/make_build_host_resolution_spec.sh --format progress --jobs 1`
- `nix fmt -- --clear-cache --fail-on-change`
- `nix flake check --offline --impure --no-update-lock-file`
- verified normal closure omits optional packages and opt-in closure includes `prime-agent`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns registry-backed optional packages off by default so Nix builds no longer require network access during the build. They now build only when `NIX_INCLUDE_OPTIONAL_PACKAGES=1` is set. Also adds Nix download retry attempts (5) and a 10-second connection timeout, plus a spec test covering the opt-in behavior.

<sup>Written for commit 2e7928f784b3efed3d246d80c6b2409b4d966548. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

