### PR TITLE
fix(k3s): keep local access off MagicDNS

### DIFF
--- a/home-manager/services/k3s/activate.sh
+++ b/home-manager/services/k3s/activate.sh
@@ -211,5 +211,11 @@ if [ -f "$K3S_KUBECONFIG" ]; then
   require_sudo || exit 0
   run_sudo cp "$K3S_KUBECONFIG" "$KUBE_DIR/config"
   run_sudo chown "$(id -u):$(id -g)" "$KUBE_DIR/config"
+  # k3s publishes a remotely reachable API hostname in its root kubeconfig.
+  # Local host operations must not depend on Tailscale MagicDNS, which is
+  # deliberately disabled on servers to preserve the system resolver.
+  run @sed@ -i -E \
+    's#^([[:space:]]*server:)[[:space:]]*https://[^:]+:6443$#\1 https://127.0.0.1:6443#' \
+    "$KUBE_DIR/config"
   run chmod 600 "$KUBE_DIR/config"
 fi

--- a/home-manager/services/k3s/default.nix
+++ b/home-manager/services/k3s/default.nix
@@ -14,6 +14,7 @@ let
     diff = "${pkgs.diffutils}/bin/diff";
     find = "${pkgs.findutils}/bin/find";
     findmnt = "${pkgs.util-linux}/bin/findmnt";
+    sed = "${pkgs.gnused}/bin/sed";
     smartctl = "${pkgs.smartmontools}/bin/smartctl";
     systemctl = "${pkgs.systemd}/bin/systemctl";
     tune2fs = "${pkgs.e2fsprogs}/bin/tune2fs";

--- a/spec/activate_kyber_spec.sh
+++ b/spec/activate_kyber_spec.sh
@@ -138,6 +138,11 @@ It 'explicitly disables Tailscale DNS'
 When run bash -c "grep -F '\"--accept-dns=false\"' '$PWD/named-hosts/kyber/default.nix'"
 The output should include '--accept-dns=false'
 End
+
+It 'keeps local k3s access independent of Tailscale DNS'
+When run bash -c "grep -q 'server:).*https://127.0.0.1:6443' '$PWD/home-manager/services/k3s/activate.sh' && grep -q 'sed = \"\${pkgs.gnused}/bin/sed\"' '$PWD/home-manager/services/k3s/default.nix'"
+The status should be success
+End
 End
 
 Describe 'named-hosts/kyber/activate-user-service-priority.sh'


### PR DESCRIPTION
## Summary

Rewrite the Kyber user-local kubeconfig to the certificate-backed loopback API endpoint after activation copies the root k3s configuration. This keeps host-local cluster operations available while Tailscale DNS remains deliberately disabled.

### Tracker linkage
- Linear: none - incident recovery has no Linear issue
- Bead: shunkakinokisoftware-vlfw

## Before / after

| Before | After |
| --- | --- |
| Local kubectl resolved the k3s API through MagicDNS and failed when that resolver was disabled. | Local kubectl connects to https://127.0.0.1:6443; the root and remote-access kubeconfig remain unchanged. |

## Breaking and irreversible changes

- Behavioral: Host-local kubectl uses loopback. Revert restores the copied remote hostname.
- Compile-time: None.
- Durable state and rollback: Home Manager rewrites only the local kubeconfig on activation; reactivation after revert restores the prior endpoint.

## Deliberate boundaries

Remote k3s API access and Tailscale DNS policy are unchanged.

## Verification

- shellcheck home-manager/services/k3s/activate.sh
- shellspec spec/activate_kyber_spec.sh - 61 examples, 0 failures
- nix flake check --no-build - compatible local evaluations passed
- The live k3s certificate SAN includes 127.0.0.1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites the Kyber user-local kubeconfig to use the certificate-backed loopback API endpoint after activation copies the root k3s configuration, so host-local kubectl keeps working when Tailscale MagicDNS is disabled.

- Root and remote-access kubeconfig files are unchanged; reactivation after revert restores the prior endpoint.
- Adds the `sed` (`gnused`) dependency to the activation script environment.
- Adds a spec assertion that the activation script and `default.nix` target loopback and `gnused`.

<sup>Written for commit 937261ab393f0569397f92d2074f8a314cf75746. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

