### PR TITLE
fix(dolt): route Kyber federation over loopback

### DIFF
--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -34,10 +34,12 @@ let
   # spoke push is a native transfer rather than a git subprocess tree that a
   # disconnected client leaves orphaned on the server.
   federationHubEnabled = publisherEnabled;
-  federationHubHost = "kyber.tail950b36.ts.net";
   federationRemotesApiPort = 3308;
-  federationHubUrl = "http://${federationHubHost}:${toString federationRemotesApiPort}";
   doltServerHost = "127.0.0.1";
+  # Kyber reaches its own remotesapi over loopback so self-federation does not
+  # depend on MagicDNS. Spokes still reach Kyber through its tailnet address.
+  federationHubHost = if federationHubEnabled then doltServerHost else "kyber.tail950b36.ts.net";
+  federationHubUrl = "http://${federationHubHost}:${toString federationRemotesApiPort}";
   beadsClientEnvironment = {
     BEADS_DOLT_AUTO_START = "0";
     BEADS_DOLT_SERVER_MODE = "1";
@@ -94,8 +96,6 @@ let
     BEADS_DOLT_SERVER_USER = "root";
     DOLT_CLI_USER = "root";
     DOLT_CLI_PASSWORD = "";
-  }
-  // lib.optionalAttrs (!federationHubEnabled) {
     BEADS_FEDERATION_HUB = federationHubUrl;
   };
 in

--- a/spec/beads_federation_sync_spec.sh
+++ b/spec/beads_federation_sync_spec.sh
@@ -143,7 +143,7 @@ The status should be success
 End
 
 It 'federates every client host and publishes only from Kyber'
-When run bash -c "grep -F 'federationSyncEnabled = clientEnabled;' '$MODULE' >/dev/null && grep -F 'publisherEnabled = isKyber;' '$MODULE' >/dev/null && ! grep -F 'dolt-backup-main = lib.mkIf (pkgs.stdenv.isLinux && serverEnabled)' '$MODULE' >/dev/null && ! grep -F 'dolt-backup-main = lib.mkIf (pkgs.stdenv.isDarwin && serverEnabled)' '$MODULE' >/dev/null"
+When run bash -c "grep -F 'federationSyncEnabled = clientEnabled;' '$MODULE' >/dev/null && grep -F 'publisherEnabled = isKyber;' '$MODULE' >/dev/null && grep -F 'federationHubHost = if federationHubEnabled then doltServerHost else \"kyber.tail950b36.ts.net\";' '$MODULE' >/dev/null && grep -F 'BEADS_FEDERATION_HUB = federationHubUrl;' '$MODULE' >/dev/null && ! grep -F 'dolt-backup-main = lib.mkIf (pkgs.stdenv.isLinux && serverEnabled)' '$MODULE' >/dev/null && ! grep -F 'dolt-backup-main = lib.mkIf (pkgs.stdenv.isDarwin && serverEnabled)' '$MODULE' >/dev/null"
 The status should be success
 End
 

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -90,6 +90,8 @@ let
           username = "shunkakinoki";
         };
         cfg = matic.config;
+        federationEnvironment =
+          cfg.home-manager.users.shunkakinoki.systemd.user.services.dolt-federation-sync.Service.Environment;
       in
       assert
         cfg.services.tailscale.extraSetFlags == [
@@ -100,6 +102,7 @@ let
           "--ssh"
         ];
       assert lib.hasInfix "tailscale set" cfg.system.activationScripts.tailscalePreferences.text;
+      assert lib.elem "BEADS_FEDERATION_HUB=http://kyber.tail950b36.ts.net:3308" federationEnvironment;
       mkEvalCheck "nixos-matic" cfg.system.build.toplevel;
 
     eval-nixos-viper =
@@ -260,6 +263,7 @@ let
             username = "ubuntu";
             system = "x86_64-linux";
           };
+          federationEnvironment = kyber.config.systemd.user.services.dolt-federation-sync.Service.Environment;
         in
         assert
           kyber.config.modules.tailscale.extraUpArgs == [
@@ -268,6 +272,7 @@ let
             "--accept-dns=false"
             "--advertise-exit-node"
           ];
+        assert lib.elem "BEADS_FEDERATION_HUB=http://127.0.0.1:3308" federationEnvironment;
         mkEvalCheck "home-kyber" kyber.activationPackage;
     };
 in


### PR DESCRIPTION
### Summary

Persist the working Kyber federation self-route in Home Manager. Kyber now reaches its own Dolt remotesapi over loopback instead of depending on MagicDNS, while spoke hosts continue to use the tailnet FQDN.

### Tracker linkage
- Linear: none — the recovery was tracked directly in Beads
- Bead: shunkakinokisoftware-l3r8

### Before / after

| Surface | Before | After |
| --- | --- | --- |
| Kyber federation sync | Fell back to the repository remote unless a machine-local dotenv override supplied the self-route | Receives `http://127.0.0.1:3308` declaratively |
| Matic federation sync | Uses Kyber through the tailnet FQDN | Unchanged |

### Breaking and irreversible changes

- Behavioral: Kyber federation sync targets its local remotesapi endpoint. Reversible by reverting this commit.
- Compile-time: None.
- Durable state and rollback: No schema or persisted-state migration. Revert restores the previous endpoint selection.

### Deliberate boundaries

- Does not change Dolt authentication, listening interfaces, firewall policy, off-site publication, or repository scope.
- Does not activate Home Manager on Kyber; deployment remains a separate operator action after merge.

### Verification

- `shellspec spec/beads_federation_sync_spec.sh` — 14 examples, 0 failures.
- `nixfmt --check home-manager/services/dolt/default.nix tests/eval.nix` — passed.
- Direct Kyber Nix evaluation — `BEADS_FEDERATION_HUB=http://127.0.0.1:3308`.
- Direct Matic Nix evaluation — `BEADS_FEDERATION_HUB=http://kyber.tail950b36.ts.net:3308`.
- `make shell-inline-check` — passed.
- `git diff --check origin/main...HEAD` — passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Kyber's federation sync over loopback so Kyber no longer depends on MagicDNS to reach its own Dolt remotesapi. Spoke hosts still use the tailnet FQDN, and Matic is unchanged.

**Changes**
- Sets `federationHubHost` to `127.0.0.1` when federation is enabled, otherwise keeps the tailnet FQDN for spokes.
- `BEADS_FEDERATION_HUB` is now always derived from `federationHubUrl` instead of being conditionally overridden.
- Adds eval assertions that Kyber gets the loopback URL and Matic gets the tailnet URL.
- Updates the federation spec to assert the new host selection logic.

<sup>Written for commit f519f5b64991e89ee22003da9dbe4e0be3cb9128. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

