### PR TITLE
fix(ci): satisfy Statix for Kamino shortcut generation

### DIFF
--- a/home-manager/programs/kamino/default.nix
+++ b/home-manager/programs/kamino/default.nix
@@ -4,7 +4,7 @@ let
   inventory = pkgs.writeText "kamino-fleet.json" (builtins.toJSON fleet);
   shortcuts = lib.concatMap (machine: [
     {
-      name = machine.name;
+      inherit (machine) name;
       body = "ssh ${machine.name} $argv";
       description = "SSH to ${machine.name} over Tailscale";
     }


### PR DESCRIPTION
The Nix lint job fails in generated Kamino shortcuts because Statix requires `inherit (machine) name` instead of assigning `machine.name`. Use the required form without changing generated shortcuts or SSH configuration.

Validated repository-wide `statix check .` and `deadnix .` (both exit 0), Nix formatting, and `git diff --check`.

The separate ARM Docker failure reports a runner shutdown rather than a build error. The latest main Docker run is already rebuilding both architectures; no speculative Docker changes are included.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Nix lint failure in the Kamino shortcut generator by using the `inherit (machine) name` form Statix requires instead of assigning `machine.name`. Generated shortcuts and SSH configuration are unchanged.

Validated with `statix check .`, `deadnix .`, Nix formatting, and `git diff --check`, all passing. The separate ARM Docker failure is a runner shutdown, not a build error, so no Docker changes are included.

<sup>Written for commit 123846179f91f67aa6f333587ea8e68aabee918f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

