### PR TITLE
fix(kamino): automate first SSH access

### DIFF
--- a/home-manager/programs/kamino/default.nix
+++ b/home-manager/programs/kamino/default.nix
@@ -51,6 +51,7 @@ in
       value = {
         HostName = machine.hostname;
         User = machine.user;
+        StrictHostKeyChecking = "accept-new";
       };
     }) fleet.machines
   );

--- a/named-hosts/kamino/README.md
+++ b/named-hosts/kamino/README.md
@@ -32,9 +32,11 @@ On a fresh machine, follow the login URL printed during activation and choose
 the intended tailnet. On an enrolled machine, the command reapplies the declared
 name and preferences without creating a new device.
 
-This keeps the existing OpenSSH server/login policy, not Tailscale SSH. Provision
-your root authorized key separately. Never put authentication keys in this command
-or in the Nix declaration. The install command does not distribute credentials.
+This keeps the existing OpenSSH server/login policy, not Tailscale SSH. Activation
+adds the declared Galactica public key from `named-hosts/pubkeys.nix` to root's
+`authorized_keys`, preserving provider keys and other existing entries. It sets
+the SSH directory/file permissions to `700`/`600` and does not copy private keys.
+Clients with a different key still need that public key provisioned separately.
 Preserve each machine's `/var/lib/tailscale`, `/etc/ssh`, `/etc/machine-id`, and
 `/root` across restart/recreation. Never clone enrolled Tailscale state or SSH
 private host keys into a second machine. DNS names alone are not cryptographic
@@ -66,9 +68,13 @@ new Fish shell to load these abbreviations; do not activate a Kamino server
 profile on your laptop. Every SSH shortcut uses the generated host configuration
 so the root login, hostname, local overrides and host-key checks stay consistent.
 
-On first SSH access, compare the presented host-key fingerprint with the VPS
-console before accepting it. The verifier deliberately will not accept unknown
-or changed SSH keys automatically.
+Kamino client aliases use OpenSSH's `StrictHostKeyChecking=accept-new`: the first
+connection records a new host key without prompting. This is trust on first use;
+later connections still reject changed keys. The fleet verifier remains strict,
+so make the first SSH connection before running it. For an independently verified
+first connection, compare and preinstall the host key using the provider console.
+Reinstallations should preserve `/etc/ssh`; a replacement machine reusing a name
+with a different key still needs an explicitly verified known-hosts update.
 
 ```sh
 kamino-fleet list 'kamino*'                 # declared names, not running machines
@@ -123,8 +129,10 @@ neither is live activation proof.
 
 Use the provider console or supplied IP first. Keep console access and an
 existing SSH session open until a second connection works over Tailscale.
-Verify the root SSH host-key fingerprint through the console. Provision the
-intended public authorized key without replacing existing keys.
+The declared Galactica public key is installed during activation. Provision any
+additional administrator public key without replacing existing entries. For
+independent first-use verification, obtain the SSH host-key fingerprint through
+the console before connecting.
 
 The curl installer tracks main. To test a reviewed but unmerged revision, clone
 the repository into `/root/dotfiles`, check out that revision, and run:
@@ -235,9 +243,10 @@ Inspect `~/.ssh/config.local` if a local override changes the generated target.
 
 ### 3. Authorize the client key and verify the server key
 
-Use the provider's SSH-key provisioning facility or the existing console/admin
-access to append the client's **public** key to `/root/.ssh/authorized_keys` on
-the intended machine. Preserve existing keys; keep `/root/.ssh` mode `700` and
+Kamino activation already installs the Galactica public key declared in
+`named-hosts/pubkeys.nix`. For a different client, use the provider's SSH-key
+provisioning facility or existing console/admin access to append its **public**
+key to `/root/.ssh/authorized_keys`. Preserve existing keys; keep `/root/.ssh` mode `700` and
 `authorized_keys` mode `600`, owned by root. Keep the private key on the client.
 Managed clients select `~/.ssh/id_ed25519` by default; authorize its `.pub` file
 or use an explicit, locally configured key.
@@ -250,8 +259,9 @@ Obtain the server's public host-key fingerprint through the trusted console:
 ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub
 ```
 
-Then, on the client, compare that fingerprint before accepting the first
-connection. If the server presents a different key type, compare the matching
+For independent first-use verification, compare that fingerprint on the client
+before connecting. The default client policy automatically records unknown keys.
+If the server presents a different key type, compare the matching
 public host key through the console. A changed key needs investigation, not an
 automatic known-hosts reset.
 

--- a/named-hosts/kamino/activate.sh
+++ b/named-hosts/kamino/activate.sh
@@ -18,6 +18,20 @@ check)
 prepare)
   mkdir -p /etc/sudoers.d
   ;;
+authorize-ssh)
+  key_file="${2:?public key file required}"
+  ssh_dir="${3:?SSH directory required}"
+  key="$(cat "$key_file")"
+  ssh-keygen -lf "$key_file" >/dev/null
+  mkdir -p "$ssh_dir"
+  chmod 700 "$ssh_dir"
+  touch "$ssh_dir/authorized_keys"
+  chmod 600 "$ssh_dir/authorized_keys"
+  chown root:root "$ssh_dir" "$ssh_dir/authorized_keys"
+  if ! grep -qxF "$key" "$ssh_dir/authorized_keys"; then
+    printf '\n%s\n' "$key" >>"$ssh_dir/authorized_keys"
+  fi
+  ;;
 user-manager)
   hostnamectl set-hostname "${2:?name required}"
   loginctl enable-linger root

--- a/named-hosts/kamino/default.nix
+++ b/named-hosts/kamino/default.nix
@@ -28,6 +28,9 @@ let
     "--accept-dns=false"
     "--ssh=false"
   ];
+  authorizedKey = pkgs.writeText "kamino-authorized-key.pub" (
+    (import ../pubkeys.nix).galactica + "\n"
+  );
 in
 inputs.home-manager.lib.homeManagerConfiguration {
   inherit pkgs;
@@ -58,6 +61,9 @@ inputs.home-manager.lib.homeManagerConfiguration {
 
         home.activation.checkKaminoIdentity = config.lib.dag.entryBefore [ "writeBoundary" ] ''
           ${pkgs.bash}/bin/bash ${./activate.sh} check ${lib.escapeShellArg name} "${config.xdg.configHome}/kamino/name"
+        '';
+        home.activation.authorizeKaminoSsh = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+          $DRY_RUN_CMD ${pkgs.bash}/bin/bash ${./activate.sh} authorize-ssh ${authorizedKey} "${config.home.homeDirectory}/.ssh"
         '';
         home.activation.startKaminoUserManager =
           config.lib.dag.entryBetween [ "reloadSystemd" ] [ "writeBoundary" ]

--- a/tests/test_kamino_activation.py
+++ b/tests/test_kamino_activation.py
@@ -59,6 +59,7 @@ class ActivationTests(unittest.TestCase):
         result, log = self.run_phase("check")
         self.assertEqual(result.returncode, 0)
         self.assertEqual(log, [])
+
         for options in [dict(saved="kamino1"), dict(uid="1000"), dict(init="sh")]:
             result, log = self.run_phase("check", **options)
             self.assertNotEqual(result.returncode, 0)
@@ -96,3 +97,76 @@ class ActivationTests(unittest.TestCase):
         result, log = self.run_phase("invalid")
         self.assertNotEqual(result.returncode, 0)
         self.assertEqual(log, [])
+
+
+class AuthorizedKeyTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.ssh_dir = self.root / "ssh"
+        self.key = self.root / "client"
+        subprocess.run(
+            ["ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", str(self.key)],
+            check=True,
+            capture_output=True,
+        )
+        self.public_key = Path(str(self.key) + ".pub")
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        # Only ownership is mocked: tests run as an ordinary local user.
+        chown = self.bin / "chown"
+        chown.write_text('#!/bin/sh\nprintf "%s\\n" "$@" >"$OWNERSHIP_LOG"\n')
+        chown.chmod(0o755)
+
+    def authorize(self):
+        return subprocess.run(
+            [
+                "/bin/bash",
+                str(SCRIPT),
+                "authorize-ssh",
+                str(self.public_key),
+                str(self.ssh_dir),
+            ],
+            env={
+                **os.environ,
+                "PATH": f"{self.bin}:{os.environ['PATH']}",
+                "OWNERSHIP_LOG": str(self.root / "ownership"),
+            },
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    def test_fresh_install_authorizes_key_with_private_permissions(self):
+        result = self.authorize()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        authorized = self.ssh_dir / "authorized_keys"
+        self.assertEqual(
+            authorized.read_text().strip(), self.public_key.read_text().strip()
+        )
+        self.assertEqual(self.ssh_dir.stat().st_mode & 0o777, 0o700)
+        self.assertEqual(authorized.stat().st_mode & 0o777, 0o600)
+        self.assertEqual(
+            (self.root / "ownership").read_text().splitlines(),
+            ["root:root", str(self.ssh_dir), str(authorized)],
+        )
+
+    def test_reactivation_preserves_existing_entries_and_does_not_duplicate(self):
+        self.ssh_dir.mkdir()
+        authorized = self.ssh_dir / "authorized_keys"
+        existing = "restrict ssh-ed25519 AAAAexisting provider-key"
+        authorized.write_text(existing)  # Deliberately no trailing newline.
+        for _ in range(2):
+            result = self.authorize()
+            self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            authorized.read_text().splitlines(),
+            [existing, self.public_key.read_text().strip()],
+        )
+
+    def test_invalid_public_key_fails_before_creating_ssh_directory(self):
+        self.public_key.write_text("not a public key\n")
+        result = self.authorize()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(self.ssh_dir.exists())


### PR DESCRIPTION
Fresh Kamino hosts required a manual host-key prompt and did not authorize the declared laptop key, preventing the fleet shortcuts from working after installation.

Generated Kamino SSH aliases now use `StrictHostKeyChecking=accept-new`. The first connection records an unknown host key automatically; changed keys remain rejected. Kamino activation validates and appends the existing declared Galactica public key to root's authorized keys, preserves existing entries, and enforces directory/file permissions and ownership. No private keys are distributed, and existing OpenSSH login policy is preserved.

Validation: 18 Kamino Python tests pass, including fresh authorization, repeat activation, existing-key preservation and invalid-key rejection. Six SSH configuration tests pass. A temporary local OpenSSH server confirms the evaluated client policy accepts a first key and rejects its replacement without changing the trusted key. Nix formatting, Ruff, ShellCheck and shell formatting checks pass.

The local client policy is active. Kamino1 activation will be attempted after merge; its current SSH server still rejects the laptop key, so runtime acceptance requires an existing administrative connection or a one-time console bootstrap.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fresh Kamino hosts required a manual host-key prompt and didn't authorize the declared laptop key, breaking fleet shortcuts after installation. SSH aliases now use `StrictHostKeyChecking=accept-new`, and activation installs the Galactica public key into root's `authorized_keys`.

**Migration**
- Changed host keys remain rejected; only unknown ones are recorded on first connect.
- Existing authorized entries and permissions are preserved, and no private keys are distributed.
- Kamino1's server still rejects the laptop key, so its first acceptance needs an existing administrative connection or a one-time console bootstrap.

<sup>Written for commit 6a6b01cbf71768f0940cb4c31bdedf9f1bb4f5b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

