### PR TITLE
feat(dolt): opt kamino fleet into Beads federation

### DIFF
--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -6,7 +6,7 @@
   ...
 }:
 let
-  inherit (inputs.host) isGalactica isKyber isMatic;
+  inherit (inputs.host) isGalactica isKyber isMatic isKamino;
   homeDir = config.home.homeDirectory;
   repoDir = "${homeDir}/dotfiles";
   legacyBeadsDir = "${repoDir}/.beads";
@@ -22,11 +22,11 @@ let
   linearSyncIntervalSeconds = 900;
   federationSyncIntervalSeconds = 300;
   linearSyncPath = "${homeDir}/.local/bin:${homeDir}/.bun/bin:${homeDir}/.nix-profile/bin:/etc/profiles/per-user/${config.home.username}/bin:/run/current-system/sw/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
-  clientEnabled = isGalactica || isKyber || isMatic;
+  clientEnabled = isGalactica || isKyber || isMatic || isKamino;
   # bd opens its store with dozens of sequential round trips per invocation, so
   # a direct client of Kyber's Chicago server costs seconds per command on the
-  # ~260ms agent hosts. Every host serves its own Dolt and converges through the
-  # shared remote instead.
+  # ~260ms agent hosts and the Kamino Herdr fleet. Every host serves its own
+  # Dolt and converges through the shared remote instead.
   serverEnabled = clientEnabled;
   # Kyber alone publishes the shared history to the configured remotes.
   publisherEnabled = isKyber;

--- a/named-hosts/kamino/README.md
+++ b/named-hosts/kamino/README.md
@@ -121,7 +121,8 @@ shellspec spec/install_spec.sh spec/make_build_host_resolution_spec.sh spec/ssh_
 ```
 
 The evaluation checks cover root identity, common tools/configs, SSH aliases,
-upgrade targeting and absence of Kyber-only services. Linux CI builds the parent
+upgrade targeting, Beads peer Dolt/federation-sync (local server + Kyber hub),
+and continued absence of Kyber-only Linear sync / backup publisher services. Linux CI builds the parent
 and hundredth generated profile. Evaluation is not a successful Linux build;
 neither is live activation proof.
 

--- a/spec/beads_federation_sync_spec.sh
+++ b/spec/beads_federation_sync_spec.sh
@@ -127,8 +127,8 @@ When run bash -c "grep -F 'BEADS_DOLT_SERVER_MODE = \"1\";' '$MODULE' >/dev/null
 The status should be success
 End
 
-It 'enables Dolt clients on Galactica, Kyber, and Matic'
-When run bash -c "grep -F 'clientEnabled = isGalactica || isKyber || isMatic;' '$MODULE' >/dev/null && grep -F 'doltServerHost = \"127.0.0.1\";' '$MODULE' >/dev/null"
+It 'enables Dolt clients on Galactica, Kyber, Matic, and Kamino'
+When run bash -c "grep -F 'clientEnabled = isGalactica || isKyber || isMatic || isKamino;' '$MODULE' >/dev/null && grep -F 'doltServerHost = \"127.0.0.1\";' '$MODULE' >/dev/null"
 The status should be success
 End
 

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -202,6 +202,14 @@ let
         assert cfg.systemd.user.services.herdr-server.Install.WantedBy == [ "default.target" ];
         assert cfg.systemd.user.services.herdr-server.Unit.X-SwitchMethod == "restart";
         assert cfg.systemd.user.services.herdr-server.Service.EnvironmentFile == [ "-/root/dotfiles/.env" ];
+        assert cfg.systemd.user.services ? dolt;
+        assert cfg.systemd.user.services ? dolt-federation-sync;
+        assert cfg.systemd.user.timers ? dolt-federation-sync;
+        assert !(cfg.systemd.user.services ? dolt-linear-sync);
+        assert !(cfg.systemd.user.services ? dolt-backup-main);
+        assert !(cfg.systemd.user.services ? dolt-federation-hub);
+        assert !(cfg.systemd.user.services ? dolt-federation-access);
+        assert lib.elem "BEADS_FEDERATION_HUB=http://kyber.tail950b36.ts.net:3308" cfg.systemd.user.services.dolt-federation-sync.Service.Environment;
         mkEvalCheck "home-kamino" kamino.activationPackage;
       eval-home-kamino100 =
         let
@@ -240,6 +248,10 @@ let
         assert lib.hasInfix "--hostname=kamino100" cfg.home.activation.configureKaminoTailscale.data;
         assert lib.hasInfix "--accept-dns=false" cfg.home.activation.configureKaminoTailscale.data;
         assert lib.hasInfix "--ssh=false" cfg.home.activation.configureKaminoTailscale.data;
+        assert cfg.systemd.user.services ? dolt;
+        assert cfg.systemd.user.services ? dolt-federation-sync;
+        assert !(cfg.systemd.user.services ? dolt-linear-sync);
+        assert !(cfg.systemd.user.services ? dolt-backup-main);
         mkEvalCheck "home-kamino100" kamino.activationPackage;
       eval-home-andor =
         let


### PR DESCRIPTION
## Summary
- Opt the Kamino Herdr fleet (`isKamino`) into Beads peer-replica Dolt: local client/server + federation-sync through the Kyber hub.
- Keep Linear sync and backup publisher Kyber-only (`publisherEnabled` / `linearSyncEnabled` unchanged).
- Update kamino eval assertions and README so Dolt/federation-sync are expected while Linear sync / backup publisher stay absent.
- Federation remotesapi grants need no script change: `federation-access.sh` already admits every local-tailnet peer (including kamino/kaminoN) without opening live SQL root access.

## Test plan
- [x] `shellspec spec/beads_federation_sync_spec.sh spec/dolt_federation_access_spec.sh` (34 examples, 0 failures)
- [x] `nix eval --impure .#checks.x86_64-linux.eval-home-kamino.drvPath`
- [x] `nix eval --impure .#checks.x86_64-linux.eval-home-kamino100.drvPath`
- [ ] Activate a kamino host and confirm `dolt` + `dolt-federation-sync` units; confirm no `dolt-linear-sync` / `dolt-backup-main`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opts the Kamino Herdr fleet into Beads peer-replica Dolt, so Kamino hosts now run a local Dolt client/server and federation-sync through the Kyber hub. Linear sync and backup publishing stay Kyber-only.

- Kamino eval assertions now expect `dolt` and `dolt-federation-sync` units and confirm `dolt-linear-sync` and `dolt-backup-main` stay absent.
- Updates the Kamino README so Dolt/federation-sync is the expected state.
- No `federation-access.sh` change is needed; it already admits every local-tailnet peer, including kamino hosts.

<sup>Written for commit f5cb3551ac1e0d92abcb319237614e0250a12395. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

