### PR TITLE
fix(hooks): route Pi, Hermes, and OpenClaw traces hooks through the upload guard

### DIFF
--- a/config/hermes/plugins/traces/__init__.py.tpl
+++ b/config/hermes/plugins/traces/__init__.py.tpl
@@ -10,6 +10,8 @@ from pathlib import Path
 
 AGENT_ID = "hermes"
 TIMEOUT_SECONDS = 30
+# The guard dedupes and caps the detached uploads `traces hook agent` starts.
+TRACES_HOOK_GUARD = Path.home() / "dotfiles/config/shared/hooks/traces-agent-hook.sh"
 
 
 def _resolve_traces_bin() -> str | None:
@@ -49,8 +51,9 @@ def _call_hook(event: str, session_id: str) -> None:
     payload = json.dumps({"sessionKey": session_id, "session_id": session_id})
     try:
         proc = subprocess.Popen(
-            [binary, "hook", "agent", event, "--agent", AGENT_ID],
+            [str(TRACES_HOOK_GUARD), event, "--agent", AGENT_ID],
             cwd=cwd,
+            env={**os.environ, "TRACES_BIN": binary},
             stdin=subprocess.PIPE,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/config/openclaw/hooks/traces/handler.js.tpl
+++ b/config/openclaw/hooks/traces/handler.js.tpl
@@ -4,6 +4,11 @@ import os from "node:os";
 import path from "node:path";
 
 const AGENT_ID = "openclaw";
+// The guard dedupes and caps the detached uploads `traces hook agent` starts.
+const TRACES_HOOK_GUARD = path.join(
+  os.homedir(),
+  "dotfiles/config/shared/hooks/traces-agent-hook.sh"
+);
 
 const EVENT_MAP = {
   "agent:bootstrap": "session-start",
@@ -101,10 +106,11 @@ export default function tracesHook(event) {
   // traces reads the destination namespace from the working directory, and the
   // gateway process runs from /tmp, so cwd has to be set explicitly.
   const child = spawn(
-    resolveTracesBin(),
-    ["hook", "agent", tracesEvent, "--agent", AGENT_ID],
+    TRACES_HOOK_GUARD,
+    [tracesEvent, "--agent", AGENT_ID],
     {
       cwd,
+      env: { ...process.env, TRACES_BIN: resolveTracesBin() },
       stdio: ["pipe", "ignore", "ignore"],
       detached: true,
     }

--- a/config/pi/traces-hooks.ts
+++ b/config/pi/traces-hooks.ts
@@ -1,9 +1,18 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { spawn } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+
+// The guard dedupes and caps the detached uploads `traces hook agent` starts;
+// calling traces directly would let every Pi turn stack another upload.
+const TRACES_HOOK_GUARD = path.join(
+  os.homedir(),
+  "dotfiles/config/shared/hooks/traces-agent-hook.sh"
+);
 
 function sendTraces(event: string, sessionId: string) {
   try {
-    const child = spawn("traces", ["hook", "agent", event, "--agent", "pi"], {
+    const child = spawn(TRACES_HOOK_GUARD, [event, "--agent", "pi"], {
       stdio: ["pipe", "ignore", "ignore"],
       detached: true,
     });

--- a/config/shared/hooks/README.md
+++ b/config/shared/hooks/README.md
@@ -26,7 +26,9 @@ These hooks provide fast feedback and prevent common mistakes. They run with the
 # Traces agent hook guard
 
 `traces-agent-hook.sh <event> --agent <id>` wraps `traces hook agent` for Codex,
-Claude Code, Cursor, GitHub Copilot, Grok, and Antigravity. The traces hook
+Claude Code, Cursor, GitHub Copilot, Grok, Antigravity, Pi, Hermes, and
+OpenClaw; the Pi, Hermes, and OpenClaw adapters spawn it directly and pass
+the binary they resolved as `TRACES_BIN`. The traces hook
 starts a detached `traces share --trace-id <session> --source agent_hook`
 upload on every `prompt-submitted`, `agent-done`, and `session-end` event and
 never checks whether one is already running; each upload rescans the shared

--- a/config/shared/hooks/traces-agent-hook.sh
+++ b/config/shared/hooks/traces-agent-hook.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Guard around `traces hook agent <event> --agent <id>`.
+# Guard around `traces hook agent <event> --agent <id>`. Every agent adapter
+# (native hook configs and the Pi, Hermes, and OpenClaw extensions) goes
+# through here so the in-flight accounting sees all uploads of one user.
 #
 # The traces hook spawns a detached `traces share --trace-id ... --source
 # agent_hook` upload on every prompt-submitted, agent-done, and session-end
@@ -14,7 +16,8 @@ set -u
 event="${1:-}"
 shift || true
 
-command -v traces >/dev/null 2>&1 || exit 0
+traces_bin="${TRACES_BIN:-traces}"
+command -v "$traces_bin" >/dev/null 2>&1 || exit 0
 
 MAX_INFLIGHT_UPLOADS="${TRACES_HOOK_MAX_INFLIGHT_UPLOADS:-4}"
 STALE_UPLOAD_SECONDS="${TRACES_HOOK_STALE_UPLOAD_SECONDS:-900}"
@@ -22,7 +25,7 @@ STALE_UPLOAD_SECONDS="${TRACES_HOOK_STALE_UPLOAD_SECONDS:-900}"
 payload="$(cat)"
 
 run_hook() {
-  printf '%s' "$payload" | traces hook agent "$event" "$@" || true
+  printf '%s' "$payload" | "$traces_bin" hook agent "$event" "$@" || true
   exit 0
 }
 

--- a/generated/hooks/traces/hermes/__init__.py
+++ b/generated/hooks/traces/hermes/__init__.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 AGENT_ID = "hermes"
 TIMEOUT_SECONDS = 30
+# The guard dedupes and caps the detached uploads `traces hook agent` starts.
+TRACES_HOOK_GUARD = Path.home() / "dotfiles/config/shared/hooks/traces-agent-hook.sh"
 
 
 def _resolve_traces_bin() -> str | None:
@@ -49,8 +51,9 @@ def _call_hook(event: str, session_id: str) -> None:
     payload = json.dumps({"sessionKey": session_id, "session_id": session_id})
     try:
         proc = subprocess.Popen(
-            [binary, "hook", "agent", event, "--agent", AGENT_ID],
+            [str(TRACES_HOOK_GUARD), event, "--agent", AGENT_ID],
             cwd=cwd,
+            env={**os.environ, "TRACES_BIN": binary},
             stdin=subprocess.PIPE,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/generated/hooks/traces/openclaw/handler.js
+++ b/generated/hooks/traces/openclaw/handler.js
@@ -4,6 +4,11 @@ import os from "node:os";
 import path from "node:path";
 
 const AGENT_ID = "openclaw";
+// The guard dedupes and caps the detached uploads `traces hook agent` starts.
+const TRACES_HOOK_GUARD = path.join(
+  os.homedir(),
+  "dotfiles/config/shared/hooks/traces-agent-hook.sh"
+);
 
 const EVENT_MAP = {
   "agent:bootstrap": "session-start",
@@ -101,10 +106,11 @@ export default function tracesHook(event) {
   // traces reads the destination namespace from the working directory, and the
   // gateway process runs from /tmp, so cwd has to be set explicitly.
   const child = spawn(
-    resolveTracesBin(),
-    ["hook", "agent", tracesEvent, "--agent", AGENT_ID],
+    TRACES_HOOK_GUARD,
+    [tracesEvent, "--agent", AGENT_ID],
     {
       cwd,
+      env: { ...process.env, TRACES_BIN: resolveTracesBin() },
       stdio: ["pipe", "ignore", "ignore"],
       detached: true,
     }

--- a/spec/traces_agent_hook_spec.sh
+++ b/spec/traces_agent_hook_spec.sh
@@ -106,6 +106,13 @@ The status should be success
 The file "$HOOK_LOG" should not be exist
 End
 
+It 'runs the binary named by TRACES_BIN when traces is off PATH'
+mv "$TEMP_BIN/traces" "$TEMP_BIN/traces-resolved"
+When call env PATH="$TEMP_BIN:/usr/bin:/bin" TRACES_BIN="$TEMP_BIN/traces-resolved" bash -c "printf '{\"session_id\":\"trace-a\"}' | '$GUARD' agent-done --agent hermes"
+The status should be success
+The contents of file "$HOOK_LOG" should include 'args:hook agent agent-done --agent hermes'
+End
+
 It 'exits successfully when traces is not installed'
 rm -f "$TEMP_BIN/traces"
 When call env PATH="$TEMP_BIN:/usr/bin:/bin" bash -c "printf '{}' | '$GUARD' session-start --agent codex"
@@ -126,6 +133,17 @@ When run bash -c "
     done
   done
   jq -r '.. | objects | .command? // empty' config/antigravity/hooks.json | grep -Fq '\$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh agent-done --agent antigravity' || { echo 'missing antigravity'; exit 1; }
+  for adapter in \
+    config/pi/traces-hooks.ts \
+    config/openclaw/hooks/traces/handler.js.tpl \
+    generated/hooks/traces/openclaw/handler.js \
+    config/hermes/plugins/traces/__init__.py.tpl \
+    generated/hooks/traces/hermes/__init__.py; do
+    grep -Fq 'dotfiles/config/shared/hooks/traces-agent-hook.sh' \"\$adapter\" || { echo \"missing guard in \$adapter\"; exit 1; }
+    if grep -Eq '\"hook\", \"agent\"' \"\$adapter\"; then
+      echo \"unguarded traces hook in \$adapter\"; exit 1
+    fi
+  done
   for config in generated/hooks/moshi/claude/settings.json generated/hooks/moshi/codex/hooks.json generated/hooks/moshi/cursor/hooks.json generated/hooks/moshi/grok/plugin/hooks/hooks.json config/copilot/config.json config/antigravity/hooks.json; do
     if jq -r '.. | objects | .command? // empty' \"\$config\" | grep -Eq '(^|&& |; )traces hook agent'; then
       echo \"unguarded traces hook in \$config\"; exit 1


### PR DESCRIPTION
## Summary

Follow-up to #2623. After deploying the guard on kyber, `orchestration.slice` re-tripped within minutes: eight `traces share --source agent_hook` uploads were running, four per trace, all spawned inside `roborev.service` by Pi review sessions. The Pi extension, the Hermes plugin, and the OpenClaw hook handler spawn `traces hook agent` directly, so they never went through `traces-agent-hook.sh` and its per-trace / per-user in-flight accounting could not see them.

- `config/pi/traces-hooks.ts`, `config/openclaw/hooks/traces/handler.js.tpl`, `config/hermes/plugins/traces/__init__.py.tpl` (and the generated copies) now spawn the guard with `<event> --agent <id>`; Hermes and OpenClaw pass the binary they resolve as `TRACES_BIN`.
- `traces-agent-hook.sh` honors `TRACES_BIN` for both the availability check and the real hook call.
- Spec asserts every adapter references the guard and contains no direct `"hook", "agent"` spawn; new example covers `TRACES_BIN`.

## Verification

- `shellspec spec/traces_agent_hook_spec.sh spec/generate_hooks_spec.sh spec/hermes_hydrate_spec.sh spec/openclaw_hydrate_spec.sh spec/coverage_spec.sh`: 198 examples, 0 failures.
- `bash -n`, `python3 -m py_compile`, `node --check` on the guard and generated adapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUr65L3V6Vn3me8AWBaUfV


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the Pi, Hermes, and OpenClaw traces hooks through the shared upload guard so their uploads no longer bypass the per-trace in-flight dedup and cap, preventing duplicate `traces share` uploads that tripped the circuit breaker. The guard now also honors `TRACES_BIN` so adapters that resolve the binary themselves keep working when `traces` is off `PATH`.

**Changes**
- Pi, Hermes, and OpenClaw adapters now spawn `traces-agent-hook.sh` instead of calling `traces hook agent` directly.
- The guard uses `TRACES_BIN` (when set) for the availability check and the real hook call.
- Specs assert every adapter references the guard and add coverage for `TRACES_BIN`.

<sup>Written for commit 83ca2514573ec3f2a2a9adffe963f6e6a0393bab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

