### PR TITLE
feat(codex): add cliproxy profile

### DIFF
--- a/config/antigravity/settings.tpl.json
+++ b/config/antigravity/settings.tpl.json
@@ -11,6 +11,10 @@
       "command(tail)",
       "command(stat)",
       "command(file)",
+      "command(find)",
+      "command(grep)",
+      "command(rg)",
+      "command(sed)",
       "command(git)"
     ]
   }

--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -76,6 +76,10 @@ name = "OpenRouter"
 base_url = "https://openrouter.ai/api/v1"
 env_key = "OPENROUTER_API_KEY"
 
+[profiles.cliproxy]
+model = "gpt-5.6-sol"
+model_provider = "cliproxyapi"
+
 [profiles.qwen-local]
 model = "qwen3.5-0.8b-optiq"
 model_provider = "lmstudio"

--- a/config/codex/config.tpl.toml
+++ b/config/codex/config.tpl.toml
@@ -76,6 +76,10 @@ name = "OpenRouter"
 base_url = "https://openrouter.ai/api/v1"
 env_key = "OPENROUTER_API_KEY"
 
+[profiles.cliproxy]
+model = "__GPT__"
+model_provider = "cliproxyapi"
+
 [profiles.qwen-local]
 model = "__QWEN_LOCAL__"
 model_provider = "lmstudio"


### PR DESCRIPTION
Adds a `cliproxy` Codex profile that routes through the existing `cliproxyapi` provider, so `codex --profile cliproxy` uses CLIProxyAPI instead of the direct ChatGPT backend.

```toml
[profiles.cliproxy]
model = "gpt-5.6-sol"
model_provider = "cliproxyapi"
```

Also fixes `config/antigravity/settings.tpl.json`: #2639 added the search-command allowlist entries to the generated `settings.json` only, so running `scripts/llm-update.sh` reverted them. The template now carries them; generated output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XBUtBxwaeQSui13iaKD9x


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `cliproxy` Codex profile that routes through the existing `cliproxyapi` provider, so `codex --profile cliproxy` uses CLIProxyAPI instead of the direct ChatGPT backend.

**Bug Fixes**
- Moves the search-command allowlist entries (`find`, `grep`, `rg`, `sed`) into `config/antigravity/settings.tpl.json` so `scripts/llm-update.sh` no longer reverts them.

<sup>Written for commit c787b2fe45405de335152523b83208f3166535d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

