### PR TITLE
fix(pi): use event context for declarative fallback handler

### DIFF
--- a/config/pi/fallback.ts
+++ b/config/pi/fallback.ts
@@ -225,55 +225,35 @@ export function createFallbackPolicy(config: FallbackConfig): FallbackPolicy {
   };
 }
 
-/** The slice of Pi's ExtensionAPI this needs. */
-interface FallbackHost {
-  on(event: string, handler: (event: unknown, ctx: unknown) => unknown): void;
-  ui: { notify(message: string, type?: "info" | "warning" | "error"): void };
-  modelRegistry: { find(provider: string, modelId: string): unknown };
-  setModel(model: unknown): Promise<boolean>;
-  sendMessage(
-    message: { customType: string; content: string; display: boolean },
-    options?: { triggerTurn?: boolean }
-  ): void;
-}
-
-function attachFallback(host: FallbackHost, configPath: string): void {
+function attachFallback(host: ExtensionAPI, configPath: string): void {
   const config = loadFallbackConfig(configPath);
   if (!config.enabled || config.fallback_models.length === 0) return;
 
   const policy = createFallbackPolicy(config);
-  // Ref of the model this extension last selected, so a model that is active
-  // without us having chosen it can only have come from the user. Pi emits
-  // model_select and OMP does not, so both hosts are covered by comparing
-  // ctx.model instead of subscribing to an event only one of them has.
+  // Respect model changes made by the user between fallback attempts.
   let appliedRef: string | undefined;
 
-  const notify = (message: string, level: "info" | "warning" = "info") => {
-    if (config.notify_on_fallback)
-      host.ui.notify(`[fallback] ${message}`, level);
-  };
-
-  const selectRef = async (ref: string): Promise<boolean> => {
-    const { provider, id } = splitModelRef(ref);
-    const model = host.modelRegistry.find(provider, id);
-    if (!model) return false;
-    if (!(await host.setModel(model))) return false;
-    appliedRef = ref;
-    return true;
-  };
-
   host.on("after_provider_response", (event) => {
-    policy.recordStatus((event as { status?: number }).status);
+    policy.recordStatus(event.status);
   });
 
   host.on("agent_end", async (event, ctx) => {
-    const messages = (event as { messages?: unknown[] }).messages ?? [];
-    const last = messages[messages.length - 1] as
-      | { role?: string; stopReason?: string; errorMessage?: string }
-      | undefined;
-    const currentRef = modelRef(
-      (ctx as { model?: { provider?: string; id?: string } }).model
-    );
+    const notify = (message: string, level: "info" | "warning" = "info") => {
+      if (config.notify_on_fallback) ctx.ui.notify(`[fallback] ${message}`, level);
+    };
+
+    const selectRef = async (ref: string): Promise<boolean> => {
+      const { provider, id } = splitModelRef(ref);
+      const model = ctx.modelRegistry.find(provider, id);
+      if (!model) return false;
+      if (!(await host.setModel(model))) return false;
+      appliedRef = ref;
+      return true;
+    };
+
+    const messages = event.messages;
+    const last = messages[messages.length - 1];
+    const currentRef = modelRef(ctx.model);
 
     // The user switched models behind our back: their choice wins outright.
     if (appliedRef !== undefined && currentRef !== appliedRef) {
@@ -302,7 +282,7 @@ function attachFallback(host: FallbackHost, configPath: string): void {
         policy.commit();
         notify(
           `${decision.from} failed (${decision.status ?? "error"}) -> ${decision.to}`,
-          "warning"
+          "warning",
         );
         host.sendMessage(
           {
@@ -310,7 +290,7 @@ function attachFallback(host: FallbackHost, configPath: string): void {
             content: "Continue.",
             display: false,
           },
-          { triggerTurn: true }
+          { triggerTurn: true },
         );
         return;
       }
@@ -324,8 +304,5 @@ function attachFallback(host: FallbackHost, configPath: string): void {
 }
 
 export default function piRuntimeFallback(pi: ExtensionAPI): void {
-  attachFallback(
-    pi as unknown as FallbackHost,
-    join(homedir(), ".pi", "agent", "fallback.json")
-  );
+  attachFallback(pi, join(homedir(), ".pi", "agent", "fallback.json"));
 }

--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -235,6 +235,13 @@ lib.mkIf clientEnabled {
         "DOLT_CLI_PASSWORD="
       ]
       ++ lib.optional federationHubEnabled "BEADS_DOLT_REMOTESAPI_PORT=${toString federationRemotesApiPort}";
+    }
+    // lib.optionalAttrs isKyber {
+      # DOLT_BACKUP performs the off-site snapshot inside the server process.
+      # Bound that bulk writer so it cannot starve Kine and PostgreSQL on the
+      # shared root disk; normal transactional writes remain far below 20 MB/s.
+      IOAccounting = true;
+      IOWriteBandwidthMax = "/ 20M";
     };
     Install = {
       WantedBy = [ "default.target" ];

--- a/spec/beads_federation_sync_spec.sh
+++ b/spec/beads_federation_sync_spec.sh
@@ -38,7 +38,7 @@ setup_federation() {
   repo_slug="${TEST_REPO_ID//\//_}"
   CHECKPOINT_FILE="$STATE_HOME/beads-federation-sync/last-success-$repo_slug"
   export DOTFILES_ENV_FILE="$ENV_FILE"
-  for command in date mkdir mv sleep timeout; do
+  for command in date mkdir mv sleep tail timeout; do
     ln -s "$(command -v "$command")" "$COREUTILS/bin/$command"
   done
 
@@ -134,6 +134,11 @@ End
 
 It 'serves Dolt locally on every client host'
 When run bash -c "grep -F 'serverEnabled = clientEnabled;' '$MODULE' >/dev/null && grep -F 'pkgs.stdenv.hostPlatform.isLinux && serverEnabled' '$MODULE' >/dev/null && grep -F 'pkgs.stdenv.hostPlatform.isDarwin && serverEnabled' '$MODULE' >/dev/null"
+The status should be success
+End
+
+It 'bounds Kyber Dolt backup writes without constraining other hosts'
+When run bash -c "service=\$(sed -n '/systemd.user.services.dolt =/,/Install =/p' '$MODULE'); grep -F 'lib.optionalAttrs isKyber' <<<\"\$service\" >/dev/null && grep -F 'IOAccounting = true;' <<<\"\$service\" >/dev/null && grep -F 'IOWriteBandwidthMax = \"/ 20M\";' <<<\"\$service\" >/dev/null"
 The status should be success
 End
 

--- a/spec/pi_fallback.test.ts
+++ b/spec/pi_fallback.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+test("a 504 on free reports exhaustion through the event context", () => {
+  const testHome = mkdtempSync(join(tmpdir(), "pi-fallback-"));
+  try {
+    const agentDir = join(testHome, ".pi", "agent");
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, "fallback.json"), JSON.stringify({
+      enabled: true,
+      fallback_models: ["cliproxyapi/free"],
+    }));
+    const result = spawnSync(process.execPath, ["-e", `
+      import fallback from ${JSON.stringify(resolve("config/pi/fallback.ts"))};
+      const handlers = new Map();
+      const notices = [];
+      fallback({
+        on: (event, handler) => handlers.set(event, handler),
+        setModel: () => { throw new Error("must stay on free"); },
+        sendMessage: () => { throw new Error("must not retry indefinitely"); },
+      });
+      handlers.get("after_provider_response")({ status: 504 });
+      await handlers.get("agent_end")({ messages: [{
+        role: "assistant", stopReason: "error", errorMessage: "504 status code",
+      }] }, {
+        model: { provider: "cliproxyapi", id: "free" },
+        ui: { notify: (message) => notices.push(message) },
+        modelRegistry: { find: () => { throw new Error("no alternate model"); } },
+      });
+      if (notices.length !== 1 || !notices[0].includes("no fallback model available")) {
+        throw new Error(JSON.stringify(notices));
+      }
+      console.log("exhaustion handled");
+    `], { env: { ...process.env, HOME: testHome }, encoding: "utf8" });
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("exhaustion handled");
+  } finally {
+    rmSync(testHome, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Pi's fallback handler accessed `ui` and `modelRegistry` on the extension API instead of the event context. When a provider response exhausted the fallback chain, notification handling could throw a TypeError. Use the actual SDK types and event context so provider failures are reported correctly.

Home Manager already installs `config/pi/fallback.ts` at `~/.pi/agent/extensions/fallback.ts`, so the corrected source is deployed by the existing declarative configuration. The default and fallback remain `cliproxyapi/free` only.

Validation:
- Regression test fails on the original handler and passes with the fix.
- Focused TypeScript check passes.
- 105 model configuration checks pass.
- Kyber's installed fix returned `OK` from a live `free` request.

This fixes the handler error; it does not eliminate upstream HTTP 504 timeouts.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Pi fallback handler so provider failures report correctly instead of throwing a TypeError, and caps Kyber's Dolt backup write bandwidth so the off-site snapshot cannot starve other services on the shared root disk.

**Bug Fixes**
- Fallback handler now reads `ui`, `modelRegistry`, and model state from the event context, typed with the official `ExtensionAPI`.
- Existing Home Manager config already deploys the corrected `config/pi/fallback.ts`, so no manual rollout is needed.
- Regression test covers a 504 on `free` with no alternate model; upstream HTTP 504 timeouts are still possible.
- Kyber's Dolt backup gets a 20 MB/s write cap plus IO accounting; other hosts are unaffected.

<sup>Written for commit a7bde5e0ab556d77c0a9912366d3296c8432fc53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

