### PR TITLE
fix(cliproxy): pin OAuth credentials to priority 300

### DIFF
--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -61,6 +61,21 @@ render_opencode_api_key_entries() {
   done <"$template"
 }
 
+# OAuth credentials default to priority 0, which loses to openai-compatibility
+# providers like surplus (150). Pin all auth files to the given priority so native
+# executors are selected first for cold bindings under fill-first routing.
+ensure_oauth_priority() {
+  local auth_dir="$1" target_priority="$2"
+  local f current
+  for f in "$auth_dir"/*.json; do
+    [ -f "$f" ] || continue
+    current="$(jq -r '.priority // 0' "$f" 2>/dev/null)" || continue
+    if [ "$current" != "$target_priority" ]; then
+      jq --argjson p "$target_priority" '.priority = $p' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+    fi
+  done
+}
+
 if cliproxy_has_objectstore_credentials; then
   mkdir -p "$AUTH_DIR"
 
@@ -68,6 +83,8 @@ if cliproxy_has_objectstore_credentials; then
     echo "⚠️  Local auth cache empty; hydrating from S3" >&2
     cliproxy_sync_auth_from_s3 "$AUTH_DIR"
   fi
+
+  ensure_oauth_priority "$AUTH_DIR" 300
 
   if [ -n "$(ls -A "$AUTH_DIR" 2>/dev/null)" ]; then
     cliproxy_sync_auth_to_s3 "$AUTH_DIR"

--- a/spec/cliproxyapi_spec.sh
+++ b/spec/cliproxyapi_spec.sh
@@ -506,4 +506,58 @@ The status should be success
 End
 End
 
+Describe 'OAuth credential priority enforcement'
+setup_oauth_priority() {
+  TEMP_PRIORITY=$(mktemp -d)
+  sed -n '/^ensure_oauth_priority() {/,/^}/p' "$SCRIPT" >"$TEMP_PRIORITY/fn.sh"
+}
+
+cleanup_oauth_priority() {
+  rm -rf "$TEMP_PRIORITY"
+}
+
+Before 'setup_oauth_priority'
+After 'cleanup_oauth_priority'
+
+It 'bumps priority 0 auth files to the target'
+cat >"$TEMP_PRIORITY/codex-test-user.json" <<'JSON'
+{"provider":"codex","account":"test@example.com","priority":0}
+JSON
+When run bash -c '. "$1/fn.sh"; ensure_oauth_priority "$1" 300; cat "$1/codex-test-user.json"' _ "$TEMP_PRIORITY"
+The output should include '"priority": 300'
+The status should be success
+End
+
+It 'leaves auth files already at the target priority unchanged'
+cat >"$TEMP_PRIORITY/codex-already-set.json" <<'JSON'
+{"provider":"codex","account":"test@example.com","priority":300}
+JSON
+cp "$TEMP_PRIORITY/codex-already-set.json" "$TEMP_PRIORITY/codex-already-set.json.orig"
+When run bash -c '. "$1/fn.sh"; ensure_oauth_priority "$1" 300; diff "$1/codex-already-set.json.orig" "$1/codex-already-set.json"'  _ "$TEMP_PRIORITY"
+The status should be success
+End
+
+It 'bumps all provider types equally'
+cat >"$TEMP_PRIORITY/claude-user.json" <<'JSON'
+{"provider":"claude","account":"test@example.com","priority":0}
+JSON
+cat >"$TEMP_PRIORITY/gemini-user.json" <<'JSON'
+{"provider":"gemini","account":"test@example.com","priority":0}
+JSON
+When run bash -c '. "$1/fn.sh"; ensure_oauth_priority "$1" 300; jq -r .priority "$1/claude-user.json"; jq -r .priority "$1/gemini-user.json"' _ "$TEMP_PRIORITY"
+The first line of output should eq '300'
+The second line of output should eq '300'
+The status should be success
+End
+
+It 'adds priority field when missing'
+cat >"$TEMP_PRIORITY/codex-no-priority.json" <<'JSON'
+{"provider":"codex","account":"new@example.com"}
+JSON
+When run bash -c '. "$1/fn.sh"; ensure_oauth_priority "$1" 300; jq -r .priority "$1/codex-no-priority.json"' _ "$TEMP_PRIORITY"
+The output should eq '300'
+The status should be success
+End
+End
+
 End


### PR DESCRIPTION
## Summary
- OAuth credentials default to priority 0, losing to openai-compatibility providers like surplus (150) for shared models like gpt-5.6-luna
- Added `ensure_oauth_priority()` to start.sh that patches all auth JSON files to priority 300 before cliproxy launches
- Runs after S3 hydration, before S3 upload - persists across restarts

## Test plan
- [x] 41 shellspec tests pass (4 new for priority enforcement)
- [ ] Deploy to Kyber and confirm codex sessions bind to OAuth credential instead of surplus

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNKtmZGj6QMSorvwxt2oyF

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
OAuth credentials default to priority 0, losing to openai-compatibility providers like surplus (150) for shared models like gpt-5.6-luna. `ensure_oauth_priority()` now pins all auth JSON files to priority 300 before cliproxy launches, so native executors are selected first under fill-first routing.

**Bug Fixes**
- Runs after S3 hydration and before S3 upload, so the priority persists across restarts.
- Adds 4 shellspec tests covering priority bump, no-op on already-set files, all provider types, and missing priority field.
- Needs a deploy to Kyber to confirm codex sessions bind to OAuth credentials.

<sup>Written for commit ec1a05cca6cc5fcc18a7f2aeb5cbcaaab4cc261d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

