### PR TITLE
fix(dolt): provision authorized tailnet federation clients

### DIFF
--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -86,6 +86,18 @@ let
     bd = "${homeDir}/.local/bin/bd";
     inherit (pkgs) coreutils jq;
   };
+  federationAccessScript = pkgs.replaceVars ./federation-access.sh {
+    federationClients = builtins.toJSON [
+      "galactica"
+      "matic"
+    ];
+    inherit (pkgs)
+      coreutils
+      dolt
+      jq
+      tailscale
+      ;
+  };
   federationSyncEnvironment = {
     HOME = homeDir;
     PATH = linearSyncPath;
@@ -272,6 +284,36 @@ lib.mkIf clientEnabled {
           IOWriteBandwidthMax = "/ 20M";
         };
         Install.WantedBy = [ "default.target" ];
+      };
+
+  # Provision the mirror's independent privilege store without coupling server
+  # availability to peer discovery. This only adds the approved client grants;
+  # client removal/address rotation requires an explicit account revocation.
+  systemd.user.services.dolt-federation-access =
+    lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && federationHubEnabled)
+      {
+        Unit = {
+          Description = "Provision approved Dolt federation clients";
+          After = [ "dolt-federation-hub.service" ];
+          Requires = [ "dolt-federation-hub.service" ];
+        };
+        Service = {
+          Type = "oneshot";
+          ExecStart = "${pkgs.bash}/bin/bash ${federationAccessScript} --apply";
+          TimeoutStartSec = 180;
+        };
+        Install.WantedBy = [ "default.target" ];
+      };
+
+  systemd.user.timers.dolt-federation-access =
+    lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && federationHubEnabled)
+      {
+        Unit.Description = "Reconcile approved Dolt federation client access";
+        Timer = {
+          OnBootSec = "2min";
+          OnUnitActiveSec = "5min";
+        };
+        Install.WantedBy = [ "timers.target" ];
       };
 
   # Persist the same client selection in the user manager so Herdr, OpenClaw,

--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -87,10 +87,6 @@ let
     inherit (pkgs) coreutils jq;
   };
   federationAccessScript = pkgs.replaceVars ./federation-access.sh {
-    federationClients = builtins.toJSON [
-      "galactica"
-      "matic"
-    ];
     inherit (pkgs)
       coreutils
       dolt
@@ -300,7 +296,7 @@ lib.mkIf clientEnabled {
         Service = {
           Type = "oneshot";
           ExecStart = "${pkgs.bash}/bin/bash ${federationAccessScript} --apply";
-          TimeoutStartSec = 180;
+          TimeoutStartSec = 600;
         };
         Install.WantedBy = [ "default.target" ];
       };

--- a/home-manager/services/dolt/federation-access.sh
+++ b/home-manager/services/dolt/federation-access.sh
@@ -63,10 +63,10 @@ fi
 while IFS= read -r address; do
   sql "CREATE USER IF NOT EXISTS 'root'@'$address' IDENTIFIED BY ''; GRANT SUPER, CLONE_ADMIN ON *.* TO 'root'@'$address';" >/dev/null || fail 'mirror grant failed'
   grants=$(sql "SHOW GRANTS FOR 'root'@'$address'") || fail 'mirror grant verification failed'
-  printf '%s' "$grants" | @jq@/bin/jq -e '
-    [.rows[] | .[]] as $grants |
-    any($grants[]; startswith("GRANT SUPER ON *.* TO ")) and
-    any($grants[]; startswith("GRANT CLONE_ADMIN ON *.* TO "))
+  printf '%s' "$grants" | @jq@/bin/jq -e --arg host "$address" '
+    ([.rows[] | .[]] | sort) ==
+    (["GRANT SUPER ON *.* TO `root`@`" + $host + "`",
+      "GRANT CLONE_ADMIN ON *.* TO `root`@`" + $host + "`"] | sort)
   ' >/dev/null 2>&1 || fail 'mirror grants not confirmed'
 done <<<"$addresses"
 echo 'Federation access: approved client grants verified'

--- a/home-manager/services/dolt/federation-access.sh
+++ b/home-manager/services/dolt/federation-access.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# The mirror has its own privilege store. Resolve only explicitly approved
-# clients; never grant wildcard access or copy credentials from the live DB.
+# The mirror has its own privilege store. Admit every local-tailnet machine
+# in the authenticated network map, including offline peers and this hub.
+# Never grant wildcard access or copy credentials from the live DB.
 mode=${1:---dry-run}
 case "$mode" in
 --dry-run | --apply) ;;
@@ -24,20 +25,25 @@ sql() {
 }
 
 peers=$(@coreutils@/bin/timeout 15 @tailscale@/bin/tailscale status --json 2>/dev/null) || fail 'peer discovery failed'
-# Validate the entire plan before touching SQL. Require one node per name,
-# and accept only literal Tailscale addresses (also excludes SQL metacharacters).
-addresses=$(printf '%s' "$peers" | @jq@/bin/jq -er --argjson clients '@federationClients@' '
+# The local network map is ACL-filtered: a machine must be allowed to reach
+# this hub by tailnet policy. Names are not an authorization allowlist.
+# Validate the complete plan before SQL, excluding foreign shared-in nodes.
+addresses=$(printf '%s' "$peers" | @jq@/bin/jq -er '
   def tailnet_ip:
     if test("^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$") then
       split(".") | map(tonumber) |
       .[0] == 100 and .[1] >= 64 and .[1] <= 127 and
       all(.[]; . >= 0 and . <= 255)
     else test("^fd7a:115c:a1e0:[0-9a-f:]+$") end;
-  . as $status |
   if .BackendState != "Running" then error("tailnet unavailable") else . end |
-  [$clients[] as $client |
-    [$status.Peer[]? | select(.HostName == $client)] |
-    if length != 1 then error("missing or ambiguous client") else .[0] end |
+  .CurrentTailnet.MagicDNSSuffix as $suffix |
+  if ($suffix | type) != "string" or ($suffix | length) == 0 then
+    error("missing tailnet identity") else . end |
+  if (.Peer | type) != "object" or (.Self | type) != "object" then
+    error("invalid network map") else . end |
+  [.Self, (.Peer[] | select(.InNetworkMap == true))] |
+  [.[] | select(.Expired != true) |
+    select((.DNSName // "" | rtrimstr(".")) | endswith("." + $suffix)) |
     .TailscaleIPs |
     if type != "array" or length == 0 then error("missing addresses") else . end |
     .[] | if type == "string" and tailnet_ip then . else error("invalid address") end

--- a/home-manager/services/dolt/federation-access.sh
+++ b/home-manager/services/dolt/federation-access.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The mirror has its own privilege store. Resolve only explicitly approved
+# clients; never grant wildcard access or copy credentials from the live DB.
+mode=${1:---dry-run}
+case "$mode" in
+--dry-run | --apply) ;;
+*)
+  echo 'Usage: federation-access --dry-run|--apply' >&2
+  exit 64
+  ;;
+esac
+
+fail() {
+  echo "Federation access: $1" >&2
+  exit 1
+}
+
+sql() {
+  @coreutils@/bin/timeout 15 @dolt@/bin/dolt \
+    --host 127.0.0.1 --port 3309 --user root --password '' --no-tls \
+    sql -r json -q "$1" 2>/dev/null
+}
+
+peers=$(@coreutils@/bin/timeout 15 @tailscale@/bin/tailscale status --json 2>/dev/null) || fail 'peer discovery failed'
+# Validate the entire plan before touching SQL. Require one node per name,
+# and accept only literal Tailscale addresses (also excludes SQL metacharacters).
+addresses=$(printf '%s' "$peers" | @jq@/bin/jq -er --argjson clients '@federationClients@' '
+  def tailnet_ip:
+    if test("^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$") then
+      split(".") | map(tonumber) |
+      .[0] == 100 and .[1] >= 64 and .[1] <= 127 and
+      all(.[]; . >= 0 and . <= 255)
+    else test("^fd7a:115c:a1e0:[0-9a-f:]+$") end;
+  . as $status |
+  if .BackendState != "Running" then error("tailnet unavailable") else . end |
+  [$clients[] as $client |
+    [$status.Peer[]? | select(.HostName == $client)] |
+    if length != 1 then error("missing or ambiguous client") else .[0] end |
+    .TailscaleIPs |
+    if type != "array" or length == 0 then error("missing addresses") else . end |
+    .[] | if type == "string" and tailnet_ip then . else error("invalid address") end
+  ] | unique | if length == 0 then error("empty plan") else .[] end
+' 2>/dev/null) || fail 'approved client addresses unavailable or invalid'
+
+accounts=$(sql "SELECT User, Host, plugin, LENGTH(authentication_string) AS password_length FROM mysql.user") || fail 'mirror account read failed'
+while IFS= read -r address; do
+  # Never replace an existing password or authentication plugin.
+  printf '%s' "$accounts" | @jq@/bin/jq -e --arg host "$address" '
+    .rows | type == "array" and
+    all(.[]; if .User == "root" and .Host == $host then
+      .plugin == "mysql_native_password" and (.password_length | tostring) == "0"
+    else true end)
+  ' >/dev/null 2>&1 || fail 'existing account conflicts with approved policy'
+done <<<"$addresses"
+
+if [ "$mode" = '--dry-run' ]; then
+  echo 'Federation access: approved client plan validated (no changes)'
+  exit 0
+fi
+
+while IFS= read -r address; do
+  sql "CREATE USER IF NOT EXISTS 'root'@'$address' IDENTIFIED BY ''; GRANT SUPER, CLONE_ADMIN ON *.* TO 'root'@'$address';" >/dev/null || fail 'mirror grant failed'
+  grants=$(sql "SHOW GRANTS FOR 'root'@'$address'") || fail 'mirror grant verification failed'
+  printf '%s' "$grants" | @jq@/bin/jq -e '
+    [.rows[] | .[]] as $grants |
+    any($grants[]; startswith("GRANT SUPER ON *.* TO ")) and
+    any($grants[]; startswith("GRANT CLONE_ADMIN ON *.* TO "))
+  ' >/dev/null 2>&1 || fail 'mirror grants not confirmed'
+done <<<"$addresses"
+echo 'Federation access: approved client grants verified'

--- a/spec/dolt_federation_access_spec.sh
+++ b/spec/dolt_federation_access_spec.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016,SC2329
+
+Describe 'Dolt federation access'
+SCRIPT="$PWD/home-manager/services/dolt/federation-access.sh"
+
+Describe 'script properties'
+It 'uses strict bash mode and validates placeholder syntax'
+When run bash -c "grep -F 'set -euo pipefail' '$SCRIPT' >/dev/null && sed 's|@[A-Za-z_][A-Za-z0-9_]*@|/usr|g' '$SCRIPT' | bash -n"
+The status should be success
+End
+
+It 'exposes only dry-run and apply modes'
+When run bash -c "grep -F -- '--dry-run | --apply' '$SCRIPT' >/dev/null && grep -F \"Usage: federation-access --dry-run|--apply\" '$SCRIPT' >/dev/null"
+The status should be success
+End
+End
+
+Describe 'runtime behavior'
+setup_federation_access() {
+  TEST_ROOT=$(mktemp -d)
+  FAKE_TAILSCALE_ROOT="$TEST_ROOT/tailscale"
+  FAKE_DOLT_ROOT="$TEST_ROOT/dolt"
+  COREUTILS="$TEST_ROOT/coreutils"
+  RENDERED_SCRIPT="$TEST_ROOT/federation-access.sh"
+  TAILSCALE_LOG="$TEST_ROOT/tailscale.log"
+  DOLT_LOG="$TEST_ROOT/dolt.log"
+  DOLT_INVOCATION_LOG="$TEST_ROOT/dolt-invocations.log"
+  CLIENTS_JSON='["client-one","client-two","client-three","client-four"]'
+  jq_prefix=$(dirname "$(dirname "$(command -v jq)")")
+
+  mkdir -p "$FAKE_TAILSCALE_ROOT/bin" "$FAKE_DOLT_ROOT/bin" "$COREUTILS/bin"
+  : >"$TAILSCALE_LOG"
+  : >"$DOLT_LOG"
+  : >"$DOLT_INVOCATION_LOG"
+  export DOLT_INVOCATION_LOG DOLT_LOG TAILSCALE_LOG
+  ln -s "$(command -v timeout)" "$COREUTILS/bin/timeout"
+
+  cat >"$FAKE_TAILSCALE_ROOT/bin/tailscale" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$TAILSCALE_LOG"
+
+case "${FAKE_TAILSCALE_MODE:-valid}" in
+  missing)
+    payload='{"BackendState":"Running","Peer":{"one":{"HostName":"client-one","TailscaleIPs":["100.64.1.1"]},"two":{"HostName":"client-two","TailscaleIPs":["100.64.1.2"]},"three":{"HostName":"client-three","TailscaleIPs":["100.64.1.3"]}}}'
+    ;;
+  ambiguous)
+    payload='{"BackendState":"Running","Peer":{"one":{"HostName":"client-one","TailscaleIPs":["100.64.1.1"]},"duplicate":{"HostName":"client-one","TailscaleIPs":["100.64.1.9"]},"two":{"HostName":"client-two","TailscaleIPs":["100.64.1.2"]},"three":{"HostName":"client-three","TailscaleIPs":["100.64.1.3"]},"four":{"HostName":"client-four","TailscaleIPs":["100.64.1.4"]}}}'
+    ;;
+  invalid-ip)
+    payload='{"BackendState":"Running","Peer":{"one":{"HostName":"client-one","TailscaleIPs":["100.64.1.256"]},"two":{"HostName":"client-two","TailscaleIPs":["100.64.1.2"]},"three":{"HostName":"client-three","TailscaleIPs":["100.64.1.3"]},"four":{"HostName":"client-four","TailscaleIPs":["100.64.1.4"]}}}'
+    ;;
+  non-tailnet)
+    payload='{"BackendState":"Running","Peer":{"one":{"HostName":"client-one","TailscaleIPs":["192.0.2.10"]},"two":{"HostName":"client-two","TailscaleIPs":["100.64.1.2"]},"three":{"HostName":"client-three","TailscaleIPs":["100.64.1.3"]},"four":{"HostName":"client-four","TailscaleIPs":["100.64.1.4"]}}}'
+    ;;
+  injection)
+    payload='{"BackendState":"Running","Peer":{"one":{"HostName":"client-one","TailscaleIPs":["100.64.1.1; DROP TABLE mysql.user; PRIVATE_TAILNET_PAYLOAD"]},"two":{"HostName":"client-two","TailscaleIPs":["100.64.1.2"]},"three":{"HostName":"client-three","TailscaleIPs":["100.64.1.3"]},"four":{"HostName":"client-four","TailscaleIPs":["100.64.1.4"]}}}'
+    ;;
+  *)
+    payload='{"BackendState":"Running","Peer":{"one":{"HostName":"client-one","TailscaleIPs":["100.64.1.1"]},"two":{"HostName":"client-two","TailscaleIPs":["100.64.1.2"]},"three":{"HostName":"client-three","TailscaleIPs":["100.64.1.3"]},"four":{"HostName":"client-four","TailscaleIPs":["100.64.1.4"]}}}'
+    ;;
+esac
+
+printf '%s\n' "$payload"
+EOF
+  chmod +x "$FAKE_TAILSCALE_ROOT/bin/tailscale"
+
+  cat >"$FAKE_DOLT_ROOT/bin/dolt" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$DOLT_INVOCATION_LOG"
+
+query=''
+previous_argument=''
+for argument in "$@"; do
+  if [ "$previous_argument" = '-q' ]; then
+    query="$argument"
+    break
+  fi
+  previous_argument="$argument"
+done
+printf '%s\n' "$query" >>"$DOLT_LOG"
+
+case "$query" in
+  'SELECT User, Host, plugin, LENGTH(authentication_string) AS password_length FROM mysql.user')
+    case "${FAKE_DOLT_MODE:-empty}" in
+      password-conflict)
+        printf '%s\n' 'PRIVATE_ACCOUNT_DATA' >&2
+        printf '%s\n' '{"rows":[{"User":"root","Host":"100.64.1.1","plugin":"mysql_native_password","password_length":32}]}'
+        ;;
+      plugin-conflict)
+        printf '%s\n' 'PRIVATE_ACCOUNT_DATA' >&2
+        printf '%s\n' '{"rows":[{"User":"root","Host":"100.64.1.1","plugin":"caching_sha2_password","password_length":0}]}'
+        ;;
+      existing)
+        printf '%s\n' '{"rows":[{"User":"root","Host":"100.64.1.1","plugin":"mysql_native_password","password_length":0},{"User":"root","Host":"100.64.1.2","plugin":"mysql_native_password","password_length":0},{"User":"root","Host":"100.64.1.3","plugin":"mysql_native_password","password_length":0},{"User":"root","Host":"100.64.1.4","plugin":"mysql_native_password","password_length":0}]}'
+        ;;
+      *)
+        printf '%s\n' '{"rows":[]}'
+        ;;
+    esac
+    ;;
+  "CREATE USER IF NOT EXISTS "*)
+    if [ "${FAKE_DOLT_MODE:-}" = 'grant-failure' ]; then
+      printf '%s\n' 'PRIVATE_SQL_ERROR' >&2
+      exit 42
+    fi
+    printf '%s\n' '{"rows":[]}'
+    ;;
+  "SHOW GRANTS FOR "*)
+    if [ "${FAKE_DOLT_MODE:-}" = 'readback-failure' ]; then
+      printf '%s\n' 'PRIVATE_SQL_ERROR' >&2
+      exit 43
+    fi
+    grant_host=$(printf '%s\n' "$query" | awk -F "'" '{ print $4 }')
+    case "${FAKE_DOLT_MODE:-}" in
+      extra-grant)
+        printf '%s\n' '{"rows":[["GRANT SUPER ON *.* TO `root`@`100.64.1.1`","GRANT CLONE_ADMIN ON *.* TO `root`@`100.64.1.1`","GRANT SELECT ON *.* TO `root`@`100.64.1.1`"]]}'
+        ;;
+      grant-option)
+        printf '%s\n' '{"rows":[["GRANT SUPER ON *.* TO `root`@`100.64.1.1` WITH GRANT OPTION","GRANT CLONE_ADMIN ON *.* TO `root`@`100.64.1.1`"]]}'
+        ;;
+      *)
+        printf '{"rows":[["GRANT SUPER ON *.* TO `root`@`%s`","GRANT CLONE_ADMIN ON *.* TO `root`@`%s`"]]}\n' "$grant_host" "$grant_host"
+        ;;
+    esac
+    ;;
+  *)
+    printf '%s\n' '{"rows":[]}'
+    ;;
+esac
+EOF
+  chmod +x "$FAKE_DOLT_ROOT/bin/dolt"
+
+  sed \
+    -e "s|@coreutils@|$COREUTILS|g" \
+    -e "s|@dolt@|$FAKE_DOLT_ROOT|g" \
+    -e "s|@jq@|$jq_prefix|g" \
+    -e "s|@tailscale@|$FAKE_TAILSCALE_ROOT|g" \
+    -e "s|@federationClients@|$CLIENTS_JSON|g" \
+    "$SCRIPT" >"$RENDERED_SCRIPT"
+  chmod +x "$RENDERED_SCRIPT"
+}
+
+cleanup_federation_access() {
+  unset DOLT_INVOCATION_LOG DOLT_LOG TAILSCALE_LOG
+  rm -rf "$TEST_ROOT"
+}
+
+Before 'setup_federation_access'
+After 'cleanup_federation_access'
+
+It 'performs a dry run without SQL writes'
+When run env FAKE_DOLT_MODE=empty bash "$RENDERED_SCRIPT" --dry-run
+The status should be success
+The output should include 'Federation access: approved client plan validated (no changes)'
+The output should not include 'PRIVATE_TAILNET_PAYLOAD'
+The contents of file "$DOLT_LOG" should include 'SELECT User, Host, plugin'
+The contents of file "$DOLT_LOG" should not include 'CREATE USER'
+The contents of file "$DOLT_LOG" should not include 'GRANT SUPER'
+End
+
+It 'applies four exact host grants through loopback port 3309'
+When run bash -c "env FAKE_DOLT_MODE=empty bash '$RENDERED_SCRIPT' --apply && test \"\$(awk '/^CREATE USER IF NOT EXISTS / { count++ } END { print count + 0 }' '$DOLT_LOG')\" -eq 4 && awk 'BEGIN { valid = 0 } { if (\$0 !~ /--host 127.0.0.1 --port 3309/) exit 1; valid = 1 } END { exit valid ? 0 : 1 }' '$DOLT_INVOCATION_LOG'"
+The status should be success
+The output should include 'Federation access: approved client grants verified'
+The contents of file "$DOLT_LOG" should include '100.64.1.1'
+The contents of file "$DOLT_LOG" should include '100.64.1.2'
+The contents of file "$DOLT_LOG" should include '100.64.1.3'
+The contents of file "$DOLT_LOG" should include '100.64.1.4'
+The contents of file "$DOLT_LOG" should not include "'root'@'%'"
+The contents of file "$DOLT_INVOCATION_LOG" should not include '--port 3307'
+End
+
+It 'rejects a missing approved peer before any SQL access'
+When run env FAKE_TAILSCALE_MODE=missing bash "$RENDERED_SCRIPT" --apply
+The status should equal 1
+The stderr should include 'approved client addresses unavailable or invalid'
+The contents of file "$DOLT_LOG" should equal ''
+The contents of file "$DOLT_INVOCATION_LOG" should equal ''
+End
+
+It 'rejects an ambiguous approved peer before any SQL access'
+When run env FAKE_TAILSCALE_MODE=ambiguous bash "$RENDERED_SCRIPT" --apply
+The status should equal 1
+The stderr should include 'approved client addresses unavailable or invalid'
+The contents of file "$DOLT_LOG" should equal ''
+The contents of file "$DOLT_INVOCATION_LOG" should equal ''
+End
+
+It 'rejects an invalid IP before any SQL access'
+When run env FAKE_TAILSCALE_MODE=invalid-ip bash "$RENDERED_SCRIPT" --apply
+The status should equal 1
+The stderr should include 'approved client addresses unavailable or invalid'
+The contents of file "$DOLT_LOG" should equal ''
+The contents of file "$DOLT_INVOCATION_LOG" should equal ''
+End
+
+It 'rejects a non-Tailnet IP before any SQL access'
+When run env FAKE_TAILSCALE_MODE=non-tailnet bash "$RENDERED_SCRIPT" --apply
+The status should equal 1
+The stderr should include 'approved client addresses unavailable or invalid'
+The contents of file "$DOLT_LOG" should equal ''
+The contents of file "$DOLT_INVOCATION_LOG" should equal ''
+End
+
+It 'rejects an injected address without printing the peer payload'
+When run env FAKE_TAILSCALE_MODE=injection bash "$RENDERED_SCRIPT" --apply
+The status should equal 1
+The stderr should include 'approved client addresses unavailable or invalid'
+The stderr should not include 'PRIVATE_TAILNET_PAYLOAD'
+The output should not include 'PRIVATE_TAILNET_PAYLOAD'
+The contents of file "$DOLT_LOG" should equal ''
+The contents of file "$DOLT_INVOCATION_LOG" should equal ''
+End
+
+It 'rejects a nonempty existing password before SQL writes'
+When run env FAKE_DOLT_MODE=password-conflict bash "$RENDERED_SCRIPT" --apply
+The status should equal 1
+The stderr should include 'existing account conflicts with approved policy'
+The stderr should not include 'PRIVATE_ACCOUNT_DATA'
+The output should not include 'PRIVATE_ACCOUNT_DATA'
+The contents of file "$DOLT_LOG" should include 'SELECT User, Host, plugin'
+The contents of file "$DOLT_LOG" should not include 'CREATE USER'
+The contents of file "$DOLT_LOG" should not include 'GRANT SUPER'
+End
+
+It 'rejects an authentication plugin conflict before SQL writes'
+When run env FAKE_DOLT_MODE=plugin-conflict bash "$RENDERED_SCRIPT" --apply
+The status should equal 1
+The stderr should include 'existing account conflicts with approved policy'
+The stderr should not include 'PRIVATE_ACCOUNT_DATA'
+The output should not include 'PRIVATE_ACCOUNT_DATA'
+The contents of file "$DOLT_LOG" should include 'SELECT User, Host, plugin'
+The contents of file "$DOLT_LOG" should not include 'CREATE USER'
+The contents of file "$DOLT_LOG" should not include 'GRANT SUPER'
+End
+
+It 'redacts a grant failure'
+When run env FAKE_DOLT_MODE=grant-failure bash "$RENDERED_SCRIPT" --apply
+The status should equal 1
+The stderr should include 'Federation access: mirror grant failed'
+The stderr should not include 'PRIVATE_SQL_ERROR'
+The output should not include 'PRIVATE_SQL_ERROR'
+The contents of file "$DOLT_LOG" should include 'CREATE USER IF NOT EXISTS'
+End
+
+It 'redacts a grant readback failure'
+When run env FAKE_DOLT_MODE=readback-failure bash "$RENDERED_SCRIPT" --apply
+The status should equal 1
+The stderr should include 'Federation access: mirror grant verification failed'
+The stderr should not include 'PRIVATE_SQL_ERROR'
+The output should not include 'PRIVATE_SQL_ERROR'
+The contents of file "$DOLT_LOG" should include 'SHOW GRANTS FOR'
+End
+
+It 'rejects an extra privilege in grant readback'
+When run env FAKE_DOLT_MODE=extra-grant bash "$RENDERED_SCRIPT" --apply
+The status should equal 1
+The stderr should include 'Federation access: mirror grants not confirmed'
+The contents of file "$DOLT_LOG" should include 'SHOW GRANTS FOR'
+End
+
+It 'rejects grant option in grant readback'
+When run env FAKE_DOLT_MODE=grant-option bash "$RENDERED_SCRIPT" --apply
+The status should equal 1
+The stderr should include 'Federation access: mirror grants not confirmed'
+The contents of file "$DOLT_LOG" should include 'SHOW GRANTS FOR'
+End
+
+It 'reconciles existing accounts without replacing their authentication'
+When run env FAKE_DOLT_MODE=existing bash "$RENDERED_SCRIPT" --apply
+The status should be success
+The output should include 'Federation access: approved client grants verified'
+The contents of file "$DOLT_LOG" should include 'SELECT User, Host, plugin'
+The contents of file "$DOLT_LOG" should include 'CREATE USER IF NOT EXISTS'
+The contents of file "$DOLT_LOG" should not include 'ALTER USER'
+The contents of file "$DOLT_LOG" should not include 'DROP USER'
+End
+End
+End

--- a/spec/dolt_federation_access_spec.sh
+++ b/spec/dolt_federation_access_spec.sh
@@ -26,7 +26,6 @@ setup_federation_access() {
   TAILSCALE_LOG="$TEST_ROOT/tailscale.log"
   DOLT_LOG="$TEST_ROOT/dolt.log"
   DOLT_INVOCATION_LOG="$TEST_ROOT/dolt-invocations.log"
-  CLIENTS_JSON='["client-one","client-two","client-three","client-four"]'
   jq_prefix=$(dirname "$(dirname "$(command -v jq)")")
 
   mkdir -p "$FAKE_TAILSCALE_ROOT/bin" "$FAKE_DOLT_ROOT/bin" "$COREUTILS/bin"
@@ -62,7 +61,18 @@ case "${FAKE_TAILSCALE_MODE:-valid}" in
     ;;
 esac
 
-printf '%s\n' "$payload"
+printf '%s\n' "$payload" | jq --arg mode "${FAKE_TAILSCALE_MODE:-valid}" '
+  .CurrentTailnet = {MagicDNSSuffix: "example.ts.net"} |
+  .Self = {DNSName: "hub.example.ts.net.", TailscaleIPs: ["100.64.1.1"]} |
+  .Peer |= with_entries(.value += {
+    DNSName: (.value.HostName + ".example.ts.net."), InNetworkMap: true, Online: false
+  }) |
+  if $mode == "foreign" then .Peer.four.DNSName = "foreign.other.ts.net."
+  elif $mode == "removed" then .Peer.four.InNetworkMap = false
+  elif $mode == "expired" then .Peer.four.Expired = true
+  elif $mode == "no-identity" then del(.CurrentTailnet)
+  else . end
+'
 EOF
   chmod +x "$FAKE_TAILSCALE_ROOT/bin/tailscale"
 
@@ -138,7 +148,6 @@ EOF
     -e "s|@dolt@|$FAKE_DOLT_ROOT|g" \
     -e "s|@jq@|$jq_prefix|g" \
     -e "s|@tailscale@|$FAKE_TAILSCALE_ROOT|g" \
-    -e "s|@federationClients@|$CLIENTS_JSON|g" \
     "$SCRIPT" >"$RENDERED_SCRIPT"
   chmod +x "$RENDERED_SCRIPT"
 }
@@ -173,20 +182,46 @@ The contents of file "$DOLT_LOG" should not include "'root'@'%'"
 The contents of file "$DOLT_INVOCATION_LOG" should not include '--port 3307'
 End
 
-It 'rejects a missing approved peer before any SQL access'
+It 'does not depend on a fixed hostname inventory'
 When run env FAKE_TAILSCALE_MODE=missing bash "$RENDERED_SCRIPT" --apply
-The status should equal 1
-The stderr should include 'approved client addresses unavailable or invalid'
-The contents of file "$DOLT_LOG" should equal ''
-The contents of file "$DOLT_INVOCATION_LOG" should equal ''
+The status should be success
+The output should include 'approved client grants verified'
+The contents of file "$DOLT_LOG" should not include '100.64.1.4'
 End
 
-It 'rejects an ambiguous approved peer before any SQL access'
+It 'admits approved nodes even when their hostnames are duplicated'
 When run env FAKE_TAILSCALE_MODE=ambiguous bash "$RENDERED_SCRIPT" --apply
+The status should be success
+The output should include 'approved client grants verified'
+The contents of file "$DOLT_LOG" should include '100.64.1.9'
+End
+
+It 'excludes foreign shared-in machines'
+When run env FAKE_TAILSCALE_MODE=foreign bash "$RENDERED_SCRIPT" --apply
+The status should be success
+The output should include 'approved client grants verified'
+The contents of file "$DOLT_LOG" should not include '100.64.1.4'
+End
+
+It 'excludes peers removed from the authenticated network map'
+When run env FAKE_TAILSCALE_MODE=removed bash "$RENDERED_SCRIPT" --apply
+The status should be success
+The output should include 'approved client grants verified'
+The contents of file "$DOLT_LOG" should not include '100.64.1.4'
+End
+
+It 'excludes expired peers'
+When run env FAKE_TAILSCALE_MODE=expired bash "$RENDERED_SCRIPT" --apply
+The status should be success
+The output should include 'approved client grants verified'
+The contents of file "$DOLT_LOG" should not include '100.64.1.4'
+End
+
+It 'fails closed without a current tailnet identity'
+When run env FAKE_TAILSCALE_MODE=no-identity bash "$RENDERED_SCRIPT" --apply
 The status should equal 1
 The stderr should include 'approved client addresses unavailable or invalid'
 The contents of file "$DOLT_LOG" should equal ''
-The contents of file "$DOLT_INVOCATION_LOG" should equal ''
 End
 
 It 'rejects an invalid IP before any SQL access'


### PR DESCRIPTION
## Summary
- Discover all local-tailnet machines from the authenticated Tailscale network map, including offline peers and the hub; no fixed hostname allowlist.
- Exclude foreign shared-in, expired, and removed-map peers. Tailnet network policy remains authoritative for visibility and reachability.
- Validate addresses before SQL writes, preserve credentials, and verify exact host-specific SUPER plus CLONE_ADMIN grants without grant option.
- Independent bounded service and timer; no wildcard accounts or database restarts. Removed accounts require explicit revocation.

## Validation
- Final head c9ec7c14: 143 focused tests passed, zero failures.
- ShellCheck, shell formatting, Nix formatting, and diff checks passed.
- Exact-head Kyber Home Manager build and generated provisioner live dry run passed.
- Live repair verified 20 host-specific accounts covering all 10 current machines, including Kamino 1-4.
- Read-only remotes API probes through Kamino 1 succeeded for both mirrors using the hub Tailscale IP. Previously approved clients also passed.

## Remaining gates
- Merge and activate Home Manager to enable automatic reconciliation; current live grants are already repaired.
- Kamino 1 cannot resolve the hub MagicDNS name, although direct-IP authentication works. DNS recovery is tracked separately.
- GitHub CI is separate from the passing focused local checks.