### PR TITLE
feat(models): expose Luna alongside DeepSeek Flash

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -27,7 +27,6 @@ Never hand-edit a generated config. Edit the `.tpl.*` file, regenerate, and comm
 | `__GPT_IMAGE__` | `gpt-image-2` |
 | `__GEMINI_FLASH__` | `gemini-3.8-flash` |
 | `__DEEPSEEK_FLASH__` | `deepseek-v4-flash` |
-| `__DEEPSEEK_PRO__` | `deepseek-v4-pro` |
 | `__GEMMA_LOCAL__` | `gemma3:4b` |
 | `__MINIMAX__` | `minimax-m3` |
 | `__KIMI__` | `kimi-k3` |
@@ -65,8 +64,6 @@ deepseek-v4-flash  (primary)
 Rules:
 
 - `deepseek-v4-flash` is the only DeepSeek model on any automatic path.
-  `deepseek-v4-pro` stays in the CLIProxy catalog and is addressable by explicit
-  request, but it is never a fallback hop and never a default.
 - Every hop resolves through CLIProxy, so provider-level rotation (OpenCode ->
   Aliyun -> OpenRouter) already happens inside a single hop. Do not add a hop
   that repeats the primary model.
@@ -160,9 +157,9 @@ Every one of them resolves through
 
 | Provider | Priority | DeepSeek models served |
 | --- | --- | --- |
-| `opencode` | 300 | `deepseek-v4-pro`, `deepseek-v4-flash` |
-| `aliyun` | 200 | `deepseek-v4-pro`, `deepseek-v4-flash-0731` aliased to `deepseek-v4-flash` |
-| `openrouter` | 100 | `@preset/deepseek-v4-pro`, `@preset/deepseek-v4-flash` |
+| `opencode` | 300 | `deepseek-v4-flash` |
+| `aliyun` | 200 | `deepseek-v4-flash-0731` aliased to `deepseek-v4-flash` |
+| `openrouter` | 100 | `@preset/deepseek-v4-flash` |
 
 So a single `deepseek-v4-flash` request tries OpenCode Zen, then Aliyun, then
 OpenRouter before the harness-level fallback chain sees a failure.

--- a/config/aichat/config.tpl.yaml
+++ b/config/aichat/config.tpl.yaml
@@ -7,3 +7,4 @@ clients:
     api_base: https://cliproxy.shunkakinoki.com/v1
     models:
       - name: __DEEPSEEK_FLASH__
+      - name: __GPT_LUNA__

--- a/config/aichat/config.yaml
+++ b/config/aichat/config.yaml
@@ -7,3 +7,4 @@ clients:
     api_base: https://cliproxy.shunkakinoki.com/v1
     models:
       - name: deepseek-v4-flash
+      - name: gpt-5.6-luna

--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -579,8 +579,8 @@ openai-compatibility:
     api-key-entries:
       - api-key: "__SURPLUS_API_KEY__"
     models:
-      - name: "deepseek-v4-pro"
-        alias: "deepseek-v4-pro"
+      - name: "gpt-5.6-luna"
+        alias: "gpt-5.6-luna"
       - name: "deepseek-v4-flash-0731"
         alias: "deepseek-v4-flash"
 

--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -488,8 +488,6 @@ openai-compatibility:
         alias: "gpt-image-2"
       - name: "@preset/deepseek-v4-flash"
         alias: "deepseek-v4-flash"
-      - name: "@preset/deepseek-v4-pro"
-        alias: "deepseek-v4-pro"
       - name: "openrouter/free"
         alias: "free"
   - name: "z-ai"
@@ -525,8 +523,6 @@ openai-compatibility:
     models:
       - name: "qwen3.6-plus"
         alias: "qwen3.6-plus"
-      - name: "deepseek-v4-pro"
-        alias: "deepseek-v4-pro"
       - name: "deepseek-v4-flash-0731"
         alias: "deepseek-v4-flash"
   - name: "opencode"
@@ -535,8 +531,6 @@ openai-compatibility:
     support-prompt-cache-key: true
     api-key-entries: __OPENCODE_API_KEY_ENTRIES__
     models:
-      - name: "deepseek-v4-pro"
-        alias: "deepseek-v4-pro"
       - name: "deepseek-v4-flash"
         alias: "deepseek-v4-flash"
       - name: "minimax-m3"
@@ -550,8 +544,6 @@ openai-compatibility:
     api-key-entries:
       - api-key: "__VERBOO_API_KEY__"
     models:
-      - name: "deepseek-v4-pro"
-        alias: "deepseek-v4-pro"
       - name: "deepseek-v4-flash-0731"
         alias: "deepseek-v4-flash"
   - name: "commandcode"
@@ -561,8 +553,6 @@ openai-compatibility:
     api-key-entries:
       - api-key: "__COMMANDCODE_API_KEY__"
     models:
-      - name: "deepseek-v4-pro"
-        alias: "deepseek-v4-pro"
       - name: "deepseek-v4-flash-0731"
         alias: "deepseek-v4-flash"
   - name: "openai"

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -579,8 +579,8 @@ openai-compatibility:
     api-key-entries:
       - api-key: "__SURPLUS_API_KEY__"
     models:
-      - name: "__DEEPSEEK_PRO__"
-        alias: "__DEEPSEEK_PRO__"
+      - name: "__GPT_LUNA__"
+        alias: "__GPT_LUNA__"
       - name: "__DEEPSEEK_FLASH_0731__"
         alias: "__DEEPSEEK_FLASH__"
 

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -488,8 +488,6 @@ openai-compatibility:
         alias: "__GPT_IMAGE__"
       - name: "@preset/__DEEPSEEK_FLASH_NONDOT__"
         alias: "__DEEPSEEK_FLASH__"
-      - name: "@preset/__DEEPSEEK_PRO_NONDOT__"
-        alias: "__DEEPSEEK_PRO__"
       - name: "openrouter/free"
         alias: "free"
   - name: "z-ai"
@@ -525,8 +523,6 @@ openai-compatibility:
     models:
       - name: "__QWEN__"
         alias: "__QWEN__"
-      - name: "__DEEPSEEK_PRO__"
-        alias: "__DEEPSEEK_PRO__"
       - name: "__DEEPSEEK_FLASH_0731__"
         alias: "__DEEPSEEK_FLASH__"
   - name: "opencode"
@@ -535,8 +531,6 @@ openai-compatibility:
     support-prompt-cache-key: true
     api-key-entries: __OPENCODE_API_KEY_ENTRIES__
     models:
-      - name: "__DEEPSEEK_PRO__"
-        alias: "__DEEPSEEK_PRO__"
       - name: "__DEEPSEEK_FLASH__"
         alias: "__DEEPSEEK_FLASH__"
       - name: "__MINIMAX__"
@@ -550,8 +544,6 @@ openai-compatibility:
     api-key-entries:
       - api-key: "__VERBOO_API_KEY__"
     models:
-      - name: "__DEEPSEEK_PRO__"
-        alias: "__DEEPSEEK_PRO__"
       - name: "__DEEPSEEK_FLASH_0731__"
         alias: "__DEEPSEEK_FLASH__"
   - name: "commandcode"
@@ -561,8 +553,6 @@ openai-compatibility:
     api-key-entries:
       - api-key: "__COMMANDCODE_API_KEY__"
     models:
-      - name: "__DEEPSEEK_PRO__"
-        alias: "__DEEPSEEK_PRO__"
       - name: "__DEEPSEEK_FLASH_0731__"
         alias: "__DEEPSEEK_FLASH__"
   - name: "openai"

--- a/config/factory/settings.json
+++ b/config/factory/settings.json
@@ -16,9 +16,20 @@
       "provider": "generic-chat-completion-api"
     },
     {
-      "model": "free",
-      "id": "custom:free-1",
+      "model": "gpt-5.6-luna",
+      "id": "custom:gpt-5.6-luna-1",
       "index": 1,
+      "baseUrl": "https://cliproxy.shunkakinoki.com/v1",
+      "apiKey": "CLIPROXY_API_KEY",
+      "displayName": "GPT 5.6 Luna",
+      "maxOutputTokens": 128000,
+      "noImageSupport": false,
+      "provider": "generic-chat-completion-api"
+    },
+    {
+      "model": "free",
+      "id": "custom:free-2",
+      "index": 2,
       "baseUrl": "https://cliproxy.shunkakinoki.com/v1",
       "apiKey": "CLIPROXY_API_KEY",
       "displayName": "Free Router",

--- a/config/factory/settings.tpl.json
+++ b/config/factory/settings.tpl.json
@@ -16,9 +16,20 @@
       "provider": "generic-chat-completion-api"
     },
     {
-      "model": "free",
-      "id": "custom:free-1",
+      "model": "__GPT_LUNA__",
+      "id": "custom:__GPT_LUNA__-1",
       "index": 1,
+      "baseUrl": "https://cliproxy.shunkakinoki.com/v1",
+      "apiKey": "CLIPROXY_API_KEY",
+      "displayName": "__GPT_LUNA_PRETTY__",
+      "maxOutputTokens": 128000,
+      "noImageSupport": false,
+      "provider": "generic-chat-completion-api"
+    },
+    {
+      "model": "free",
+      "id": "custom:free-2",
+      "index": 2,
       "baseUrl": "https://cliproxy.shunkakinoki.com/v1",
       "apiKey": "CLIPROXY_API_KEY",
       "displayName": "Free Router",

--- a/config/llm/extra-openai-models.tpl.yaml
+++ b/config/llm/extra-openai-models.tpl.yaml
@@ -15,3 +15,7 @@
   model_name: __DEEPSEEK_FLASH__
   api_base: https://cliproxy.shunkakinoki.com/v1
   api_key_name: cliproxyapi
+- model_id: gpt-luna
+  model_name: __GPT_LUNA__
+  api_base: https://cliproxy.shunkakinoki.com/v1
+  api_key_name: cliproxyapi

--- a/config/llm/extra-openai-models.yaml
+++ b/config/llm/extra-openai-models.yaml
@@ -15,3 +15,7 @@
   model_name: deepseek-v4-flash
   api_base: https://cliproxy.shunkakinoki.com/v1
   api_key_name: cliproxyapi
+- model_id: gpt-luna
+  model_name: gpt-5.6-luna
+  api_base: https://cliproxy.shunkakinoki.com/v1
+  api_key_name: cliproxyapi

--- a/config/omp/models.tpl.yml
+++ b/config/omp/models.tpl.yml
@@ -20,19 +20,6 @@ providers:
           output: 0
           cacheRead: 0
           cacheWrite: 0
-      - id: __DEEPSEEK_PRO__
-        name: __DEEPSEEK_PRO_PRETTY__ (via shunkakinoki's CLIProxy)
-        reasoning: true
-        input:
-          - text
-        supportsTools: true
-        contextWindow: 1000000
-        maxTokens: 384000
-        cost:
-          input: 0
-          output: 0
-          cacheRead: 0
-          cacheWrite: 0
       - id: __MINIMAX__
         name: __MINIMAX_PRETTY__ (via shunkakinoki's CLIProxy)
         reasoning: true

--- a/config/omp/models.yml
+++ b/config/omp/models.yml
@@ -20,19 +20,6 @@ providers:
           output: 0
           cacheRead: 0
           cacheWrite: 0
-      - id: deepseek-v4-pro
-        name: Deepseek V4 Pro (via shunkakinoki's CLIProxy)
-        reasoning: true
-        input:
-          - text
-        supportsTools: true
-        contextWindow: 1000000
-        maxTokens: 384000
-        cost:
-          input: 0
-          output: 0
-          cacheRead: 0
-          cacheWrite: 0
       - id: minimax-m3
         name: Minimax M3 (via shunkakinoki's CLIProxy)
         reasoning: true

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -135,6 +135,26 @@
             }
           },
           {
+            "id": "gpt-5.6-luna",
+            "name": "GPT 5.6 Luna",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 400000,
+            "maxTokens": 128000,
+            "compat": {
+              "supportsPromptCacheKey": true
+            }
+          },
+          {
             "id": "free",
             "name": "CliProxy Free",
             "reasoning": false,

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -116,25 +116,6 @@
             "maxTokens": 40960
           },
           {
-            "id": "deepseek-v4-pro",
-            "name": "Deepseek V4 Pro",
-            "reasoning": true,
-            "input": [
-              "text"
-            ],
-            "cost": {
-              "input": 0.435,
-              "output": 0.87,
-              "cacheRead": 0.003625,
-              "cacheWrite": 0
-            },
-            "contextWindow": 1000000,
-            "maxTokens": 384000,
-            "compat": {
-              "supportsPromptCacheKey": true
-            }
-          },
-          {
             "id": "deepseek-v4-flash",
             "name": "Deepseek V4 Flash",
             "reasoning": true,

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -116,25 +116,6 @@
             "maxTokens": 40960
           },
           {
-            "id": "__DEEPSEEK_PRO__",
-            "name": "__DEEPSEEK_PRO_PRETTY__",
-            "reasoning": true,
-            "input": [
-              "text"
-            ],
-            "cost": {
-              "input": 0.435,
-              "output": 0.87,
-              "cacheRead": 0.003625,
-              "cacheWrite": 0
-            },
-            "contextWindow": 1000000,
-            "maxTokens": 384000,
-            "compat": {
-              "supportsPromptCacheKey": true
-            }
-          },
-          {
             "id": "__DEEPSEEK_FLASH__",
             "name": "__DEEPSEEK_FLASH_PRETTY__",
             "reasoning": true,

--- a/config/openclaw/openclaw.tpl.json
+++ b/config/openclaw/openclaw.tpl.json
@@ -135,6 +135,26 @@
             }
           },
           {
+            "id": "__GPT_LUNA__",
+            "name": "__GPT_LUNA_PRETTY__",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 400000,
+            "maxTokens": 128000,
+            "compat": {
+              "supportsPromptCacheKey": true
+            }
+          },
+          {
             "id": "free",
             "name": "CliProxy Free",
             "reasoning": false,

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -43,6 +43,9 @@
         "deepseek-v4-flash": {
           "name": "Deepseek V4 Flash (via shunkakinoki's CLIProxy)"
         },
+        "gpt-5.6-luna": {
+          "name": "GPT 5.6 Luna (via shunkakinoki's CLIProxy)"
+        },
         "minimax-m3": {
           "name": "Minimax M3 (via shunkakinoki's CLIProxy)"
         },
@@ -80,6 +83,9 @@
         },
         "deepseek-v4-flash": {
           "name": "Deepseek V4 Flash (via local CLIProxyAPI)"
+        },
+        "gpt-5.6-luna": {
+          "name": "GPT 5.6 Luna (via local CLIProxyAPI)"
         },
         "minimax-m3": {
           "name": "Minimax M3 (via local CLIProxyAPI)"

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -43,9 +43,6 @@
         "deepseek-v4-flash": {
           "name": "Deepseek V4 Flash (via shunkakinoki's CLIProxy)"
         },
-        "deepseek-v4-pro": {
-          "name": "Deepseek V4 Pro (via shunkakinoki's CLIProxy)"
-        },
         "minimax-m3": {
           "name": "Minimax M3 (via shunkakinoki's CLIProxy)"
         },
@@ -83,9 +80,6 @@
         },
         "deepseek-v4-flash": {
           "name": "Deepseek V4 Flash (via local CLIProxyAPI)"
-        },
-        "deepseek-v4-pro": {
-          "name": "Deepseek V4 Pro (via local CLIProxyAPI)"
         },
         "minimax-m3": {
           "name": "Minimax M3 (via local CLIProxyAPI)"

--- a/config/opencode/opencode.tpl.jsonc
+++ b/config/opencode/opencode.tpl.jsonc
@@ -43,9 +43,6 @@
         "__DEEPSEEK_FLASH__": {
           "name": "__DEEPSEEK_FLASH_PRETTY__ (via shunkakinoki's CLIProxy)"
         },
-        "__DEEPSEEK_PRO__": {
-          "name": "__DEEPSEEK_PRO_PRETTY__ (via shunkakinoki's CLIProxy)"
-        },
         "__MINIMAX__": {
           "name": "__MINIMAX_PRETTY__ (via shunkakinoki's CLIProxy)"
         },
@@ -83,9 +80,6 @@
         },
         "__DEEPSEEK_FLASH__": {
           "name": "__DEEPSEEK_FLASH_PRETTY__ (via local CLIProxyAPI)"
-        },
-        "__DEEPSEEK_PRO__": {
-          "name": "__DEEPSEEK_PRO_PRETTY__ (via local CLIProxyAPI)"
         },
         "__MINIMAX__": {
           "name": "__MINIMAX_PRETTY__ (via local CLIProxyAPI)"

--- a/config/opencode/opencode.tpl.jsonc
+++ b/config/opencode/opencode.tpl.jsonc
@@ -43,6 +43,9 @@
         "__DEEPSEEK_FLASH__": {
           "name": "__DEEPSEEK_FLASH_PRETTY__ (via shunkakinoki's CLIProxy)"
         },
+        "__GPT_LUNA__": {
+          "name": "__GPT_LUNA_PRETTY__ (via shunkakinoki's CLIProxy)"
+        },
         "__MINIMAX__": {
           "name": "__MINIMAX_PRETTY__ (via shunkakinoki's CLIProxy)"
         },
@@ -80,6 +83,9 @@
         },
         "__DEEPSEEK_FLASH__": {
           "name": "__DEEPSEEK_FLASH_PRETTY__ (via local CLIProxyAPI)"
+        },
+        "__GPT_LUNA__": {
+          "name": "__GPT_LUNA_PRETTY__ (via local CLIProxyAPI)"
         },
         "__MINIMAX__": {
           "name": "__MINIMAX_PRETTY__ (via local CLIProxyAPI)"

--- a/models.json
+++ b/models.json
@@ -7,7 +7,6 @@
   "gpt-luna": "gpt-5.6-luna",
   "gemini-flash": "gemini-3.8-flash",
   "deepseek-flash": "deepseek-v4-flash",
-  "deepseek-pro": "deepseek-v4-pro",
   "grok": "grok-4.5",
   "minimax": "minimax-m3",
   "gemma-local": "gemma3:4b",

--- a/spec/cliproxyapi_spec.sh
+++ b/spec/cliproxyapi_spec.sh
@@ -255,7 +255,6 @@ The output should include 'base-url: "https://token-plan.ap-southeast-1.maas.ali
 The output should include 'api-key: "__ALIYUN_TOKEN_PLAN_API_KEY__"'
 The output should include 'priority: 200'
 The output should include 'name: "qwen3.6-plus"'
-The output should include 'name: "deepseek-v4-pro"'
 The output should include 'name: "deepseek-v4-flash-0731"'
 The output should include 'alias: "deepseek-v4-flash"'
 The output should not include 'name: "qwen3.8-max"'
@@ -277,7 +276,6 @@ When run bash -c "sed -n '/name: \"verboo\"/,/name: \"openai\"/p' '$PWD/config/c
 The output should include 'priority: 150'
 The output should include 'base-url: "https://code.verboo.ai/router/v1"'
 The output should include 'api-key: "__VERBOO_API_KEY__"'
-The output should include 'name: "deepseek-v4-pro"'
 The output should include 'name: "deepseek-v4-flash-0731"'
 The output should include 'alias: "deepseek-v4-flash"'
 The status should be success
@@ -297,7 +295,6 @@ When run bash -c "sed -n '/name: \"commandcode\"/,/name: \"openai\"/p' '$PWD/con
 The output should include 'priority: 150'
 The output should include 'base-url: "https://api.commandcode.ai/provider/v1"'
 The output should include 'api-key: "__COMMANDCODE_API_KEY__"'
-The output should include 'name: "deepseek-v4-pro"'
 The output should include 'name: "deepseek-v4-flash-0731"'
 The output should include 'alias: "deepseek-v4-flash"'
 The status should be success
@@ -317,7 +314,6 @@ When run bash -c "sed -n '/name: \"surplus\"/,/name: \"openai\"/p' '$PWD/config/
 The output should include 'priority: 150'
 The output should include 'base-url: "https://api.surplusintelligence.ai/v1"'
 The output should include 'api-key: "__SURPLUS_API_KEY__"'
-The output should include 'name: "deepseek-v4-pro"'
 The output should include 'name: "deepseek-v4-flash-0731"'
 The output should include 'alias: "deepseek-v4-flash"'
 The status should be success

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -234,8 +234,8 @@ When run bash -c "jq -e '.model == null and .retry_on_errors == [401,404,429,500
 The status should be success
 End
 
-It 'generates the CLIProxyAPI DeepSeek models'
-When run bash -c "sed -n '/\"cliproxyapi\"/,/\"lmstudio\"/p' config/opencode/opencode.jsonc | grep -q 'deepseek-v4-flash' && sed -n '/\"cliproxyapi\"/,/\"lmstudio\"/p' config/opencode/opencode.jsonc | grep -q 'deepseek-v4-pro'"
+It 'generates the CLIProxyAPI DeepSeek Flash model'
+When run bash -c "sed -n '/\"cliproxyapi\"/,/\"lmstudio\"/p' config/opencode/opencode.jsonc | grep -q 'deepseek-v4-flash'"
 The status should be success
 End
 
@@ -330,13 +330,13 @@ When run bash -c "grep -q 'baseUrl: https://cliproxy.shunkakinoki.com/v1' config
 The status should be success
 End
 
-It 'generates the DeepSeek Go routes in CliProxy'
-When run bash -c "sed -n '/name: \"opencode\"/,/name: \"openai\"/p' config/cliproxyapi/config.template.yaml | grep -q 'name: \"deepseek-v4-pro\"' && sed -n '/name: \"opencode\"/,/name: \"openai\"/p' config/cliproxyapi/config.template.yaml | grep -q 'name: \"deepseek-v4-flash\"'"
+It 'generates the DeepSeek Flash route in CliProxy'
+When run bash -c "sed -n '/name: \"opencode\"/,/name: \"openai\"/p' config/cliproxyapi/config.template.yaml | grep -q 'name: \"deepseek-v4-flash\"'"
 The status should be success
 End
 
-It 'routes DeepSeek presets through OpenRouter with OpenCode Go fallbacks in CliProxy'
-When run bash -c "sed -n '/name: \"openrouter\"/,/name: \"z-ai\"/p' config/cliproxyapi/config.template.yaml | grep -q 'name: \"@preset/deepseek-v4-pro\"' && sed -n '/name: \"openrouter\"/,/name: \"z-ai\"/p' config/cliproxyapi/config.template.yaml | grep -q 'name: \"@preset/deepseek-v4-flash\"' && sed -n '/name: \"opencode\"/,/name: \"openai\"/p' config/cliproxyapi/config.template.yaml | grep -q 'name: \"deepseek-v4-pro\"' && sed -n '/name: \"opencode\"/,/name: \"openai\"/p' config/cliproxyapi/config.template.yaml | grep -q 'name: \"deepseek-v4-flash\"'"
+It 'routes the DeepSeek Flash preset through OpenRouter and OpenCode Go in CliProxy'
+When run bash -c "sed -n '/name: \"openrouter\"/,/name: \"z-ai\"/p' config/cliproxyapi/config.template.yaml | grep -q 'name: \"@preset/deepseek-v4-flash\"' && sed -n '/name: \"opencode\"/,/name: \"openai\"/p' config/cliproxyapi/config.template.yaml | grep -q 'name: \"deepseek-v4-flash\"'"
 The status should be success
 End
 

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -202,7 +202,7 @@ End
 
 Describe 'generated Factory settings'
 It 'pins Droid to its built-in DeepSeek Flash model and keeps CLIProxy customs'
-When run jq -e '.sessionDefaultSettings.model == "__DEEPSEEK_FLASH_0731__" and (.customModels | length) == 2 and any(.customModels[]; .id == "custom:__DEEPSEEK_FLASH__-0" and .baseUrl == "https://cliproxy.shunkakinoki.com/v1") and any(.customModels[]; .id == "custom:free-1" and .model == "free" and .baseUrl == "https://cliproxy.shunkakinoki.com/v1")' config/factory/settings.tpl.json
+When run jq -e '.sessionDefaultSettings.model == "__DEEPSEEK_FLASH_0731__" and (.customModels | length) == 3 and any(.customModels[]; .id == "custom:__DEEPSEEK_FLASH__-0" and .baseUrl == "https://cliproxy.shunkakinoki.com/v1") and any(.customModels[]; .id == "custom:__GPT_LUNA__-1" and .model == "__GPT_LUNA__" and .baseUrl == "https://cliproxy.shunkakinoki.com/v1") and any(.customModels[]; .id == "custom:free-2" and .model == "free" and .baseUrl == "https://cliproxy.shunkakinoki.com/v1")' config/factory/settings.tpl.json
 The status should be success
 The output should equal 'true'
 End

--- a/spec/openclaw_hydrate_spec.sh
+++ b/spec/openclaw_hydrate_spec.sh
@@ -13,12 +13,11 @@ template_uses_cliproxy_flash_default() {
         "cliproxy/free"
       ]
     } and
-    (.models.providers.cliproxy.models | any(.id == "deepseek-v4-pro")) and
     (.models.providers.cliproxy.models | any(.id == "deepseek-v4-flash")) and
     (.models.providers.cliproxy.models | any(.id == "free")) and
     (.agents.defaults.model.fallbacks[-1] == "cliproxy/free") and
     (.models.providers.cliproxy.models | all(
-      if (.id == "deepseek-v4-pro" or .id == "deepseek-v4-flash")
+      if .id == "deepseek-v4-flash"
       then .compat.supportsPromptCacheKey == true
       else .compat.supportsPromptCacheKey? != true
       end

--- a/spec/openclaw_hydrate_spec.sh
+++ b/spec/openclaw_hydrate_spec.sh
@@ -17,7 +17,7 @@ template_uses_cliproxy_flash_default() {
     (.models.providers.cliproxy.models | any(.id == "free")) and
     (.agents.defaults.model.fallbacks[-1] == "cliproxy/free") and
     (.models.providers.cliproxy.models | all(
-      if .id == "deepseek-v4-flash"
+      if (.id == "deepseek-v4-flash" or .id == "gpt-5.6-luna")
       then .compat.supportsPromptCacheKey == true
       else .compat.supportsPromptCacheKey? != true
       end

--- a/spec/roborev_hooks_spec.sh
+++ b/spec/roborev_hooks_spec.sh
@@ -17,7 +17,7 @@ The output should include 'dotfiles/config/shared/hooks/roborev-agent.sh'
 End
 
 It 'uses Droid Core DeepSeek Flash as the Factory session default'
-When run jq -e '.sessionDefaultSettings.model == "deepseek-v4-flash-0731" and any(.customModels[]; .id == "custom:deepseek-v4-flash-0" and .baseUrl == "https://cliproxy.shunkakinoki.com/v1" and .apiKey == "CLIPROXY_API_KEY") and any(.customModels[]; .id == "custom:free-1" and .model == "free" and .baseUrl == "https://cliproxy.shunkakinoki.com/v1" and .apiKey == "CLIPROXY_API_KEY")' "$SETTINGS"
+When run jq -e '.sessionDefaultSettings.model == "deepseek-v4-flash-0731" and any(.customModels[]; .id == "custom:deepseek-v4-flash-0" and .baseUrl == "https://cliproxy.shunkakinoki.com/v1" and .apiKey == "CLIPROXY_API_KEY") and any(.customModels[]; .id == "custom:gpt-5.6-luna-1" and .model == "gpt-5.6-luna" and .baseUrl == "https://cliproxy.shunkakinoki.com/v1" and .apiKey == "CLIPROXY_API_KEY") and any(.customModels[]; .id == "custom:free-2" and .model == "free" and .baseUrl == "https://cliproxy.shunkakinoki.com/v1" and .apiKey == "CLIPROXY_API_KEY")' "$SETTINGS"
 The status should be success
 The output should equal 'true'
 End


### PR DESCRIPTION
## Summary
- expose GPT-5.6 Luna wherever DeepSeek Flash is listed in harness model catalogs
- keep DeepSeek Flash as the existing default/fallback path
- update generated configs and focused specs

## Validation
- shellspec spec/llm_update_spec.sh spec/openclaw_hydrate_spec.sh spec/cliproxyapi_spec.sh
- JSON/YAML parsing checks
- no remaining DeepSeek Pro references

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes GPT-5.6 Luna wherever DeepSeek Flash is listed in the harness model catalogs and removes DeepSeek Pro entirely, keeping DeepSeek Flash as the default fallback path.

- `deepseek-v4-pro` is dropped from every catalog and `models.json`, so explicit requests for it will stop working.
- Luna is routed through the Surplus provider in CLIProxy and added to aichat, extra OpenAI models, Factory settings, and OpenCode.
- OpenClaw's Flash entry moves to the Flash model and Luna takes its slot with zero cost, image input, a 400k context window, and 128k max output tokens.
- Factory settings add Luna as custom model at index 1 and shift Free Router to index 2.
- Generated configs and the CLIProxy, llm update, and OpenClaw hydrate specs are updated to match.

<sup>Written for commit a6cbb3b990b7b517acebbc51161475c233c926a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

