### PR TITLE
fix: manage the local Crabbox CLI through ulb

### DIFF
--- a/.local-binaries.txt
+++ b/.local-binaries.txt
@@ -29,6 +29,7 @@
 ~/ghq/github.com/NousResearch/hermes-agent/.venv/bin/hermes
 ~/ghq/github.com/NousResearch/hermes-agent/.venv/bin/hermes-agent
 ~/ghq/github.com/NousResearch/hermes-agent/.venv/bin/hermes-acp
+~/ghq/github.com/openclaw/crabbox/crabbox
 ~/ghq/github.com/openclaw/crabbox/worker/dist-node/crabbox-coordinator#node-build
 ~/ghq/github.com/nwiizo/ccswarm/target/release/ccswarm
 ~/ghq/github.com/openai/symphony/elixir/bin/symphony

--- a/home-manager/modules/local-binaries/sync-local-binaries.sh
+++ b/home-manager/modules/local-binaries/sync-local-binaries.sh
@@ -32,6 +32,9 @@ while IFS= read -r line || [ -n "$line" ]; do
   \#*) continue ;;
   esac
 
+  # Build flags belong to the updater, not the executable path or alias.
+  line="${line%%#*}"
+
   # Parse optional alias (path:alias)
   alias_name=""
   case "$line" in

--- a/scripts/update-local-binaries.sh
+++ b/scripts/update-local-binaries.sh
@@ -462,8 +462,9 @@ main() {
   log_info "🔄 Updating local binaries"
   [ -n "$filter" ] && echo "  Filter: $filter"
 
-  # Track unique repos to avoid duplicate builds
+  # Pull each repo once, but build every distinct target within it.
   declare -A seen_repos
+  declare -A seen_targets
 
   while IFS= read -r line || [ -n "$line" ]; do
     # Skip comments and empty lines
@@ -489,17 +490,31 @@ main() {
     *:*) line="${line%:*}" ;;
     esac
 
-    # Get repo directory and check if already processed
+    local target_key="$line#$flags"
+    if [ -n "${seen_targets[$target_key]:-}" ]; then
+      continue
+    fi
+    seen_targets[$target_key]=1
+
+    # A repo can contain different build systems, such as a CLI and coordinator.
     local repo_dir
     repo_dir="$(get_repo_dir "$line")"
 
     if [ -n "${seen_repos[$repo_dir]:-}" ]; then
+      [ "${seen_repos[$repo_dir]}" = failed ] && continue
+      if build_repo "$repo_dir" "$line" "$flags"; then
+        SUCCESSES+=("$(get_repo_name "$repo_dir") ($(basename "$line"))")
+      else
+        FAILURES+=("$(get_repo_name "$repo_dir") ($(basename "$line"), build failed)")
+      fi
       continue
     fi
-    seen_repos[$repo_dir]=1
-
     # Update repo (continue on failure)
-    update_repo "$line" "$flags" || true
+    if update_repo "$line" "$flags"; then
+      seen_repos[$repo_dir]=ready
+    else
+      seen_repos[$repo_dir]=failed
+    fi
 
   done <"$CONFIG_FILE"
 

--- a/spec/local_binaries_spec.sh
+++ b/spec/local_binaries_spec.sh
@@ -69,4 +69,26 @@ The output should include 'ln -sf'
 End
 End
 
+Describe 'build flag parsing'
+setup_flagged_binary() {
+  FLAG_FIXTURE=$(mktemp -d)
+  mkdir -p "$FLAG_FIXTURE/dotfiles" "$FLAG_FIXTURE/source"
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$FLAG_FIXTURE/source/coordinator"
+  chmod +x "$FLAG_FIXTURE/source/coordinator"
+  printf '%s\n' "$FLAG_FIXTURE/source/coordinator:local-coordinator#node-build" >"$FLAG_FIXTURE/dotfiles/.local-binaries.txt"
+}
+cleanup_flagged_binary() { rm -rf "$FLAG_FIXTURE"; }
+sync_flagged_binary() {
+  env HOME="$FLAG_FIXTURE" bash "$SCRIPT" >/dev/null
+  readlink "$FLAG_FIXTURE/.local/bin/local-coordinator"
+}
+Before 'setup_flagged_binary'
+After 'cleanup_flagged_binary'
+It 'links the executable using the alias without its build flags'
+When call sync_flagged_binary
+The output should eq "$FLAG_FIXTURE/source/coordinator"
+The status should be success
+End
+End
+
 End

--- a/spec/update_local_binaries_spec.sh
+++ b/spec/update_local_binaries_spec.sh
@@ -564,4 +564,65 @@ The output should include 'exit 1'
 End
 End
 
+Describe 'multiple targets in one repository'
+setup_targets() {
+  TARGET_FIXTURE=$(mktemp -d)
+  mkdir -p "$TARGET_FIXTURE/scripts" "$TARGET_FIXTURE/tools" "$TARGET_FIXTURE/repo/.git" "$TARGET_FIXTURE/repo/cmd/crabbox" "$TARGET_FIXTURE/repo/worker/node_modules"
+  cp "$SCRIPT" "$TARGET_FIXTURE/scripts/update-local-binaries.sh"
+  touch "$TARGET_FIXTURE/repo/go.mod" "$TARGET_FIXTURE/repo/worker/package.json" "$TARGET_FIXTURE/repo/worker/node_modules/fixture"
+  printf '%s\n' "$TARGET_FIXTURE/repo/crabbox" "$TARGET_FIXTURE/repo/crabbox:alias" "$TARGET_FIXTURE/repo/worker/dist-node/crabbox-coordinator#node-build" >"$TARGET_FIXTURE/.local-binaries.txt"
+  cat >"$TARGET_FIXTURE/tools/git" <<'FIXTURE'
+#!/usr/bin/env bash
+if [ "$1" = pull ]; then
+  echo pull >>"$TARGET_CALLS"
+  exit "${TARGET_PULL_EXIT:-0}"
+fi
+FIXTURE
+  cat >"$TARGET_FIXTURE/tools/go" <<'FIXTURE'
+#!/usr/bin/env bash
+echo "go $*" >>"$TARGET_CALLS"
+exit "${TARGET_BUILD_EXIT:-0}"
+FIXTURE
+  cat >"$TARGET_FIXTURE/tools/npm" <<'FIXTURE'
+#!/usr/bin/env bash
+echo "npm $*" >>"$TARGET_CALLS"
+mkdir -p dist-node
+touch dist-node/server.mjs
+FIXTURE
+  chmod +x "$TARGET_FIXTURE/tools/"*
+}
+cleanup_targets() { rm -rf "$TARGET_FIXTURE"; }
+run_targets() {
+  local result=0
+  env PATH="$TARGET_FIXTURE/tools:$PATH" TARGET_CALLS="$TARGET_FIXTURE/calls" TARGET_PULL_EXIT="${1:-0}" TARGET_BUILD_EXIT="${2:-0}" bash "$TARGET_FIXTURE/scripts/update-local-binaries.sh" >"$TARGET_FIXTURE/output" 2>&1 || result=$?
+  cat "$TARGET_FIXTURE/calls"
+  return "$result"
+}
+Before 'setup_targets'
+After 'cleanup_targets'
+
+It 'pulls once and builds the CLI and coordinator, ignoring alias duplicates'
+When call run_targets
+The output should eq "pull
+go build ./cmd/crabbox
+npm ci
+npm run build:node"
+The status should be success
+End
+
+It 'does not build later targets after a failed repository update'
+When call run_targets 1
+The output should eq "pull
+pull"
+The status should be failure
+End
+
+It 'does not hide a failed CLI build with a later coordinator build'
+When call run_targets 0 1
+The output should eq "pull
+go build ./cmd/crabbox"
+The status should be failure
+End
+End
+
 End


### PR DESCRIPTION
Register the Crabbox Go CLI in the canonical local-binary list so local sync links the source-built executable into `~/.local/bin`.

The updater now pulls each repository once and builds each distinct listed target, allowing the CLI and Node coordinator to coexist. Duplicate aliases still build once, and a failed update or first build stops later targets from using that checkout. Sync strips build flags before resolving executable paths and aliases.

Validation: 89 focused ShellSpec examples passed, including real updater and sync fixtures; ShellCheck and `git diff --check` passed. The local Crabbox candidate was separately built from the host-trust fix in https://github.com/openclaw/crabbox/pull/1785 and its native OpenSSH recycled-endpoint regression passed under the race detector. The manifest points to the local checkout; its selected Git branch determines the compiled revision. No coordinator service was restarted.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers the Crabbox Go CLI in the local binary list so local sync links the source-built executable into `~/.local/bin`. The updater now pulls each repository once and builds each distinct listed target, letting the CLI and Node coordinator share a checkout without redundant pulls.

**Behavior changes**
- Duplicate aliases still build once; a failed update or first build stops later targets from that checkout.
- Sync strips build flags before resolving executable paths and aliases.

<sup>Written for commit f4f44ea3829a5c53995833ecbe1ba69d46e936df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

