### PR TITLE
fix(dolt): keep large Linear sync progress out of argv

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,12 @@ cp -rf source dest          # NOT: cp -r source dest
 - Do not add a separate global, user-local, curl-installed, or independently auto-updating copy of a CLI that the repository already manages.
 - Use a vendor installer only when the repository does not manage the CLI or the user explicitly requests the standalone installation.
 
+## Durable Configuration and Incident Repair
+
+- Repair one-off host or database incidents directly in place, with appropriate backups and verification.
+- Keep Home Manager configuration and managed scripts focused on durable, declarative behavior and general fixes that prevent recurrence.
+- Do not embed incident-specific migrations, recovery commands, or temporary repair workarounds into recurring services or activation scripts.
+
 ## Repository Privacy Guidance
 
 - Never record private repository names, identifiers, checkout paths, or references in any tracked file, documentation, fixture, example, log, or generated configuration in this repository.

--- a/home-manager/services/dolt/linear-sync.sh
+++ b/home-manager/services/dolt/linear-sync.sh
@@ -447,11 +447,13 @@ fi
 # are skipped; without that, a window larger than the API budget re-pushes the
 # same batches forever and the checkpoint never advances.
 issues_before_pull="$("$bd_cli" -C "$repo_dir" list --all --json --limit 0 --skip-labels)"
-pushed_progress=""
+pushed_progress_input=/dev/null
 if [ -s "$push_progress_file" ]; then
-  pushed_progress="$(<"$push_progress_file")"
+  pushed_progress_input="$push_progress_file"
 fi
-closed_push_entries="$(@jq@/bin/jq -r --arg previous_sync "$previous_sync" --arg pushed "$pushed_progress" '
+# Keep deferred progress content out of jq's argv. The file may contain many
+# batches, so passing it with --arg exceeds Linux's per-argument limit.
+closed_push_entries="$(@jq@/bin/jq -r --arg previous_sync "$previous_sync" --rawfile pushed "$pushed_progress_input" '
   (if type == "object" and has("issues") then .issues else . end)
   | ($pushed | split("\n") | map(select(length > 0))) as $already_pushed
   | [

--- a/spec/beads_linear_sync_spec.sh
+++ b/spec/beads_linear_sync_spec.sh
@@ -76,6 +76,11 @@ When run bash -c "grep -F '@jq@/bin/jq' '$SCRIPT' >/dev/null"
 The status should be success
 End
 
+It 'passes deferred push progress to jq through a bounded file input'
+When run bash -c "grep -F -- '--rawfile pushed' '$SCRIPT' >/dev/null && ! grep -F -- '--arg pushed' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
 It 'supports the current Beads list envelope'
 When run bash -c "grep -F 'if type == \"object\" and has(\"issues\") then .issues else . end' '$SCRIPT' >/dev/null"
 The status should be success
@@ -378,6 +383,24 @@ The output should include 'terminal Beads batch 1/1'
 The contents of file "$COMMAND_LOG" should include 'linear sync --push --issues df-11,df-12 --no-wait'
 The file "$CHECKPOINT_FILE" should be exist
 The file "$progress_file" should not be exist
+End
+
+It 'handles a deferred push progress file larger than 128 KiB'
+mkdir -p "$STATE_HOME/beads-linear-sync"
+progress_file="$STATE_HOME/beads-linear-sync/push-progress-test%2Frepo-one"
+{
+  for progress_index in {1..6000}; do
+    printf 'deferred-%s 2099-01-01T00:00:00Z\n' "$progress_index"
+  done
+  printf '%s\n' 'df-closed 2099-01-01T00:00:00Z'
+} >"$progress_file"
+test "$(wc -c <"$progress_file")" -gt 131072
+When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LIST_JSON='[{"id":"df-closed","status":"closed","updated_at":"2099-01-01T00:00:00Z","external_ref":"https://linear.app/test/issue/TEST-1/closed"}]' XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
+The status should be success
+The output should include 'No terminal Beads to push'
+The output should include 'Pulling complete Linear state'
+The contents of file "$COMMAND_LOG" should not include 'linear sync --push --issues df-closed'
+The file "$CHECKPOINT_FILE" should be exist
 End
 
 It 'fails closed after an ordinary Linear pull failure'


### PR DESCRIPTION
Read deferred Linear push progress with jq --rawfile so files larger than the Linux argument limit no longer prevent inbound sync. Preserve revision deduplication and terminal-before-pull ordering. Add an AGENTS.md rule separating in-place incident recovery from durable Home Manager configuration. Validation: 56 focused ShellSpec examples passed, including a progress file larger than 128 KiB; rendered Bash syntax and git diff --check passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reads deferred Linear push progress with `jq --rawfile` instead of `--arg`, so checkpoints larger than Linux's per-argument limit no longer block inbound sync. Preserves the existing deduplication and terminal-before-pull ordering.

- Adds an `AGENTS.md` rule keeping one-off incident repairs out of durable Home Manager services.
- Adds a ShellSpec example verifying a progress file larger than 128 KiB still syncs correctly.

<sup>Written for commit 638cc017d22cd2685941bbdd06492a1a445954e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

