### PR TITLE
fix(opencode): omit unsupported prompt cache keys

### DIFF
--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -22,7 +22,7 @@
       "options": {
         "baseURL": "https://cliproxy.shunkakinoki.com/v1",
         "apiKey": "{env:CLIPROXY_API_KEY}",
-        "setCacheKey": true
+        "setCacheKey": false
       },
       "models": {
         "claude-opus-5": {
@@ -63,7 +63,7 @@
       "options": {
         "baseURL": "http://localhost:8317/v1",
         "apiKey": "{env:CLIPROXY_API_KEY}",
-        "setCacheKey": true
+        "setCacheKey": false
       },
       "models": {
         "claude-opus-5": {

--- a/config/opencode/opencode.tpl.jsonc
+++ b/config/opencode/opencode.tpl.jsonc
@@ -22,7 +22,7 @@
       "options": {
         "baseURL": "https://cliproxy.shunkakinoki.com/v1",
         "apiKey": "{env:CLIPROXY_API_KEY}",
-        "setCacheKey": true
+        "setCacheKey": false
       },
       "models": {
         "__CLAUDE_OPUS__": {
@@ -63,7 +63,7 @@
       "options": {
         "baseURL": "http://localhost:8317/v1",
         "apiKey": "{env:CLIPROXY_API_KEY}",
-        "setCacheKey": true
+        "setCacheKey": false
       },
       "models": {
         "__CLAUDE_OPUS__": {


### PR DESCRIPTION
OpenCode requests through the configured OpenAI-compatible CLIProxy providers fail because the upstream rejects `promptCacheKey`. Set `setCacheKey` to `false` for both local and remote providers in the deployed JSONC configuration and its source template. Model choices and provider order stay unchanged.

Validation: both JSONC files parse, both provider settings are disabled, and `git diff --check` passes. A live OpenCode request using `gpt-5.6-luna` reproduced the unsupported-parameter error with the existing option; the same model returned the expected response with this option disabled. The live probe used a temporary configuration override; fleet activation remains separate.
