### PR TITLE
fix(antigravity): allow repository searches in headless reviews

### DIFF
--- a/config/antigravity/settings.json
+++ b/config/antigravity/settings.json
@@ -11,6 +11,10 @@
       "command(tail)",
       "command(stat)",
       "command(file)",
+      "command(find)",
+      "command(grep)",
+      "command(rg)",
+      "command(sed)",
       "command(git)"
     ]
   }

--- a/spec/antigravity_config_spec.sh
+++ b/spec/antigravity_config_spec.sh
@@ -66,6 +66,21 @@ The error should include 'refusing to replace invalid Antigravity settings'
 The contents of file "$TEMP_HOME/.gemini/antigravity-cli/settings.json" should equal '{broken'
 End
 
+It 'installs headless review search permissions without replacing deny or ask rules'
+mkdir -p "$TEMP_HOME/.gemini/antigravity-cli"
+cat >"$TEMP_HOME/.gemini/antigravity-cli/settings.json" <<'JSON'
+{
+  "permissions": {
+    "allow": ["command(pwd)"],
+    "deny": ["command(sudo)"],
+    "ask": ["command(git push)"]
+  }
+}
+JSON
+When run bash -c 'HOME="$1" bash "$2" "$3" "$4" jq && jq -e '\''.permissions | (.allow | contains(["command(find)", "command(grep)", "command(rg)", "command(sed)"])) and (.allow | index("command(*)") == null) and .deny == ["command(sudo)"] and .ask == ["command(git push)"]'\'' "$1/.gemini/antigravity-cli/settings.json" >/dev/null' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS" "$HOOKS"
+The status should be success
+End
+
 It 'installs every managed named hook into the global customization root'
 When run bash -c 'HOME="$1" bash "$2" "$3" "$4" jq && jq -e '\''(keys == ["moshi-hook", "traces-share-to-traces"]) and (.["traces-share-to-traces"].Stop | length == 1)'\'' "$1/.gemini/config/hooks.json" >/dev/null && find "$1/.gemini/config/hooks.json" -prune -perm 644 -print -quit | grep -q .' _ "$TEMP_HOME" "$SCRIPT" "$SETTINGS" "$HOOKS"
 The status should be success


### PR DESCRIPTION
Antigravity headless reviews request `find`, `grep`, `rg`, and `sed`, but the managed permission list omitted them. Such requests cannot prompt in print mode and can end with no review output. Add these explicit command permissions through the existing settings activation path.

The activation regression verifies all four entries are installed, no blanket command wildcard is added, and existing deny/ask rules remain intact. These are command-level permissions, including the normal capabilities of each command.

Validation: 14 ShellSpec activation examples pass; ShellCheck and git diff --check pass. Live host activation and a completed RoboRev review are not yet verified.

The separate OpenClaw reporting defect is addressed in https://github.com/junhoyeo/tokscale/pull/1285 (issue https://github.com/junhoyeo/tokscale/issues/1284), linked to the current OpenClaw v2026.9.2 release. Public-profile backfill still depends on the upstream fix being released, installed, and submitted.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing `find`, `grep`, `rg`, and `sed` permissions to Antigravity headless reviews so search commands no longer fail silently. The activation path installs these explicitly without a blanket wildcard, preserving existing deny and ask rules.

<sup>Written for commit 73b3e9f0f2fe8ef41fd00a450e427df5db6b181e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

