### PR TITLE
fix(nix): provide lld for Linux Rust builds

### DIFF
--- a/home-manager/modules/cargo-globals/default.nix
+++ b/home-manager/modules/cargo-globals/default.nix
@@ -15,7 +15,7 @@ in
 {
   # Install cargo global packages from Cargo.toml using home-manager activation
   home.activation.installCargoGlobals = config.lib.dag.entryAfter [ "writeBoundary" ] ''
-    export PATH=${pkgs.rustup}/bin:${pkgs.cargo}/bin:${pkgs.rustc}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:${pkgs.perl}/bin:$PATH
+    export PATH=${pkgs.rustup}/bin:${pkgs.cargo}/bin:${pkgs.rustc}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.gcc}/bin:${pkgs.binutils}/bin:${pkgs.lld}/bin:${pkgs.pkg-config}/bin:${pkgs.perl}/bin:$PATH
     export CARGO_HOME="$HOME/.cargo"
     export PKG_CONFIG_PATH="${pkgs.openssl.dev}/lib/pkgconfig${libiconvPkgConfigPath}''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
     export OPENSSL_DIR="${pkgs.openssl.dev}"
@@ -40,7 +40,7 @@ in
       Service = {
         Type = "simple";
         Environment = [
-          "PATH=${pkgs.rustup}/bin:${pkgs.cargo}/bin:${pkgs.rustc}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.gcc}/bin:${pkgs.pkg-config}/bin:${pkgs.perl}/bin:${pkgs.coreutils}/bin:${pkgs.bash}/bin"
+          "PATH=${pkgs.rustup}/bin:${pkgs.cargo}/bin:${pkgs.rustc}/bin:${pkgs.dasel}/bin:${pkgs.jq}/bin:${pkgs.gcc}/bin:${pkgs.binutils}/bin:${pkgs.lld}/bin:${pkgs.pkg-config}/bin:${pkgs.perl}/bin:${pkgs.coreutils}/bin:${pkgs.bash}/bin"
           "CARGO_HOME=%h/.cargo"
           "HOME=%h"
           "PKG_CONFIG_PATH=${pkgs.openssl.dev}/lib/pkgconfig${libiconvPkgConfigPath}"

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -164,6 +164,7 @@ with pkgs;
   keychain
   libiconv
   libsecret
+  lld
   nspr
   nss
   opencode

--- a/home-manager/services/make-updater/default.nix
+++ b/home-manager/services/make-updater/default.nix
@@ -52,6 +52,7 @@ in
             pkgs.gnused
             pkgs.go
             pkgs.jq
+            pkgs.lld
             pkgs.libtool
             pkgs.neovim
             pkgs.nix

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -152,6 +152,26 @@ let
         mkEvalCheck "home-${name}" (import ../hosts/linux ({ inherit inputs; } // args)).activationPackage
       )
     ) filteredHomeConfigs
+    // lib.optionalAttrs (lib.hasSuffix "linux" system) {
+      eval-home-linux-rust-linker =
+        let
+          linux = import ../hosts/linux {
+            inherit inputs;
+            username = "ubuntu";
+            inherit system;
+          };
+          cfg = linux.config;
+          packageNames = map lib.getName cfg.home.packages;
+          cargoActivation = cfg.home.activation.installCargoGlobals.data;
+          cargoServicePath = builtins.head cfg.systemd.user.services.install-cargo-globals.Service.Environment;
+          updaterPath = builtins.head cfg.systemd.user.services.make-updater.Service.Environment;
+        in
+        assert lib.elem "lld" packageNames;
+        assert lib.hasInfix "lld-" cargoActivation;
+        assert lib.hasInfix "lld-" cargoServicePath;
+        assert lib.hasInfix "lld-" updaterPath;
+        mkEvalCheck "home-linux-rust-linker" linux.activationPackage;
+    }
     // lib.optionalAttrs (system == "x86_64-linux") {
       eval-home-kamino =
         let


### PR DESCRIPTION
## Summary

Linux Rust/Cargo linking can request `-fuse-ld=lld`, but the managed Linux environment only exposed gcc/binutils. This produces `collect2: fatal error: cannot find ld` during cargo installs.

- Add lld to the shared Linux Home Manager package set.
- Add lld and binutils to Cargo global activation and service PATHs.
- Add lld to the scheduled make-updater PATH.
- Add Linux Nix evaluation assertions for the package and all three PATHs.

## Validation

- nixfmt check passed.
- git diff check passed.
- Targeted eval-home-linux-rust-linker reached and passed during nix flake check --offline --system x86_64-linux --impure --no-build.
- Full x86_64 flake check remains red on pre-existing unrelated docker.service builder failures and .manpath evaluation failures; the new linker check passed.

Fixes shunkakinokisoftware-pgwh.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Linux Rust/Cargo builds failing with `collect2: fatal error: cannot find ld` by making `lld` available in the managed Linux environment. Resolves shunkakinokisoftware-pgwh.

**Changes**
- Adds `lld` to the shared Linux Home Manager package set.
- Adds `lld` and `binutils` to the Cargo activation and service PATHs, and `lld` to the `make-updater` PATH.
- Adds Linux eval assertions covering the package and all three PATHs.

**Validation**
- Targeted Linux eval check passes; full x86_64 check is red only on pre-existing unrelated failures.

<sup>Written for commit cb7472d1510c72801768e1fc233df1ed7d4f4df3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

