### PR TITLE
fix(herdr): supervise the desktop server with launchd

### DIFF
--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -19,6 +19,7 @@ let
   dockerPostgres = ./docker-postgres;
   dotfilesUpdater = import ./dotfiles-updater { inherit inputs pkgs; };
   gasTown = import ./gas-town { inherit pkgs; };
+  herdr = ./herdr;
   hermes = ./hermes;
   k3s = ./k3s;
   keydApplicationMapper = ./keyd-application-mapper;
@@ -52,6 +53,7 @@ in
   firewall
   dotfilesUpdater
   gasTown
+  herdr
   hermes
   k3s
   keydApplicationMapper

--- a/home-manager/services/herdr/default.nix
+++ b/home-manager/services/herdr/default.nix
@@ -1,0 +1,31 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  homeDir = config.home.homeDirectory;
+in
+{
+  launchd.agents.herdr-server = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "${pkgs.bash}/bin/bash"
+        "${./start.sh}"
+        "${pkgs.llm-agents.herdr}/bin/herdr"
+      ];
+      WorkingDirectory = homeDir;
+      RunAtLoad = true;
+      KeepAlive = true;
+      ThrottleInterval = 10;
+      EnvironmentVariables = {
+        HOME = homeDir;
+        PATH = "${homeDir}/.local/bin:${homeDir}/.bun/bin:/etc/profiles/per-user/${config.home.username}/bin:${homeDir}/.nix-profile/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
+      };
+      StandardOutPath = "${homeDir}/.config/herdr/herdr-launchd.log";
+      StandardErrorPath = "${homeDir}/.config/herdr/herdr-launchd.error.log";
+    };
+  };
+}

--- a/home-manager/services/herdr/start.sh
+++ b/home-manager/services/herdr/start.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Use the shared shell injector on every server start, including after login.
+# shellcheck source=/dev/null
+. "${HOME}/.config/shell/load-env-file.sh"
+_hm_load_env_file
+
+exec "$1" server

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -73,6 +73,10 @@ It 'has spec file for home-manager/services/caam/setup.sh'
 The path "spec/caam_sync_service_spec.sh" should be exist
 End
 
+It 'has spec file for home-manager/services/herdr/start.sh'
+The path "spec/herdr_service_spec.sh" should be exist
+End
+
 It 'has spec file for home-manager/services/caam/sync.sh'
 The path "spec/caam_sync_service_spec.sh" should be exist
 End
@@ -586,6 +590,7 @@ home-manager/services/openclaw/k3s-proxy.sh
 home-manager/services/qmd/activate.sh
 home-manager/services/roborev/activate.sh
 home-manager/services/roborev/start.sh
+home-manager/services/herdr/start.sh
 home-manager/modules/tailscale/activate-create-dirs.sh
 home-manager/modules/tailscale/activate-install-service.sh
 home-manager/modules/tailscale/activate-up.sh

--- a/spec/herdr_service_spec.sh
+++ b/spec/herdr_service_spec.sh
@@ -1,0 +1,35 @@
+# shellcheck shell=bash
+Describe 'Herdr server environment'
+SCRIPT="$PWD/home-manager/services/herdr/start.sh"
+
+setup() {
+  TEMP_HOME=$(mktemp -d)
+  mkdir -p "$TEMP_HOME/dotfiles" "$TEMP_HOME/.config/shell"
+  cp -f home-manager/modules/dotenv/load-env-file.sh home-manager/modules/dotenv/print-env-file.sh "$TEMP_HOME/.config/shell/"
+  cat >"$TEMP_HOME/dotfiles/.env" <<'ENV'
+HERDR_TEST_VALUE="value with spaces"
+HERDR_TEST_LITERAL=$(touch should-not-exist)
+ENV
+  cat >"$TEMP_HOME/herdr" <<'CLI'
+#!/usr/bin/env bash
+printf '%s\n' "$HERDR_TEST_VALUE" "$HERDR_TEST_LITERAL" "$*"
+CLI
+  chmod +x "$TEMP_HOME/herdr"
+}
+
+cleanup() {
+  rm -rf "$TEMP_HOME"
+}
+
+Before 'setup'
+After 'cleanup'
+
+It 'loads values through the shared parser without evaluating shell expressions'
+When run env -u DOTFILES_ENV_FILE -u HM_PRINT_ENV_FILE HOME="$TEMP_HOME" bash "$SCRIPT" "$TEMP_HOME/herdr"
+The status should be success
+The line 1 of output should equal 'value with spaces'
+# shellcheck disable=SC2016
+The line 2 of output should equal '$(touch should-not-exist)'
+The line 3 of output should equal 'server'
+End
+End


### PR DESCRIPTION
## Summary

Declare the desktop Herdr server as a Home Manager launchd agent so it starts at login and restarts after an unexpected exit. The service uses the pinned Herdr package and the existing shared shell dotenv injector on every start, preserving the same environment parsing as interactive shells.

The wrapper sources `~/.config/shell/load-env-file.sh` and calls `_hm_load_env_file` before executing the server. No additional dotenv parser or recurring wake scheduler is introduced.

Stacked on #2656, which repairs the existing shell formatting and ShellCheck failures on the pinned base.

## Validation

- Home Manager activation-package build for the desktop host passed.
- Generated launchd plist passed `plutil -lint`.
- Nix formatting, ShellCheck, Bash syntax, and `git diff --check` passed.
- 163 ShellSpec examples passed, including the Herdr environment regression, the shell coverage registry, and the prerequisite tests.
- An isolated child-process check verified quoted values and literal shell syntax through the shared injector.

Source publication is separate from activation. The live service has not been loaded or restarted. Rollback removes the service declaration through Home Manager; existing Herdr state is preserved.
