### PR TITLE
fix(kamino): repair activation dependencies and Nix warnings

### DIFF
--- a/home-manager/nix/nix.nix
+++ b/home-manager/nix/nix.nix
@@ -15,14 +15,12 @@
         "flakes"
       ];
       extra-substituters = [
-        "https://cache.garnix.io"
         "https://cache.numtide.com"
         "https://cloudtide.cachix.org"
         "https://nix-community.cachix.org"
         "https://yazi.cachix.org"
       ];
       extra-trusted-public-keys = [
-        "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
         "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
         "cloudtide.cachix.org-1:9NZ1Mah2+u8cd/CmVffFV23z5uFNpZSrhfgTt5fuN/4="
         "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="

--- a/home-manager/services/ssh-agent/default.nix
+++ b/home-manager/services/ssh-agent/default.nix
@@ -4,7 +4,7 @@
   ...
 }:
 let
-  inherit (pkgs.stdenv) isLinux;
+  inherit (pkgs.stdenv.hostPlatform) isLinux;
 in
 {
   # Configure keychain for Linux systems

--- a/named-hosts/kamino/activate.sh
+++ b/named-hosts/kamino/activate.sh
@@ -21,8 +21,9 @@ prepare)
 authorize-ssh)
   key_file="${2:?public key file required}"
   ssh_dir="${3:?SSH directory required}"
+  ssh_keygen="${4:?ssh-keygen binary required}"
   key="$(cat "$key_file")"
-  ssh-keygen -lf "$key_file" >/dev/null
+  "$ssh_keygen" -lf "$key_file" >/dev/null
   mkdir -p "$ssh_dir"
   chmod 700 "$ssh_dir"
   touch "$ssh_dir/authorized_keys"

--- a/named-hosts/kamino/default.nix
+++ b/named-hosts/kamino/default.nix
@@ -55,6 +55,10 @@ inputs.home-manager.lib.homeManagerConfiguration {
           '';
         };
         programs.home-manager.enable = true;
+        # The installer manages Determinate Nix and garbage collection. Reuse its
+        # client during activation instead of mixing Lix with its configuration.
+        nix.enable = lib.mkForce false;
+        nix.gc.automatic = lib.mkForce false;
         xdg.enable = true;
         systemd.user.startServices = true;
         xdg.configFile."kamino/name".text = "${name}\n";
@@ -63,7 +67,7 @@ inputs.home-manager.lib.homeManagerConfiguration {
           ${pkgs.bash}/bin/bash ${./activate.sh} check ${lib.escapeShellArg name} "${config.xdg.configHome}/kamino/name"
         '';
         home.activation.authorizeKaminoSsh = config.lib.dag.entryAfter [ "writeBoundary" ] ''
-          $DRY_RUN_CMD ${pkgs.bash}/bin/bash ${./activate.sh} authorize-ssh ${authorizedKey} "${config.home.homeDirectory}/.ssh"
+          $DRY_RUN_CMD ${pkgs.bash}/bin/bash ${./activate.sh} authorize-ssh ${authorizedKey} "${config.home.homeDirectory}/.ssh" ${pkgs.openssh}/bin/ssh-keygen
         '';
         home.activation.startKaminoUserManager =
           config.lib.dag.entryBetween [ "reloadSystemd" ] [ "writeBoundary" ]

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -7,6 +7,17 @@
     # Current Foundry nightlies link forge and cast against libudev, which the
     # upstream binary derivation does not yet include in its Linux runtime.
     foundry-bin = prev.foundry-bin.overrideAttrs (old: {
+      # Upstream still evaluates deprecated stdenv.isLinux in this list.
+      nativeBuildInputs =
+        with prev;
+        [
+          pkg-config
+          openssl
+          xz
+          makeWrapper
+          installShellFiles
+        ]
+        ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
       buildInputs =
         (old.buildInputs or [ ]) ++ prev.lib.optionals prev.stdenv.hostPlatform.isLinux [ prev.udev ];
     });

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -180,6 +180,10 @@ let
         in
         assert cfg.home.username == "root";
         assert cfg.home.homeDirectory == "/root";
+        assert !cfg.nix.enable;
+        assert !cfg.nix.gc.automatic;
+        assert !(cfg.xdg.configFile ? "nix/nix.conf");
+        assert lib.hasInfix "/bin/ssh-keygen" cfg.home.activation.authorizeKaminoSsh.data;
         assert !(cfg.home.activation ? hardenSshd);
         assert !(cfg.home.activation ? setupK3s);
         assert !(cfg.systemd.user.services ? openclaw-gateway);

--- a/tests/fish.nix
+++ b/tests/fish.nix
@@ -7,9 +7,9 @@ let
       homeDirectory = "/homeless-shelter";
     };
   };
-  nixPathInit = pkgs.writeText "00-nix-path.fish" (
-    fishModule.xdg.configFile."fish/conf.d/00-nix-path.fish".text
-  );
+  nixPathInit =
+    pkgs.writeText "00-nix-path.fish"
+      fishModule.xdg.configFile."fish/conf.d/00-nix-path.fish".text;
 in
 {
   fish-ssh-startup = pkgs.runCommand "fish-ssh-startup" { } ''

--- a/tests/test_kamino_activation.py
+++ b/tests/test_kamino_activation.py
@@ -1,6 +1,7 @@
 """Run activation phases with inert OS commands, never touching host services."""
 
 import os
+import shutil
 import subprocess
 import tempfile
 import unittest
@@ -106,14 +107,18 @@ class AuthorizedKeyTests(unittest.TestCase):
         self.root = Path(self.directory.name)
         self.ssh_dir = self.root / "ssh"
         self.key = self.root / "client"
+        self.ssh_keygen = shutil.which("ssh-keygen")
         subprocess.run(
-            ["ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", str(self.key)],
+            [self.ssh_keygen, "-q", "-t", "ed25519", "-N", "", "-f", str(self.key)],
             check=True,
             capture_output=True,
         )
         self.public_key = Path(str(self.key) + ".pub")
         self.bin = self.root / "bin"
         self.bin.mkdir()
+        # Home Manager activation has a restricted PATH without OpenSSH.
+        for name in ["cat", "mkdir", "chmod", "touch", "grep"]:
+            (self.bin / name).symlink_to(shutil.which(name))
         # Only ownership is mocked: tests run as an ordinary local user.
         chown = self.bin / "chown"
         chown.write_text('#!/bin/sh\nprintf "%s\\n" "$@" >"$OWNERSHIP_LOG"\n')
@@ -127,10 +132,11 @@ class AuthorizedKeyTests(unittest.TestCase):
                 "authorize-ssh",
                 str(self.public_key),
                 str(self.ssh_dir),
+                self.ssh_keygen,
             ],
             env={
                 **os.environ,
-                "PATH": f"{self.bin}:{os.environ['PATH']}",
+                "PATH": str(self.bin),
                 "OWNERSHIP_LOG": str(self.root / "ownership"),
             },
             capture_output=True,


### PR DESCRIPTION
Kamino activation failed at `authorizeKaminoSsh` because Home Manager clears PATH and the script called an undeclared `ssh-keygen`. Pass the pinned OpenSSH executable explicitly and exercise key installation with OpenSSH absent from PATH.

Keep Kamino's installer-managed Determinate Nix responsible for its client, configuration, and garbage collection. Home Manager activation now uses the installed client rather than Lix, which rejected the Determinate-specific settings.

Remove the retired Garnix cache and trust key ([service retirement notice](https://garnix.io/blog/shutting-down/)). Override Foundry's build-tool list to use `stdenv.hostPlatform.isLinux` without evaluating the upstream deprecated attribute, and update the SSH-agent module to use the same host-platform API. Also fix the unnecessary parentheses flagged by Statix in the Fish startup regression check.

Validation:
- Seven activation tests passed, including restricted-PATH authorization, preservation of existing keys, idempotence, and rejection of invalid keys.
- ShellCheck, Ruff, Nix formatting, Statix, and changed-file Deadnix checks passed.
- Live Kamino1: strict warnings-as-errors evaluation, focused Linux checks, full build, and activation passed. Fresh passwordless SSH returns clean Linux/x86_64 platform output; Herdr 0.8.2 is running and reports protocol compatibility. The subsequent clean build emitted zero warnings, and activation no longer emits any of the reported Nix or ssh-keygen errors. Follow-up optional-service/native-variant cleanup is tracked in #2613.
