### PR TITLE
feat(codex): enable Astra experimental context compaction

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -57,6 +57,9 @@ unified_exec = true
 voice_transcription = true
 workspace_dependencies = true
 
+[features.context_management]
+experimental_mode = true
+
 [agents]
 enabled = true
 max_concurrent_threads_per_session = 300

--- a/config/codex/config.tpl.toml
+++ b/config/codex/config.tpl.toml
@@ -57,6 +57,9 @@ unified_exec = true
 voice_transcription = true
 workspace_dependencies = true
 
+[features.context_management]
+experimental_mode = true
+
 [agents]
 enabled = true
 max_concurrent_threads_per_session = 300


### PR DESCRIPTION
## Summary
- Enable `features.context_management.experimental_mode` for OpenAI Codex Astra experimental context compaction (SHUN-4069).
- Syncs both `config/codex/config.toml` and `config/codex/config.tpl.toml`.
- Source: https://x.com/daniel_mac8/status/2096044102357856367

## Test plan
- [ ] After home-manager activation, confirm `~/.codex/config.toml` includes `[features.context_management]` with `experimental_mode = true`
- [ ] Start a Codex session with Astra and verify experimental compaction / context notes behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables OpenAI Codex's experimental context compaction by setting `experimental_mode = true` under `[features.context_management]` in both `config/codex/config.toml` and `config/codex/config.tpl.toml` (SHUN-4069). This turns on Astra's experimental compaction behavior in new Codex sessions.

- After home-manager activation, `~/.codex/config.toml` will include the new `[features.context_management]` section.

<sup>Written for commit c3d4b734cf4e3fc2d00fa044d0898fa209a79187. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

