### PR TITLE
fix(beads): use private Dolt remote

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -55,4 +55,4 @@ issue-prefix: df
 dolt.auto-start: "false"
 dolt.idle-timeout: "0"
 
-sync.remote: "git+https://github.com/shunkakinoki/beads"
+sync.remote: "git+https://github.com/shunkakinoki/beads.git"

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -55,4 +55,4 @@ issue-prefix: df
 dolt.auto-start: "false"
 dolt.idle-timeout: "0"
 
-sync.remote: "git+https://github.com/shunkakinoki/dotfiles.git"
+sync.remote: "git+https://github.com/shunkakinoki/beads"


### PR DESCRIPTION
## Summary

Point the dotfiles Beads configuration at the private `shunkakinoki/beads` Dolt repository so future synchronization cannot recreate the public `dotfiles` `refs/dolt/data` ref.

### Tracker linkage
- Linear: none — no external issue was provided
- Bead: shunkakinokisoftware-4iwx

## Validation

- `git diff --check`
- Verified the tracked config contains the private remote
- Verified the public `refs/dolt/data` ref is absent
- Verified the private Dolt ref is reachable

## Security

The public `dotfiles` Dolt ref was deleted separately before this PR. This change prevents the tracked configuration from recreating it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Points the Beads sync remote in `.beads/config.yaml` at the private `shunkakinoki/beads` Dolt repository instead of the public `shunkakinoki/dotfiles` repo, so future synchronization can no longer recreate the deleted public `refs/dolt/data` ref.

<sup>Written for commit 11bec20149abeaedabf606ad03f0bf585aa7ca8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

