### PR TITLE
feat(codex): point the cliproxy profile at luna and add coxec

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -127,13 +127,15 @@ OMP fallback uses the shared chain (`deepseek-v4-flash` -> `free`).
 
 ### Fish shortcuts
 
-The `l` suffix means local (LM Studio), `h` means headless.
+The `l` suffix means local (LM Studio), `c` means CLIProxyAPI, `h` means
+headless.
 
 | Function | Model |
 | --- | --- |
 | `ocxe`, `ocxeh` | `cliproxyapi/deepseek-v4-flash` |
 | `ocxel`, `ocxelh` | `lmstudio/qwen3.5-0.8b-optiq` |
 | `coxe`, `coxeh` | `gpt-5.6-sol` |
+| `coxec`, `coxech` | `gpt-5.6-luna` (`--profile cliproxy`) |
 | `coxel`, `coxelh` | `qwen3.5-0.8b-optiq` (`--oss --local-provider lmstudio`) |
 | `pixe`, `pixeh` | `cliproxyapi/deepseek-v4-flash` |
 | `pixel`, `pixelh` | `lmstudio/qwen3.5-0.8b-optiq` |

--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -77,7 +77,7 @@ base_url = "https://openrouter.ai/api/v1"
 env_key = "OPENROUTER_API_KEY"
 
 [profiles.cliproxy]
-model = "gpt-5.6-sol"
+model = "gpt-5.6-luna"
 model_provider = "cliproxyapi"
 
 [profiles.qwen-local]

--- a/config/codex/config.tpl.toml
+++ b/config/codex/config.tpl.toml
@@ -77,7 +77,7 @@ base_url = "https://openrouter.ai/api/v1"
 env_key = "OPENROUTER_API_KEY"
 
 [profiles.cliproxy]
-model = "__GPT__"
+model = "__GPT_LUNA__"
 model_provider = "cliproxyapi"
 
 [profiles.qwen-local]

--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -147,6 +147,8 @@
       corc = "_corc_function";
       coxe = "_coxe_function";
       coxeh = "_coxeh_function";
+      coxec = "_coxec_function";
+      coxech = "_coxech_function";
       coxel = "_coxel_function";
       coxelh = "_coxelh_function";
       decaf = "_decaf_function";
@@ -284,6 +286,8 @@
         "copy"
         "_coxe_function"
         "_coxeh_function"
+        "_coxec_function"
+        "_coxech_function"
         "_coxel_function"
         "_coxelh_function"
         "_decaf_function"

--- a/home-manager/programs/fish/functions/_coxec_function.fish
+++ b/home-manager/programs/fish/functions/_coxec_function.fish
@@ -1,0 +1,14 @@
+function _coxec_function --description "Run Codex with a free-form prompt through CLIProxyAPI"
+  # Run Codex with a free-form prompt (spaces allowed) on the cliproxy profile,
+  # which carries the model and provider, so no caam profile is consumed.
+  # Usage: coxec [<prompt words...>]
+
+  if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
+    codex --dangerously-bypass-approvals-and-sandbox resume $argv[2]
+  else if test (count $argv) -eq 0
+    codex --dangerously-bypass-approvals-and-sandbox --profile cliproxy -c model_reasoning_summary_format=experimental
+  else
+    set -l prompt (string join " " -- $argv)
+    codex --dangerously-bypass-approvals-and-sandbox exec --profile cliproxy -c model_reasoning_summary_format=experimental -- "$prompt"
+  end
+end

--- a/home-manager/programs/fish/functions/_coxech_function.fish
+++ b/home-manager/programs/fish/functions/_coxech_function.fish
@@ -1,0 +1,18 @@
+function _coxech_function --description "Run Codex headlessly through CLIProxyAPI"
+  # Prompt for input and run Codex on the cliproxy profile
+  # Usage: coxech
+
+  set -l prompt
+  if test (count $argv) -gt 0
+    set prompt (string join " " $argv)
+  else
+    read -P "Prompt: " prompt
+  end
+
+  if test -z "$prompt"
+    echo "No prompt provided, aborting." >&2
+    return 1
+  end
+
+  codex --dangerously-bypass-approvals-and-sandbox exec --profile cliproxy -c model_reasoning_summary_format=experimental -- "$prompt"
+end

--- a/spec/fish/_coxec_function_test.fish
+++ b/spec/fish/_coxec_function_test.fish
@@ -1,0 +1,33 @@
+set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_coxec_function.fish
+
+# ── no args: interactive mode ─────────────────────────────
+set log1 (mktemp)
+function codex; echo $argv >> $log1; end
+
+_coxec_function
+
+@test "no args uses the cliproxy profile" (grep -c -- "--profile cliproxy" $log1) -ge 1
+@test "no args keeps experimental reasoning summaries" (grep -c "model_reasoning_summary_format=experimental" $log1) -ge 1
+@test "no args includes bypass flag" (grep -c -- "--dangerously-bypass-approvals-and-sandbox" $log1) -ge 1
+
+# ── with args: exec mode ──────────────────────────────────
+set log2 (mktemp)
+function codex; echo $argv >> $log2; end
+
+_coxec_function hello world
+
+@test "with args uses exec subcommand" (grep -c -- " exec " $log2) -ge 1
+@test "with args builds prompt" (grep -c "hello world" $log2) -ge 1
+@test "with args uses the cliproxy profile" (grep -c -- "--profile cliproxy" $log2) -ge 1
+@test "with args includes bypass flag" (grep -c -- "--dangerously-bypass-approvals-and-sandbox" $log2) -ge 1
+
+# ── resume mode ────────────────────────────────────────────
+set log3 (mktemp)
+function codex; echo $argv >> $log3; end
+
+_coxec_function --resume session-123
+
+@test "resume uses resume subcommand" (grep -c '^--dangerously-bypass-approvals-and-sandbox resume session-123$' $log3) -ge 1
+
+rm -f $log1 $log2 $log3

--- a/spec/fish/_coxech_function_test.fish
+++ b/spec/fish/_coxech_function_test.fish
@@ -1,0 +1,24 @@
+set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_coxech_function.fish
+
+# ── with args: prompt taken from argv ─────────────────────
+set log1 (mktemp)
+function codex; echo $argv >> $log1; end
+
+_coxech_function hello world
+
+@test "with args uses exec subcommand" (grep -c -- " exec " $log1) -ge 1
+@test "with args builds prompt" (grep -c "hello world" $log1) -ge 1
+@test "with args uses the cliproxy profile" (grep -c -- "--profile cliproxy" $log1) -ge 1
+@test "with args keeps experimental reasoning summaries" (grep -c "model_reasoning_summary_format=experimental" $log1) -ge 1
+@test "with args includes bypass flag" (grep -c -- "--dangerously-bypass-approvals-and-sandbox" $log1) -ge 1
+
+# ── empty prompt aborts ───────────────────────────────────
+set log2 (mktemp)
+function codex; echo $argv >> $log2; end
+
+_coxech_function "" 2>/dev/null
+
+@test "an empty prompt does not launch codex" (wc -l < $log2 | string trim) -eq 0
+
+rm -f $log1 $log2


### PR DESCRIPTION
Points the Codex `cliproxy` profile at `gpt-5.6-luna` and adds two shell aliases on it.

## Profile model

`[profiles.cliproxy]` rendered `gpt-5.6-sol` (`__GPT__`). It now renders `gpt-5.6-luna` via `__GPT_LUNA__`, which already exists in `models.json` as `gpt-luna`, so no renderer change was needed.

```toml
[profiles.cliproxy]
model = "gpt-5.6-luna"
model_provider = "cliproxyapi"
```

This matches the model the fleet seats on the same profile in shunkakinokisoftware.

## `coxec` / `coxech`

`c` joins `l` (local) and `h` (headless) in the suffix vocabulary, so `coxec` is the free-form variant and `coxech` the headless one.

Both invoke `codex` directly rather than through `_caam_exec_function`, unlike `coxe`/`coxeh`. CLIProxyAPI authenticates with `CLIPROXY_API_KEY` from the environment, so routing through caam would burn a credential profile the request never uses. `--profile cliproxy` carries the model and provider, so neither function hardcodes a model and neither needs template substitution.

## Verification

Exercised both functions in fish against a stubbed `codex`:

```
--dangerously-bypass-approvals-and-sandbox --profile cliproxy -c model_reasoning_summary_format=experimental
--dangerously-bypass-approvals-and-sandbox exec --profile cliproxy -c model_reasoning_summary_format=experimental -- hello world
--dangerously-bypass-approvals-and-sandbox resume session-123
--dangerously-bypass-approvals-and-sandbox exec --profile cliproxy -c model_reasoning_summary_format=experimental -- headless prompt
```

An empty prompt to `coxech` launches nothing, as intended. Fishtape specs are added for both.

Fishtape reports 14/14 passing across both new specs. Pre-commit and pre-push hooks were bypassed at the author's request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XBUtBxwaeQSui13iaKD9x
