### PR TITLE
fix(fish): wait out or reap a stale git index.lock in grr and gco

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -299,6 +299,7 @@
         "_fzf_preview_name"
         "_fzf_shell_history"
         "_gco_function"
+        "_git_index_lock_wait"
         "_grco_function"
         "_grcr_function"
         "_grr_function"

--- a/home-manager/programs/fish/functions/_gco_function.fish
+++ b/home-manager/programs/fish/functions/_gco_function.fish
@@ -1,4 +1,5 @@
 function _gco_function --description "Checkout default branch and pull latest changes"
   set -l default_branch (git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+  _git_index_lock_wait 30; or return 1
   git checkout $default_branch && git branch --set-upstream-to=origin/$default_branch $default_branch && git pull
 end

--- a/home-manager/programs/fish/functions/_git_index_lock_wait.fish
+++ b/home-manager/programs/fish/functions/_git_index_lock_wait.fish
@@ -1,0 +1,59 @@
+function _git_index_lock_wait --description "Wait for .git/index.lock to clear; remove it only when nothing holds it"
+  set -l max_wait 30
+  if test (count $argv) -ge 1
+    set max_wait $argv[1]
+  end
+
+  set -l lock (git rev-parse --git-path index.lock 2>/dev/null)
+  if test -z "$lock"; or not test -e "$lock"
+    return 0
+  end
+
+  # A live writer finishes within seconds even on a large index, so poll
+  # briefly before deciding anything.
+  set -l waited 0
+  while test -e "$lock"; and test $waited -lt $max_wait
+    sleep 1
+    set waited (math $waited + 1)
+  end
+  if not test -e "$lock"
+    return 0
+  end
+
+  # Git never records the lock owner, so "stale" is inferred: no process has
+  # the file open and no git process runs inside this repository. A lock that
+  # outlives its writer is left behind only by a killed process (SIGKILL skips
+  # git's cleanup handler), which is the case worth reaping automatically.
+  set -l repo (git rev-parse --show-toplevel 2>/dev/null)
+  set -l holders
+  if command -q lsof
+    set holders (lsof -t -- "$lock" 2>/dev/null)
+    if test (count $holders) -eq 0
+      set -l pid
+      for line in (lsof -a -c git -d cwd -F pn 2>/dev/null)
+        switch $line
+          case 'p*'
+            set pid (string sub -s 2 -- $line)
+          case 'n*'
+            if string match -qr '^n'(string escape --style=regex -- $repo)'(/|$)' -- $line
+              set -a holders $pid
+            end
+        end
+      end
+    end
+  else
+    set holders (pgrep -x git)
+  end
+
+  if test (count $holders) -eq 0
+    set -l mtime (stat -f %m "$lock" 2>/dev/null; or stat -c %Y "$lock" 2>/dev/null)
+    set -l age (math (date +%s) - $mtime)
+    echo "git: removing stale index.lock (age $age s, no holder)" >&2
+    rm -f -- "$lock"
+    return 0
+  end
+
+  echo "git: index.lock is held by a running process; wait or stop it first:" >&2
+  ps -o pid=,etime=,command= -p (string join , $holders) 2>/dev/null | head -5 >&2
+  return 1
+end

--- a/home-manager/programs/fish/functions/_grr_function.fish
+++ b/home-manager/programs/fish/functions/_grr_function.fish
@@ -26,11 +26,10 @@ function _grr_function --description "Refresh to origin default branch every 3 m
     set -l default_branch (git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
     set -l ts (date '+%Y-%m-%d %H:%M:%S')
     set -l ok 0
-    set -l index_lock (git rev-parse --git-path index.lock 2>/dev/null)
 
-    # Another Git process owns the index. Do not race it or remove its lock;
-    # retry on the next cycle instead.
-    if test -n "$index_lock"; and test -e "$index_lock"
+    # Another Git process may own the index: wait for it, reap a lock whose
+    # writer is gone, and only skip the cycle when a live process still holds it.
+    if not _git_index_lock_wait 30
       echo "[$ts] grr: git index is locked, skipping" >&2
       if test $once -eq 1
         return 1
@@ -58,7 +57,14 @@ function _grr_function --description "Refresh to origin default branch every 3 m
             set ok 1
             echo "[$ts] grr: ok (pulled origin/$default_branch)"
           else if string match -q '*index.lock*' -- $pull_output
-            echo "[$ts] grr: git index became locked, will retry" >&2
+            # A writer slipped in between the check and the pull; one more try
+            # after it clears beats waiting a whole interval.
+            if _git_index_lock_wait 30; and git pull --ff-only origin $default_branch
+              set ok 1
+              echo "[$ts] grr: ok (pulled origin/$default_branch)"
+            else
+              echo "[$ts] grr: git index became locked, will retry" >&2
+            end
           else
             printf '%s\n' $pull_output >&2
             echo "[$ts] grr: pull failed, will retry" >&2


### PR DESCRIPTION
## Summary

`grr` skipped an entire refresh interval whenever any process held `.git/index.lock`, and `gco` failed with "Unable to create index.lock". On a checkout shared by editors and agent sessions that lock appears constantly for a few seconds at a time, and a killed writer leaves it behind for good.

- New `_git_index_lock_wait [seconds]`: polls for the lock to clear, removes it only when `lsof` shows no holder and no `git` process has the repository as its working directory, otherwise prints the holder and fails.
- `grr` uses it before each cycle and retries the pull once when a writer slips in mid-cycle.
- `gco` uses it before checkout.

## Verification

Sourced the helper against a scratch repository: no lock returns 0; an orphaned lock is reaped after the wait; a lock held open by a live process is kept and the function returns 1. `fish -n` passes on all three functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppA1UCrSWDA4uBVJPoMAu


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `grr` and `gco` so a stale or transient `.git/index.lock` no longer blocks refresh or checkout. Both previously failed or skipped a cycle whenever any process held the lock; they now wait up to 30 seconds, remove the lock only when nothing holds it, and print the holder if a process is still active.

**Changes**
- Adds `_git_index_lock_wait`, which polls for the lock and reaps it only when no `lsof` holder and no in-repo `git` process exists.
- `grr` retries the pull once if a writer slips in mid-cycle.

<sup>Written for commit b5105e781e867ac7ca5e38482eb4d8a1d9ede7f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

