### PR TITLE
feat(cliproxyapi): route credentials with round-robin

### DIFF
--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -178,7 +178,7 @@ quota-exceeded:
   # antigravity-credits: true # Whether to use credits as last-resort fallback when all free-tier auths are exhausted for Claude models
 # Routing strategy for selecting credentials when multiple match.
 routing:
-  strategy: "fill-first" # round-robin (default), weighted-round-robin, fill-first
+  strategy: "round-robin" # round-robin (default), weighted-round-robin, fill-first
   # weighted-round-robin uses each credential's integer weight (default 1, maximum 1,000,000).
   # Non-positive weights exclude the credential while this strategy is active.
   # For OAuth/file credentials, add a top-level numeric "weight" field to the auth JSON.

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -178,7 +178,7 @@ quota-exceeded:
   # antigravity-credits: true # Whether to use credits as last-resort fallback when all free-tier auths are exhausted for Claude models
 # Routing strategy for selecting credentials when multiple match.
 routing:
-  strategy: "fill-first" # round-robin (default), weighted-round-robin, fill-first
+  strategy: "round-robin" # round-robin (default), weighted-round-robin, fill-first
   # weighted-round-robin uses each credential's integer weight (default 1, maximum 1,000,000).
   # Non-positive weights exclude the credential while this strategy is active.
   # For OAuth/file credentials, add a top-level numeric "weight" field to the auth JSON.

--- a/home-manager/services/cliproxyapi/scripts/start.sh
+++ b/home-manager/services/cliproxyapi/scripts/start.sh
@@ -63,7 +63,7 @@ render_opencode_api_key_entries() {
 
 # OAuth credentials default to priority 0, which loses to openai-compatibility
 # providers like surplus (150). Pin all auth files to the given priority so native
-# executors are selected first for cold bindings under fill-first routing.
+# executors are selected first for cold bindings.
 ensure_oauth_priority() {
   local auth_dir="$1" target_priority="$2"
   local f current

--- a/spec/cliproxyapi_spec.sh
+++ b/spec/cliproxyapi_spec.sh
@@ -367,7 +367,7 @@ It 'keeps provider selection sticky for eight hours per client session'
 When run bash -c "sed -n '/^routing:/,/^[a-z]/p' '$PWD/config/cliproxyapi/config.template.yaml'"
 The output should include 'session-affinity: true'
 The output should include 'session-affinity-ttl: "8h"'
-The output should include 'strategy: "fill-first"'
+The output should include 'strategy: "round-robin"'
 The status should be success
 End
 
@@ -445,7 +445,7 @@ The status should be success
 End
 
 It 'keeps behavior-changing official examples inactive'
-When run bash -c "grep -Fq '  # antigravity-credits: true' config/cliproxyapi/config.template.yaml && grep -Fq 'ws-auth: false' config/cliproxyapi/config.template.yaml && grep -Fq 'strategy: \"fill-first\"' config/cliproxyapi/config.template.yaml"
+When run bash -c "grep -Fq '  # antigravity-credits: true' config/cliproxyapi/config.template.yaml && grep -Fq 'ws-auth: false' config/cliproxyapi/config.template.yaml && grep -Fq 'strategy: \"round-robin\"' config/cliproxyapi/config.template.yaml"
 The status should be success
 End
 End


### PR DESCRIPTION
## Summary

Switch `routing.strategy` from `fill-first` to `round-robin` so a second Codex subscription at the same priority actually shares load.

Under `fill-first`, `pickReadyAtPriorityLocked` calls `view.pickFirst`, which returns the first ready entry in a priority bucket and never advances a cursor. Buckets are sorted by `auth.ID` (the auth filename), so every cold request goes to the same credential and a same-priority sibling is only reached on cooldown/429 failover. `round-robin` uses `pickRoundRobin`, which advances `lastPicked`.

Priority tiering is unchanged: all strategies only break ties *within* the highest ready priority tier, so the OpenCode (300) -> Aliyun (200) -> OpenRouter (100) hop order still holds.

`session-affinity: true` with an 8h TTL is also unchanged, so a bound session stays on its credential; round-robin only affects cold picks, new bindings, and post-failover rebinds.

## Changes

- `config/cliproxyapi/config.tpl.yaml` + generated `config.template.yaml`: `strategy: "round-robin"`
- `spec/cliproxyapi_spec.sh`: update the two assertions pinning the strategy value
- `home-manager/services/cliproxyapi/scripts/start.sh`: drop the now-stale `fill-first` mention from the priority-pinning comment (the rationale is strategy-independent)

## Testing

`shellspec spec/cliproxyapi_spec.sh` - 41 examples, 0 failures.

## Trade-off

Both subscription quota windows now drain in parallel rather than keeping the second as an intact reserve, and cold bindings lose some Codex prompt-cache locality. In exchange, sustained throughput before hitting any single account's 5h cap goes up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `cliproxyapi` credential routing from `fill-first` to `round-robin` so cold bindings alternate across equal-priority credentials instead of always landing on the lexicographically first auth ID. Previously a second same-priority Codex subscription stayed idle until the first hit cooldown or failover; now both quota windows drain in parallel. Priority tiering and 8h session affinity are unchanged, so the trade-off is losing prompt-cache locality on cold bindings in exchange for higher sustained throughput before hitting any single account's 5h cap.

<sup>Written for commit ee6312bde408f05337a6bf99a477a610c966adb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

