### PR TITLE
fix(pi): trigger free fallback for SDK HTTP errors

### DIFF
--- a/config/pi/fallback.ts
+++ b/config/pi/fallback.ts
@@ -152,8 +152,15 @@ export function createFallbackPolicy(config: FallbackConfig): FallbackPolicy {
   let primaryRef: string | undefined;
 
   const isRetryable = (errorMessage: string): boolean => {
-    if (lastStatus !== undefined && config.retry_on_errors.includes(lastStatus))
+    // OpenAI SDKs throw on non-2xx responses before Pi emits onResponse.
+    const messageStatus = errorMessage.match(
+      /(?:^|API error \(|HTTP(?: error)?[ :]+|status(?: code)?[ :]+)([45]\d{2})\b/i
+    )?.[1];
+    const status = messageStatus === undefined ? lastStatus : Number(messageStatus);
+    if (status !== undefined && config.retry_on_errors.includes(status)) {
+      lastStatus = status;
       return true;
+    }
     const haystack = errorMessage.toLowerCase();
     return config.retryable_error_patterns.some((pattern) =>
       haystack.includes(pattern.toLowerCase())
@@ -232,6 +239,10 @@ function attachFallback(host: ExtensionAPI, configPath: string): void {
   const policy = createFallbackPolicy(config);
   // Respect model changes made by the user between fallback attempts.
   let appliedRef: string | undefined;
+
+  host.on("before_provider_request", () => {
+    policy.recordStatus(undefined);
+  });
 
   host.on("after_provider_response", (event) => {
     policy.recordStatus(event.status);

--- a/spec/pi_fallback.test.ts
+++ b/spec/pi_fallback.test.ts
@@ -33,6 +33,15 @@ test("a 504 on free reports exhaustion through the event context", () => {
       if (notices.length !== 1 || !notices[0].includes("no fallback model available")) {
         throw new Error(JSON.stringify(notices));
       }
+      notices.length = 0;
+      handlers.get("before_provider_request")({});
+      await handlers.get("agent_end")({ messages: [{
+        role: "assistant", stopReason: "error", errorMessage: "400 invalid request",
+      }] }, {
+        model: { provider: "cliproxyapi", id: "free" },
+        ui: { notify: (message) => notices.push(message) },
+      });
+      if (notices.length !== 0) throw new Error("stale status triggered fallback");
       console.log("exhaustion handled");
     `], { env: { ...process.env, HOME: testHome }, encoding: "utf8" });
     expect(result.stderr).toBe("");

--- a/spec/pi_fallback_runtime.test.ts
+++ b/spec/pi_fallback_runtime.test.ts
@@ -1,0 +1,221 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+async function runScenario(
+  primary: string,
+  failFree: boolean,
+  retries: number,
+  api = "openai-responses",
+  alwaysFail = false,
+  failureStatus = 504
+) {
+  const requests: string[] = [];
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const body = (await request.json()) as { model: string };
+      requests.push(body.model);
+      if (
+        alwaysFail ||
+        body.model !== "free" ||
+        (failFree && requests.length === 1)
+      ) {
+        return new Response(null, { status: failureStatus });
+      }
+      if (api === "openai-responses") {
+        const response = {
+          id: "test",
+          status: "completed",
+          output: [
+            {
+              type: "message",
+              id: "msg-test",
+              role: "assistant",
+              status: "completed",
+              content: [{ type: "output_text", text: "OK", annotations: [] }]
+            }
+          ],
+          usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 }
+        };
+        const events = [
+          { type: "response.created", response: { id: "test" } },
+          {
+            type: "response.output_item.added",
+            output_index: 0,
+            item: {
+              type: "message",
+              id: "msg-test",
+              role: "assistant",
+              content: []
+            }
+          },
+          {
+            type: "response.content_part.added",
+            output_index: 0,
+            content_index: 0,
+            part: { type: "output_text", text: "", annotations: [] }
+          },
+          {
+            type: "response.output_text.delta",
+            output_index: 0,
+            content_index: 0,
+            delta: "OK"
+          },
+          {
+            type: "response.output_item.done",
+            output_index: 0,
+            item: response.output[0]
+          },
+          { type: "response.completed", response }
+        ];
+        return new Response(
+          events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""),
+          { headers: { "content-type": "text/event-stream" } }
+        );
+      }
+      const chunk = {
+        id: "test",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "free",
+        choices: [
+          {
+            index: 0,
+            delta: { role: "assistant", content: "OK" },
+            finish_reason: null
+          }
+        ]
+      };
+      return new Response(
+        `data: ${JSON.stringify(chunk)}\n\ndata: ${JSON.stringify({ ...chunk, choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\ndata: [DONE]\n\n`,
+        { headers: { "content-type": "text/event-stream" } }
+      );
+    }
+  });
+  const testHome = mkdtempSync(join(tmpdir(), "pi-runtime-"));
+  try {
+    const agent = join(testHome, ".pi", "agent");
+    mkdirSync(agent, { recursive: true });
+    writeFileSync(
+      join(agent, "settings.json"),
+      JSON.stringify({
+        defaultProvider: "cliproxyapi",
+        defaultModel: primary,
+        retry: { enabled: retries > 0, maxRetries: retries, baseDelayMs: 1 },
+        providerRetry: { maxRetries: 0 }
+      })
+    );
+    writeFileSync(
+      join(agent, "fallback.json"),
+      JSON.stringify({ enabled: true, fallback_models: ["cliproxyapi/free"] })
+    );
+    writeFileSync(
+      join(agent, "models.json"),
+      JSON.stringify({
+        providers: {
+          cliproxyapi: {
+            baseUrl: `http://127.0.0.1:${server.port}/v1`,
+            apiKey: "test-dummy",
+            api,
+            models: ["primary", "free"].map((id) => ({
+              id,
+              reasoning: false,
+              input: ["text"],
+              contextWindow: 131072,
+              maxTokens: 100
+            }))
+          }
+        }
+      })
+    );
+    const child = Bun.spawn(
+      [
+        process.execPath,
+        resolve(
+          "node_modules/@earendil-works/pi-coding-agent/dist/bundle/cli.js"
+        ),
+        "--offline",
+        "--no-session",
+        "--no-tools",
+        "--no-extensions",
+        "--no-skills",
+        "--no-context-files",
+        "-e",
+        resolve("config/pi/fallback.ts"),
+        "-p",
+        "Reply OK"
+      ],
+      {
+        cwd: testHome,
+        env: { ...process.env, HOME: testHome, PI_CODING_AGENT_DIR: agent },
+        stdout: "pipe",
+        stderr: "pipe"
+      }
+    );
+    const timer = setTimeout(() => child.kill(), 15000);
+    try {
+      const [stdout, stderr, status] = await Promise.all([
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+        child.exited
+      ]);
+      return { stdout, stderr, status, requests };
+    } finally {
+      clearTimeout(timer);
+    }
+  } finally {
+    server.stop(true);
+    rmSync(testHome, { recursive: true, force: true });
+  }
+}
+
+test("a failed primary falls back to free and finishes the prompt", async () => {
+  const result = await runScenario("primary", false, 0);
+  expect(result.requests).toEqual(["primary", "free"]);
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain("OK");
+}, 20000);
+
+test("a transient failure on free retries free and finishes", async () => {
+  const result = await runScenario("free", true, 1);
+  expect(result.requests).toEqual(["free", "free"]);
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain("OK");
+}, 20000);
+
+test("completion API errors also fall back to free", async () => {
+  const result = await runScenario("primary", false, 0, "openai-completions");
+  expect(result.requests).toEqual(["primary", "free"]);
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain("OK");
+}, 20000);
+
+test("permanent free failure stops at the native retry budget", async () => {
+  const result = await runScenario("free", true, 1, "openai-responses", true);
+  expect(result.requests).toEqual(["free", "free"]);
+  expect(result.status).toBe(1);
+  expect(result.stderr).toContain("504");
+}, 20000);
+
+test("non-retryable primary errors do not trigger fallback", async () => {
+  const result = await runScenario(
+    "primary",
+    false,
+    0,
+    "openai-responses",
+    false,
+    400
+  );
+  expect(result.requests).toEqual(["primary"]);
+  expect(result.status).toBe(1);
+}, 20000);
+
+test("fallback cooperates with enabled native retries", async () => {
+  const result = await runScenario("primary", false, 3);
+  expect(result.requests).toEqual(["primary", "free"]);
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain("OK");
+}, 20000);


### PR DESCRIPTION
Pi skipped fallback for OpenAI HTTP failures because the SDK throws before the `after_provider_response` event. Recognize the HTTP status in SDK error messages and clear the previous request's status before each request. A retryable primary failure now selects `cliproxyapi/free` and continues the prompt.

The default and only fallback target remain `cliproxyapi/free`. Transient errors on `free` use Pi's existing bounded native retry policy. The existing Home Manager declaration installs the corrected handler.

Validation:
- A real Pi CLI regression reproduced the missing fallback before this change.
- Seven focused tests pass, covering Responses and Completions failures, free-only retry, bounded exhaustion, non-retryable errors, stale status, and cooperation with native retries.
- Six tests also pass against Kyber's installed Pi 0.85.0; the additional native-retry interaction check passes locally.
- Focused TypeScript validation and all 105 model configuration checks pass.

The handler is applied to Kyber's source and runtime. Upstream HTTP timeouts can still occur; this change repairs fallback handling rather than provider availability.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Pi's fallback so OpenAI SDK HTTP failures now route to `cliproxyapi/free` instead of erroring out. The SDK throws before the `after_provider_response` event, so the fallback policy now parses the HTTP status from the error message and clears the previous request's status before each request.

- Retryable primary failures now continue the prompt on the free model.
- Adds runtime tests covering Responses and Completions failures, retries, exhaustion, non-retryable errors, and stale status.

<sup>Written for commit 20ed5f45fc21e0ff2a9bd06aaa9de4fe5820ebe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

