### PR TITLE
fix(tailscale): preserve enrollment on DNS-only activation

### DIFF
--- a/home-manager/modules/tailscale/activate-up.sh
+++ b/home-manager/modules/tailscale/activate-up.sh
@@ -52,4 +52,10 @@ restore_resolved_stub() {
 # Restore the resolved integration before enabling DNS acceptance. A stale
 # direct resolv.conf can otherwise feed Tailscale its own resolver as upstream.
 restore_resolved_stub
-"$TAILSCALE_BIN" up "$@" --accept-dns=true
+if [ "$#" -gt 0 ]; then
+  "$TAILSCALE_BIN" up "$@" --accept-dns=true
+else
+  # Empty arguments leave enrollment to the host activation. Update only DNS,
+  # preserving existing non-default preferences such as the node hostname.
+  "$TAILSCALE_BIN" set --accept-dns=true
+fi

--- a/spec/tailscale_dns_routing_spec.sh
+++ b/spec/tailscale_dns_routing_spec.sh
@@ -13,6 +13,12 @@ cleanup() { rm -rf "$TEST_ROOT"; }
 run_activation() {
   tailscale_mock() {
     printf '%s\n' "$*" >>"$DNS_LOG"
+    if [ "$1" = up ] && [ -n "${EXISTING_HOSTNAME:-}" ]; then
+      case " $* " in
+      *" --hostname=$EXISTING_HOSTNAME "*) ;;
+      *) return 1 ;;
+      esac
+    fi
     return "${TAILSCALE_STATUS:-0}"
   }
   id() { printf '0\n'; }
@@ -30,16 +36,41 @@ The status should be success
 The contents of file "$DNS_LOG" should eq 'up --ssh=false --accept-dns=true'
 End
 
-It 'enables DNS acceptance when no other node flags are supplied'
+It 'updates DNS without enrollment when no node flags are supplied'
 When call run_activation
 The status should be success
-The contents of file "$DNS_LOG" should eq 'up --accept-dns=true'
+The contents of file "$DNS_LOG" should eq 'set --accept-dns=true'
+End
+
+It 'preserves an enrolled node hostname on repeated activation'
+export EXISTING_HOSTNAME=kamino3
+activate_twice() {
+  run_activation "$@" && run_activation "$@"
+}
+When call activate_twice
+The status should be success
+The contents of file "$DNS_LOG" should eq 'set --accept-dns=true
+set --accept-dns=true'
+End
+
+It 'passes explicit enrollment arguments through unchanged'
+export EXISTING_HOSTNAME=kamino3
+When call run_activation --hostname=kamino3 --ssh=false
+The status should be success
+The contents of file "$DNS_LOG" should eq 'up --hostname=kamino3 --ssh=false --accept-dns=true'
 End
 
 It 'reports a failed Tailscale configuration instead of claiming success'
 export TAILSCALE_STATUS=42
 When call run_activation
 The status should equal 42
-The contents of file "$DNS_LOG" should eq 'up --accept-dns=true'
+The contents of file "$DNS_LOG" should eq 'set --accept-dns=true'
+End
+
+It 'reports an explicit enrollment failure'
+export TAILSCALE_STATUS=42
+When call run_activation --hostname=kamino3 --ssh=false
+The status should equal 42
+The contents of file "$DNS_LOG" should eq 'up --hostname=kamino3 --ssh=false --accept-dns=true'
 End
 End


### PR DESCRIPTION
An enrolled host with empty `extraUpArgs` fails activation because the shared service invokes `tailscale up --accept-dns=true` without its existing hostname. Use `tailscale set --accept-dns=true` for this path so DNS updates preserve node preferences and do not trigger enrollment. Explicit enrollment arguments retain the existing `tailscale up` behavior.

Validation: 95 focused ShellSpec examples pass; ShellCheck and `git diff --check` pass. The new tests reproduce three failures against the original script, including repeated activation with an existing hostname. Live host activation has not been performed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Tailscale activation for enrolled hosts with no `extraUpArgs` so DNS-only updates no longer drop the existing hostname or re-trigger enrollment. The script now runs `tailscale set --accept-dns=true` when no arguments are supplied, and keeps `tailscale up "$@" --accept-dns=true` when explicit enrollment flags are present.

<sup>Written for commit 9ac37a6e9e40106b85478935f62d481af1d673eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

