### PR TITLE
fix(kamino): clean up optional service and CLI activation checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1405,9 +1405,11 @@ systemctl-code-syncer: ## Restart code-syncer systemd user service.
 
 .PHONY: systemctl-docker-postgres
 systemctl-docker-postgres: ## Restart docker-postgres systemd user service.
-	@echo "🔄 Restarting docker-postgres..."
-	@systemctl --user restart docker-postgres.service || true
-	@echo "✅ docker-postgres restarted"
+	@if [ "$$(systemctl --user show --property=LoadState --value docker-postgres.service)" = "not-found" ]; then \
+		echo "Skipping docker-postgres.service (not installed)"; \
+	else \
+		systemctl --user restart docker-postgres.service && echo "✅ docker-postgres restarted"; \
+	fi
 
 .PHONY: systemctl-dolt
 systemctl-dolt: ## Restart Dolt systemd user service.
@@ -1478,9 +1480,11 @@ systemctl-obsidian: ## Restart Obsidian headless systemd user service.
 
 .PHONY: systemctl-ollama
 systemctl-ollama: ## Restart ollama systemd user service.
-	@echo "🔄 Restarting ollama..."
-	@systemctl --user restart ollama.service || true
-	@echo "✅ ollama restarted"
+	@if [ "$$(systemctl --user show --property=LoadState --value ollama.service)" = "not-found" ]; then \
+		echo "Skipping ollama.service (not installed)"; \
+	else \
+		systemctl --user restart ollama.service && echo "✅ ollama restarted"; \
+	fi
 
 .PHONY: systemctl-openclaw
 systemctl-openclaw: ## Restart OpenClaw gateway systemd user service.

--- a/home-manager/modules/npm-globals/install-npm-globals.sh
+++ b/home-manager/modules/npm-globals/install-npm-globals.sh
@@ -116,13 +116,13 @@ x86_64 | amd64) PLATFORM_CPU="x64" ;;
 esac
 
 # Prints the name of a platform-native optionalDependency declared in the given
-# package.json that is NOT installed, or nothing if all present / none declared.
+# package.json when none of its current-platform variants are installed.
 # Emits "<native-dep-name> <declaring-version>" so callers can install the exact
 # binary that bun dropped, at the version that matches its declaring wrapper.
 missing_native_from_pkg() {
   local pj="$1"
   [ -f "$pj" ] || return 0
-  local opt_deps name decl_ver
+  local opt_deps name decl_ver missing=""
   opt_deps=$(jq -r '.optionalDependencies // {} | keys[]' "$pj" 2>/dev/null || true)
   [ -n "$opt_deps" ] || return 0
   decl_ver=$(jq -r '.version // empty' "$pj" 2>/dev/null || true)
@@ -133,10 +133,12 @@ missing_native_from_pkg() {
     *"$PLATFORM_OS"*"$PLATFORM_CPU"* | *"$PLATFORM_CPU"*"$PLATFORM_OS"*) ;;
     *) continue ;;
     esac
-    [ -d "${GLOBAL_MODULES}/${name}" ] && continue
-    printf '%s %s\n' "$name" "$decl_ver"
-    return 0
+    # Baseline/optimized and libc builds are alternatives, not prerequisites
+    # that must all be installed alongside a working platform binary.
+    [ -d "${GLOBAL_MODULES}/${name}" ] && return 0
+    [ -n "$missing" ] || missing="$name"
   done <<<"$opt_deps"
+  [ -z "$missing" ] || printf '%s %s\n' "$missing" "$decl_ver"
 }
 
 # Candidate package.json paths that may declare a package's real native binary:
@@ -154,8 +156,8 @@ native_candidate_pkgs() {
 }
 
 # Returns 0 when a package (or its immediate wrapper dependency) declares a
-# platform-native optionalDependency for the current OS/CPU that is not
-# installed. Many CLIs ship their real binary this way; a version-only skip would
+# platform-native optionalDependencies for the current OS/CPU with no installed
+# variant. Many CLIs ship their real binary this way; a version-only skip would
 # otherwise leave such a package "installed" yet non-functional (bun silently
 # drops these transitive optional deps during global installs).
 missing_native_optional_dep() {

--- a/spec/npm_globals_spec.sh
+++ b/spec/npm_globals_spec.sh
@@ -383,6 +383,26 @@ It 'reinstalls a package missing its platform-native binary'
 When run bash -c "HOME='$TEMP_HOME' MOCK_LOG='$MOCK_LOG' PATH='$MOCK_BIN:$REAL_BIN_DIR:$REAL_SYSTEM_BIN_DIR:/usr/bin:/bin' bash '$SCRIPT' >/dev/null 2>&1; cat '$MOCK_LOG'"
 The output should include 'bun add --global nativecli'
 End
+
+It 'keeps an installed native variant when an optional fallback is absent'
+jq --arg fallback "nativecli-${os_tok}-${cpu_tok}-baseline" '.optionalDependencies[$fallback] = "1.0.0"' "$GM/nativecli/package.json" >"$GM/nativecli/package.json.tmp"
+mv -f "$GM/nativecli/package.json.tmp" "$GM/nativecli/package.json"
+mkdir -p "$GM/nativecli-${os_tok}-${cpu_tok}"
+When run bash -c "HOME='$TEMP_HOME' MOCK_LOG='$MOCK_LOG' PATH='$MOCK_BIN:$REAL_BIN_DIR:$REAL_SYSTEM_BIN_DIR:/usr/bin:/bin' bash '$SCRIPT'"
+The status should be success
+The output should include 'nativecli@1.0.0 already installed, skipping'
+The output should not include 'Installing missing native binary'
+End
+
+It 'finds an installed fallback after an absent primary variant'
+jq --arg fallback "nativecli-${os_tok}-${cpu_tok}-baseline" '.optionalDependencies[$fallback] = "1.0.0"' "$GM/nativecli/package.json" >"$GM/nativecli/package.json.tmp"
+mv -f "$GM/nativecli/package.json.tmp" "$GM/nativecli/package.json"
+mkdir -p "$GM/nativecli-${os_tok}-${cpu_tok}-baseline"
+When run bash -c "HOME='$TEMP_HOME' MOCK_LOG='$MOCK_LOG' PATH='$MOCK_BIN:$REAL_BIN_DIR:$REAL_SYSTEM_BIN_DIR:/usr/bin:/bin' bash '$SCRIPT'"
+The status should be success
+The output should include 'nativecli@1.0.0 already installed, skipping'
+The output should not include 'Installing missing native binary'
+End
 End
 
 Describe 'wrapper-indirection native binary self-heal (tokscale pattern)'

--- a/tests/test_make_optional_services.py
+++ b/tests/test_make_optional_services.py
@@ -1,0 +1,62 @@
+"""Optional restart targets skip absent units and surface real failures."""
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class OptionalServiceTests(unittest.TestCase):
+    def test_restart_results(self):
+        for service in ("docker-postgres", "ollama"):
+            cases = (("not-found", "0"), ("loaded", "0"), ("loaded", "3"))
+            for state, failure in cases:
+                with self.subTest(service=service, state=state, failure=failure):
+                    with tempfile.TemporaryDirectory() as directory:
+                        root = Path(directory)
+                        mock = root / "systemctl"
+                        mock.write_text(
+                            '#!/bin/sh\nif [ "$2" = show ]; then\n'
+                            '  echo "$UNIT_STATE"\nelse\n'
+                            '  echo "$*" >> "$RESTART_LOG"\n'
+                            '  exit "$RESTART_RESULT"\nfi\n'
+                        )
+                        mock.chmod(0o755)
+                        log = root / "restart.log"
+                        result = subprocess.run(
+                            [
+                                "make",
+                                f"systemctl-{service}",
+                                "HOST=kamino1",
+                                "DETECTED_HOST=kamino1",
+                                "TAILSCALE_DNS_NAME=",
+                            ],
+                            cwd=ROOT,
+                            env={
+                                **os.environ,
+                                "PATH": f"{root}:{os.environ['PATH']}",
+                                "UNIT_STATE": state,
+                                "RESTART_RESULT": failure,
+                                "RESTART_LOG": str(log),
+                            },
+                            capture_output=True,
+                            text=True,
+                            timeout=30,
+                        )
+                        if state == "not-found":
+                            self.assertFalse(log.exists())
+                            self.assertEqual(result.returncode, 0, result.stderr)
+                            self.assertIn("Skipping", result.stdout)
+                            self.assertNotIn("restarted", result.stdout)
+                        else:
+                            self.assertEqual(
+                                log.read_text().strip(),
+                                f"--user restart {service}.service",
+                            )
+                            self.assertEqual(result.returncode == 0, failure == "0")
+                            self.assertEqual(
+                                "restarted" in result.stdout, failure == "0"
+                            )


### PR DESCRIPTION
Kamino's successful activation still attempted to restart absent Docker PostgreSQL and Ollama units, then printed success despite their errors. Skip absent units and propagate failures when an installed unit cannot restart.

The npm installer also treated every native optional dependency for the current OS/CPU as mandatory. Open Composer already had a working native binary, but missing baseline and libc alternatives triggered unnecessary reinstall attempts. Accept an installed platform variant while retaining repair when none is present.

Validation: all 69 npm ShellSpec examples passed, including missing-native repair and both orders of installed/missing alternatives. Six optional-service cases cover absent units, successful restarts, and failed restarts. ShellCheck, Ruff, and whitespace checks passed. Live Kamino1: CLI reconciliation completed without installer failures, absent services were skipped correctly, and full build plus switch both passed. The tested branch generation is active; fresh passwordless SSH and Herdr service/protocol checks pass. Optional integrations lacking credentials remain skipped. Auto-merge is enabled; the main checkout should be updated after merge.
