### PR TITLE
fix(darwin): bound the Codex hm-backup sweep to managed depth

### DIFF
--- a/hosts/darwin/activate-remove-backups.sh
+++ b/hosts/darwin/activate-remove-backups.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
-# Remove hm-backup files from ~/.codex
-find ~/.codex -name "*.hm-backup*" -delete 2>/dev/null || true
+# Remove hm-backup files from ~/.codex. Home Manager only manages files two
+# levels deep there, and ~/.codex/worktrees holds full repository checkouts
+# that would take a full sweep tens of minutes to walk.
+find ~/.codex -maxdepth 2 -name "*.hm-backup*" -delete 2>/dev/null || true


### PR DESCRIPTION
## Summary

Bounds the darwin activation step that deletes `*.hm-backup*` files under `~/.codex` to two directory levels.

## Why

Home Manager manages only `~/.codex/hooks/*`, but the sweep walked all of `~/.codex`, including the Codex worktree checkouts (196 of them on galactica, one at 7.3 GB). The `removeBackups` activation step took over thirty minutes on the last `make switch`.

## Verified

- `shellcheck` clean.
- `find ~/.codex -maxdepth 2 -name '*.hm-backup*'` returns in well under a second on galactica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppA1UCrSWDA4uBVJPoMAu


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the Darwin activation sweep that deletes Codex `hm-backup` files to two directory levels, so `make switch` no longer spends over thirty minutes walking every worktree checkout under `~/.codex`.

- Verified: the bounded `find` returns in under a second, and `shellcheck` passes.

<sup>Written for commit 24a4244df1a09c0fe9fd58f97bce6a0f497598b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

