### PR TITLE
fix(k3s): normalize final local kubeconfig

### DIFF
--- a/config/k3s/activate.sh
+++ b/config/k3s/activate.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 GALACTICA_AUTHORIZED_KEY="@galacticaAuthorizedKey@"
 KUBELET_CONFIG_NAME="@kubeletConfigName@"
-TAILSCALE_DNS="@tailscaleDns@"
 
 ensure_authorized_key() {
   local key="$1"
@@ -86,7 +85,7 @@ REMOTE_KUBECONFIG="$HOME/.kube/config"
 if [ -f "$K3S_KUBECONFIG" ]; then
   mkdir -p "$HOME/.kube"
   $SUDO_CMD cat "$K3S_KUBECONFIG" |
-    sed "s|https://127.0.0.1:6443|https://${TAILSCALE_DNS}:6443|g" \
+    @sed@ -E 's#^([[:space:]]*server:)[[:space:]]*https://[^:]+:6443$#\1 https://127.0.0.1:6443#' \
       >"$REMOTE_KUBECONFIG"
   chmod 600 "$REMOTE_KUBECONFIG"
 fi

--- a/config/k3s/default.nix
+++ b/config/k3s/default.nix
@@ -38,7 +38,7 @@ let
   galacticaAuthorizedKey = (import ../../named-hosts/pubkeys.nix).galactica;
   serverActivateScript = pkgs.replaceVars ./activate.sh {
     inherit galacticaAuthorizedKey kubeletConfigName;
-    tailscaleDns = if isK3sServer then k3s.tailscaleDns else "kyber.tail950b36.ts.net";
+    sed = "${pkgs.gnused}/bin/sed";
   };
   alertScript = pkgs.writeShellApplication {
     name = "kyber-host-alert";

--- a/home-manager/services/k3s/activate.sh
+++ b/home-manager/services/k3s/activate.sh
@@ -211,11 +211,5 @@ if [ -f "$K3S_KUBECONFIG" ]; then
   require_sudo || exit 0
   run_sudo cp "$K3S_KUBECONFIG" "$KUBE_DIR/config"
   run_sudo chown "$(id -u):$(id -g)" "$KUBE_DIR/config"
-  # k3s publishes a remotely reachable API hostname in its root kubeconfig.
-  # Local host operations must not depend on Tailscale MagicDNS, which is
-  # deliberately disabled on servers to preserve the system resolver.
-  run @sed@ -i -E \
-    's#^([[:space:]]*server:)[[:space:]]*https://[^:]+:6443$#\1 https://127.0.0.1:6443#' \
-    "$KUBE_DIR/config"
   run chmod 600 "$KUBE_DIR/config"
 fi

--- a/home-manager/services/k3s/default.nix
+++ b/home-manager/services/k3s/default.nix
@@ -14,7 +14,6 @@ let
     diff = "${pkgs.diffutils}/bin/diff";
     find = "${pkgs.findutils}/bin/find";
     findmnt = "${pkgs.util-linux}/bin/findmnt";
-    sed = "${pkgs.gnused}/bin/sed";
     smartctl = "${pkgs.smartmontools}/bin/smartctl";
     systemctl = "${pkgs.systemd}/bin/systemctl";
     tune2fs = "${pkgs.e2fsprogs}/bin/tune2fs";

--- a/spec/activate_k3s_spec.sh
+++ b/spec/activate_k3s_spec.sh
@@ -54,10 +54,14 @@ When run bash -c "grep 'KUBELET_CONFIG_TARGET' '$SCRIPT'"
 The output should include 'kubelet.conf.d/$KUBELET_CONFIG_NAME'
 End
 
-It 'uses host-specific kubelet and Tailscale substitutions'
-When run bash -c "grep 'KUBELET_CONFIG_NAME=' '$SCRIPT'; grep 'TAILSCALE_DNS=' '$SCRIPT'"
+It 'uses the host-specific kubelet substitution'
+When run grep 'KUBELET_CONFIG_NAME=' "$SCRIPT"
 The output should include '@kubeletConfigName@'
-The output should include '@tailscaleDns@'
+End
+
+It 'normalizes the final local kubeconfig to the loopback API'
+When run bash -c "grep -q 'server:).*https://127.0.0.1:6443' '$SCRIPT' && grep -q '@sed@ -E' '$SCRIPT'"
+The status should be success
 End
 
 It 'checks the system k3s service through sudo'

--- a/spec/activate_kyber_spec.sh
+++ b/spec/activate_kyber_spec.sh
@@ -140,7 +140,7 @@ The output should include '--accept-dns=false'
 End
 
 It 'keeps local k3s access independent of Tailscale DNS'
-When run bash -c "grep -q 'server:).*https://127.0.0.1:6443' '$PWD/home-manager/services/k3s/activate.sh' && grep -q 'sed = \"\${pkgs.gnused}/bin/sed\"' '$PWD/home-manager/services/k3s/default.nix'"
+When run bash -c "grep -q 'server:).*https://127.0.0.1:6443' '$PWD/config/k3s/activate.sh' && grep -q 'sed = \"\${pkgs.gnused}/bin/sed\"' '$PWD/config/k3s/default.nix'"
 The status should be success
 End
 End


### PR DESCRIPTION
## Summary

- normalize Kyber's kubeconfig in the final `k3s-server` activation hook
- stop the later hook from restoring the MagicDNS hostname after `setupK3s`
- keep the Kubernetes API certificate-backed loopback endpoint for local operations

## Tracker

- Bead: `shunkakinokisoftware-vlfw`

## Root cause

PR #2616 changed `setupK3s`, but `home.activation.k3s-server` is ordered after it and copied `/etc/rancher/k3s/k3s.yaml` again while replacing loopback with the Tailscale DNS name. With `--accept-dns=false`, local `kubectl` still failed resolution after activation.

## Verification

- ShellCheck passed for both k3s activation scripts
- ShellSpec passed: 81 examples, 0 failures
- `nix flake check --no-build` passed for compatible local evaluations
- live acceptance will rerun `make switch-kyber` and use `kubectl` without a server override


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes the final local kubeconfig to loopback so local `kubectl` works without Tailscale DNS. Previously the home-manager activation normalized it, but the later `config/k3s` hook overwrote it with the Tailscale hostname, breaking resolution when MagicDNS is disabled. The hook now normalizes directly, and the redundant rewrite is removed.

<sup>Written for commit dbd9c44ad109349ef249a9f2ba7685aae6b004a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

