### PR TITLE
fix(activation): preserve externally managed Codex servers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,11 @@ refresh-codex-daemon: ## Restart the managed Codex app-server daemon on Kyber.
 		echo "❌ Codex is not installed"; \
 		exit 1; \
 	fi; \
+	MANAGED_CODEX_BIN="$$("$$CODEX_BIN" app-server daemon version | jq -er '.managedCodexPath')"; \
+	if [ ! -e "$$MANAGED_CODEX_BIN" ]; then \
+		echo "⏭️ Codex daemon refresh skipped (no managed standalone installation; preserving the existing app server)"; \
+		exit 0; \
+	fi; \
 	echo "🔄 Refreshing the Kyber Codex app-server daemon..."; \
 	"$$CODEX_BIN" app-server daemon restart; \
 	"$$CODEX_BIN" app-server daemon version; \

--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -1,0 +1,32 @@
+# Prerequisites
+
+## CLIProxy credentials
+
+Set `CLIPROXY_API_KEY` in `~/dotfiles/.env` on every host that uses CLIProxy.
+This private, Git-ignored file is the credential source for the managed shell
+environment. Keep it readable only by its owner:
+
+```sh
+chmod 600 ~/dotfiles/.env
+```
+
+Provision the key through a private channel; never commit it, paste it into a
+command argument, or print the environment. Open a new shell after updating the
+file so `coxec`, `coxech`, and the named Codex profiles receive the key. A service
+or agent that is already running retains its previous environment until its
+owner restarts it.
+
+## Managed Codex installation
+
+The CLI version and its platform binary must match the version declared in
+`package.json`. The managed activation installs both. Check `codex --version`
+from the same shell that launches `coxec`; an older binary earlier on `PATH`
+can reject the current configuration before contacting the provider.
+
+See [MODELS.md](./MODELS.md) for the CLIProxy profiles and their model assignments.
+
+## App-server ownership
+
+The Kyber refresh target restarts an installed standalone Codex daemon. When no
+standalone installation exists, it preserves the app server owned by another
+application. Update or restart that server through its owning application.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ## Installation
 
+See [PREREQUISITES.md](./PREREQUISITES.md) for private credentials and managed CLI requirements.
+
 ```bash
  curl -fsSL https://raw.githubusercontent.com/shunkakinoki/dotfiles/main/install.sh | sh
 ```

--- a/spec/codex_daemon_refresh_spec.sh
+++ b/spec/codex_daemon_refresh_spec.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'managed Codex daemon refresh'
+setup() {
+  TEST_ROOT=$(mktemp -d)
+  export CODEX_LOG="$TEST_ROOT/codex.log"
+  export MANAGED_CODEX_PATH="$TEST_ROOT/standalone/codex"
+  mkdir -p "$TEST_ROOT/bin"
+  touch "$CODEX_LOG"
+  cat >"$TEST_ROOT/bin/codex" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$CODEX_LOG"
+case "$*" in
+  'app-server daemon version')
+    if [ "${VERSION_STATUS:-0}" -ne 0 ]; then exit "$VERSION_STATUS"; fi
+    printf '{"managedCodexPath":"%s"}\n' "$MANAGED_CODEX_PATH"
+    ;;
+  'app-server daemon restart') exit "${RESTART_STATUS:-0}" ;;
+  *) exit 1 ;;
+esac
+MOCK
+  chmod +x "$TEST_ROOT/bin/codex"
+}
+
+cleanup() { rm -rf "$TEST_ROOT"; }
+
+refresh() {
+  PATH="$TEST_ROOT/bin:$PATH" make --no-print-directory refresh-codex-daemon \
+    DETECTED_HOST="${TEST_HOST:-kyber}" TAILSCALE_DNS_NAME= GIT_COMMIT_SHA=test
+}
+
+install_managed_binary() {
+  mkdir -p "$(dirname "$MANAGED_CODEX_PATH")"
+  touch "$MANAGED_CODEX_PATH"
+}
+
+Before 'setup'
+After 'cleanup'
+
+It 'preserves an externally owned app server when no standalone installation exists'
+When call refresh
+The status should be success
+The output should include 'preserving the existing app server'
+The contents of file "$CODEX_LOG" should eq 'app-server daemon version'
+End
+
+It 'refreshes and verifies an installed managed daemon'
+install_managed_binary
+When call refresh
+The status should be success
+The output should include 'daemon refreshed'
+The contents of file "$CODEX_LOG" should eq 'app-server daemon version
+app-server daemon restart
+app-server daemon version'
+End
+
+It 'fails when daemon ownership information cannot be read'
+export VERSION_STATUS=42
+When call refresh
+The status should be failure
+The stderr should include 'Error'
+The contents of file "$CODEX_LOG" should eq 'app-server daemon version'
+End
+
+It 'reports a failed managed restart'
+install_managed_binary
+export RESTART_STATUS=42
+When call refresh
+The status should be failure
+The output should include 'Refreshing'
+The stderr should include 'Error'
+The contents of file "$CODEX_LOG" should eq 'app-server daemon version
+app-server daemon restart'
+End
+
+It 'does not inspect or restart daemons on other hosts'
+export TEST_HOST=matic
+When call refresh
+The status should be success
+The output should include 'Kyber only'
+The contents of file "$CODEX_LOG" should eq ''
+End
+End


### PR DESCRIPTION
A host switch reached the Codex refresh step and failed because the running app server belonged to another application, while no standalone daemon was installed. Read the managed installation path reported by the CLI and skip the standalone refresh when that installation is absent. Installed daemon failures still fail the target.

Document `~/dotfiles/.env` as the private `CLIPROXY_API_KEY` prerequisite, explain shell/service environment refresh, and link the prerequisites from the README.

Validation: five executable Makefile-target tests passed for absent installation, managed restart, version-query failure, restart failure, and non-target hosts. ShellCheck and diff whitespace checks passed. Read-only live inspection confirmed the standalone installation is absent on the affected host. Running the exact proposed Makefile target there then exited successfully and preserved the application-owned server. The separate Claude daemon refresh also completed successfully.
