### PR TITLE
fix(dolt): isolate federation pushes from live Beads tables

### DIFF
--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -12,6 +12,7 @@ let
   legacyBeadsDir = "${repoDir}/.beads";
   sharedServerDir = "${homeDir}/.beads/shared-server";
   beadsDir = "${sharedServerDir}/dolt";
+  federationDir = "${homeDir}/.beads/federation-server/dolt";
   doltManifest = "${beadsDir}/beads_global/.dolt/noms/manifest";
   mirrorDir = "${homeDir}/.cache/beads-jsonl-mirror";
   remoteUrl = "https://github.com/shunkakinoki/beads";
@@ -29,10 +30,9 @@ let
   serverEnabled = clientEnabled;
   # Kyber alone publishes the shared history to the configured remotes.
   publisherEnabled = isKyber;
-  # Kyber is also the federation hub: it serves its databases over Dolt's
-  # remotesapi and every other host syncs against it instead of GitHub, so a
-  # spoke push is a native transfer rather than a git subprocess tree that a
-  # disconnected client leaves orphaned on the server.
+  # Incoming remotesapi pushes replace the receiver's working root, including
+  # ignored tables. Keep that receiver separate from the live Beads database:
+  # every host (including the hub) pulls committed history from this mirror.
   federationHubEnabled = publisherEnabled;
   federationRemotesApiPort = 3308;
   doltServerHost = "127.0.0.1";
@@ -233,8 +233,7 @@ lib.mkIf clientEnabled {
         "BEADS_DOLT_LISTEN_HOST=0.0.0.0"
         "DOLT_CLI_USER=root"
         "DOLT_CLI_PASSWORD="
-      ]
-      ++ lib.optional federationHubEnabled "BEADS_DOLT_REMOTESAPI_PORT=${toString federationRemotesApiPort}";
+      ];
     }
     // lib.optionalAttrs isKyber {
       # DOLT_BACKUP performs the off-site snapshot inside the server process.
@@ -247,6 +246,33 @@ lib.mkIf clientEnabled {
       WantedBy = [ "default.target" ];
     };
   };
+
+  systemd.user.services.dolt-federation-hub =
+    lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && federationHubEnabled)
+      {
+        Unit = {
+          Description = "Dolt committed-history federation mirror";
+          After = [
+            "network.target"
+            "dolt.service"
+          ];
+        };
+        Service = {
+          Type = "simple";
+          ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p ${federationDir}";
+          ExecStart = "${pkgs.dolt}/bin/dolt sql-server -H 0.0.0.0 -P 3309 --data-dir ${federationDir} --remotesapi-port ${toString federationRemotesApiPort}";
+          WorkingDirectory = repoDir;
+          Restart = "always";
+          RestartSec = 5;
+          Environment = [
+            "DOLT_CLI_USER=root"
+            "DOLT_CLI_PASSWORD="
+          ];
+          IOAccounting = true;
+          IOWriteBandwidthMax = "/ 20M";
+        };
+        Install.WantedBy = [ "default.target" ];
+      };
 
   # Persist the same client selection in the user manager so Herdr, OpenClaw,
   # and other systemd-launched agents do not inherit a stale shared-server mode.
@@ -288,10 +314,12 @@ lib.mkIf clientEnabled {
           X-SwitchMethod = "restart";
           After = [
             "dolt.service"
+            "dolt-federation-hub.service"
             "network-online.target"
           ];
           Wants = [
             "dolt.service"
+            "dolt-federation-hub.service"
             "network-online.target"
           ];
         };
@@ -335,11 +363,13 @@ lib.mkIf clientEnabled {
           After = [
             "dolt.service"
             "network-online.target"
-          ];
+          ]
+          ++ lib.optional federationHubEnabled "dolt-federation-hub.service";
           Wants = [
             "dolt.service"
             "network-online.target"
-          ];
+          ]
+          ++ lib.optional federationHubEnabled "dolt-federation-hub.service";
         };
         Service = {
           Type = "oneshot";

--- a/home-manager/services/dolt/start.sh
+++ b/home-manager/services/dolt/start.sh
@@ -57,11 +57,8 @@ server_args=(
   --loglevel info
 )
 
-# The federation hub serves its databases to the other hosts over Dolt's
-# native remotesapi, so a spoke push is one transfer inside this process
-# rather than a git subprocess tree the server cannot cancel.
-if [ -n "${BEADS_DOLT_REMOTESAPI_PORT:-}" ]; then
-  server_args+=(--remotesapi-port "$BEADS_DOLT_REMOTESAPI_PORT")
-fi
+# Never expose the live working database as a push receiver: incoming pushes
+# discard ignored, clone-local tables. A separate federation mirror receives
+# committed history; Beads pulls it while retaining its local working tables.
 
 exec "@dolt@/bin/dolt" sql-server "${server_args[@]}"

--- a/spec/dolt_start_spec.sh
+++ b/spec/dolt_start_spec.sh
@@ -135,6 +135,11 @@ It 'points --data-dir at the beads directory'
 When run bash -c "grep -- '--data-dir' '$SCRIPT'"
 The output should include '--data-dir'
 End
+
+It 'does not expose the live server as a remotes API receiver'
+When run bash -c "! grep -Eq -- 'BEADS_DOLT_REMOTESAPI_PORT|--remotesapi-port' '$SCRIPT'"
+The status should be success
+End
 End
 
 End
@@ -170,5 +175,65 @@ End
 It 'provides an explicit empty DOLT_CLI_PASSWORD in the systemd dolt service environment'
 When run grep -F '"DOLT_CLI_PASSWORD="' "$MODULE"
 The output should include '"DOLT_CLI_PASSWORD="'
+End
+
+It 'does not configure the live service with a remotes API port'
+When run bash -c "! sed -n '/^  systemd.user.services.dolt =/,/^  systemd.user.services.dolt-federation-hub =/p' '$MODULE' | grep -F 'BEADS_DOLT_REMOTESAPI_PORT='"
+The status should be success
+End
+
+It 'keeps the federation mirror in a separate data directory'
+When run grep -F 'federationDir = "${homeDir}/.beads/federation-server/dolt";' "$MODULE"
+The output should include 'federationDir = "${homeDir}/.beads/federation-server/dolt";'
+End
+
+It 'enables the federation mirror only for the Kyber publisher'
+When run bash -c "grep -F 'publisherEnabled = isKyber;' '$MODULE' >/dev/null && grep -F 'federationHubEnabled = publisherEnabled;' '$MODULE' >/dev/null && grep -F 'systemd.user.services.dolt-federation-hub =' '$MODULE' >/dev/null"
+The status should be success
+End
+
+It 'creates the federation data directory before starting the mirror'
+When run grep -F 'ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p ${federationDir}";' "$MODULE"
+The output should include 'ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p ${federationDir}";'
+End
+
+It 'runs the federation mirror on dedicated SQL and remotes API ports'
+When run grep -F 'ExecStart = "${pkgs.dolt}/bin/dolt sql-server -H 0.0.0.0 -P 3309 --data-dir ${federationDir} --remotesapi-port ${toString federationRemotesApiPort}";' "$MODULE"
+The output should include 'ExecStart = "${pkgs.dolt}/bin/dolt sql-server -H 0.0.0.0 -P 3309 --data-dir ${federationDir} --remotesapi-port ${toString federationRemotesApiPort}";'
+End
+
+It 'uses remotes API port 3308 for federation clients'
+When run grep -F 'federationRemotesApiPort = 3308;' "$MODULE"
+The output should include 'federationRemotesApiPort = 3308;'
+End
+
+It 'keeps the federation hub URL on the remotes API port'
+When run grep -F 'federationHubUrl = "http://${federationHubHost}:${toString federationRemotesApiPort}";' "$MODULE"
+The output should include 'federationHubUrl = "http://${federationHubHost}:${toString federationRemotesApiPort}";'
+End
+
+It 'uses the repository as the federation mirror working directory'
+When run bash -c "sed -n '/^  systemd.user.services.dolt-federation-hub =/,/^  systemd.user.services.dolt-backup-main =/p' '$MODULE' | grep -F 'WorkingDirectory = repoDir;'"
+The output should include 'WorkingDirectory = repoDir;'
+End
+
+It 'starts the federation mirror after the network and live Dolt services'
+When run bash -c "sed -n '/^  systemd.user.services.dolt-federation-hub =/,/^  systemd.user.services.dolt-backup-main =/p' '$MODULE' | grep -F '\"network.target\"' >/dev/null && sed -n '/^  systemd.user.services.dolt-federation-hub =/,/^  systemd.user.services.dolt-backup-main =/p' '$MODULE' | grep -F '\"dolt.service\"' >/dev/null"
+The status should be success
+End
+
+It 'limits federation mirror I/O writes to 20M'
+When run bash -c "sed -n '/^  systemd.user.services.dolt-federation-hub =/,/^  systemd.user.services.dolt-backup-main =/p' '$MODULE' | grep -F 'IOWriteBandwidthMax = \"/ 20M\";'"
+The output should include 'IOWriteBandwidthMax = "/ 20M";'
+End
+
+It 'orders and wants the federation mirror before linear sync'
+When run bash -c "sed -n '/^  systemd.user.services.dolt-linear-sync =/,/^  systemd.user.timers.dolt-linear-sync =/p' '$MODULE' | awk '/\"dolt-federation-hub.service\"/ { count++ } END { exit count == 2 ? 0 : 1 }'"
+The status should be success
+End
+
+It 'orders and wants the federation mirror before federation sync'
+When run bash -c "sed -n '/^  systemd.user.services.dolt-federation-sync =/,/^  systemd.user.timers.dolt-federation-sync =/p' '$MODULE' | awk '/\"dolt-federation-hub.service\"/ { count++ } END { exit count == 2 ? 0 : 1 }'"
+The status should be success
 End
 End


### PR DESCRIPTION
## Summary
- Serve incoming federation pushes from a separate committed-history mirror.
- Keep the live Beads SQL server free of remotes API writes so ignored local tables survive.
- Preserve existing client URLs and order reconciliation after the mirror service.
- Keep database seeding and repair as direct operator actions, outside managed recurring scripts.

## Verification
- Reproduced ignored-table loss with an incoming push on Dolt 2.3.1 in a disposable database.
- Verified a consumer pull from the separate mirror preserves the ignored table and receives committed records.
- 105 focused ShellSpec examples passed; ShellCheck, Nix parse, and diff checks passed.
- Home Manager build and live activation verification are in progress.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents incoming federation pushes from replacing ignored, clone-local tables in the live Beads database by serving pushes from a separate committed-history mirror.

**Changes**
- The live Dolt server no longer passes a remotesapi port; a new `dolt-federation-hub` systemd service runs a Dolt SQL server with remotesapi on its own data directory and ports.
- Beads pulls committed records from that mirror, so pushes never touch the live working tables.
- The mirror runs only on the Kyber publisher host, and sync services start after it.
- ShellSpec coverage asserts the live service has no remotesapi listener and the mirror is correctly configured.

<sup>Written for commit 13eef97cc585fa993a8b81bb3fe3597974bf01c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

