### PR TITLE
fix(beads): provision dotfiles and pin worker server ownership

### DIFF
--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -489,9 +489,8 @@ nonstream-keepalive-interval: 0
 # user-agent stays commented so CPA's maintained baseline applies; an explicit stale value
 # is worse than the built-in one, and it is only a fallback for clients that omit the header.
 codex-header-defaults:
-#   user-agent: "codex_cli_rs/0.114.0 (Mac OS 14.2.0; x86_64) vscode/1.111.0"
+  #   user-agent: "codex_cli_rs/0.114.0 (Mac OS 14.2.0; x86_64) vscode/1.111.0"
   beta-features: "multi_agent"
-
 # OpenAI compatibility providers
 openai-compatibility:
   # Temporary campaign provider: serves stealth/ox-alpha under the same

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -489,9 +489,8 @@ nonstream-keepalive-interval: 0
 # user-agent stays commented so CPA's maintained baseline applies; an explicit stale value
 # is worse than the built-in one, and it is only a fallback for clients that omit the header.
 codex-header-defaults:
-#   user-agent: "codex_cli_rs/0.114.0 (Mac OS 14.2.0; x86_64) vscode/1.111.0"
+  #   user-agent: "codex_cli_rs/0.114.0 (Mac OS 14.2.0; x86_64) vscode/1.111.0"
   beta-features: "multi_agent"
-
 # OpenAI compatibility providers
 openai-compatibility:
   # Temporary campaign provider: serves stealth/ox-alpha under the same

--- a/home-manager/services/dolt/client-environment.sh
+++ b/home-manager/services/dolt/client-environment.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 /bin/launchctl setenv BEADS_DOLT_AUTO_START 0
+/bin/launchctl setenv BEADS_DOLT_DATA_DIR "@beadsDir@"
 /bin/launchctl setenv BEADS_DOLT_SERVER_MODE 1
 /bin/launchctl setenv BEADS_DOLT_SERVER_HOST "@doltServerHost@"
 /bin/launchctl setenv BEADS_DOLT_SERVER_PORT 3307

--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -47,6 +47,7 @@ let
   federationHubUrl = "http://${federationHubHost}:${toString federationRemotesApiPort}";
   beadsClientEnvironment = {
     BEADS_DOLT_AUTO_START = "0";
+    BEADS_DOLT_DATA_DIR = beadsDir;
     BEADS_DOLT_SERVER_MODE = "1";
     BEADS_DOLT_SERVER_HOST = doltServerHost;
     BEADS_DOLT_SERVER_PORT = "3307";
@@ -55,7 +56,7 @@ let
     DOLT_CLI_PASSWORD = "";
   };
   beadsLaunchctlEnvironmentScript = pkgs.replaceVars ./client-environment.sh {
-    inherit doltServerHost;
+    inherit doltServerHost beadsDir;
   };
   linearSyncEnabled = isKyber;
   federationSyncEnabled = clientEnabled;
@@ -107,6 +108,7 @@ let
     HOME = homeDir;
     PATH = linearSyncPath;
     BEADS_DOLT_AUTO_START = "0";
+    BEADS_DOLT_DATA_DIR = beadsDir;
     BEADS_DOLT_SERVER_MODE = "1";
     BEADS_DOLT_SERVER_HOST = doltServerHost;
     BEADS_DOLT_SERVER_PORT = "3307";

--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -325,6 +325,13 @@ lib.mkIf clientEnabled {
   # and other systemd-launched agents do not inherit a stale shared-server mode.
   systemd.user.sessionVariables = lib.mkIf pkgs.stdenv.hostPlatform.isLinux beadsClientEnvironment;
 
+  # Herdr launches workers without a login shell. Give its child processes the
+  # managed server policy directly so they cannot start a competing Dolt server.
+  systemd.user.services.herdr-server = lib.mkIf isKamino {
+    Unit.After = [ "dolt.service" ];
+    Service.Environment = lib.mapAttrsToList (name: value: "${name}=${value}") beadsClientEnvironment;
+  };
+
   systemd.user.services.dolt-backup-main =
     lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && publisherEnabled)
       {

--- a/home-manager/services/dolt/federation-sync.sh
+++ b/home-manager/services/dolt/federation-sync.sh
@@ -168,7 +168,7 @@ fi
 
 log "Synchronizing Dolt remote"
 sync_status=0
-sync_output="$(@coreutils@/bin/timeout 120 "$bd_cli" -C "$repo_dir" sync --yes 2>&1)" || sync_status=$?
+sync_output="$(@coreutils@/bin/timeout 120 "$bd_cli" -C "$repo_dir" sync --yes --json 2>&1)" || sync_status=$?
 if [ "$sync_status" -ne 0 ]; then
   log "Dolt sync failed with status $sync_status"
   printf '%s\n' "$sync_output" | @coreutils@/bin/tail -n 5

--- a/home-manager/services/dolt/federation-sync.sh
+++ b/home-manager/services/dolt/federation-sync.sh
@@ -35,6 +35,15 @@ if [ "${1:-}" != "--repo" ]; then
   declare -A seen_repo_names=()
   overall_status=0
 
+  # The managed server also serves this checkout. It is outside the ghq root
+  # used for additional repositories and must be provisioned on fresh hosts.
+  if BEADS_SYNC_REPO_DIR="$HOME/dotfiles" BEADS_SYNC_REPO_NAME="dotfiles" BEADS_SYNC_REPO_CONTEXT="dotfiles" "$BASH" "$0" --repo; then
+    :
+  else
+    overall_status=$?
+    log "Dotfiles federation failed with status $overall_status"
+  fi
+
   for repo_index in "${!repo_names[@]}"; do
     configured_repo="${repo_names[$repo_index]}"
     repo_context="repository $((repo_index + 1))/${#repo_names[@]}"

--- a/named-hosts/kamino/README.md
+++ b/named-hosts/kamino/README.md
@@ -94,6 +94,18 @@ machine was replaced: the verifier does not maintain a device-ID registry.
 
 Local service checks on each machine:
 
+Set `BEADS_SYNC_REPOS=org/repo` in the machine-local `~/dotfiles/.env` before
+starting Beads federation. Use comma-separated repository identifiers for
+multiple checkouts; the dotfiles checkout is included automatically. Keep this
+file private and untracked. The managed Dolt service owns port 3307, and Herdr
+workers receive its connection settings directly instead of starting their own
+servers. Existing project-local databases require a backed-up, stopped-server
+cutover into `~/.beads/shared-server/dolt`; provisioning never replaces them.
+
+Confirm both `bd --readonly ping` and `bd --readonly ready --json` in each
+checkout, plus a successful `dolt-federation-sync.service` run. An active timer
+or a passing local read alone does not prove federation readiness.
+
 ```sh
 hostname
 systemctl is-active tailscaled

--- a/spec/beads_federation_sync_spec.sh
+++ b/spec/beads_federation_sync_spec.sh
@@ -34,7 +34,7 @@ setup_federation() {
   COREUTILS="$TEST_ROOT/coreutils"
   TEST_REPO_ID="test/repo-one"
   TEST_REPO="$TEST_ROOT/ghq/github.com/$TEST_REPO_ID"
-  mkdir -p "$COREUTILS/bin" "$TEST_REPO/.beads"
+  mkdir -p "$COREUTILS/bin" "$TEST_REPO/.beads" "$TEST_ROOT/dotfiles/.beads"
   printf 'BEADS_SYNC_REPOS=%q\n' "$TEST_REPO_ID" >"$ENV_FILE"
   repo_slug="${TEST_REPO_ID//\//_}"
   CHECKPOINT_FILE="$STATE_HOME/beads-federation-sync/last-success-$repo_slug"
@@ -109,6 +109,8 @@ When run env COMMAND_LOG="$COMMAND_LOG" XDG_STATE_HOME="$STATE_HOME" HOME="$TEST
 The status should be success
 The output should include 'Dolt federation complete'
 The file "$CHECKPOINT_FILE" should be exist
+The file "$STATE_HOME/beads-federation-sync/last-success-dotfiles" should be exist
+The contents of file "$COMMAND_LOG" should include '/dotfiles ping'
 The contents of file "$COMMAND_LOG" should include 'sync --yes'
 The contents of file "$COMMAND_LOG" should include 'ready --json'
 The contents of file "$COMMAND_LOG" should include 'dolt remote add origin git+https://example.invalid/org/repo.git --allow-git-origin'

--- a/spec/beads_federation_sync_spec.sh
+++ b/spec/beads_federation_sync_spec.sh
@@ -111,7 +111,7 @@ The output should include 'Dolt federation complete'
 The file "$CHECKPOINT_FILE" should be exist
 The file "$STATE_HOME/beads-federation-sync/last-success-dotfiles" should be exist
 The contents of file "$COMMAND_LOG" should include '/dotfiles ping'
-The contents of file "$COMMAND_LOG" should include 'sync --yes'
+The contents of file "$COMMAND_LOG" should include 'sync --yes --json'
 The contents of file "$COMMAND_LOG" should include 'ready --json'
 The contents of file "$COMMAND_LOG" should include 'dolt remote add origin git+https://example.invalid/org/repo.git --allow-git-origin'
 End

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -207,6 +207,8 @@ let
         assert lib.elem "BEADS_DOLT_SERVER_MODE=1"
           cfg.systemd.user.services.herdr-server.Service.Environment;
         assert lib.elem "dolt.service" cfg.systemd.user.services.herdr-server.Unit.After;
+        assert lib.elem "BEADS_DOLT_DATA_DIR=/root/.beads/shared-server/dolt"
+          cfg.systemd.user.services.herdr-server.Service.Environment;
         assert cfg.systemd.user.services ? dolt;
         assert cfg.systemd.user.services ? dolt-federation-sync;
         assert cfg.systemd.user.timers ? dolt-federation-sync;

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -202,6 +202,9 @@ let
         assert cfg.systemd.user.services.herdr-server.Install.WantedBy == [ "default.target" ];
         assert cfg.systemd.user.services.herdr-server.Unit.X-SwitchMethod == "restart";
         assert cfg.systemd.user.services.herdr-server.Service.EnvironmentFile == [ "-/root/dotfiles/.env" ];
+        assert lib.elem "BEADS_DOLT_AUTO_START=0" cfg.systemd.user.services.herdr-server.Service.Environment;
+        assert lib.elem "BEADS_DOLT_SERVER_MODE=1" cfg.systemd.user.services.herdr-server.Service.Environment;
+        assert lib.elem "dolt.service" cfg.systemd.user.services.herdr-server.Unit.After;
         assert cfg.systemd.user.services ? dolt;
         assert cfg.systemd.user.services ? dolt-federation-sync;
         assert cfg.systemd.user.timers ? dolt-federation-sync;

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -202,8 +202,10 @@ let
         assert cfg.systemd.user.services.herdr-server.Install.WantedBy == [ "default.target" ];
         assert cfg.systemd.user.services.herdr-server.Unit.X-SwitchMethod == "restart";
         assert cfg.systemd.user.services.herdr-server.Service.EnvironmentFile == [ "-/root/dotfiles/.env" ];
-        assert lib.elem "BEADS_DOLT_AUTO_START=0" cfg.systemd.user.services.herdr-server.Service.Environment;
-        assert lib.elem "BEADS_DOLT_SERVER_MODE=1" cfg.systemd.user.services.herdr-server.Service.Environment;
+        assert lib.elem "BEADS_DOLT_AUTO_START=0"
+          cfg.systemd.user.services.herdr-server.Service.Environment;
+        assert lib.elem "BEADS_DOLT_SERVER_MODE=1"
+          cfg.systemd.user.services.herdr-server.Service.Environment;
         assert lib.elem "dolt.service" cfg.systemd.user.services.herdr-server.Unit.After;
         assert cfg.systemd.user.services ? dolt;
         assert cfg.systemd.user.services ? dolt-federation-sync;


### PR DESCRIPTION
Fresh workers skipped the dotfiles database during federation, and headless Herdr workers did not inherit the managed Dolt connection settings. Repository-local servers could then compete with the managed server on port 3307; local integrity checks could also target a preserved database copy.

Include dotfiles in federation, pass server ownership and canonical data-directory settings directly to workers and sync jobs, and retain structured synchronization errors in the journal. Document machine-local repository scope and preserved-database cutovers. Two comment-only CLIProxy YAML formatting corrections repair the formatter failure inherited from the base.

Validation: 28 focused ShellSpec tests, ShellCheck, Kamino Nix evaluation, and the full repository formatter pass. The Nix-generated service units are built and installed on kamino1–4. Both dotfiles and application `bd ping`/`bd ready` checks pass on all four. Preserved application databases were copied without replacement or deletion; missing dotfiles databases were provisioned and synchronized. Application federation remains held by existing issue-history conflicts on kamino1–3 and a full integrity-scan timeout on kamino4; no conflict-winner policy has been applied.
