### PR TITLE
fix: enable fleet DNS and provision fresh Beads databases

### DIFF
--- a/home-manager/modules/tailscale/activate-up.sh
+++ b/home-manager/modules/tailscale/activate-up.sh
@@ -53,6 +53,25 @@ restore_resolved_stub() {
   run_root_cmd ln -sfn "$stub" "$resolv"
 }
 
+restore_tailnet_dns() {
+  if ! command -v resolvectl >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local tailnet_domain
+  tailnet_domain=$("$TAILSCALE_BIN" status --json | jq -er '.CurrentTailnet.MagicDNSSuffix | select(type == "string" and length > 0)')
+  if [[ ! "$tailnet_domain" =~ ^[a-zA-Z0-9][a-zA-Z0-9.-]+$ ]]; then
+    echo "Invalid tailnet DNS suffix" >&2
+    return 1
+  fi
+
+  # Keep public lookups on the host resolver while private tailnet names
+  # continue to resolve for services that do not use the Tailscale CLI.
+  run_root_cmd resolvectl dns tailscale0 100.100.100.100
+  run_root_cmd resolvectl domain tailscale0 "~$tailnet_domain"
+  run_root_cmd resolvectl default-route tailscale0 no
+}
+
 accept_dns_false=false
 for arg in "$@"; do
   if [ "$arg" = "--accept-dns=false" ]; then
@@ -79,6 +98,7 @@ fi
 if [ "$accept_dns_false" = true ]; then
   "$TAILSCALE_BIN" set --accept-dns=false || true
   restore_resolved_stub
+  restore_tailnet_dns
 fi
 
 exit "$up_status"

--- a/home-manager/modules/tailscale/activate-up.sh
+++ b/home-manager/modules/tailscale/activate-up.sh
@@ -60,7 +60,7 @@ restore_tailnet_dns() {
 
   local tailnet_domain
   tailnet_domain=$("$TAILSCALE_BIN" status --json | jq -er '.CurrentTailnet.MagicDNSSuffix | select(type == "string" and length > 0)')
-  if [[ ! "$tailnet_domain" =~ ^[a-zA-Z0-9][a-zA-Z0-9.-]+$ ]]; then
+  if [[ ! $tailnet_domain =~ ^[a-zA-Z0-9][a-zA-Z0-9.-]+$ ]]; then
     echo "Invalid tailnet DNS suffix" >&2
     return 1
   fi

--- a/home-manager/modules/tailscale/activate-up.sh
+++ b/home-manager/modules/tailscale/activate-up.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
-# Apply persisted Tailscale node flags and restore host DNS when MagicDNS
-# is disabled. extraUpArgs are declared in Home Manager, but the system
-# tailscaled unit never ran `tailscale up`, so CorpDNS could stay true
-# across reboots and overwrite /etc/resolv.conf with a resolver that
-# SERVFAILs when no upstreams are configured.
+# Apply managed Tailscale flags using systemd-resolved for host DNS.
 # Usage: activate-up.sh <tailscale_bin> [tailscale up args...]
 set -euo pipefail
 
@@ -49,56 +45,11 @@ restore_resolved_stub() {
     fi
   fi
 
-  echo "Restoring systemd-resolved stub resolv.conf (Tailscale MagicDNS disabled)"
+  echo "Restoring systemd-resolved stub resolv.conf for Tailscale DNS"
   run_root_cmd ln -sfn "$stub" "$resolv"
 }
 
-restore_tailnet_dns() {
-  if ! command -v resolvectl >/dev/null 2>&1; then
-    return 0
-  fi
-
-  local tailnet_domain
-  tailnet_domain=$("$TAILSCALE_BIN" status --json | jq -er '.CurrentTailnet.MagicDNSSuffix | select(type == "string" and length > 0)')
-  if [[ ! $tailnet_domain =~ ^[a-zA-Z0-9][a-zA-Z0-9.-]+$ ]]; then
-    echo "Invalid tailnet DNS suffix" >&2
-    return 1
-  fi
-
-  # Keep public lookups on the host resolver while private tailnet names
-  # continue to resolve for services that do not use the Tailscale CLI.
-  run_root_cmd resolvectl dns tailscale0 100.100.100.100
-  run_root_cmd resolvectl domain tailscale0 "~$tailnet_domain"
-  run_root_cmd resolvectl default-route tailscale0 no
-}
-
-accept_dns_false=false
-for arg in "$@"; do
-  if [ "$arg" = "--accept-dns=false" ]; then
-    accept_dns_false=true
-    break
-  fi
-done
-
-up_status=0
-if [ "$#" -gt 0 ]; then
-  attempt=1
-  while [ "$attempt" -le 5 ]; do
-    if "$TAILSCALE_BIN" up "$@"; then
-      up_status=0
-      break
-    fi
-    up_status=$?
-    echo "tailscale up failed (attempt ${attempt}/5, status ${up_status})" >&2
-    attempt=$((attempt + 1))
-    sleep 2
-  done
-fi
-
-if [ "$accept_dns_false" = true ]; then
-  "$TAILSCALE_BIN" set --accept-dns=false || true
-  restore_resolved_stub
-  restore_tailnet_dns
-fi
-
-exit "$up_status"
+# Restore the resolved integration before enabling DNS acceptance. A stale
+# direct resolv.conf can otherwise feed Tailscale its own resolver as upstream.
+restore_resolved_stub
+"$TAILSCALE_BIN" up "$@" --accept-dns=true

--- a/home-manager/modules/tailscale/default.nix
+++ b/home-manager/modules/tailscale/default.nix
@@ -48,6 +48,7 @@ let
     [Service]
     Type=oneshot
     RemainAfterExit=yes
+    Environment=PATH=${lib.makeBinPath [ pkgs.jq ]}:/usr/bin:/bin
     ExecStart=${pkgs.bash}/bin/bash ${./activate-up.sh} ${cfg.tailscaled.package}/bin/tailscale ${lib.escapeShellArgs cfg.extraUpArgs}
 
     [Install]

--- a/home-manager/modules/tailscale/default.nix
+++ b/home-manager/modules/tailscale/default.nix
@@ -42,13 +42,14 @@ let
     [Unit]
     Description=Apply Tailscale node flags
     Documentation=https://tailscale.com/kb/
-    After=tailscaled.service systemd-resolved.service
-    Wants=tailscaled.service systemd-resolved.service
+    After=tailscaled.service systemd-resolved.service network-online.target
+    Wants=tailscaled.service systemd-resolved.service network-online.target
 
     [Service]
     Type=oneshot
     RemainAfterExit=yes
-    Environment=PATH=${lib.makeBinPath [ pkgs.jq ]}:/usr/bin:/bin
+    Restart=on-failure
+    RestartSec=5
     ExecStart=${pkgs.bash}/bin/bash ${./activate-up.sh} ${cfg.tailscaled.package}/bin/tailscale ${lib.escapeShellArgs cfg.extraUpArgs}
 
     [Install]

--- a/home-manager/programs/fish/functions/_vpn_function.fish
+++ b/home-manager/programs/fish/functions/_vpn_function.fish
@@ -1,32 +1,32 @@
 function _vpn_function --description "Connect/disconnect Tailscale exit node through kyber"
-  set -l kyber_host kyber
+    set -l kyber_host kyber
 
-  switch "$argv[1]"
-    case on
-      # Clear exit-node advertising first; can't both advertise and use an exit node.
-      tailscale set --advertise-exit-node=false
-      # --accept-dns=true routes DNS through the exit node; without it
-      # DNS queries break while tunnelled and name resolution fails.
-      tailscale set --exit-node=$kyber_host --accept-dns=true
-      and echo "VPN connected through kyber"
-    case off
-      tailscale set --exit-node= --accept-dns=false
-      and echo "VPN disconnected"
-    case status
-      tailscale status
-    case ''
-      # Toggle: if exit node is set, turn off; otherwise turn on
-      set -l current (tailscale status --json 2>/dev/null | jq -r '.ExitNodeStatus.ID // empty')
-      if test -n "$current"
-        tailscale set --exit-node= --accept-dns=false
-        and echo "VPN disconnected"
-      else
-        tailscale set --advertise-exit-node=false
-        tailscale set --exit-node=$kyber_host --accept-dns=true
-        and echo "VPN connected through kyber"
-      end
-    case '*'
-      echo "Usage: vpn [on|off|status]"
-      return 1
-  end
+    switch "$argv[1]"
+        case on
+            # Clear exit-node advertising first; can't both advertise and use an exit node.
+            tailscale set --advertise-exit-node=false
+            # --accept-dns=true routes DNS through the exit node; without it
+            # DNS queries break while tunnelled and name resolution fails.
+            tailscale set --exit-node=$kyber_host --accept-dns=true
+            and echo "VPN connected through kyber"
+        case off
+            tailscale set --exit-node= --accept-dns=true
+            and echo "VPN disconnected"
+        case status
+            tailscale status
+        case ''
+            # Toggle: if exit node is set, turn off; otherwise turn on
+            set -l current (tailscale status --json 2>/dev/null | jq -r '.ExitNodeStatus.ID // empty')
+            if test -n "$current"
+                tailscale set --exit-node= --accept-dns=true
+                and echo "VPN disconnected"
+            else
+                tailscale set --advertise-exit-node=false
+                tailscale set --exit-node=$kyber_host --accept-dns=true
+                and echo "VPN connected through kyber"
+            end
+        case '*'
+            echo "Usage: vpn [on|off|status]"
+            return 1
+    end
 end

--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -87,8 +87,12 @@ let
     inherit (pkgs) bash;
     inherit linearSyncScript;
   };
+  ensureDatabaseScript = pkgs.replaceVars ./ensure-database.sh {
+    inherit (pkgs) dolt jq;
+  };
   federationSyncScript = pkgs.replaceVars ./federation-sync.sh {
     bd = "${homeDir}/.local/bin/bd";
+    inherit ensureDatabaseScript;
     inherit (pkgs) coreutils jq;
   };
   federationAccessScript = pkgs.replaceVars ./federation-access.sh {

--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -6,7 +6,12 @@
   ...
 }:
 let
-  inherit (inputs.host) isGalactica isKyber isMatic isKamino;
+  inherit (inputs.host)
+    isGalactica
+    isKyber
+    isMatic
+    isKamino
+    ;
   homeDir = config.home.homeDirectory;
   repoDir = "${homeDir}/dotfiles";
   legacyBeadsDir = "${repoDir}/.beads";

--- a/home-manager/services/dolt/ensure-database.sh
+++ b/home-manager/services/dolt/ensure-database.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_dir="${1:?repository directory required}"
+remote_url="${2:?database remote required}"
+database=$("@jq@/bin/jq" -er '.dolt_database | select(type == "string" and length > 0)' "$repo_dir/.beads/metadata.json" 2>/dev/null) || {
+  echo "Cannot read configured Dolt database name" >&2
+  exit 1
+}
+if [[ ! $database =~ ^[A-Za-z_][A-Za-z0-9_-]*$ ]]; then
+  echo "Invalid configured Dolt database name" >&2
+  exit 1
+fi
+
+sql=(
+  "@dolt@/bin/dolt"
+  --host "${BEADS_DOLT_SERVER_HOST:-127.0.0.1}"
+  --port "${BEADS_DOLT_SERVER_PORT:-3307}"
+  --user "${BEADS_DOLT_SERVER_USER:-root}"
+  --no-tls sql --result-format json -q
+)
+
+# Query the server independently of Beads: ping alone cannot distinguish a
+# missing database from an unavailable server or an incompatible schema.
+databases=$("${sql[@]}" "SHOW DATABASES" 2>/dev/null) || {
+  status=$?
+  echo "Dolt server database discovery failed" >&2
+  exit "$status"
+}
+database_exists=$("@jq@/bin/jq" -r --arg database "$database" '
+  if (.rows | type) != "array" or any(.rows[]; (.Database | type) != "string")
+  then error("invalid database inventory")
+  else any(.rows[]; .Database == $database)
+  end' <<<"$databases" 2>/dev/null) || {
+  echo "Dolt server returned an invalid database inventory" >&2
+  exit 1
+}
+if [ "$database_exists" = true ]; then
+  exit 0
+fi
+
+# A new host may clone committed history. A host with preserved local data
+# needs an explicit cutover so unpublished work is never silently orphaned.
+for legacy_store in "$repo_dir/.beads/dolt/$database" "$repo_dir/.beads/dolt"; do
+  if [ -f "$legacy_store/.dolt/noms/manifest" ]; then
+    echo "Preserved local database requires a verified cutover before provisioning" >&2
+    exit 1
+  fi
+done
+
+# Remote URLs are configuration, never SQL. Reject SQL delimiters and control
+# characters rather than accepting a connection string with embedded syntax.
+if [[ $remote_url =~ ://[^/]*@ || $remote_url == *"?"* || $remote_url == *"#"* || $remote_url == *"'"* || $remote_url == *\\* || $remote_url == *$'\n'* || $remote_url == *$'\r'* ]]; then
+  echo "Invalid database remote URL" >&2
+  exit 1
+fi
+
+echo "Provisioning missing database from its configured remote"
+# Native server cloning is a single create operation and can complete large
+# transfers without the Beads bootstrap client's separate deadline. Existing
+# databases are never dropped or reinitialized; a competing create fails.
+"${sql[@]}" "CALL DOLT_CLONE('$remote_url', '$database')" >/dev/null 2>&1 || {
+  status=$?
+  echo "Dolt database clone failed" >&2
+  exit "$status"
+}

--- a/home-manager/services/dolt/federation-sync.sh
+++ b/home-manager/services/dolt/federation-sync.sh
@@ -89,17 +89,6 @@ repo_slug="${repo_slug//\//_}"
 repo_slug="${repo_slug//[^[:alnum:]_.-]/_}"
 sync_checkpoint_file="$sync_state_dir/last-success-$repo_slug"
 
-for _attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
-  if "$bd_cli" -C "$repo_dir" ping >/dev/null 2>&1; then
-    break
-  fi
-  if [ "$_attempt" -eq 12 ]; then
-    log "Beads did not become ready within 60 seconds"
-    exit 1
-  fi
-  @coreutils@/bin/sleep 5
-done
-
 cycle_started="$(@coreutils@/bin/date -u '+%Y-%m-%dT%H:%M:%SZ')"
 # Spokes converge on the hub's remotesapi endpoint for this repository's
 # database; the hub itself keeps the repository's sync.remote as the off-site
@@ -112,13 +101,33 @@ configured_dolt_remote() {
     return 0
   fi
 
-  database="$(@jq@/bin/jq -r '.dolt_database // "beads"' "$repo_dir/.beads/metadata.json" 2>/dev/null || true)"
+  database="$(@jq@/bin/jq -er '.dolt_database | select(type == "string" and length > 0)' "$repo_dir/.beads/metadata.json" 2>/dev/null || true)"
   if [ -z "$database" ]; then
     log "Dolt database name is not recorded in .beads/metadata.json"
     return 1
   fi
   printf '%s/%s\n' "${BEADS_FEDERATION_HUB%/}" "$database"
 }
+
+configured_remote="$(configured_dolt_remote)" || exit 1
+if [ -z "$configured_remote" ]; then
+  log "Dolt sync remote is not configured"
+  exit 1
+fi
+if ! "$BASH" "@ensureDatabaseScript@" "$repo_dir" "$configured_remote"; then
+  log "Database provisioning failed; federation did not run"
+  exit 1
+fi
+# Cloned history excludes Beads' node-local runtime tables. The supported
+# initializer restores them and retains the remote schema migration guard.
+if ! "$bd_cli" -C "$repo_dir" migrate schema --json >/dev/null 2>&1; then
+  log "Beads database initialization failed; federation did not run"
+  exit 1
+fi
+if ! "$bd_cli" -C "$repo_dir" ping >/dev/null 2>&1; then
+  log "Provisioned database did not pass Beads connectivity verification"
+  exit 1
+fi
 
 ensure_dolt_remote() {
   local configured_remote
@@ -155,6 +164,11 @@ if [ "$sync_status" -ne 0 ]; then
   log "Dolt sync failed with status $sync_status"
   printf '%s\n' "$sync_output" | @coreutils@/bin/tail -n 5
   exit "$sync_status"
+fi
+
+if ! "$bd_cli" -C "$repo_dir" ready --json >/dev/null 2>&1; then
+  log "Federated database did not pass Beads work-discovery verification"
+  exit 1
 fi
 
 @coreutils@/bin/mkdir -p "$sync_state_dir"

--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -3,7 +3,7 @@
   username,
   hostname ? "aarch64-darwin",
   isRunner ? false,
-  tailscaleSetFlags ? [ "--accept-dns=false" ],
+  tailscaleSetFlags ? [ "--accept-dns=true" ],
 }:
 let
   inherit (inputs)

--- a/named-hosts/andor/README.md
+++ b/named-hosts/andor/README.md
@@ -13,7 +13,7 @@ Home Manager configuration:
 sudo hostnamectl set-hostname andor
 curl -fsSL https://tailscale.com/install.sh | sh
 sudo systemctl enable --now tailscaled
-sudo tailscale up --accept-dns=false --ssh
+sudo tailscale up --accept-dns=true --ssh
 curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux
 git clone https://github.com/shunkakinoki/dotfiles ~/dotfiles
 cd ~/dotfiles

--- a/named-hosts/andor/default.nix
+++ b/named-hosts/andor/default.nix
@@ -17,7 +17,7 @@ let
   baseHost = import ../../lib/host.nix;
   tailscaleUpArgs = [
     "--reset"
-    "--accept-dns=false"
+    "--accept-dns=true"
     "--ssh"
   ];
 in

--- a/named-hosts/galactica/default.nix
+++ b/named-hosts/galactica/default.nix
@@ -5,7 +5,7 @@
 }:
 let
   tailscaleSetFlags = [
-    "--accept-dns=false"
+    "--accept-dns=true"
     "--accept-routes=true"
     "--ssh=false"
   ];

--- a/named-hosts/kamino/README.md
+++ b/named-hosts/kamino/README.md
@@ -25,7 +25,7 @@ The installer runs the host-specific Tailscale enrollment command during its
 `make nix-switch` phase:
 
 ```sh
-tailscale up --hostname=kamino1 --accept-dns=false --ssh=false
+tailscale up --hostname=kamino1 --accept-dns=true --ssh=false
 ```
 
 On a fresh machine, follow the login URL printed during activation and choose
@@ -152,7 +152,7 @@ and applies the named service configuration. Its Tailscale phase runs
 `make nix-switch` instead of requiring a separate command afterward.
 
 MagicDNS must be enabled in the tailnet and client access rules must permit TCP
-22. Server-side `--accept-dns=false` does not prevent publishing the node name.
+22. Managed servers and clients both keep DNS acceptance enabled.
 The profile uses OpenSSH over Tailscale, not Tailscale SSH. Root on the parent VPS
 controls the whole VPS, not an isolated worker.
 
@@ -164,7 +164,7 @@ The final command below is run automatically by `make nix-switch`:
 ```sh
 hostname                          # must print kamino1
 systemctl is-active tailscaled    # must print active
-tailscale up --hostname=kamino1 --accept-dns=false --ssh=false
+tailscale up --hostname=kamino1 --accept-dns=true --ssh=false
 ```
 
 Open the login URL printed by the switch in your browser and choose the intended
@@ -200,10 +200,9 @@ deleting its state. Do not use `--reset` or `--force-reauth` as routine sync ste
 
 Connect the client to the same tailnet using its existing Tailscale installation.
 On Linux, enable DNS acceptance with `sudo tailscale set --accept-dns=true`;
-in the macOS/Windows app, enable **Use Tailscale DNS settings**. This is a
-**client** setting: Kamino servers deliberately keep DNS acceptance disabled.
-Clients with their own managed DNS configuration need a working split-DNS route
-for the tailnet suffix instead; do not overwrite that configuration blindly.
+in the macOS/Windows app, enable **Use Tailscale DNS settings**. The managed
+Kamino configuration also enables DNS acceptance. Verify that both public
+domains and tailnet names resolve after enrollment.
 
 The tailnet's network access policy and the server firewall must allow this
 client to reach the target's TCP port 22. Membership or a successful

--- a/named-hosts/kamino/default.nix
+++ b/named-hosts/kamino/default.nix
@@ -25,7 +25,7 @@ let
   };
   tailscaleUpArgs = [
     "--hostname=${name}"
-    "--accept-dns=false"
+    "--accept-dns=true"
     "--ssh=false"
   ];
   authorizedKey = pkgs.writeText "kamino-authorized-key.pub" (

--- a/named-hosts/kyber/README.md
+++ b/named-hosts/kyber/README.md
@@ -148,23 +148,11 @@ while ICMP and HTTPS-by-IP still worked. cliproxy stayed "running" but could
 not hydrate auth from R2; k3s image pulls failed the same way. SSH over the
 tailnet still worked because it does not need public DNS.
 
-`--accept-dns=false` was already declared in `modules.tailscale.extraUpArgs`,
-but `installSystemService` only installed `tailscaled`. The `tailscale-up`
-oneshot existed only for user-level services, so the flags never applied after
-boot. `tailscale set --accept-dns=false` also does not restore a previously
-overwritten resolv.conf.
-
-Recovery:
-
-```bash
-sudo tailscale set --accept-dns=false
-sudo ln -sfn /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
-systemctl --user restart cliproxyapi.service
-```
-
-Durability: `tailscale-up.service` now runs `extraUpArgs` after `tailscaled`
-and re-links the systemd-resolved stub whenever `--accept-dns=false` is set.
-Host health alerts if Tailscale rewrites resolv.conf or public lookups fail.
+The fleet now keeps `--accept-dns=true`. The managed activation restores the
+systemd-resolved stub before applying Tailscale flags so Tailscale can register
+its DNS configuration with the host resolver. Do not disable DNS acceptance to
+repair public resolution: verify the host's upstream resolvers and the tailnet's
+DNS settings, then test both public and tailnet names.
 
 For diagnosis, check filesystem headroom, I/O pressure, kubelet GC messages,
 and CRI health before restarting services:

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -18,7 +18,7 @@ let
   tailscaleUpArgs = [
     "--reset"
     "--ssh=false"
-    "--accept-dns=false"
+    "--accept-dns=true"
     "--advertise-exit-node"
   ];
 in

--- a/spec/activate_kyber_spec.sh
+++ b/spec/activate_kyber_spec.sh
@@ -139,9 +139,9 @@ When run bash -c "grep -F '\"--ssh=false\"' '$PWD/named-hosts/kyber/default.nix'
 The output should include '--ssh=false'
 End
 
-It 'explicitly disables Tailscale DNS'
-When run bash -c "grep -F '\"--accept-dns=false\"' '$PWD/named-hosts/kyber/default.nix'"
-The output should include '--accept-dns=false'
+It 'explicitly enables Tailscale DNS'
+When run bash -c "grep -F '\"--accept-dns=true\"' '$PWD/named-hosts/kyber/default.nix'"
+The output should include '--accept-dns=true'
 End
 
 It 'keeps local k3s access independent of Tailscale DNS'

--- a/spec/activate_tailscale_spec.sh
+++ b/spec/activate_tailscale_spec.sh
@@ -141,8 +141,8 @@ The output should include 'tailscaleSetFlags'
 End
 
 It 'sources Galactica preferences from its named host definition'
-When run bash -c "grep -F '\"--accept-dns=false\"' '$PWD/named-hosts/galactica/default.nix' && grep -F '\"--accept-routes=true\"' '$PWD/named-hosts/galactica/default.nix' && grep -F '\"--ssh=false\"' '$PWD/named-hosts/galactica/default.nix' && grep -F 'inherit inputs username tailscaleSetFlags;' '$PWD/named-hosts/galactica/default.nix'"
-The output should include '--accept-dns=false'
+When run bash -c "grep -F '\"--accept-dns=true\"' '$PWD/named-hosts/galactica/default.nix' && grep -F '\"--accept-routes=true\"' '$PWD/named-hosts/galactica/default.nix' && grep -F '\"--ssh=false\"' '$PWD/named-hosts/galactica/default.nix' && grep -F 'inherit inputs username tailscaleSetFlags;' '$PWD/named-hosts/galactica/default.nix'"
+The output should include '--accept-dns=true'
 The output should include '--accept-routes=true'
 The output should include '--ssh=false'
 The output should include 'tailscaleSetFlags'
@@ -160,23 +160,9 @@ When run bash -c "grep 'TAILSCALE_BIN\" up' '$SCRIPT'"
 The output should include 'up'
 End
 
-It 'retries tailscale up before giving up'
-When run bash -c "grep 'attempt' '$SCRIPT' && grep 'sleep 2' '$SCRIPT'"
-The output should include 'sleep 2'
-End
 End
 
-Describe 'dns restore'
-It 'detects --accept-dns=false'
-When run bash -c "grep -F -- '--accept-dns=false' '$SCRIPT'"
-The output should include '--accept-dns=false'
-End
-
-It 'forces accept-dns off even if up already ran'
-When run bash -c "grep -F -- 'set --accept-dns=false' '$SCRIPT'"
-The output should include 'set --accept-dns=false'
-End
-
+Describe 'DNS integration'
 It 'restores the systemd-resolved stub resolv.conf'
 When run bash -c "grep 'stub-resolv.conf' '$SCRIPT' && grep 'ln -sfn' '$SCRIPT'"
 The output should include 'stub-resolv.conf'

--- a/spec/beads_database_provisioning_spec.sh
+++ b/spec/beads_database_provisioning_spec.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'Provisioning a missing Beads database'
+setup() {
+  TEST_ROOT=$(mktemp -d)
+  REPO_DIR="$TEST_ROOT/repo"
+  DOLT_DIR="$TEST_ROOT/dolt"
+  JQ_DIR="$TEST_ROOT/jq"
+  RENDERED_SCRIPT="$TEST_ROOT/ensure-database.sh"
+  export DATABASE_STATE="$TEST_ROOT/database-state"
+  export DATABASE_COMMANDS="$TEST_ROOT/commands"
+  mkdir -p "$REPO_DIR/.beads" "$DOLT_DIR/bin" "$JQ_DIR/bin"
+  printf '{"dolt_database":"beads_fixture"}\n' >"$REPO_DIR/.beads/metadata.json"
+  touch "$DATABASE_COMMANDS"
+  ln -s "$(command -v jq)" "$JQ_DIR/bin/jq"
+  cat >"$DOLT_DIR/bin/dolt" <<'EOF'
+#!/usr/bin/env bash
+query="${!#}"
+printf '%s\n' "$query" >>"$DATABASE_COMMANDS"
+case "$query" in
+  'SHOW DATABASES')
+    if [ "${FAKE_INVALID_INVENTORY:-0}" = 1 ]; then printf '{"rows":null}\n'; exit 0; fi
+    if [ "${FAKE_SERVER_UNAVAILABLE:-0}" = 1 ]; then exit 42; fi
+    if [ -f "$DATABASE_STATE" ]; then
+      printf '{"rows":[{"Database":"beads_fixture"}]}\n'
+    else
+      printf '{"rows":[{"Database":"mysql"}]}\n'
+    fi
+    ;;
+  'CALL DOLT_CLONE('* )
+    if [ "${FAKE_CLONE_FAILURE:-0}" = 1 ]; then exit 43; fi
+    touch "$DATABASE_STATE"
+    printf '{"rows":[{"status":0}]}\n'
+    ;;
+  *) exit 44 ;;
+esac
+EOF
+  chmod +x "$DOLT_DIR/bin/dolt"
+  sed -e "s|@dolt@|$DOLT_DIR|g" -e "s|@jq@|$JQ_DIR|g" home-manager/services/dolt/ensure-database.sh >"$RENDERED_SCRIPT"
+}
+
+cleanup() { rm -rf "$TEST_ROOT"; }
+run_twice() {
+  bash "$RENDERED_SCRIPT" "$REPO_DIR" 'https://example.invalid/fixture'
+  bash "$RENDERED_SCRIPT" "$REPO_DIR" 'https://example.invalid/fixture'
+  grep -c 'CALL DOLT_CLONE' "$DATABASE_COMMANDS"
+}
+Before 'setup'
+After 'cleanup'
+
+It 'clones the configured database once and leaves it intact on rerun'
+When call run_twice
+The status should be success
+The output should eq "Provisioning missing database from its configured remote
+1"
+The file "$DATABASE_STATE" should be exist
+End
+
+It 'does not reinitialize an existing database'
+touch "$DATABASE_STATE"
+When run bash "$RENDERED_SCRIPT" "$REPO_DIR" 'https://example.invalid/fixture'
+The status should be success
+The contents of file "$DATABASE_COMMANDS" should eq 'SHOW DATABASES'
+End
+
+It 'does not mistake an unreachable server for a missing database'
+When run env FAKE_SERVER_UNAVAILABLE=1 bash "$RENDERED_SCRIPT" "$REPO_DIR" 'https://example.invalid/fixture'
+The status should equal 42
+The stderr should include 'Dolt server database discovery failed'
+The file "$DATABASE_STATE" should not be exist
+The contents of file "$DATABASE_COMMANDS" should eq 'SHOW DATABASES'
+End
+
+It 'preserves a repository-local database for an explicit cutover'
+mkdir -p "$REPO_DIR/.beads/dolt/beads_fixture/.dolt/noms"
+touch "$REPO_DIR/.beads/dolt/beads_fixture/.dolt/noms/manifest"
+When run bash "$RENDERED_SCRIPT" "$REPO_DIR" 'https://example.invalid/fixture'
+The status should equal 1
+The stderr should include 'Preserved local database'
+The file "$DATABASE_STATE" should not be exist
+The contents of file "$DATABASE_COMMANDS" should eq 'SHOW DATABASES'
+End
+
+It 'propagates clone failure without claiming provisioning succeeded'
+When run env FAKE_CLONE_FAILURE=1 bash "$RENDERED_SCRIPT" "$REPO_DIR" 'https://example.invalid/fixture'
+The status should equal 43
+The stderr should include 'Dolt database clone failed'
+The output should include 'Provisioning missing database'
+The file "$DATABASE_STATE" should not be exist
+End
+
+It 'rejects SQL syntax in configured database names'
+printf '{"dolt_database":"fixture; DROP DATABASE other"}\n' >"$REPO_DIR/.beads/metadata.json"
+When run bash "$RENDERED_SCRIPT" "$REPO_DIR" 'https://example.invalid/fixture'
+The status should equal 1
+The stderr should include 'Invalid configured Dolt database name'
+The file "$DATABASE_COMMANDS" should be empty file
+End
+
+It 'rejects SQL delimiters in a remote URL'
+When run bash "$RENDERED_SCRIPT" "$REPO_DIR" "https://example.invalid/fixture'"
+The status should equal 1
+The stderr should include 'Invalid database remote URL'
+The file "$DATABASE_STATE" should not be exist
+End
+It 'rejects credential-bearing remote URLs without logging them'
+When run bash "$RENDERED_SCRIPT" "$REPO_DIR" 'https://user:secret@example.invalid/fixture'
+The status should equal 1
+The stderr should eq 'Invalid database remote URL'
+The file "$DATABASE_STATE" should not be exist
+End
+
+It 'does not expose the checkout path when metadata is missing'
+rm -f "$REPO_DIR/.beads/metadata.json"
+When run bash "$RENDERED_SCRIPT" "$REPO_DIR" 'https://example.invalid/fixture'
+The status should equal 1
+The stderr should eq 'Cannot read configured Dolt database name'
+The file "$DATABASE_COMMANDS" should be empty file
+End
+It 'does not clone when the server returns an invalid database inventory'
+When run env FAKE_INVALID_INVENTORY=1 bash "$RENDERED_SCRIPT" "$REPO_DIR" 'https://example.invalid/fixture'
+The status should equal 1
+The stderr should eq 'Dolt server returned an invalid database inventory'
+The contents of file "$DATABASE_COMMANDS" should eq 'SHOW DATABASES'
+The file "$DATABASE_STATE" should not be exist
+End
+End

--- a/spec/beads_federation_sync_spec.sh
+++ b/spec/beads_federation_sync_spec.sh
@@ -26,6 +26,7 @@ Describe 'runtime behavior'
 setup_federation() {
   TEST_ROOT=$(mktemp -d)
   FAKE_BD="$TEST_ROOT/bd"
+  FAKE_ENSURE_DATABASE="$TEST_ROOT/ensure-database.sh"
   RENDERED_SCRIPT="$TEST_ROOT/federation-sync.sh"
   COMMAND_LOG="$TEST_ROOT/commands.log"
   STATE_HOME="$TEST_ROOT/state"
@@ -49,8 +50,11 @@ if [ "${1:-}" = "-C" ]; then
   shift 2
 fi
 case "${1:-} ${2:-}" in
+  "migrate schema")
+    exit "${FAKE_INITIALIZE_STATUS:-0}"
+    ;;
   "ping ")
-    exit 0
+    exit "${FAKE_PING_STATUS:-0}"
     ;;
   "config get")
     if [ "${3:-}" = "sync.remote" ]; then
@@ -74,12 +78,21 @@ case "${1:-} ${2:-}" in
   "sync --yes")
     exit "${FAKE_SYNC_STATUS:-0}"
     ;;
+  "ready --json")
+    exit "${FAKE_READY_STATUS:-0}"
+    ;;
 esac
 EOF
   chmod +x "$FAKE_BD"
+  cat >"$FAKE_ENSURE_DATABASE" <<'EOF'
+#!/usr/bin/env bash
+printf 'ensure-database\n' >>"$COMMAND_LOG"
+exit "${FAKE_PROVISION_STATUS:-0}"
+EOF
   sed \
     -e "s|@bd@|$FAKE_BD|g" \
     -e "s|@coreutils@|$COREUTILS|g" \
+    -e "s|@ensureDatabaseScript@|$FAKE_ENSURE_DATABASE|g" \
     "$SCRIPT" >"$RENDERED_SCRIPT"
 }
 
@@ -97,6 +110,7 @@ The status should be success
 The output should include 'Dolt federation complete'
 The file "$CHECKPOINT_FILE" should be exist
 The contents of file "$COMMAND_LOG" should include 'sync --yes'
+The contents of file "$COMMAND_LOG" should include 'ready --json'
 The contents of file "$COMMAND_LOG" should include 'dolt remote add origin git+https://example.invalid/org/repo.git --allow-git-origin'
 End
 
@@ -104,6 +118,38 @@ It 'propagates a federation failure without advancing the checkpoint'
 When run env COMMAND_LOG="$COMMAND_LOG" FAKE_SYNC_STATUS=42 XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" bash "$RENDERED_SCRIPT"
 The status should equal 42
 The output should include 'Repository federation failed with status 42'
+The file "$CHECKPOINT_FILE" should not be exist
+End
+
+It 'does not synchronize or claim readiness after provisioning fails'
+When run env COMMAND_LOG="$COMMAND_LOG" FAKE_PROVISION_STATUS=1 XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" bash "$RENDERED_SCRIPT"
+The status should equal 1
+The output should include 'Database provisioning failed'
+The file "$CHECKPOINT_FILE" should not be exist
+The contents of file "$COMMAND_LOG" should not include 'sync --yes'
+End
+
+It 'does not synchronize or checkpoint when Beads initialization fails'
+When run env COMMAND_LOG="$COMMAND_LOG" FAKE_INITIALIZE_STATUS=1 XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" bash "$RENDERED_SCRIPT"
+The status should equal 1
+The output should include 'Beads database initialization failed'
+The file "$CHECKPOINT_FILE" should not be exist
+The contents of file "$COMMAND_LOG" should not include 'ping'
+The contents of file "$COMMAND_LOG" should not include 'sync --yes'
+End
+
+It 'does not synchronize a database that Beads cannot open'
+When run env COMMAND_LOG="$COMMAND_LOG" FAKE_PING_STATUS=1 XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" bash "$RENDERED_SCRIPT"
+The status should equal 1
+The output should include 'Beads connectivity verification'
+The file "$CHECKPOINT_FILE" should not be exist
+The contents of file "$COMMAND_LOG" should not include 'sync --yes'
+End
+
+It 'does not advance readiness when work discovery fails after sync'
+When run env COMMAND_LOG="$COMMAND_LOG" FAKE_READY_STATUS=1 XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" bash "$RENDERED_SCRIPT"
+The status should equal 1
+The output should include 'work-discovery verification'
 The file "$CHECKPOINT_FILE" should not be exist
 End
 

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -621,6 +621,7 @@ home-manager/services/dolt/start.sh
 home-manager/services/dolt/backup-dolt-main.sh
 home-manager/services/dolt/beads-linear-complete.sh
 home-manager/services/dolt/client-environment.sh
+home-manager/services/dolt/federation-access.sh
 home-manager/services/dolt/federation-sync.sh
 home-manager/services/dolt/linear-sync.sh
 home-manager/services/dotfiles-updater/update.sh

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -297,6 +297,10 @@ It 'has spec file for home-manager/services/dolt/federation-sync.sh'
 The path "spec/beads_federation_sync_spec.sh" should be exist
 End
 
+It 'has spec file for home-manager/services/dolt/ensure-database.sh'
+The path "spec/beads_database_provisioning_spec.sh" should be exist
+End
+
 It 'has spec file for home-manager/services/dolt/client-environment.sh'
 The path "spec/beads_federation_sync_spec.sh" should be exist
 End
@@ -621,6 +625,7 @@ home-manager/services/dolt/start.sh
 home-manager/services/dolt/backup-dolt-main.sh
 home-manager/services/dolt/beads-linear-complete.sh
 home-manager/services/dolt/client-environment.sh
+home-manager/services/dolt/ensure-database.sh
 home-manager/services/dolt/federation-access.sh
 home-manager/services/dolt/federation-sync.sh
 home-manager/services/dolt/linear-sync.sh

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -214,8 +214,8 @@ When run bash -c "grep '\"model\": \"shunkakinoki/deepseek-v4-flash\"' config/op
 The output should include 'shunkakinoki/deepseek-v4-flash'
 End
 
-It 'enables stable prompt cache keys for both CLIProxy providers'
-When run bash -c "sed -n '/\"shunkakinoki\"/,/\"cliproxyapi\"/p' config/opencode/opencode.jsonc | grep -q '\"setCacheKey\": true' && sed -n '/\"cliproxyapi\"/,/\"lmstudio\"/p' config/opencode/opencode.jsonc | grep -q '\"setCacheKey\": true'"
+It 'omits unsupported prompt cache keys for both CLIProxy providers'
+When run bash -c "sed -n '/\"shunkakinoki\"/,/\"cliproxyapi\"/p' config/opencode/opencode.jsonc | grep -q '\"setCacheKey\": false' && sed -n '/\"cliproxyapi\"/,/\"lmstudio\"/p' config/opencode/opencode.jsonc | grep -q '\"setCacheKey\": false'"
 The status should be success
 End
 

--- a/spec/tailscale_dns_routing_spec.sh
+++ b/spec/tailscale_dns_routing_spec.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'Tailnet DNS routing when global Tailscale DNS is disabled'
+  setup() {
+    TEST_ROOT=$(mktemp -d)
+    export DNS_LOG="$TEST_ROOT/dns.log"
+    export TAILNET_SUFFIX="example-tail.ts.net"
+    touch "$DNS_LOG"
+  }
+
+  cleanup() {
+    rm -rf "$TEST_ROOT"
+  }
+
+  run_activation() {
+    tailscale_mock() {
+      if [ "$1" = status ]; then
+        printf '{"CurrentTailnet":{"MagicDNSSuffix":"%s"}}\n' "$TAILNET_SUFFIX"
+      fi
+    }
+    resolvectl() { printf '%s\n' "$*" >>"$DNS_LOG"; }
+    id() { printf '0\n'; }
+    readlink() { printf '/run/systemd/resolve/stub-resolv.conf\n'; }
+    export -f tailscale_mock resolvectl id readlink
+    bash home-manager/modules/tailscale/activate-up.sh tailscale_mock "$@"
+  }
+
+  Before 'setup'
+  After 'cleanup'
+
+  It 'routes only the discovered tailnet domain to its private resolver'
+    When call run_activation --accept-dns=false
+    The status should be success
+    The contents of file "$DNS_LOG" should eq "dns tailscale0 100.100.100.100
+domain tailscale0 ~example-tail.ts.net
+default-route tailscale0 no"
+  End
+
+  It 'leaves DNS untouched when Tailscale manages DNS'
+    When call run_activation --accept-dns=true
+    The status should be success
+    The file "$DNS_LOG" should be empty file
+  End
+
+  It 'rejects a missing suffix before changing resolver routes'
+    TAILNET_SUFFIX=""
+    When call run_activation --accept-dns=false
+    The status should be failure
+    The file "$DNS_LOG" should be empty file
+  End
+End

--- a/spec/tailscale_dns_routing_spec.sh
+++ b/spec/tailscale_dns_routing_spec.sh
@@ -1,52 +1,45 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2329
 
-Describe 'Tailnet DNS routing when global Tailscale DNS is disabled'
+Describe 'Managed Tailscale DNS acceptance'
 setup() {
   TEST_ROOT=$(mktemp -d)
   export DNS_LOG="$TEST_ROOT/dns.log"
-  export TAILNET_SUFFIX="example-tail.ts.net"
   touch "$DNS_LOG"
 }
 
-cleanup() {
-  rm -rf "$TEST_ROOT"
-}
+cleanup() { rm -rf "$TEST_ROOT"; }
 
 run_activation() {
   tailscale_mock() {
-    if [ "$1" = status ]; then
-      printf '{"CurrentTailnet":{"MagicDNSSuffix":"%s"}}\n' "$TAILNET_SUFFIX"
-    fi
+    printf '%s\n' "$*" >>"$DNS_LOG"
+    return "${TAILSCALE_STATUS:-0}"
   }
-  resolvectl() { printf '%s\n' "$*" >>"$DNS_LOG"; }
   id() { printf '0\n'; }
   readlink() { printf '/run/systemd/resolve/stub-resolv.conf\n'; }
-  export -f tailscale_mock resolvectl id readlink
+  export -f tailscale_mock id readlink
   bash home-manager/modules/tailscale/activate-up.sh tailscale_mock "$@"
 }
 
 Before 'setup'
 After 'cleanup'
 
-It 'routes only the discovered tailnet domain to its private resolver'
-When call run_activation --accept-dns=false
+It 'enables DNS acceptance while applying the other node flags'
+When call run_activation --ssh=false
 The status should be success
-The contents of file "$DNS_LOG" should eq "dns tailscale0 100.100.100.100
-domain tailscale0 ~example-tail.ts.net
-default-route tailscale0 no"
+The contents of file "$DNS_LOG" should eq 'up --ssh=false --accept-dns=true'
 End
 
-It 'leaves DNS untouched when Tailscale manages DNS'
-When call run_activation --accept-dns=true
+It 'enables DNS acceptance when no other node flags are supplied'
+When call run_activation
 The status should be success
-The file "$DNS_LOG" should be empty file
+The contents of file "$DNS_LOG" should eq 'up --accept-dns=true'
 End
 
-It 'rejects a missing suffix before changing resolver routes'
-TAILNET_SUFFIX=""
-When call run_activation --accept-dns=false
-The status should be failure
-The file "$DNS_LOG" should be empty file
+It 'reports a failed Tailscale configuration instead of claiming success'
+export TAILSCALE_STATUS=42
+When call run_activation
+The status should equal 42
+The contents of file "$DNS_LOG" should eq 'up --accept-dns=true'
 End
 End

--- a/spec/tailscale_dns_routing_spec.sh
+++ b/spec/tailscale_dns_routing_spec.sh
@@ -2,51 +2,51 @@
 # shellcheck disable=SC2329
 
 Describe 'Tailnet DNS routing when global Tailscale DNS is disabled'
-  setup() {
-    TEST_ROOT=$(mktemp -d)
-    export DNS_LOG="$TEST_ROOT/dns.log"
-    export TAILNET_SUFFIX="example-tail.ts.net"
-    touch "$DNS_LOG"
+setup() {
+  TEST_ROOT=$(mktemp -d)
+  export DNS_LOG="$TEST_ROOT/dns.log"
+  export TAILNET_SUFFIX="example-tail.ts.net"
+  touch "$DNS_LOG"
+}
+
+cleanup() {
+  rm -rf "$TEST_ROOT"
+}
+
+run_activation() {
+  tailscale_mock() {
+    if [ "$1" = status ]; then
+      printf '{"CurrentTailnet":{"MagicDNSSuffix":"%s"}}\n' "$TAILNET_SUFFIX"
+    fi
   }
+  resolvectl() { printf '%s\n' "$*" >>"$DNS_LOG"; }
+  id() { printf '0\n'; }
+  readlink() { printf '/run/systemd/resolve/stub-resolv.conf\n'; }
+  export -f tailscale_mock resolvectl id readlink
+  bash home-manager/modules/tailscale/activate-up.sh tailscale_mock "$@"
+}
 
-  cleanup() {
-    rm -rf "$TEST_ROOT"
-  }
+Before 'setup'
+After 'cleanup'
 
-  run_activation() {
-    tailscale_mock() {
-      if [ "$1" = status ]; then
-        printf '{"CurrentTailnet":{"MagicDNSSuffix":"%s"}}\n' "$TAILNET_SUFFIX"
-      fi
-    }
-    resolvectl() { printf '%s\n' "$*" >>"$DNS_LOG"; }
-    id() { printf '0\n'; }
-    readlink() { printf '/run/systemd/resolve/stub-resolv.conf\n'; }
-    export -f tailscale_mock resolvectl id readlink
-    bash home-manager/modules/tailscale/activate-up.sh tailscale_mock "$@"
-  }
-
-  Before 'setup'
-  After 'cleanup'
-
-  It 'routes only the discovered tailnet domain to its private resolver'
-    When call run_activation --accept-dns=false
-    The status should be success
-    The contents of file "$DNS_LOG" should eq "dns tailscale0 100.100.100.100
+It 'routes only the discovered tailnet domain to its private resolver'
+When call run_activation --accept-dns=false
+The status should be success
+The contents of file "$DNS_LOG" should eq "dns tailscale0 100.100.100.100
 domain tailscale0 ~example-tail.ts.net
 default-route tailscale0 no"
-  End
+End
 
-  It 'leaves DNS untouched when Tailscale manages DNS'
-    When call run_activation --accept-dns=true
-    The status should be success
-    The file "$DNS_LOG" should be empty file
-  End
+It 'leaves DNS untouched when Tailscale manages DNS'
+When call run_activation --accept-dns=true
+The status should be success
+The file "$DNS_LOG" should be empty file
+End
 
-  It 'rejects a missing suffix before changing resolver routes'
-    TAILNET_SUFFIX=""
-    When call run_activation --accept-dns=false
-    The status should be failure
-    The file "$DNS_LOG" should be empty file
-  End
+It 'rejects a missing suffix before changing resolver routes'
+TAILNET_SUFFIX=""
+When call run_activation --accept-dns=false
+The status should be failure
+The file "$DNS_LOG" should be empty file
+End
 End

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -50,7 +50,7 @@ let
         };
         activation = galactica.config.system.activationScripts.tailscaleDns.text;
       in
-      assert lib.hasInfix "--accept-dns=false" activation;
+      assert lib.hasInfix "--accept-dns=true" activation;
       assert lib.hasInfix "--accept-routes=true" activation;
       assert lib.hasInfix "--ssh=false" activation;
       mkEvalCheck "darwin-galactica" galactica.system;
@@ -247,7 +247,7 @@ let
         assert cfg.programs.ssh.settings.kamino100.data.HostName == "kamino100.tail950b36.ts.net";
         assert lib.hasInfix "tailscale kamino100" cfg.home.activation.configureKaminoTailscale.data;
         assert lib.hasInfix "--hostname=kamino100" cfg.home.activation.configureKaminoTailscale.data;
-        assert lib.hasInfix "--accept-dns=false" cfg.home.activation.configureKaminoTailscale.data;
+        assert lib.hasInfix "--accept-dns=true" cfg.home.activation.configureKaminoTailscale.data;
         assert lib.hasInfix "--ssh=false" cfg.home.activation.configureKaminoTailscale.data;
         assert cfg.systemd.user.services ? dolt;
         assert cfg.systemd.user.services ? dolt-federation-sync;
@@ -265,7 +265,7 @@ let
         assert
           andor.config.modules.tailscale.extraUpArgs == [
             "--reset"
-            "--accept-dns=false"
+            "--accept-dns=true"
             "--ssh"
           ];
         mkEvalCheck "home-andor" andor.activationPackage;
@@ -282,7 +282,7 @@ let
           kyber.config.modules.tailscale.extraUpArgs == [
             "--reset"
             "--ssh=false"
-            "--accept-dns=false"
+            "--accept-dns=true"
             "--advertise-exit-node"
           ];
         assert lib.elem "BEADS_FEDERATION_HUB=http://127.0.0.1:3308" federationEnvironment;

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -209,7 +209,8 @@ let
         assert !(cfg.systemd.user.services ? dolt-backup-main);
         assert !(cfg.systemd.user.services ? dolt-federation-hub);
         assert !(cfg.systemd.user.services ? dolt-federation-access);
-        assert lib.elem "BEADS_FEDERATION_HUB=http://kyber.tail950b36.ts.net:3308" cfg.systemd.user.services.dolt-federation-sync.Service.Environment;
+        assert lib.elem "BEADS_FEDERATION_HUB=http://kyber.tail950b36.ts.net:3308"
+          cfg.systemd.user.services.dolt-federation-sync.Service.Environment;
         mkEvalCheck "home-kamino" kamino.activationPackage;
       eval-home-kamino100 =
         let

--- a/tests/test_kamino_activation.py
+++ b/tests/test_kamino_activation.py
@@ -39,7 +39,7 @@ class ActivationTests(unittest.TestCase):
                 arguments.extend(
                     [
                         "--hostname=kamino100",
-                        "--accept-dns=false",
+                        "--accept-dns=true",
                         "--ssh=false",
                     ]
                 )
@@ -85,7 +85,7 @@ class ActivationTests(unittest.TestCase):
         result, log = self.run_phase("tailscale")
         self.assertEqual(result.returncode, 0)
         self.assertEqual(
-            log, ["tailscale up --hostname=kamino100 --accept-dns=false --ssh=false"]
+            log, ["tailscale up --hostname=kamino100 --accept-dns=true --ssh=false"]
         )
         result, _ = self.run_phase("tailscale", fail="tailscale")
         self.assertEqual(result.returncode, 3)


### PR DESCRIPTION
Managed hosts disabled Tailscale DNS as a workaround for an earlier resolver failure, leaving services unable to resolve tailnet peers. Enable DNS acceptance across host definitions and preserve it when disconnecting an exit node. Restore the systemd-resolved stub before applying Linux node flags, and let the activation service recover from transient startup failures.

Fresh machines also need their Beads databases. Provision a missing database from its configured remote, initialize Beads' local runtime tables through its supported command, and require connectivity, synchronization, and work discovery before recording success. Existing databases are retained; preserved legacy stores require an explicit cutover. Invalid discovery results and failed initialization stop provisioning without exposing remote URLs or checkout paths in new error messages.

Validation: 240 focused ShellSpec examples and 7 Python activation tests pass. A real two-server Dolt/Beads test proves fresh provisioning, work discovery, a verified checkpoint, and rerun without recloning. ShellCheck, formatting, and diff checks pass. Darwin check derivations evaluate; Linux evaluation remains pending under local Nix database contention. Live verification on one affected Linux host confirms public and tailnet resolution with DNS acceptance enabled, plus successful Beads ping and work discovery. Fleet-wide activation is not yet verified.
