### PR TITLE
fix(fish): initialize Nix paths before SSH plugin startup

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -248,6 +248,11 @@
   };
 
   xdg.configFile = {
+    # Fish loads conf.d before config.fish, including shellInit. SSH command
+    # sessions can start without Nix on PATH, so plugins need these paths early.
+    "fish/conf.d/00-nix-path.fish".text = ''
+      set -gx PATH $HOME/.nix-profile/bin /etc/profiles/per-user/${config.home.username}/bin /nix/var/nix/profiles/default/bin $PATH
+    '';
     "fish/themes/dracula.theme".source = ./dracula.theme;
     "fish/completions".source = ./completions;
   }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -15,5 +15,6 @@ let
   };
   overlayChecks = import ./overlays.nix { inherit pkgs lib inputs; };
   libChecks = import ./lib.nix { inherit pkgs lib inputs; };
+  fishChecks = import ./fish.nix { inherit pkgs lib; };
 in
-evalChecks // overlayChecks // libChecks
+evalChecks // overlayChecks // libChecks // fishChecks

--- a/tests/fish.nix
+++ b/tests/fish.nix
@@ -1,0 +1,44 @@
+{ pkgs, lib }:
+let
+  fishModule = import ../home-manager/programs/fish {
+    inherit pkgs lib;
+    config.home = {
+      username = "fish-startup-test";
+      homeDirectory = "/homeless-shelter";
+    };
+  };
+  nixPathInit = pkgs.writeText "00-nix-path.fish" (
+    fishModule.xdg.configFile."fish/conf.d/00-nix-path.fish".text
+  );
+in
+{
+  fish-ssh-startup = pkgs.runCommand "fish-ssh-startup" { } ''
+    export HOME="$TMPDIR/home"
+    export XDG_CONFIG_HOME="$HOME/.config"
+    export XDG_DATA_HOME="$HOME/.local/share"
+    export TERM=xterm
+    mkdir -p "$XDG_CONFIG_HOME/fish/conf.d" "$HOME/.nix-profile"
+    ln -s ${pkgs.grc}/bin "$HOME/.nix-profile/bin"
+    cp ${nixPathInit} "$XDG_CONFIG_HOME/fish/conf.d/00-nix-path.fish"
+    # Exercise the real plugin that previously printed its missing-grc warning.
+    cat > "$XDG_CONFIG_HOME/fish/conf.d/plugin-grc.fish" <<'FISH'
+    set -g fish_function_path ${pkgs.fishPlugins.grc.src}/functions $fish_function_path
+    source ${pkgs.fishPlugins.grc.src}/conf.d/grc.fish
+    FISH
+
+    expected="$(${pkgs.coreutils}/bin/uname -s)
+    $(${pkgs.coreutils}/bin/uname -m)"
+    # No Nix profile paths or saved Fish universal variables in the environment.
+    for mode in --no-config noninteractive --login --interactive; do
+      flags="$mode"
+      if [ "$mode" = noninteractive ]; then flags=""; fi
+      PATH=${pkgs.coreutils}/bin ${pkgs.fish}/bin/fish $flags \
+        -c 'uname -s; uname -m' > actual 2> errors
+      test "$(cat actual)" = "$expected"
+      test ! -s errors
+    done
+    PATH=${pkgs.coreutils}/bin ${pkgs.fish}/bin/fish \
+      -c 'command -q grc; and functions -q ls'
+    touch "$out"
+  '';
+}


### PR DESCRIPTION
Fish loads Home Manager plugin files in `conf.d` before `config.fish`. An SSH command can therefore load the grc plugin before the Nix profile is on PATH, printing `You need to install grc!` into Herdr’s platform probe and causing `unsupported remote platform`.

Add the user, per-user, and default Nix profile paths in `00-nix-path.fish`, before plugin initialization. Keep the existing login and interactive path setup.

Validation:
- Reproduced the warning with the real grc plugin and a minimal SSH-style PATH; the fix produces clean platform output in non-interactive, login, and interactive shells.
- Passed the new native Nix `fish-ssh-startup` check and Nix formatting checks.
- Evaluated the generated Kamino1 startup file successfully.
- Full Linux activation evaluation on macOS stopped when a Linux `docker.service` build helper could not execute.
- Live Kamino1 inspection confirmed that the active profile contains a working grc 1.13, while the early startup file is absent. The actual SSH probe emits two grc warnings before Linux/x86_64.
- A controlled comparison on Kamino1 using its active Fish configuration and Herdr’s `/bin/sh -s` probe reproduced the warning with a minimal PATH. Providing the Nix profile paths before Fish startup returned exactly `Linux\nx86_64\n`, exit 0, and empty stderr. No persistent host configuration was changed.

The change takes effect after Home Manager activation on the remote host.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Fish plugin startup when Nix isn't on PATH, so SSH command sessions no longer print the missing-grc warning that breaks Herdr's platform probe. Adds an early `conf.d/00-nix-path.fish` that sets user, per-user, and default Nix profile paths before plugin initialization, and adds a native Fish startup test. The change takes effect after Home Manager activation on the remote host.

<sup>Written for commit f43052343f0435ed1b60a1d9e37cb755f66d7ff0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


