### PR TITLE
fix(tailscale): pass managed DNS flag only once

### DIFF
--- a/home-manager/modules/tailscale/activate-up.sh
+++ b/home-manager/modules/tailscale/activate-up.sh
@@ -53,7 +53,7 @@ restore_resolved_stub() {
 # direct resolv.conf can otherwise feed Tailscale its own resolver as upstream.
 restore_resolved_stub
 if [ "$#" -gt 0 ]; then
-  "$TAILSCALE_BIN" up "$@" --accept-dns=true
+  "$TAILSCALE_BIN" up "$@"
 else
   # Empty arguments leave enrollment to the host activation. Update only DNS,
   # preserving existing non-default preferences such as the node hostname.

--- a/spec/tailscale_dns_routing_spec.sh
+++ b/spec/tailscale_dns_routing_spec.sh
@@ -30,10 +30,16 @@ run_activation() {
 Before 'setup'
 After 'cleanup'
 
-It 'enables DNS acceptance while applying the other node flags'
-When call run_activation --ssh=false
+It 'passes the managed DNS flag exactly once with the other node flags'
+When call run_activation --ssh=false --accept-dns=true
 The status should be success
 The contents of file "$DNS_LOG" should eq 'up --ssh=false --accept-dns=true'
+End
+
+It 'preserves the exit-node host arguments without duplicating DNS acceptance'
+When call run_activation --reset --ssh=false --accept-dns=true --advertise-exit-node
+The status should be success
+The contents of file "$DNS_LOG" should eq 'up --reset --ssh=false --accept-dns=true --advertise-exit-node'
 End
 
 It 'updates DNS without enrollment when no node flags are supplied'
@@ -55,7 +61,7 @@ End
 
 It 'passes explicit enrollment arguments through unchanged'
 export EXISTING_HOSTNAME=kamino3
-When call run_activation --hostname=kamino3 --ssh=false
+When call run_activation --hostname=kamino3 --ssh=false --accept-dns=true
 The status should be success
 The contents of file "$DNS_LOG" should eq 'up --hostname=kamino3 --ssh=false --accept-dns=true'
 End
@@ -69,7 +75,7 @@ End
 
 It 'reports an explicit enrollment failure'
 export TAILSCALE_STATUS=42
-When call run_activation --hostname=kamino3 --ssh=false
+When call run_activation --hostname=kamino3 --ssh=false --accept-dns=true
 The status should equal 42
 The contents of file "$DNS_LOG" should eq 'up --hostname=kamino3 --ssh=false --accept-dns=true'
 End


### PR DESCRIPTION
The system Tailscale activation supplied `--accept-dns=true` twice: once in the named host arguments and once in the shared script. Tailscale 1.102.3 rejects repeated flags, causing activation to stop with exit 2.

Pass explicit host arguments through unchanged. The no-argument path continues to update DNS with `tailscale set`, preserving enrolled node preferences.

Validation: 34 focused ShellSpec examples passed, including the exit-node argument sequence; ShellCheck and diff whitespace checks passed. Reproduced the installed CLI rejecting duplicate DNS flags through its help-only path without changing network settings.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Tailscale activation failing on Tailscale 1.102.3 by stopping the duplicate `--accept-dns=true` flag when explicit host arguments are supplied. Explicit arguments now pass through unchanged, while the no-argument path continues to update DNS with `tailscale set`, preserving enrolled node preferences.

<sup>Written for commit 5f87c528e3e89e3e9981759d936415ed79a3bbf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

