### PR TITLE
fix(kyber): bound Dolt backup writes

### DIFF
--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -235,6 +235,13 @@ lib.mkIf clientEnabled {
         "DOLT_CLI_PASSWORD="
       ]
       ++ lib.optional federationHubEnabled "BEADS_DOLT_REMOTESAPI_PORT=${toString federationRemotesApiPort}";
+    }
+    // lib.optionalAttrs isKyber {
+      # DOLT_BACKUP performs the off-site snapshot inside the server process.
+      # Bound that bulk writer so it cannot starve Kine and PostgreSQL on the
+      # shared root disk; normal transactional writes remain far below 20 MB/s.
+      IOAccounting = true;
+      IOWriteBandwidthMax = "/ 20M";
     };
     Install = {
       WantedBy = [ "default.target" ];

--- a/spec/beads_federation_sync_spec.sh
+++ b/spec/beads_federation_sync_spec.sh
@@ -38,7 +38,7 @@ setup_federation() {
   repo_slug="${TEST_REPO_ID//\//_}"
   CHECKPOINT_FILE="$STATE_HOME/beads-federation-sync/last-success-$repo_slug"
   export DOTFILES_ENV_FILE="$ENV_FILE"
-  for command in date mkdir mv sleep timeout; do
+  for command in date mkdir mv sleep tail timeout; do
     ln -s "$(command -v "$command")" "$COREUTILS/bin/$command"
   done
 
@@ -134,6 +134,11 @@ End
 
 It 'serves Dolt locally on every client host'
 When run bash -c "grep -F 'serverEnabled = clientEnabled;' '$MODULE' >/dev/null && grep -F 'pkgs.stdenv.hostPlatform.isLinux && serverEnabled' '$MODULE' >/dev/null && grep -F 'pkgs.stdenv.hostPlatform.isDarwin && serverEnabled' '$MODULE' >/dev/null"
+The status should be success
+End
+
+It 'bounds Kyber Dolt backup writes without constraining other hosts'
+When run bash -c "service=\$(sed -n '/systemd.user.services.dolt =/,/Install =/p' '$MODULE'); grep -F 'lib.optionalAttrs isKyber' <<<\"\$service\" >/dev/null && grep -F 'IOAccounting = true;' <<<\"\$service\" >/dev/null && grep -F 'IOWriteBandwidthMax = \"/ 20M\";' <<<\"\$service\" >/dev/null"
 The status should be success
 End
 


### PR DESCRIPTION
### Summary

Cap Kyber Dolt server writes at 20 MB/s so scheduled off-site snapshots cannot starve Kine and PostgreSQL on the shared root disk. The cap is Kyber-only and preserves backup execution.

### Tracker linkage
- Linear: none — incident remediation is tracked directly in Beads
- Bead: shunkakinokisoftware-yque

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Kyber root-disk writes | DOLT_BACKUP could saturate the disk | Dolt service writes are capped at 20 MB/s |

### Breaking and irreversible changes

- Behavioral: Kyber Dolt bulk writes may take longer under load.
- Compile-time: None.
- Durable state and rollback: No data migration; revert removes the ceiling on the next activation.

### Deliberate boundaries

- K3s, PostgreSQL, and non-Kyber Dolt services are unchanged.
- Backup cadence and contents are unchanged.

### Verification

- `shellspec spec/beads_federation_sync_spec.sh` — 14 examples passed.
- `nix eval --json .#homeConfigurations.kyber.config.systemd.user.services.dolt.Service` — rendered `IOAccounting=true` and `IOWriteBandwidthMax=/ 20M`.
- Native `x86_64-linux` activation build and live switch will run on Kyber after review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps Kyber Dolt server writes at 20 MB/s so scheduled off-site snapshots cannot starve Kine and PostgreSQL on the shared root disk. The ceiling is Kyber-only and preserves backup execution.

- Adds a shellspec test confirming the I/O bandwidth limit is applied only on Kyber.

<sup>Written for commit 0929496e6999bb0ef45007e0af6077099aec4fb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

