### PR TITLE
style(dolt): format Linear result classification

### DIFF
--- a/home-manager/services/dolt/linear-sync.sh
+++ b/home-manager/services/dolt/linear-sync.sh
@@ -185,21 +185,21 @@ run_linear() {
 
   # Only fixed categories leave this boundary, never source error strings.
   case "$output" in
-    *"searching local issues"*) category="local-read" ;;
-    *"building state cache"*) category="state-cache" ;;
-    *"batch pushing issues"*) category="batch-push" ;;
-    *"context deadline exceeded"* | *"context canceled"*) category="context-timeout" ;;
-    *"lock wait timeout"* | *"deadlock"*) category="database-lock" ;;
-    *) category="unclean-result" ;;
+  *"searching local issues"*) category="local-read" ;;
+  *"building state cache"*) category="state-cache" ;;
+  *"batch pushing issues"*) category="batch-push" ;;
+  *"context deadline exceeded"* | *"context canceled"*) category="context-timeout" ;;
+  *"lock wait timeout"* | *"deadlock"*) category="database-lock" ;;
+  *) category="unclean-result" ;;
   esac
   case "${output,,}" in
-    *"rate limit"* | *"too many requests"*) cause="rate-limit" ;;
-    *"deadline exceeded"* | *"timeout"* | *"context canceled"*) cause="timeout" ;;
-    *"connection"* | *"broken pipe"* | *"unexpected eof"* | *"no such host"*) cause="connection" ;;
-    *"deadlock"* | *"lock wait"* | *"transaction conflict"*) cause="database-lock" ;;
-    *"not found"* | *"not exist"*) cause="not-found" ;;
-    *"unauthorized"* | *"forbidden"* | *"authentication"*) cause="authentication" ;;
-    *) cause="unknown" ;;
+  *"rate limit"* | *"too many requests"*) cause="rate-limit" ;;
+  *"deadline exceeded"* | *"timeout"* | *"context canceled"*) cause="timeout" ;;
+  *"connection"* | *"broken pipe"* | *"unexpected eof"* | *"no such host"*) cause="connection" ;;
+  *"deadlock"* | *"lock wait"* | *"transaction conflict"*) cause="database-lock" ;;
+  *"not found"* | *"not exist"*) cause="not-found" ;;
+  *"unauthorized"* | *"forbidden"* | *"authentication"*) cause="authentication" ;;
+  *) cause="unknown" ;;
   esac
   if [ "$status" -eq 124 ]; then
     category="command-timeout"


### PR DESCRIPTION
## Summary
Apply the repository shell formatter to the result-classification cases introduced by #2636. This is indentation only, with no behavior change.

## Validation
- shfmt 3.14.0 with repository options (-i 2 -s) reports no changes for the script and regression spec.
- ShellCheck and git diff --check pass.
- The 74-example Linear suite passes again after formatting. The functional head also passed 49 Dolt startup and federation examples.

## Recovery status
A full managed sync completed and wrote a checkpoint. The merged functional fix is built, but activation is not complete: the local safety guard blocked the required service stop, so an operator must perform the switch. No stop occurred and the existing timer remains active.