### PR TITLE
fix(kubernetes): install GKE auth plugin

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -69,7 +69,9 @@ with pkgs;
   gnumake
   gomi
   go-task
-  google-cloud-sdk
+  (google-cloud-sdk.withExtraComponents [
+    google-cloud-sdk.components.gke-gcloud-auth-plugin
+  ])
   gping
   grc
   gron


### PR DESCRIPTION
## Summary
- extend the pinned Google Cloud SDK package with `gke-gcloud-auth-plugin`
- restore authenticated kubectl access for saved GKE contexts

## Validation
- `make nix-format-check`
- `make build` (Galactica darwin configuration)

## Delivery
P0 infrastructure recovery tooling; operator authorized bypass/admin merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `gke-gcloud-auth-plugin` to the `google-cloud-sdk` package so `kubectl` can authenticate to saved GKE contexts again.

<sup>Written for commit be4a5fd224a1bf874c01d33f3454a8f407e28d4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

