### PR TITLE
fix(kamino): add fleet SSH and session shortcuts

### DIFF
--- a/home-manager/programs/kamino/default.nix
+++ b/home-manager/programs/kamino/default.nix
@@ -1,9 +1,50 @@
-{ pkgs, ... }:
+{ lib, pkgs, ... }:
 let
   fleet = import ../../../named-hosts/kamino/fleet.nix { };
   inventory = pkgs.writeText "kamino-fleet.json" (builtins.toJSON fleet);
+  shortcuts = lib.concatMap (machine: [
+    {
+      name = machine.name;
+      body = "ssh ${machine.name} $argv";
+      description = "SSH to ${machine.name} over Tailscale";
+    }
+    {
+      name = "${machine.name}d";
+      body = ''ssh -t ${machine.name} "tmux new-session -A -s desktop"'';
+      description = "Attach to ${machine.name} tmux desktop session";
+    }
+    {
+      name = "${machine.name}h";
+      body = "herdr --remote ${machine.name} $argv";
+      description = "Attach to Herdr on ${machine.name}";
+    }
+    {
+      name = "${machine.name}m";
+      body = ''ssh -t ${machine.name} "tmux new-session -A -s mobile"'';
+      description = "Attach to ${machine.name} tmux mobile session";
+    }
+    {
+      name = "${machine.name}z";
+      body = ''ssh -t ${machine.name} "zellij attach -c desktop"'';
+      description = "Attach to ${machine.name} Zellij desktop session";
+    }
+  ]) fleet.machines;
 in
 {
+  programs.fish = {
+    shellAbbrs = builtins.listToAttrs (
+      map (shortcut: lib.nameValuePair shortcut.name "_${shortcut.name}_function") shortcuts
+    );
+    functions = builtins.listToAttrs (
+      map (
+        shortcut:
+        lib.nameValuePair "_${shortcut.name}_function" {
+          inherit (shortcut) body description;
+        }
+      ) shortcuts
+    );
+  };
+
   programs.ssh.settings = builtins.listToAttrs (
     map (machine: {
       inherit (machine) name;

--- a/named-hosts/kamino/README.md
+++ b/named-hosts/kamino/README.md
@@ -49,6 +49,23 @@ ssh -t kamino2 'tmux new-session -A -s work'
 ssh -t kamino3 'zellij attach -c work'
 ```
 
+Fish also provides the same shortcuts as Kyber and Matic for `kamino` and
+every numbered host through `kamino100`:
+
+| Shortcut | Action |
+| --- | --- |
+| `kamino1` | OpenSSH login as root over Tailscale |
+| `kamino1d` | Attach/create the tmux `desktop` session |
+| `kamino1h` | Attach to Herdr (`herdr --remote kamino1`) |
+| `kamino1m` | Attach/create the tmux `mobile` session |
+| `kamino1z` | Attach/create the Zellij `desktop` session |
+
+Replace `kamino1` with any declared fleet name. SSH and Herdr shortcuts forward
+additional arguments. Apply your **client's** normal dotfiles profile and open a
+new Fish shell to load these abbreviations; do not activate a Kamino server
+profile on your laptop. Every SSH shortcut uses the generated host configuration
+so the root login, hostname, local overrides and host-key checks stay consistent.
+
 On first SSH access, compare the presented host-key fingerprint with the VPS
 console before accepting it. The verifier deliberately will not accept unknown
 or changed SSH keys automatically.

--- a/tests/kamino-shortcuts.fish
+++ b/tests/kamino-shortcuts.fish
@@ -1,0 +1,64 @@
+# The Nix check loads the actual generated functions before this behavior test.
+if test (count $argv) -eq 0
+    echo 'No fleet hosts supplied to the shortcut check' >&2
+    exit 1
+end
+
+function ssh
+    set -g called ssh $argv
+    return $command_status
+end
+
+function herdr
+    set -g called herdr $argv
+    return $command_status
+end
+
+function expect_call
+    if test (count $called) -ne (count $argv)
+        printf 'Wrong argument count for %s\n' "$called" >&2
+        exit 1
+    end
+    for index in (seq (count $argv))
+        if test "$called[$index]" != "$argv[$index]"
+            printf 'Argument %s: expected <%s>, got <%s>\n' $index "$argv[$index]" "$called[$index]" >&2
+            exit 1
+        end
+    end
+end
+
+set -g command_status 0
+for host in $argv
+    set -l shortcut _{$host}_function
+    $shortcut 'printf hello' 'two words'
+    expect_call ssh $host 'printf hello' 'two words'
+
+    set shortcut _{$host}d_function
+    $shortcut
+    expect_call ssh -t $host 'tmux new-session -A -s desktop'
+
+    set shortcut _{$host}h_function
+    $shortcut --help 'two words'
+    expect_call herdr --remote $host --help 'two words'
+
+    set shortcut _{$host}m_function
+    $shortcut
+    expect_call ssh -t $host 'tmux new-session -A -s mobile'
+
+    set shortcut _{$host}z_function
+    $shortcut
+    expect_call ssh -t $host 'zellij attach -c desktop'
+
+    set -g command_status 23
+    for suffix in '' d h m z
+        set shortcut _{$host}{$suffix}_function
+        $shortcut
+        if test $status -ne 23
+            printf 'Lost command failure status: %s\n' $shortcut >&2
+            exit 1
+        end
+    end
+    set -g command_status 0
+end
+
+printf 'Verified all five shortcuts for %s fleet hosts\n' (count $argv)

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -15,6 +15,29 @@ let
   };
 in
 {
+  lib-kamino-shortcuts =
+    let
+      kamino = import ../home-manager/programs/kamino { inherit lib pkgs; };
+      fish = kamino.programs.fish;
+      fleet = import ../named-hosts/kamino/fleet.nix { };
+      functions = pkgs.writeText "kamino-shortcuts.fish" (
+        lib.concatStringsSep "\n" (
+          lib.mapAttrsToList (name: value: ''
+            function ${name}
+              ${value.body}
+            end
+          '') fish.functions
+        )
+        + "\nsource ${./kamino-shortcuts.fish} $argv\n"
+      );
+    in
+    assert builtins.length (builtins.attrNames fish.shellAbbrs) == 5 * builtins.length fleet.machines;
+    assert lib.all (name: builtins.hasAttr name fish.functions) (builtins.attrValues fish.shellAbbrs);
+    pkgs.runCommand "lib-kamino-shortcuts" { nativeBuildInputs = [ pkgs.fish ]; } ''
+      fish --no-config ${functions} ${lib.escapeShellArgs (map (machine: machine.name) fleet.machines)}
+      touch "$out"
+    '';
+
   lib-kamino-fleet =
     let
       fleet = import ../named-hosts/kamino/fleet.nix { count = 100; };


### PR DESCRIPTION
Kamino hosts had generated SSH configuration but no Fish shortcuts like Kyber and Matic. Generate the base SSH, desktop tmux, Herdr, mobile tmux, and Zellij shortcuts from the existing fleet inventory, including every numbered host through kamino100.

SSH shortcuts use the configured host alias so the root username, Tailscale hostname, host-key checks, and local overrides apply consistently. The runbook documents the commands and client activation.

Validation: the Nix behavior check exercises all five shortcuts across 101 hosts, including argument boundaries and failure propagation; 468 Fish tests pass with the inherited CAAM_CODEX_PROFILE unset; 15 Kamino Python tests and six SSH configuration tests pass; the Kamino100 Home Manager check evaluates successfully.

Live client configuration and shortcut loading were verified. Kamino1 is reachable and its server key matches a previously trusted key, but login still rejects the available client keys. Server-side key authorization and remote session acceptance remain tracked separately.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Fish shell shortcuts for Kamino fleet hosts, matching what Kyber and Matic already have. Kamino previously only had generated SSH config; now every host through kamino100 gets SSH, desktop tmux, Herdr, mobile tmux, and Zellij shortcuts.

- SSH shortcuts use the configured host alias so the root username, Tailscale hostname, host-key checks, and local overrides apply consistently.
- The runbook documents the shortcuts and client activation; tests exercise all five shortcuts across 101 hosts, including argument forwarding and failure propagation.

<sup>Written for commit 9313970eb6f83b2378092e7b0063f7ba708415aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

