### PR TITLE
feat(dolt): federate beads through the kyber remotesapi hub

### DIFF
--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -29,6 +29,14 @@ let
   serverEnabled = clientEnabled;
   # Kyber alone publishes the shared history to the configured remotes.
   publisherEnabled = isKyber;
+  # Kyber is also the federation hub: it serves its databases over Dolt's
+  # remotesapi and every other host syncs against it instead of GitHub, so a
+  # spoke push is a native transfer rather than a git subprocess tree that a
+  # disconnected client leaves orphaned on the server.
+  federationHubEnabled = publisherEnabled;
+  federationHubHost = "kyber.tail950b36.ts.net";
+  federationRemotesApiPort = 3308;
+  federationHubUrl = "http://${federationHubHost}:${toString federationRemotesApiPort}";
   doltServerHost = "127.0.0.1";
   beadsClientEnvironment = {
     BEADS_DOLT_AUTO_START = "0";
@@ -74,7 +82,21 @@ let
   };
   federationSyncScript = pkgs.replaceVars ./federation-sync.sh {
     bd = "${homeDir}/.local/bin/bd";
-    inherit (pkgs) coreutils;
+    inherit (pkgs) coreutils jq;
+  };
+  federationSyncEnvironment = {
+    HOME = homeDir;
+    PATH = linearSyncPath;
+    BEADS_DOLT_AUTO_START = "0";
+    BEADS_DOLT_SERVER_MODE = "1";
+    BEADS_DOLT_SERVER_HOST = doltServerHost;
+    BEADS_DOLT_SERVER_PORT = "3307";
+    BEADS_DOLT_SERVER_USER = "root";
+    DOLT_CLI_USER = "root";
+    DOLT_CLI_PASSWORD = "";
+  }
+  // lib.optionalAttrs (!federationHubEnabled) {
+    BEADS_FEDERATION_HUB = federationHubUrl;
   };
 in
 lib.mkIf clientEnabled {
@@ -187,17 +209,7 @@ lib.mkIf clientEnabled {
           ThrottleInterval = federationSyncIntervalSeconds;
           RunAtLoad = true;
           WorkingDirectory = homeDir;
-          EnvironmentVariables = {
-            HOME = homeDir;
-            PATH = linearSyncPath;
-            BEADS_DOLT_AUTO_START = "0";
-            BEADS_DOLT_SERVER_MODE = "1";
-            BEADS_DOLT_SERVER_HOST = doltServerHost;
-            BEADS_DOLT_SERVER_PORT = "3307";
-            BEADS_DOLT_SERVER_USER = "root";
-            DOLT_CLI_USER = "root";
-            DOLT_CLI_PASSWORD = "";
-          };
+          EnvironmentVariables = federationSyncEnvironment;
           StandardOutPath = "/tmp/dolt-federation-sync.log";
           StandardErrorPath = "/tmp/dolt-federation-sync.error.log";
         };
@@ -215,13 +227,14 @@ lib.mkIf clientEnabled {
       RestartSec = 5;
       WorkingDirectory = repoDir;
       # Kyber's WAN firewall drops all new public-interface ingress. Binding
-      # all addresses makes the SQL service reachable on tailscale0 while
-      # retaining the public-ingress deny boundary.
+      # all addresses makes the SQL and remotesapi services reachable on
+      # tailscale0 while retaining the public-ingress deny boundary.
       Environment = [
         "BEADS_DOLT_LISTEN_HOST=0.0.0.0"
         "DOLT_CLI_USER=root"
         "DOLT_CLI_PASSWORD="
-      ];
+      ]
+      ++ lib.optional federationHubEnabled "BEADS_DOLT_REMOTESAPI_PORT=${toString federationRemotesApiPort}";
     };
     Install = {
       WantedBy = [ "default.target" ];
@@ -324,17 +337,7 @@ lib.mkIf clientEnabled {
         Service = {
           Type = "oneshot";
           ExecStart = "${pkgs.bash}/bin/bash ${federationSyncScript}";
-          Environment = [
-            "HOME=${homeDir}"
-            "PATH=${linearSyncPath}"
-            "BEADS_DOLT_AUTO_START=0"
-            "BEADS_DOLT_SERVER_MODE=1"
-            "BEADS_DOLT_SERVER_HOST=${doltServerHost}"
-            "BEADS_DOLT_SERVER_PORT=3307"
-            "BEADS_DOLT_SERVER_USER=root"
-            "DOLT_CLI_USER=root"
-            "DOLT_CLI_PASSWORD="
-          ];
+          Environment = lib.mapAttrsToList (name: value: "${name}=${value}") federationSyncEnvironment;
         };
       };
 

--- a/home-manager/services/dolt/federation-sync.sh
+++ b/home-manager/services/dolt/federation-sync.sh
@@ -101,27 +101,46 @@ for _attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
 done
 
 cycle_started="$(@coreutils@/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')"
+# Spokes converge on the hub's remotesapi endpoint for this repository's
+# database; the hub itself keeps the repository's sync.remote as the off-site
+# backup. The database name is the repository's own, not the hub's.
+configured_dolt_remote() {
+  local database
+
+  if [ -z "${BEADS_FEDERATION_HUB:-}" ]; then
+    "$bd_cli" -C "$repo_dir" config get sync.remote 2>/dev/null || true
+    return 0
+  fi
+
+  database="$(@jq@/bin/jq -r '.dolt_database // "beads"' "$repo_dir/.beads/metadata.json" 2>/dev/null || true)"
+  if [ -z "$database" ]; then
+    log "Dolt database name is not recorded in .beads/metadata.json"
+    return 1
+  fi
+  printf '%s/%s\n' "${BEADS_FEDERATION_HUB%/}" "$database"
+}
+
 ensure_dolt_remote() {
   local configured_remote
   local current_remote
 
-  configured_remote="$("$bd_cli" -C "$repo_dir" config get sync.remote 2>/dev/null || true)"
+  configured_remote="$(configured_dolt_remote)" || return 1
   if [ -z "$configured_remote" ]; then
     log "Dolt sync remote is not configured"
     return 1
   fi
 
   current_remote="$("$bd_cli" -C "$repo_dir" dolt remote list 2>/dev/null | awk '$1 == "origin" { print $2; exit }')"
-  if [ -z "$current_remote" ]; then
-    log "Registering configured Dolt remote"
-    "$bd_cli" -C "$repo_dir" dolt remote add origin "$configured_remote" --allow-git-origin >/dev/null
+  if [ "$current_remote" = "$configured_remote" ]; then
     return 0
   fi
 
-  if [ "$current_remote" != "$configured_remote" ]; then
-    log "Configured Dolt remote does not match sync.remote"
-    return 1
+  if [ -n "$current_remote" ]; then
+    log "Replacing Dolt remote origin"
+    "$bd_cli" -C "$repo_dir" dolt remote remove origin >/dev/null
   fi
+  log "Registering configured Dolt remote"
+  "$bd_cli" -C "$repo_dir" dolt remote add origin "$configured_remote" --allow-git-origin >/dev/null
 }
 
 if ! ensure_dolt_remote; then
@@ -130,7 +149,13 @@ if ! ensure_dolt_remote; then
 fi
 
 log "Synchronizing Dolt remote"
-@coreutils@/bin/timeout 120 "$bd_cli" -C "$repo_dir" sync --yes >/dev/null 2>&1
+sync_status=0
+sync_output="$(@coreutils@/bin/timeout 120 "$bd_cli" -C "$repo_dir" sync --yes 2>&1)" || sync_status=$?
+if [ "$sync_status" -ne 0 ]; then
+  log "Dolt sync failed with status $sync_status"
+  printf '%s\n' "$sync_output" | @coreutils@/bin/tail -n 5
+  exit "$sync_status"
+fi
 
 @coreutils@/bin/mkdir -p "$sync_state_dir"
 printf '%s\n' "$cycle_started" >"$sync_checkpoint_file.tmp"

--- a/home-manager/services/dolt/start.sh
+++ b/home-manager/services/dolt/start.sh
@@ -50,8 +50,18 @@ done
 # scans @beadsDir@ at startup and exposes each subdirectory as a database
 # by that name.
 
-exec "@dolt@/bin/dolt" sql-server \
-  -H "$listen_host" \
-  -P 3307 \
-  --data-dir "@beadsDir@" \
+server_args=(
+  -H "$listen_host"
+  -P 3307
+  --data-dir "@beadsDir@"
   --loglevel info
+)
+
+# The federation hub serves its databases to the other hosts over Dolt's
+# native remotesapi, so a spoke push is one transfer inside this process
+# rather than a git subprocess tree the server cannot cancel.
+if [ -n "${BEADS_DOLT_REMOTESAPI_PORT:-}" ]; then
+  server_args+=(--remotesapi-port "$BEADS_DOLT_REMOTESAPI_PORT")
+fi
+
+exec "@dolt@/bin/dolt" sql-server "${server_args[@]}"


### PR DESCRIPTION
## Summary

Replaces git+https as the multi-writer transport between the Dolt servers with a hub-and-spoke topology over Dolt's native remotesapi.

- Kyber's `dolt sql-server` gains `--remotesapi-port 3308` (tailscale-only, like the SQL port; WAN ingress stays dropped).
- Galactica and matic run their federation sync with `BEADS_FEDERATION_HUB=http://kyber.tail950b36.ts.net:3308`. The sync script derives `<hub>/<dolt_database>` from the repository's `.beads/metadata.json` and converges the Dolt `origin` on it, replacing a mismatched origin instead of failing.
- Kyber keeps the repository's `sync.remote` (GitHub git+https) as the only off-site push.
- A failed `bd sync` now logs its exit status and the last five output lines.

## Why

A client that times out mid-push over git+https makes Dolt kill only the direct `git push` child; the helper chain (`git remote-https` -> `git-remote-https` -> `git send-pack`) is reparented to PID 1 with its pipes open, and the server blocks every later remote operation behind it. remotesapi pushes are in-process gRPC transfers the server can cancel, so the failure mode no longer exists. It also stops each spoke from keeping a 3 GB git-remote-cache for 22 MB of live data.

## Verified

- Local two-server probe on dolt 2.3.1: remotesapi clone, push, and pull between two `sql-server` processes; push of a fresh commit takes ~2 s; the hub's working set reflects the pushed rows.
- `nix eval` of `homeConfigurations.kyber`, `darwinConfigurations.galactica`, and `nixosConfigurations.matic`: kyber's dolt unit carries `BEADS_DOLT_REMOTESAPI_PORT=3308` and no hub variable; galactica and matic carry `BEADS_FEDERATION_HUB` and no remotesapi port.
- `nixfmt`, `shfmt -i 2 -s`, `shellcheck` clean.
- Kyber's SQL port already answers on tailscale from galactica (`nc` to 3307 succeeds).

## Rollout

1. Merge, `make switch` on kyber (opens 3308), then on galactica and matic.
2. The first federation cycle on each spoke replaces `origin` with the hub URL and syncs; spokes can then drop `.beads/shared-server/dolt/<db>/.dolt/git-remote-cache`.
3. Rollback: revert, switch, and the next cycle re-points `origin` at the GitHub remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppA1UCrSWDA4uBVJPoMAu


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces git+https with Dolt's native remotesapi as the multi-writer transport between the Dolt servers. Kyber now exposes its databases over remotesapi on port 3308 (tailscale-only), and galactica and matic sync against that hub instead of pushing to GitHub; a spoke push is now an in-process gRPC transfer the server can cancel, so a client that times out mid-push no longer leaves an orphaned git helper chain that wedges the server.

- The federation sync script derives the hub URL per repository from `.beads/metadata.json` and replaces a mismatched origin instead of failing.
- A failed sync now logs its exit status and the last five output lines.
- Kyber alone keeps pushing to GitHub as the off-site backup.

**Rollout**

1. Merge, `make switch` on kyber first (opens 3308), then on galactica and matic.
2. The first federation cycle on each spoke re-points `origin` at the hub URL; spokes can then drop their local `git-remote-cache`.
3. Rollback: revert, switch, and the next cycle re-points `origin` back at GitHub.

<sup>Written for commit e018722c32293060323162b77089bdecd4b6be86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

