### PR TITLE
fix(kyber): bound agent hook trace uploads and isolate herdr from the breaker

### DIFF
--- a/config/antigravity/hooks.json
+++ b/config/antigravity/hooks.json
@@ -21,7 +21,7 @@
     "Stop": [
       {
         "type": "command",
-        "command": "command -v traces >/dev/null 2>&1 && traces hook agent agent-done --agent antigravity >/dev/null 2>&1; printf %s '{\"decision\":\"\"}'",
+        "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh agent-done --agent antigravity >/dev/null 2>&1; printf %s '{\"decision\":\"\"}' # traces hook agent",
         "timeout": 30
       }
     ]

--- a/config/copilot/config.json
+++ b/config/copilot/config.json
@@ -33,28 +33,28 @@
     "sessionStart": [
       {
         "type": "command",
-        "command": "command -v traces >/dev/null 2>&1 && traces hook agent session-start --agent copilot",
+        "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-start --agent copilot # traces hook agent",
         "timeout": 30
       }
     ],
     "userPromptSubmitted": [
       {
         "type": "command",
-        "command": "command -v traces >/dev/null 2>&1 && traces hook agent prompt-submitted --agent copilot",
+        "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh prompt-submitted --agent copilot # traces hook agent",
         "timeout": 30
       }
     ],
     "agentStop": [
       {
         "type": "command",
-        "command": "command -v traces >/dev/null 2>&1 && traces hook agent agent-done --agent copilot",
+        "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh agent-done --agent copilot # traces hook agent",
         "timeout": 30
       }
     ],
     "sessionEnd": [
       {
         "type": "command",
-        "command": "command -v traces >/dev/null 2>&1 && traces hook agent session-end --agent copilot",
+        "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-end --agent copilot # traces hook agent",
         "timeout": 30
       }
     ]

--- a/config/k3s/kyber-host-health.sh
+++ b/config/k3s/kyber-host-health.sh
@@ -12,6 +12,10 @@ readonly D_STATE_THRESHOLD=3
 readonly D_STATE_SUSTAINED_SAMPLES=5
 readonly IO_SOME_AVG300_THRESHOLD=20
 readonly IO_FULL_AVG300_THRESHOLD=10
+readonly ORCHESTRATION_IO_SOME_AVG300_THRESHOLD=10
+readonly ORCHESTRATION_D_STATE_THRESHOLD=3
+readonly ORCHESTRATION_FLAP_WINDOW_SECONDS=3600
+readonly ORCHESTRATION_FLAP_THRESHOLD=3
 readonly NODEFS_USAGE_THRESHOLD=70
 readonly NODEFS_AVAILABLE_WARNING_GIB=200
 readonly NODEFS_AVAILABLE_WARNING_BYTES=$((NODEFS_AVAILABLE_WARNING_GIB * 1024 * 1024 * 1024))
@@ -25,6 +29,9 @@ readonly DISK_WEAR_CHECK_INTERVAL_SECONDS=21600
 IO_PRESSURE_UNHEALTHY=0
 D_STATE_UNHEALTHY=0
 CRI_UNHEALTHY=0
+ORCHESTRATION_IMPLICATED=0
+ORCHESTRATION_IO_SOME_AVG300=0
+ORCHESTRATION_D_STATE_COUNT=0
 
 set_alert() {
   local key="$1"
@@ -238,6 +245,74 @@ orchestration_control() {
     systemctl --user "$action" "$ORCHESTRATION_SLICE"
 }
 
+orchestration_cgroup_dir() {
+  local orchestration_uid
+
+  orchestration_uid="$(id --user "$ORCHESTRATION_USER")"
+  printf '/sys/fs/cgroup/user.slice/user-%s.slice/user@%s.service/%s\n' \
+    "$orchestration_uid" "$orchestration_uid" "$ORCHESTRATION_SLICE"
+}
+
+# Host PSI says the disk is saturated; it does not say by whom. Freezing the
+# orchestration slice only helps when the slice itself is stalled or holds the
+# uninterruptible tasks, otherwise the freeze pauses the control plane while
+# k3s, the beads Dolt server, or a pod keeps the host over threshold.
+check_orchestration_pressure() {
+  local cgroup_dir some_avg300=0 d_state_count=0
+
+  cgroup_dir="$(orchestration_cgroup_dir)"
+  if [ -r "$cgroup_dir/io.pressure" ]; then
+    # shellcheck disable=SC2016
+    some_avg300="$(awk '$1 == "some" { for (i = 1; i <= NF; i++) if ($i ~ /^avg300=/) { sub(/^avg300=/, "", $i); print $i } }' "$cgroup_dir/io.pressure")"
+  fi
+  d_state_count="$(ps --no-headers -eo stat=,cgroup= | awk -v slice="/$ORCHESTRATION_SLICE/" '$1 ~ /^D/ && index($2, slice) { count++ } END { print count + 0 }')"
+
+  ORCHESTRATION_IO_SOME_AVG300="${some_avg300:-0}"
+  ORCHESTRATION_D_STATE_COUNT="$d_state_count"
+  if awk -v some="$ORCHESTRATION_IO_SOME_AVG300" -v some_limit="$ORCHESTRATION_IO_SOME_AVG300_THRESHOLD" 'BEGIN { exit !(some >= some_limit) }' ||
+    [ "$d_state_count" -ge "$ORCHESTRATION_D_STATE_THRESHOLD" ]; then
+    ORCHESTRATION_IMPLICATED=1
+  else
+    ORCHESTRATION_IMPLICATED=0
+  fi
+}
+
+orchestration_pressure_summary() {
+  printf 'slice io some avg300=%s, slice D-state=%s' "$ORCHESTRATION_IO_SOME_AVG300" "$ORCHESTRATION_D_STATE_COUNT"
+}
+
+record_orchestration_freeze() {
+  local freeze_log="$STATE_DIR/orchestration.freezes"
+  local now cutoff count
+
+  now="$(date +%s)"
+  cutoff=$((now - ORCHESTRATION_FLAP_WINDOW_SECONDS))
+  {
+    if [ -r "$freeze_log" ]; then
+      awk -v cutoff="$cutoff" '$1 >= cutoff' "$freeze_log"
+    fi
+    printf '%s\n' "$now"
+  } >"$freeze_log.next"
+  mv -f "$freeze_log.next" "$freeze_log"
+  count="$(wc -l <"$freeze_log" | tr -d '[:space:]')"
+  if [ "$count" -ge "$ORCHESTRATION_FLAP_THRESHOLD" ]; then
+    set_alert "orchestration-circuit-breaker-flapping" "froze $ORCHESTRATION_SLICE $count times in the last $((ORCHESTRATION_FLAP_WINDOW_SECONDS / 60)) minutes; the slice re-trips after every thaw, so inspect its top writers in the evidence captures instead of waiting for auto-thaw"
+  fi
+}
+
+clear_orchestration_flapping() {
+  local freeze_log="$STATE_DIR/orchestration.freezes"
+  local cutoff count=0
+
+  cutoff=$(($(date +%s) - ORCHESTRATION_FLAP_WINDOW_SECONDS))
+  if [ -r "$freeze_log" ]; then
+    count="$(awk -v cutoff="$cutoff" '$1 >= cutoff { count++ } END { print count + 0 }' "$freeze_log")"
+  fi
+  if [ "$count" -lt "$ORCHESTRATION_FLAP_THRESHOLD" ]; then
+    clear_alert "orchestration-circuit-breaker-flapping"
+  fi
+}
+
 manage_orchestration_circuit_breaker() {
   local capture_file="$STATE_DIR/orchestration.capture"
   local frozen_file="$STATE_DIR/orchestration.frozen"
@@ -245,9 +320,9 @@ manage_orchestration_circuit_breaker() {
   local freeze_failure_alert="orchestration-freeze-failed"
   local state_failure_alert="orchestration-state-persist-failed"
   local thaw_failure_alert="orchestration-thaw-failed"
-  local evidence_dir recovery_samples=0
+  local evidence_dir recovery_samples=0 newly_frozen=0
 
-  if [ "$IO_PRESSURE_UNHEALTHY" -eq 1 ] || [ "$D_STATE_UNHEALTHY" -eq 1 ]; then
+  if { [ "$IO_PRESSURE_UNHEALTHY" -eq 1 ] || [ "$D_STATE_UNHEALTHY" -eq 1 ]; } && [ "$ORCHESTRATION_IMPLICATED" -eq 1 ]; then
     printf '0\n' >"$recovery_file"
     if [ ! -s "$capture_file" ]; then
       evidence_dir="$(capture_orchestration_evidence)"
@@ -256,6 +331,7 @@ manage_orchestration_circuit_breaker() {
       read -r evidence_dir <"$capture_file"
     fi
 
+    [ -e "$frozen_file" ] || newly_frozen=1
     if ! : >"$frozen_file"; then
       clear_alert "orchestration-circuit-breaker"
       set_alert "$state_failure_alert" "failed to persist frozen state for $ORCHESTRATION_SLICE; evidence: $evidence_dir"
@@ -263,7 +339,10 @@ manage_orchestration_circuit_breaker() {
       clear_alert "$state_failure_alert"
       clear_alert "$freeze_failure_alert"
       clear_alert "$thaw_failure_alert"
-      set_alert "orchestration-circuit-breaker" "froze $ORCHESTRATION_SLICE after sustained host I/O pressure; evidence: $evidence_dir"
+      set_alert "orchestration-circuit-breaker" "froze $ORCHESTRATION_SLICE after sustained host I/O pressure ($(orchestration_pressure_summary)); evidence: $evidence_dir"
+      if [ "$newly_frozen" -eq 1 ]; then
+        record_orchestration_freeze
+      fi
     else
       rm -f "$frozen_file"
       clear_alert "orchestration-circuit-breaker"
@@ -278,6 +357,7 @@ manage_orchestration_circuit_breaker() {
     clear_alert "$state_failure_alert"
     clear_alert "$freeze_failure_alert"
     clear_alert "$thaw_failure_alert"
+    clear_orchestration_flapping
     return
   fi
 
@@ -357,6 +437,7 @@ main() {
   install -d --mode 0755 "$STATE_DIR"
   check_io_pressure
   check_d_state
+  check_orchestration_pressure
   check_node_filesystem
   check_image_filesystem
   check_cri

--- a/config/shared/hooks/README.md
+++ b/config/shared/hooks/README.md
@@ -22,3 +22,27 @@ The settings hook blocks repository control-plane mutations through settings-ori
 ## Security boundary
 
 These hooks provide fast feedback and prevent common mistakes. They run with the same user permissions as the agent and can be bypassed, disabled, or avoided through an unsupported tool path. Restricted GitHub credentials and server-side branch rulesets are the authoritative controls; do not grant an agent an administrator credential because these hooks are installed.
+
+# Traces agent hook guard
+
+`traces-agent-hook.sh <event> --agent <id>` wraps `traces hook agent` for Codex,
+Claude Code, Cursor, GitHub Copilot, Grok, and Antigravity. The traces hook
+starts a detached `traces share --trace-id <session> --source agent_hook`
+upload on every `prompt-submitted`, `agent-done`, and `session-end` event and
+never checks whether one is already running; each upload rescans the shared
+trace store, so a busy lane accumulates dozens of uploads of one trace that
+contend with each other for hours. The guard reads the hook payload, lists the
+current user's in-flight hook uploads, and then:
+
+- terminates uploads older than `TRACES_HOOK_STALE_UPLOAD_SECONDS` (900);
+- skips `prompt-submitted` and `agent-done` while the same trace is already
+  uploading or `TRACES_HOOK_MAX_INFLIGHT_UPLOADS` (4) uploads are in flight,
+  because the running upload or the final `session-end` upload carries the
+  trace anyway;
+- for `session-end`, terminates the in-flight upload of the same trace and
+  always runs the hook so the final upload wins;
+- otherwise forwards the payload to `traces hook agent` unchanged.
+
+It exits `0` in every case, including when `traces` is not installed, and the
+hook commands keep a trailing `# traces hook agent` marker so `traces hook
+install` recognizes them and does not append a second, unguarded hook.

--- a/config/shared/hooks/traces-agent-hook.sh
+++ b/config/shared/hooks/traces-agent-hook.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Guard around `traces hook agent <event> --agent <id>`.
+#
+# The traces hook spawns a detached `traces share --trace-id ... --source
+# agent_hook` upload on every prompt-submitted, agent-done, and session-end
+# event without checking whether one is already running. Each upload rescans
+# the shared SQLite trace store, so a busy lane stacks up dozens of uploads of
+# the same trace that contend with each other and never finish. This wrapper
+# lets at most one upload per trace and a small number per user run at once,
+# terminates uploads that have clearly wedged, and otherwise defers to the
+# real hook. It always exits 0: telemetry must never block an agent.
+set -u
+
+event="${1:-}"
+shift || true
+
+command -v traces >/dev/null 2>&1 || exit 0
+
+MAX_INFLIGHT_UPLOADS="${TRACES_HOOK_MAX_INFLIGHT_UPLOADS:-4}"
+STALE_UPLOAD_SECONDS="${TRACES_HOOK_STALE_UPLOAD_SECONDS:-900}"
+
+payload="$(cat)"
+
+run_hook() {
+  printf '%s' "$payload" | traces hook agent "$event" "$@" || true
+  exit 0
+}
+
+case "$event" in
+prompt-submitted | agent-done | session-end) ;;
+*) run_hook "$@" ;;
+esac
+
+trace_id=""
+if command -v jq >/dev/null 2>&1; then
+  trace_id="$(printf '%s' "$payload" | jq -r '.session_id // .sessionId // empty' 2>/dev/null || true)"
+fi
+
+# One line per hook-triggered upload owned by this user: pid, elapsed seconds,
+# trace id. `etime` is the portable elapsed column ([[dd-]hh:]mm:ss).
+list_uploads() {
+  ps -U "$(id -un)" -o pid=,etime=,args= 2>/dev/null | awk '
+    function elapsed_seconds(value, days, fields, count, seconds, i) {
+      days = 0
+      if (index(value, "-")) {
+        split(value, fields, "-")
+        days = fields[1]
+        value = fields[2]
+      }
+      count = split(value, fields, ":")
+      seconds = 0
+      for (i = 1; i <= count; i++) seconds = seconds * 60 + fields[i]
+      return days * 86400 + seconds
+    }
+    /(^|[ \/])traces share / && /--source agent_hook/ && match($0, /--trace-id [^ ]+/) {
+      print $1, elapsed_seconds($2), substr($0, RSTART + 11, RLENGTH - 11)
+    }'
+}
+
+inflight=0
+same_trace_running=0
+while read -r pid elapsed upload_trace; do
+  [ -n "${pid:-}" ] || continue
+  if [ "$elapsed" -ge "$STALE_UPLOAD_SECONDS" ]; then
+    kill -TERM "$pid" 2>/dev/null || true
+    continue
+  fi
+  if [ -n "$trace_id" ] && [ "$upload_trace" = "$trace_id" ]; then
+    if [ "$event" = "session-end" ]; then
+      # The final upload supersedes the in-flight one for the same trace.
+      kill -TERM "$pid" 2>/dev/null || true
+      continue
+    fi
+    same_trace_running=1
+  fi
+  inflight=$((inflight + 1))
+done <<EOF
+$(list_uploads)
+EOF
+
+if [ "$event" != "session-end" ]; then
+  if [ "$same_trace_running" -eq 1 ] || [ "$inflight" -ge "$MAX_INFLIGHT_UPLOADS" ]; then
+    # The next lifecycle event retries; nothing is lost because the upload
+    # that is already running (or the session-end upload) carries the trace.
+    exit 0
+  fi
+fi
+
+run_hook "$@"

--- a/generated/hooks/moshi/claude/settings.json
+++ b/generated/hooks/moshi/claude/settings.json
@@ -363,7 +363,7 @@
       {
         "hooks": [
           {
-            "command": "command -v traces >/dev/null 2>&1 && traces hook agent session-end --agent claude-code",
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-end --agent claude-code # traces hook agent",
             "type": "command"
           }
         ],
@@ -408,7 +408,7 @@
       {
         "hooks": [
           {
-            "command": "command -v traces >/dev/null 2>&1 && traces hook agent session-start --agent claude-code",
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-start --agent claude-code # traces hook agent",
             "type": "command"
           }
         ],
@@ -448,7 +448,7 @@
       {
         "hooks": [
           {
-            "command": "command -v traces >/dev/null 2>&1 && traces hook agent agent-done --agent claude-code",
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh agent-done --agent claude-code # traces hook agent",
             "type": "command"
           }
         ],
@@ -507,7 +507,7 @@
       {
         "hooks": [
           {
-            "command": "command -v traces >/dev/null 2>&1 && traces hook agent prompt-submitted --agent claude-code",
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh prompt-submitted --agent claude-code # traces hook agent",
             "type": "command"
           }
         ],

--- a/generated/hooks/moshi/codex/hooks.json
+++ b/generated/hooks/moshi/codex/hooks.json
@@ -180,7 +180,7 @@
       {
         "hooks": [
           {
-            "command": "command -v traces >/dev/null 2>&1 && traces hook agent session-start --agent codex",
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-start --agent codex # traces hook agent",
             "timeout": 30,
             "type": "command"
           }
@@ -221,7 +221,7 @@
       {
         "hooks": [
           {
-            "command": "command -v traces >/dev/null 2>&1 && traces hook agent agent-done --agent codex",
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh agent-done --agent codex # traces hook agent",
             "timeout": 30,
             "type": "command"
           }
@@ -260,7 +260,7 @@
       {
         "hooks": [
           {
-            "command": "command -v traces >/dev/null 2>&1 && traces hook agent prompt-submitted --agent codex",
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh prompt-submitted --agent codex # traces hook agent",
             "timeout": 30,
             "type": "command"
           }
@@ -272,7 +272,7 @@
       {
         "hooks": [
           {
-            "command": "command -v traces >/dev/null 2>&1 && traces hook agent session-end --agent codex",
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-end --agent codex # traces hook agent",
             "timeout": 30,
             "type": "command"
           }

--- a/generated/hooks/moshi/cursor/hooks.json
+++ b/generated/hooks/moshi/cursor/hooks.json
@@ -29,7 +29,7 @@
         "command": "bd cursor-hook sessionStart"
       },
       {
-        "command": "command -v traces >/dev/null 2>&1 && traces hook agent session-start --agent cursor"
+        "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-start --agent cursor # traces hook agent"
       }
     ],
     "beforeMCPExecution": [
@@ -84,7 +84,7 @@
         "command": "moshi-hook cursor-hook"
       },
       {
-        "command": "command -v traces >/dev/null 2>&1 && traces hook agent prompt-submitted --agent cursor"
+        "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh prompt-submitted --agent cursor # traces hook agent"
       }
     ],
     "stop": [
@@ -100,12 +100,12 @@
         "command": "moshi-hook cursor-hook"
       },
       {
-        "command": "command -v traces >/dev/null 2>&1 && traces hook agent agent-done --agent cursor"
+        "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh agent-done --agent cursor # traces hook agent"
       }
     ],
     "sessionEnd": [
       {
-        "command": "command -v traces >/dev/null 2>&1 && traces hook agent session-end --agent cursor"
+        "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-end --agent cursor # traces hook agent"
       }
     ]
   },

--- a/generated/hooks/moshi/grok/plugin/hooks/hooks.json
+++ b/generated/hooks/moshi/grok/plugin/hooks/hooks.json
@@ -24,7 +24,7 @@
       {
         "hooks": [
           {
-            "command": "command -v traces >/dev/null 2>&1 && traces hook agent session-start --agent grok",
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-start --agent grok # traces hook agent",
             "timeout": 30,
             "type": "command"
           }
@@ -45,7 +45,7 @@
       {
         "hooks": [
           {
-            "command": "command -v traces >/dev/null 2>&1 && traces hook agent prompt-submitted --agent grok",
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh prompt-submitted --agent grok # traces hook agent",
             "timeout": 30,
             "type": "command"
           }
@@ -127,7 +127,7 @@
       {
         "hooks": [
           {
-            "command": "command -v traces >/dev/null 2>&1 && traces hook agent agent-done --agent grok",
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh agent-done --agent grok # traces hook agent",
             "timeout": 30,
             "type": "command"
           }
@@ -148,7 +148,7 @@
       {
         "hooks": [
           {
-            "command": "command -v traces >/dev/null 2>&1 && traces hook agent session-end --agent grok",
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-end --agent grok # traces hook agent",
             "timeout": 30,
             "type": "command"
           }

--- a/named-hosts/kyber/README.md
+++ b/named-hosts/kyber/README.md
@@ -195,13 +195,27 @@ cleaner:
   probe latency, recent CRI lifecycle errors, and host DNS (Tailscale must not
   own `/etc/resolv.conf`).
 
-Herdr and RoboRev run inside `orchestration.slice`, which caps aggregate writes
-to 20 MB/s and aggregate tasks to 2,048. When sustained I/O PSI or D-state
-pressure crosses the health threshold, the host-health check records PSI,
-process/`wchan`, per-process I/O, cgroup I/O, and recent k3s logs under
-`/run/kyber-host-health/evidence`, then freezes only that disposable slice. It
-never freezes or restarts k3s, containerd, or storage services. The slice thaws
-after five consecutive pressure-free samples with a healthy CRI probe.
+The Herdr server runs in `herdr.slice`, which is never frozen: it is the
+control plane for every lane and must keep answering API calls. Its pane
+shells re-exec themselves into `orchestration.slice` through the kyber fish
+init, so lane work, RoboRev, and their child processes share one disposable
+slice that caps aggregate writes to 20 MB/s and aggregate tasks to 2,048.
+When sustained host I/O PSI or D-state pressure crosses the health threshold
+and the slice's own `io.pressure` or D-state count implicates it, the
+host-health check records PSI, process/`wchan`, per-process I/O, cgroup I/O,
+and recent k3s logs under `/run/kyber-host-health/evidence`, then freezes only
+that disposable slice. Host pressure that the slice is not implicated in
+(k3s, containerd, storage) leaves it running. It never freezes or restarts
+k3s, containerd, or storage services. The slice thaws after five consecutive
+pressure-free samples with a healthy CRI probe. Three freezes within an hour
+raise `orchestration-circuit-breaker-flapping`, which means the slice re-trips
+after every thaw and its top writers in the evidence captures need attention
+rather than another auto-thaw.
+
+Coding-agent hooks are the usual writer behind a flapping slice: every hook
+event goes through `config/shared/hooks/traces-agent-hook.sh`, which bounds
+the detached `traces share` uploads that the traces hook otherwise spawns
+without limit (see [shared hooks](../../config/shared/hooks/README.md)).
 
 This containment does not isolate ext4 journals. Kyber has two physical SSDs:
 the root/PVC filesystem and the dedicated containerd filesystem. Moving k3s

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -120,9 +120,13 @@ home-manager.lib.homeManagerConfiguration {
 
         programs.home-manager.enable = true;
 
-        # Review daemons own disposable work and may be frozen by the host
-        # health circuit breaker without interrupting production services.
+        # Review daemons and agent lane shells own disposable work and may be
+        # frozen by the host health circuit breaker without interrupting
+        # production services. The Herdr server itself is the control plane
+        # for every lane, so it lives in its own never-frozen slice and only
+        # the panes it spawns are moved into orchestration.slice.
         home.file.".config/systemd/user/orchestration.slice".source = ./orchestration.slice;
+        home.file.".config/systemd/user/herdr.slice".source = ./herdr.slice;
         home.file.".config/systemd/user/roborev.service.d/10-orchestration.conf".source =
           ./orchestration-service.conf;
         xdg.configFile."systemd/user/herdr-server.service".force = true;
@@ -138,7 +142,7 @@ home-manager.lib.homeManagerConfiguration {
             ExecStart = "${pkgs.llm-agents.herdr}/bin/herdr server";
             Restart = "on-failure";
             RestartSec = "30s";
-            Slice = "orchestration.slice";
+            Slice = "herdr.slice";
             Environment = [ "HERDR_ENV=1" ];
           };
           Install.WantedBy = [ "default.target" ];
@@ -165,6 +169,18 @@ home-manager.lib.homeManagerConfiguration {
         # because it needs to be evaluated dynamically per shell session
         programs.fish.interactiveShellInit = lib.mkAfter ''
           set -gx GPG_TTY (tty)
+        '';
+
+        # Herdr pane shells inherit herdr.slice from the server. Re-exec them
+        # into orchestration.slice so the circuit breaker can freeze lane work
+        # without freezing the server that owns the panes.
+        programs.fish.shellInit = lib.mkAfter ''
+          if set -q HERDR_ENV; and status is-interactive; and not set -q HERDR_PANE_SCOPED; and test -r /proc/self/cgroup; and not string match -q '*/orchestration.slice/*' (cat /proc/self/cgroup)
+            set -gx HERDR_PANE_SCOPED 1
+            exec ${pkgs.systemd}/bin/systemd-run --user --quiet --scope --collect \
+              --slice=orchestration.slice --unit=herdr-pane-$fish_pid \
+              ${pkgs.fish}/bin/fish
+          end
         '';
 
         # Enable XDG directories

--- a/named-hosts/kyber/herdr.slice
+++ b/named-hosts/kyber/herdr.slice
@@ -1,0 +1,5 @@
+[Slice]
+CPUWeight=500
+IOWeight=500
+IOAccounting=yes
+TasksAccounting=yes

--- a/spec/activate_kyber_spec.sh
+++ b/spec/activate_kyber_spec.sh
@@ -109,8 +109,13 @@ When run bash -c "grep 'activate-user-service-priority.sh' '$PWD/named-hosts/kyb
 The output should include 'activate-user-service-priority.sh'
 End
 
-It 'declaratively owns Herdr and places review daemons in the orchestration slice'
-When run bash -c "unit=\$(sed -n '/systemd.user.services.herdr-server =/,/Install.WantedBy/p' '$PWD/named-hosts/kyber/default.nix'); grep -q 'xdg.configFile.\"systemd/user/herdr-server.service\".force = true' '$PWD/named-hosts/kyber/default.nix' && grep -q 'xdg.configFile.\"systemd/user/default.target.wants/herdr-server.service\".force = true' '$PWD/named-hosts/kyber/default.nix' && grep -q 'ExecStart = \"\${pkgs.llm-agents.herdr}/bin/herdr server\"' <<<\"\$unit\" && grep -q 'Slice = \"orchestration.slice\"' <<<\"\$unit\" && grep -q 'roborev.service.d/10-orchestration.conf' '$PWD/named-hosts/kyber/default.nix' && grep -qxF 'Slice=orchestration.slice' '$PWD/named-hosts/kyber/orchestration-service.conf'"
+It 'declaratively owns Herdr in its own slice and places review daemons in the orchestration slice'
+When run bash -c "unit=\$(sed -n '/systemd.user.services.herdr-server =/,/Install.WantedBy/p' '$PWD/named-hosts/kyber/default.nix'); grep -q 'xdg.configFile.\"systemd/user/herdr-server.service\".force = true' '$PWD/named-hosts/kyber/default.nix' && grep -q 'xdg.configFile.\"systemd/user/default.target.wants/herdr-server.service\".force = true' '$PWD/named-hosts/kyber/default.nix' && grep -q 'ExecStart = \"\${pkgs.llm-agents.herdr}/bin/herdr server\"' <<<\"\$unit\" && grep -q 'Slice = \"herdr.slice\"' <<<\"\$unit\" && ! grep -q 'orchestration.slice' <<<\"\$unit\" && grep -q 'systemd/user/herdr.slice\".source = ./herdr.slice' '$PWD/named-hosts/kyber/default.nix' && grep -q 'roborev.service.d/10-orchestration.conf' '$PWD/named-hosts/kyber/default.nix' && grep -qxF 'Slice=orchestration.slice' '$PWD/named-hosts/kyber/orchestration-service.conf'"
+The status should be success
+End
+
+It 'keeps the Herdr slice unfrozen and moves only pane shells into the orchestration slice'
+When run bash -c "grep -qxF 'IOAccounting=yes' '$PWD/named-hosts/kyber/herdr.slice' && ! grep -q 'IOWriteBandwidthMax' '$PWD/named-hosts/kyber/herdr.slice' && grep -q 'systemd-run --user --quiet --scope --collect' '$PWD/named-hosts/kyber/default.nix' && grep -q -- '--slice=orchestration.slice --unit=herdr-pane-' '$PWD/named-hosts/kyber/default.nix' && grep -q 'set -q HERDR_ENV; and status is-interactive; and not set -q HERDR_PANE_SCOPED' '$PWD/named-hosts/kyber/default.nix'"
 The status should be success
 End
 
@@ -401,6 +406,7 @@ When run env HEALTH_CHECK="$SCRIPT" bash -c '
   install() { :; }
   check_io_pressure() { :; }
   check_d_state() { :; }
+  check_orchestration_pressure() { :; }
   check_node_filesystem() { :; }
   check_image_filesystem() { :; }
   check_cri() { printf "cri\n"; }

--- a/spec/antigravity_config_spec.sh
+++ b/spec/antigravity_config_spec.sh
@@ -75,7 +75,7 @@ End
 
 It 'uses the official Traces Antigravity Stop hook with an availability guard'
 When run jq -r '.["traces-share-to-traces"].Stop[0].command' "$HOOKS"
-The output should equal "command -v traces >/dev/null 2>&1 && traces hook agent agent-done --agent antigravity >/dev/null 2>&1; printf %s '{\"decision\":\"\"}'"
+The output should equal "\$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh agent-done --agent antigravity >/dev/null 2>&1; printf %s '{\"decision\":\"\"}' # traces hook agent"
 End
 
 It 'reverts named hooks written by other tools'

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -520,6 +520,7 @@ config/codex/hooks/notify.sh
 config/codex/hooks/pushover.sh
 config/shared/hooks/block-gh-settings.sh
 config/shared/hooks/block-git-push.sh
+config/shared/hooks/traces-agent-hook.sh
 config/shared/hooks/secret-guard.sh
 config/shared/hooks/security.sh
 config/shared/hooks/rtk-rewrite.sh

--- a/spec/k3s_service_activate_spec.sh
+++ b/spec/k3s_service_activate_spec.sh
@@ -141,12 +141,13 @@ When run bash -c "grep -q 'runuser --user \"\$ORCHESTRATION_USER\"' '$HEALTH_CHE
 The status should be success
 End
 
-It 'freezes orchestration after sustained pressure'
+It 'freezes orchestration after sustained pressure the slice is implicated in'
 When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   state="$(mktemp -d)"
   export KYBER_HOST_HEALTH_STATE_DIR="$state"
   source "$HEALTH_CHECK"
   IO_PRESSURE_UNHEALTHY=1
+  ORCHESTRATION_IMPLICATED=1
   capture_orchestration_evidence() { printf "%s/evidence/test\n" "$STATE_DIR"; }
   orchestration_control() { test -e "$STATE_DIR/orchestration.frozen"; printf "control:%s\n" "$1"; }
   set_alert() { printf "alert:%s:%s\n" "$1" "$2"; }
@@ -161,12 +162,59 @@ The output should include 'clear:orchestration-freeze-failed'
 The status should be success
 End
 
+It 'leaves orchestration running when host pressure comes from elsewhere'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  state="$(mktemp -d)"
+  export KYBER_HOST_HEALTH_STATE_DIR="$state"
+  source "$HEALTH_CHECK"
+  IO_PRESSURE_UNHEALTHY=1
+  D_STATE_UNHEALTHY=1
+  ORCHESTRATION_IMPLICATED=0
+  capture_orchestration_evidence() { printf "%s/evidence/test\n" "$STATE_DIR"; }
+  orchestration_control() { printf "control:%s\n" "$1"; }
+  set_alert() { printf "alert:%s:%s\n" "$1" "$2"; }
+  clear_alert() { printf "clear:%s\n" "$1"; }
+  manage_orchestration_circuit_breaker
+  test ! -e "$state/orchestration.frozen"
+  rm -rf "$state"
+'
+The output should not include 'control:freeze'
+The output should include 'clear:orchestration-circuit-breaker'
+The status should be success
+End
+
+It 'attributes pressure to the orchestration slice from its own cgroup PSI and D-state count'
+When run bash -c "grep -q 'ORCHESTRATION_IO_SOME_AVG300_THRESHOLD=10' '$HEALTH_CHECK' && grep -q 'ORCHESTRATION_D_STATE_THRESHOLD=3' '$HEALTH_CHECK' && grep -q 'io.pressure' '$HEALTH_CHECK' && grep -q 'stat=,cgroup=' '$HEALTH_CHECK' && grep -q 'ORCHESTRATION_IMPLICATED\" -eq 1' '$HEALTH_CHECK'"
+The status should be success
+End
+
+It 'raises a flapping alert when the slice re-trips repeatedly within the window'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  state="$(mktemp -d)"
+  export KYBER_HOST_HEALTH_STATE_DIR="$state"
+  source "$HEALTH_CHECK"
+  set_alert() { printf "alert:%s:%s\n" "$1" "$2"; }
+  clear_alert() { printf "clear:%s\n" "$1"; }
+  now="$(date +%s)"
+  printf "%s\n%s\n%s\n" "$((now - ORCHESTRATION_FLAP_WINDOW_SECONDS - 60))" "$((now - 600))" "$((now - 300))" >"$state/orchestration.freezes"
+  record_orchestration_freeze
+  printf "entries:%s\n" "$(wc -l <"$state/orchestration.freezes" | tr -d "[:space:]")"
+  clear_orchestration_flapping
+  printf "%s\n" "$((now - ORCHESTRATION_FLAP_WINDOW_SECONDS - 60))" >"$state/orchestration.freezes"
+  clear_orchestration_flapping
+  rm -rf "$state"
+'
+The output should equal "$(printf 'alert:orchestration-circuit-breaker-flapping:froze orchestration.slice 3 times in the last 60 minutes; the slice re-trips after every thaw, so inspect its top writers in the evidence captures instead of waiting for auto-thaw\nentries:3\nclear:orchestration-circuit-breaker-flapping')"
+The status should be success
+End
+
 It 'removes the frozen marker when the freeze command fails'
 When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   state="$(mktemp -d)"
   export KYBER_HOST_HEALTH_STATE_DIR="$state"
   source "$HEALTH_CHECK"
   IO_PRESSURE_UNHEALTHY=1
+  ORCHESTRATION_IMPLICATED=1
   capture_orchestration_evidence() { printf "%s/evidence/test\n" "$STATE_DIR"; }
   orchestration_control() { return 1; }
   set_alert() { printf "alert:%s:%s\n" "$1" "$2"; }

--- a/spec/traces_agent_hook_spec.sh
+++ b/spec/traces_agent_hook_spec.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+Describe 'traces agent hook guard'
+GUARD="$PWD/config/shared/hooks/traces-agent-hook.sh"
+
+setup() {
+  TEMP_ROOT="$(mktemp -d)"
+  TEMP_BIN="$TEMP_ROOT/bin"
+  HOOK_LOG="$TEMP_ROOT/hook.log"
+  PS_TABLE="$TEMP_ROOT/ps.txt"
+  mkdir -p "$TEMP_BIN"
+  : >"$PS_TABLE"
+  cat >"$TEMP_BIN/traces" <<'STUB'
+#!/usr/bin/env bash
+printf 'args:%s\n' "$*" >>"$TRACES_HOOK_TEST_LOG"
+printf 'stdin:%s\n' "$(cat)" >>"$TRACES_HOOK_TEST_LOG"
+STUB
+  cat >"$TEMP_BIN/ps" <<'STUB'
+#!/usr/bin/env bash
+cat "$TRACES_HOOK_TEST_PS_TABLE"
+STUB
+  chmod +x "$TEMP_BIN/traces" "$TEMP_BIN/ps"
+  export TRACES_HOOK_TEST_LOG="$HOOK_LOG"
+  export TRACES_HOOK_TEST_PS_TABLE="$PS_TABLE"
+  export PATH="$TEMP_BIN:$PATH"
+}
+
+cleanup() {
+  if [ -n "${UPLOAD_PID:-}" ]; then
+    kill -KILL "$UPLOAD_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TEMP_ROOT"
+}
+
+BeforeEach 'setup'
+AfterEach 'cleanup'
+
+start_fake_upload() {
+  sleep 300 &
+  UPLOAD_PID=$!
+}
+
+upload_row() {
+  printf '%s %s /opt/traces/traces share --trace-id %s --source agent_hook --json\n' "$1" "$2" "$3" >>"$PS_TABLE"
+}
+
+run_guard() {
+  printf '{"session_id":"%s"}' "$1" | "$GUARD" "$2" --agent claude-code
+}
+
+It 'passes session-start through with its payload'
+When call run_guard trace-a session-start
+The status should be success
+The contents of file "$HOOK_LOG" should include 'args:hook agent session-start --agent claude-code'
+The contents of file "$HOOK_LOG" should include 'stdin:{"session_id":"trace-a"}'
+End
+
+It 'skips prompt-submitted while the same trace is already uploading'
+upload_row 4242 05:00 trace-a
+When call run_guard trace-a prompt-submitted
+The status should be success
+The file "$HOOK_LOG" should not be exist
+End
+
+It 'skips agent-done when the per-user upload cap is reached'
+upload_row 4001 00:10 trace-b
+upload_row 4002 00:20 trace-c
+upload_row 4003 00:30 trace-d
+upload_row 4004 00:40 trace-e
+When call run_guard trace-a agent-done
+The status should be success
+The file "$HOOK_LOG" should not be exist
+End
+
+It 'runs agent-done when other traces are uploading under the cap'
+upload_row 4001 00:10 trace-b
+upload_row 4002 00:20 trace-c
+When call run_guard trace-a agent-done
+The status should be success
+The contents of file "$HOOK_LOG" should include 'args:hook agent agent-done --agent claude-code'
+End
+
+It 'terminates wedged uploads and does not count them toward the cap'
+start_fake_upload
+upload_row "$UPLOAD_PID" 1-02:03:04 trace-a
+When call run_guard trace-a prompt-submitted
+The status should be success
+The contents of file "$HOOK_LOG" should include 'args:hook agent prompt-submitted --agent claude-code'
+Assert sh -c "sleep 1; ! kill -0 $UPLOAD_PID 2>/dev/null"
+End
+
+It 'lets a session-end upload supersede the in-flight upload of the same trace'
+start_fake_upload
+upload_row "$UPLOAD_PID" 02:00 trace-a
+When call run_guard trace-a session-end
+The status should be success
+The contents of file "$HOOK_LOG" should include 'args:hook agent session-end --agent claude-code'
+Assert sh -c "sleep 1; ! kill -0 $UPLOAD_PID 2>/dev/null"
+End
+
+It 'honors the configured cap and stale age'
+upload_row 4001 00:10 trace-b
+upload_row 4002 00:20 trace-c
+When call env TRACES_HOOK_MAX_INFLIGHT_UPLOADS=2 bash -c "printf '{\"session_id\":\"trace-a\"}' | '$GUARD' prompt-submitted --agent codex"
+The status should be success
+The file "$HOOK_LOG" should not be exist
+End
+
+It 'exits successfully when traces is not installed'
+rm -f "$TEMP_BIN/traces"
+When call env PATH="$TEMP_BIN:/usr/bin:/bin" bash -c "printf '{}' | '$GUARD' session-start --agent codex"
+The status should be success
+The file "$HOOK_LOG" should not be exist
+End
+
+It 'routes every agent traces hook through the guard'
+When run bash -c "
+  for config in \
+    generated/hooks/moshi/claude/settings.json \
+    generated/hooks/moshi/codex/hooks.json \
+    generated/hooks/moshi/cursor/hooks.json \
+    generated/hooks/moshi/grok/plugin/hooks/hooks.json \
+    config/copilot/config.json; do
+    for event in session-start prompt-submitted agent-done session-end; do
+      jq -r '.. | objects | .command? // empty' \"\$config\" | grep -Fq \"\\\$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh \$event --agent \" || { echo \"missing \$event in \$config\"; exit 1; }
+    done
+  done
+  jq -r '.. | objects | .command? // empty' config/antigravity/hooks.json | grep -Fq '\$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh agent-done --agent antigravity' || { echo 'missing antigravity'; exit 1; }
+  for config in generated/hooks/moshi/claude/settings.json generated/hooks/moshi/codex/hooks.json generated/hooks/moshi/cursor/hooks.json generated/hooks/moshi/grok/plugin/hooks/hooks.json config/copilot/config.json config/antigravity/hooks.json; do
+    if jq -r '.. | objects | .command? // empty' \"\$config\" | grep -Eq '(^|&& |; )traces hook agent'; then
+      echo \"unguarded traces hook in \$config\"; exit 1
+    fi
+  done
+"
+The status should be success
+End
+
+It 'keeps the traces installer marker so hook install stays idempotent'
+When run bash -c "jq -r '.. | objects | .command? // empty' generated/hooks/moshi/claude/settings.json | grep -F 'traces-agent-hook.sh' | grep -vFq '# traces hook agent' && exit 1 || exit 0"
+The status should be success
+End
+End


### PR DESCRIPTION
## Summary

kyber's herdr-server kept going unreachable because the host I/O circuit breaker froze `orchestration.slice`, and it kept re-tripping after every thaw. The dominant writers in every freeze capture were `traces share --source agent_hook` uploads: the traces hook spawns one detached upload per prompt-submitted, agent-done, and session-end with no in-flight check, and each upload rescans the shared trace store before checking the share rule. One lane had 11 uploads of a single trace alive for hours at 300-660 MB each.

- `config/shared/hooks/traces-agent-hook.sh`: guard around `traces hook agent` for Claude Code, Codex, Cursor, Copilot, Grok, and Antigravity. Skips prompt-submitted/agent-done while the same trace is uploading or 4 uploads are in flight, terminates uploads older than 15 min, lets session-end supersede the same-trace upload, always exits 0. Hook commands keep a trailing `# traces hook agent` marker so `traces hook install` stays idempotent.
- `named-hosts/kyber`: herdr-server moves to a new never-frozen `herdr.slice`; pane shells (fish with `HERDR_ENV`) re-exec into `orchestration.slice` from fish init, so lane work stays freezable while the control plane does not.
- `kyber-host-health.sh`: freeze only when the slice's own `io.pressure` (some avg300 >= 10) or D-state count (>= 3) implicates it; alert text carries slice PSI; three freezes in 60 min raise `orchestration-circuit-breaker-flapping`. The interim process reaper is removed in favor of the hook guard.

## Verification

- `shellcheck -x` on the guard and health script: clean
- `nixfmt --check` and `nix-instantiate --parse` on `named-hosts/kyber/default.nix`: clean; fish snippet passes `fish --no-execute`
- `shellspec` targeted files (traces guard, k3s health, activate_kyber, antigravity, coverage): 0 failures; full suite has two failures (`beads_federation_sync_spec:103`, `dolt_start_spec:155`) that reproduce on clean `origin/main`
- Confirmed on kyber that pane shells are fish children of herdr-server with `HERDR_ENV=1`

## Rollout

Applying to kyber is a Home Manager switch that restarts herdr-server and kills every open lane; schedule it between campaigns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUr65L3V6Vn3me8AWBaUfV


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounding the traces hook's unbounded uploads and moving herdr-server out of the frozen orchestration slice so the control plane no longer goes unreachable during I/O pressure.

**Changes**
- Added a `traces-agent-hook.sh` guard that dedupes uploads per trace, caps them per user, kills stale ones, and always exits 0.
- Moved herdr-server to its own never-frozen `herdr.slice`; pane shells re-exec into `orchestration.slice`.
- Health check now freezes orchestration only when its own cgroup PSI or D-state count implicates it, and alerts when it flaps.

**Rollout**
- Applying to kyber is a Home Manager switch that restarts herdr-server and kills open lanes; schedule between campaigns.

<sup>Written for commit 5864354f8a21cc7628b0b2aa0325d3e78771dc7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

