### PR TITLE
fix(herdr): validate local worker start admission

### DIFF
--- a/config/opencode/default.nix
+++ b/config/opencode/default.nix
@@ -14,6 +14,12 @@
     force = true;
   };
 
+  # OpenCode reports lowercase bash; Claude's Bash matcher is case-sensitive.
+  home.file.".config/opencode/hooks.json" = {
+    source = ./hooks.json;
+    force = true;
+  };
+
   home.file.".config/opencode/tui.json" = {
     source = ./tui.json;
     force = true;

--- a/config/opencode/hooks.json
+++ b/config/opencode/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/dotfiles/config/shared/hooks/security.sh",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/config/shared/hooks/README.md
+++ b/config/shared/hooks/README.md
@@ -19,6 +19,28 @@ The push hook blocks explicit and implicit updates or deletions of `main`, `mast
 
 The settings hook blocks repository control-plane mutations through settings-oriented `gh` commands, REST or GraphQL API calls, and common direct HTTP clients. It splits the command line into individual invocations and judges each one by its own arguments, so quoted text that merely names a command is not matched. GraphQL is judged by the root mutation fields the document invokes, and a document the hook cannot read is treated as a settings mutation. Read-only API calls and ordinary pull request, issue, review, and comment operations remain available.
 
+## Herdr worker starts
+
+The shared security hook admits local `herdr agent start` commands only after
+reading the target pane, workspace, linked worktree, and existing agent owners.
+A worker needs an explicit pane, consistent metadata and cwd under
+`~/.herdr/worktrees/<repo>/`, and no other owner of its name or checkout.
+Settled agents retain ownership. Missing, malformed, or timed-out metadata
+blocks the command before the submitted launch executes. Multiple starts in
+one command cannot share a checkout.
+
+The local host's canonical main/co-orchestrator names, including their named
+fallback seats, remain available in the root workspace. Read-only commands,
+help, and hold prompts are unaffected. OpenCode has its own lowercase `bash`
+matcher pointing at this shared hook; its Claude-hook adapter does not match
+Claude's uppercase `Bash` entries. The helper evaluates command text and uses
+only read-only Herdr probes; it never launches, moves, or stops an agent.
+
+This is admission for local shell starts through supported hooks. It does not
+prove task or PR ownership and is not a native Herdr server policy. Direct API
+calls, unhooked remote execution, and other unsupported launch paths still
+need their authoritative lifecycle controls.
+
 ## Security boundary
 
 These hooks provide fast feedback and prevent common mistakes. They run with the same user permissions as the agent and can be bypassed, disabled, or avoided through an unsupported tool path. Restricted GitHub credentials and server-side branch rulesets are the authoritative controls; do not grant an agent an administrator credential because these hooks are installed.

--- a/config/shared/hooks/README.md
+++ b/config/shared/hooks/README.md
@@ -27,7 +27,8 @@ A worker needs an explicit pane, consistent metadata and cwd under
 `~/.herdr/worktrees/<repo>/`, and no other owner of its name or checkout.
 Settled agents retain ownership. Missing, malformed, or timed-out metadata
 blocks the command before the submitted launch executes. Multiple starts in
-one command cannot share a checkout.
+one command cannot share a checkout. Environment-changing prefixes are refused
+for worker starts because probes must inspect the same Herdr server as the launch.
 
 The local host's canonical main/co-orchestrator names, including their named
 fallback seats, remain available in the root workspace. Read-only commands,

--- a/config/shared/hooks/herdr-worker-admission.py
+++ b/config/shared/hooks/herdr-worker-admission.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Check local Herdr worker starts without executing the submitted command."""
+
+import json
+import re
+import shlex
+import shutil
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+
+class AdmissionError(Exception):
+    pass
+
+
+def invocations(command):
+    # Non-POSIX lexing retains quotes around punctuation-only arguments. The
+    # second pass removes quoting only after command boundaries are known.
+    lexer = shlex.shlex(command, posix=False, punctuation_chars=";&|()\n")
+    lexer.whitespace = " \t\r"
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    pending = []
+    comment = False
+    for token in lexer:
+        if comment and "\n" not in token:
+            continue
+        if token.startswith("#"):
+            comment = True
+            continue
+        comment = False
+        if token and all(char in ";&|()\n" for char in token):
+            if pending:
+                yield shlex.split(" ".join(pending))
+                pending = []
+        else:
+            pending.append(token)
+    if pending:
+        yield shlex.split(" ".join(pending))
+
+
+def starts(command, depth=0):
+    if depth > 4:
+        raise AdmissionError("nested shell launch cannot be verified")
+    for words in invocations(command):
+        while words and (
+            words[0] in {"command", "exec", "env", "do", "then", "else"}
+            or re.fullmatch(r"[A-Za-z_][A-Za-z_0-9]*=.*", words[0])
+        ):
+            words = words[1:]
+        if not words:
+            continue
+        executable = Path(words[0]).name
+        if executable in {"bash", "sh", "zsh", "fish"}:
+            for index, word in enumerate(words[1:], 1):
+                if word in {"-c", "-lc", "-ic"} and index + 1 < len(words):
+                    yield from starts(words[index + 1], depth + 1)
+                    break
+        if executable != "herdr":
+            continue
+        args = words[1:]
+        if args[:2] == ["agent", "start"]:
+            yield args[2:]
+        elif "agent" in args:
+            index = args.index("agent")
+            if args[index : index + 2] == ["agent", "start"]:
+                raise AdmissionError(
+                    "Herdr connection options need host-local admission"
+                )
+
+
+def probe(args):
+    binary = shutil.which("herdr")
+    if binary is None:
+        raise AdmissionError("Herdr metadata is unavailable")
+    try:
+        result = subprocess.run(
+            [binary, *args],
+            capture_output=True,
+            text=True,
+            timeout=0.8,
+            check=True,
+        )
+        value = json.loads(result.stdout)["result"]
+        if not isinstance(value, dict):
+            raise ValueError("invalid result")
+        return value
+    except (OSError, subprocess.SubprocessError, ValueError, KeyError) as error:
+        raise AdmissionError("Herdr metadata is unavailable or malformed") from error
+
+
+def require_worker_worktree(args, read=probe, home=None, host=None):
+    name = None
+    pane_target = None
+    index = 0
+    while index < len(args):
+        value = args[index]
+        if value == "--":
+            break
+        if value in {"--help", "-h"}:
+            return None
+        option, separator, argument = value.partition("=")
+        if option in {"--pane", "--kind", "--timeout"}:
+            if not separator:
+                index += 1
+                if index >= len(args):
+                    raise AdmissionError("worker start has an incomplete option")
+                argument = args[index]
+            if option == "--pane":
+                pane_target = argument
+        elif value.startswith("-") or name is not None:
+            raise AdmissionError("worker start arguments cannot be verified")
+        else:
+            name = value
+        index += 1
+    host = (host or socket.gethostname()).split(".")[0].lower()
+    orchestrators = {
+        f"{host}_orchestrator",
+        f"{host}_co_orchestrator",
+        f"{host}_orchestrator_fallback",
+        f"{host}_co_orchestrator_fallback",
+    }
+    if name in orchestrators:
+        return None
+    if not name or not pane_target or not re.fullmatch(r"w[\w-]+:p[\w-]+", pane_target):
+        raise AdmissionError("worker start requires an explicit literal pane")
+
+    pane = read(["pane", "get", pane_target]).get("pane", {})
+    workspace_id = pane.get("workspace_id")
+    if not isinstance(workspace_id, str):
+        raise AdmissionError("worker pane has no workspace identity")
+    # Pane aliases can resolve to a different workspace after a native move.
+    # Trust the returned workspace identity, never the requested pane prefix.
+    workspace = read(["workspace", "get", workspace_id]).get("workspace", {})
+    worktree = workspace.get("worktree") or {}
+    path = worktree.get("checkout_path")
+    repo = worktree.get("repo_name")
+    source = worktree.get("repo_root")
+    if (
+        workspace.get("workspace_id") != workspace_id
+        or worktree.get("is_linked_worktree") is not True
+        or not all(isinstance(value, str) and value for value in (path, repo, source))
+        or repo in {".", ".."}
+        or "/" in repo
+    ):
+        raise AdmissionError("worker requires a linked Herdr worktree")
+    checkout = Path(path).resolve()
+    root = (Path(home or Path.home()) / ".herdr" / "worktrees" / repo).resolve()
+    if (
+        not checkout.is_relative_to(root)
+        or checkout == root
+        or path != str(checkout)
+        or pane.get("cwd") != path
+    ):
+        raise AdmissionError(
+            "worker cwd must match its checkout under the Herdr worktree root"
+        )
+
+    worktrees = read(["worktree", "list", "--cwd", source]).get("worktrees")
+    if not isinstance(worktrees, list):
+        raise AdmissionError("worktree association is unavailable")
+    matches = [item for item in worktrees if item.get("path") == path]
+    if (
+        len(matches) != 1
+        or matches[0].get("is_linked_worktree") is not True
+        or matches[0].get("open_workspace_id") != workspace_id
+    ):
+        raise AdmissionError("workspace and worktree association disagree")
+
+    agents = read(["agent", "list"]).get("agents")
+    if not isinstance(agents, list):
+        raise AdmissionError("worker ownership is unavailable")
+    for agent in agents:
+        same_pane = agent.get("pane_id") == pane.get("pane_id")
+        same_name = agent.get("name") == name
+        same_checkout = agent.get("cwd") == path
+        if (same_pane or same_name or same_checkout) and not (
+            same_pane and same_name and same_checkout
+        ):
+            # A settled turn retains ownership; renaming a duplicate lane does
+            # not release the existing worker's checkout.
+            raise AdmissionError("worker name or checkout already has another owner")
+    return path
+
+
+def main(command):
+    if "herdr" not in command:
+        return 0
+    try:
+        admitted = set()
+        for args in starts(command):
+            path = require_worker_worktree(args)
+            if path is not None and path in admitted:
+                raise AdmissionError(
+                    "one command cannot start multiple workers in one checkout"
+                )
+            if path is not None:
+                admitted.add(path)
+    except (AdmissionError, ValueError, TypeError, AttributeError) as error:
+        print(f"BLOCKED by Herdr worker admission: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1] if len(sys.argv) == 2 else ""))

--- a/config/shared/hooks/herdr-worker-admission.py
+++ b/config/shared/hooks/herdr-worker-admission.py
@@ -41,27 +41,82 @@ def invocations(command):
         yield shlex.split(" ".join(pending))
 
 
-def starts(command, depth=0):
+def launch_words(words):
+    environment_changed = False
+    while words:
+        if words[0] in {"command", "exec", "do", "then", "else"}:
+            words = words[1:]
+        elif re.fullmatch(r"[A-Za-z_][A-Za-z_0-9]*=.*", words[0]):
+            environment_changed = True
+            words = words[1:]
+        elif Path(words[0]).name == "env":
+            words = words[1:]
+            while words and words[0].startswith("-"):
+                option, separator, argument = words[0].partition("=")
+                words = words[1:]
+                if option == "--":
+                    break
+                if option in {"--help", "--version"}:
+                    return [], environment_changed
+                environment_changed = True
+                if option in {
+                    "-i",
+                    "--ignore-environment",
+                    "-0",
+                    "--null",
+                    "-v",
+                    "--debug",
+                }:
+                    continue
+                if option not in {
+                    "-u",
+                    "--unset",
+                    "-C",
+                    "--chdir",
+                    "-a",
+                    "--argv0",
+                    "-S",
+                    "--split-string",
+                }:
+                    raise AdmissionError("unsupported env option in Herdr command")
+                if not separator:
+                    if not words:
+                        raise AdmissionError("incomplete env option")
+                    argument, words = words[0], words[1:]
+                if option in {"-S", "--split-string"}:
+                    words = shlex.split(argument) + words
+                    break
+        else:
+            break
+    return words, environment_changed
+
+
+def starts(command, depth=0, environment_changed=False):
     if depth > 4:
         raise AdmissionError("nested shell launch cannot be verified")
     for words in invocations(command):
-        while words and (
-            words[0] in {"command", "exec", "env", "do", "then", "else"}
-            or re.fullmatch(r"[A-Za-z_][A-Za-z_0-9]*=.*", words[0])
-        ):
-            words = words[1:]
+        words, changed = launch_words(words)
         if not words:
+            environment_changed = environment_changed or changed
             continue
+        if words[0] in {"export", "unset"}:
+            environment_changed = True
+            continue
+        changed = changed or environment_changed
         executable = Path(words[0]).name
         if executable in {"bash", "sh", "zsh", "fish"}:
             for index, word in enumerate(words[1:], 1):
                 if word in {"-c", "-lc", "-ic"} and index + 1 < len(words):
-                    yield from starts(words[index + 1], depth + 1)
+                    yield from starts(words[index + 1], depth + 1, changed)
                     break
         if executable != "herdr":
             continue
         args = words[1:]
         if args[:2] == ["agent", "start"]:
+            if changed:
+                raise AdmissionError(
+                    "worker start environment must match the admission hook"
+                )
             yield args[2:]
         elif "agent" in args:
             index = args.index("agent")
@@ -146,8 +201,11 @@ def require_worker_worktree(args, read=probe, home=None, host=None):
         or "/" in repo
     ):
         raise AdmissionError("worker requires a linked Herdr worktree")
-    checkout = Path(path).resolve()
-    root = (Path(home or Path.home()) / ".herdr" / "worktrees" / repo).resolve()
+    try:
+        checkout = Path(path).resolve()
+        root = (Path(home or Path.home()) / ".herdr" / "worktrees" / repo).resolve()
+    except (OSError, RuntimeError) as error:
+        raise AdmissionError("worker checkout path cannot be resolved") from error
     if (
         not checkout.is_relative_to(root)
         or checkout == root

--- a/config/shared/hooks/security.sh
+++ b/config/shared/hooks/security.sh
@@ -42,6 +42,15 @@ command=$(echo "$input" | jq -r '
 ' 2>/dev/null)
 [[ -z $command ]] && exit 0
 
+if [[ $command == *herdr* ]]; then
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "BLOCKED by Herdr worker admission: python3 is unavailable" >&2
+    exit 2
+  fi
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  python3 "$SCRIPT_DIR/herdr-worker-admission.py" "$command"
+fi
+
 # Hardcoded deny patterns (mirrors claude settings.json deny list)
 deny_patterns=(
   "chmod -R 777"

--- a/spec/herdr_worker_admission_spec.sh
+++ b/spec/herdr_worker_admission_spec.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+Describe 'Herdr worker admission'
+It 'preserves valid launches and rejects inconsistent or duplicate workers'
+When run python3 "$PWD/spec/herdr_worker_admission_test.py"
+The status should be success
+The stderr should include 'OK'
+End
+End

--- a/spec/herdr_worker_admission_test.py
+++ b/spec/herdr_worker_admission_test.py
@@ -1,0 +1,263 @@
+import copy
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "admission", ROOT / "config/shared/hooks/herdr-worker-admission.py"
+)
+admission = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(admission)
+
+
+class WorkerAdmissionTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.home = Path(self.temp.name)
+        self.path = self.home / ".herdr/worktrees/demo/topic"
+        self.path.mkdir(parents=True)
+        self.source = self.home / "repo"
+        self.source.mkdir()
+        self.args = ["worker", "--kind", "codex", "--pane", "w1:p1"]
+        self.data = {
+            ("pane", "get", "w1:p1"): {
+                "pane": {
+                    "pane_id": "w1:p1",
+                    "workspace_id": "w1",
+                    "cwd": str(self.path),
+                }
+            },
+            ("workspace", "get", "w1"): {
+                "workspace": {
+                    "workspace_id": "w1",
+                    "worktree": {
+                        "checkout_path": str(self.path),
+                        "is_linked_worktree": True,
+                        "repo_name": "demo",
+                        "repo_root": str(self.source),
+                    },
+                }
+            },
+            ("worktree", "list", "--cwd", str(self.source)): {
+                "worktrees": [
+                    {
+                        "path": str(self.path),
+                        "is_linked_worktree": True,
+                        "open_workspace_id": "w1",
+                    }
+                ]
+            },
+            ("agent", "list"): {"agents": []},
+        }
+        self.calls = []
+
+    def read(self, args):
+        self.calls.append(args)
+        return copy.deepcopy(self.data[tuple(args)])
+
+    def check(self, args=None):
+        return admission.require_worker_worktree(
+            args or self.args, read=self.read, home=self.home, host="host.example"
+        )
+
+    def test_valid_linked_worker_uses_only_four_read_probes(self):
+        self.assertEqual(self.check(), str(self.path))
+        self.assertEqual(
+            [args[:2] for args in self.calls],
+            [
+                ["pane", "get"],
+                ["workspace", "get"],
+                ["worktree", "list"],
+                ["agent", "list"],
+            ],
+        )
+
+    def test_root_workspace_is_refused_before_ownership_or_launch(self):
+        self.data[("workspace", "get", "w1")]["workspace"]["worktree"][
+            "is_linked_worktree"
+        ] = False
+        with self.assertRaisesRegex(admission.AdmissionError, "linked Herdr"):
+            self.check()
+        self.assertEqual(len(self.calls), 2)
+
+    def test_missing_and_malformed_metadata_are_refused(self):
+        workspace = self.data[("workspace", "get", "w1")]["workspace"]
+        for worktree in (None, {}, {"is_linked_worktree": "true"}):
+            with self.subTest(worktree=worktree):
+                workspace["worktree"] = worktree
+                with self.assertRaises(admission.AdmissionError):
+                    self.check()
+
+    def test_cwd_mismatch_is_refused(self):
+        self.data[("pane", "get", "w1:p1")]["pane"]["cwd"] = str(self.source)
+        with self.assertRaisesRegex(admission.AdmissionError, "cwd"):
+            self.check()
+
+    def test_linked_checkout_outside_herdr_root_is_refused(self):
+        self.data[("workspace", "get", "w1")]["workspace"]["worktree"][
+            "checkout_path"
+        ] = str(self.source)
+        with self.assertRaises(admission.AdmissionError):
+            self.check()
+
+    def test_contradictory_worktree_association_is_refused(self):
+        self.data[("worktree", "list", "--cwd", str(self.source))]["worktrees"][0][
+            "open_workspace_id"
+        ] = "w2"
+        with self.assertRaisesRegex(admission.AdmissionError, "disagree"):
+            self.check()
+
+    def test_moved_pane_alias_uses_returned_workspace(self):
+        pane = self.data[("pane", "get", "w1:p1")]["pane"]
+        pane.update(workspace_id="w2", pane_id="w2:p3")
+        workspace = self.data.pop(("workspace", "get", "w1"))
+        workspace["workspace"]["workspace_id"] = "w2"
+        self.data[("workspace", "get", "w2")] = workspace
+        self.data[("worktree", "list", "--cwd", str(self.source))]["worktrees"][0][
+            "open_workspace_id"
+        ] = "w2"
+        self.assertEqual(self.check(), str(self.path))
+
+    def test_settled_other_owner_blocks_renamed_duplicate(self):
+        self.data[("agent", "list")]["agents"] = [
+            {
+                "name": "worker",
+                "pane_id": "w1:p2",
+                "cwd": str(self.path),
+                "agent_status": "done",
+            }
+        ]
+        with self.assertRaisesRegex(admission.AdmissionError, "another owner"):
+            self.check(["worker_b", "--kind", "codex", "--pane", "w1:p1"])
+
+    def test_same_name_in_other_checkout_is_refused(self):
+        self.data[("agent", "list")]["agents"] = [
+            {
+                "name": "worker",
+                "pane_id": "w2:p1",
+                "cwd": str(self.source),
+            }
+        ]
+        with self.assertRaises(admission.AdmissionError):
+            self.check()
+
+    def test_target_pane_owned_under_stale_cwd_is_refused(self):
+        self.data[("agent", "list")]["agents"] = [
+            {
+                "name": "other_worker",
+                "pane_id": "w1:p1",
+                "cwd": str(self.source),
+            }
+        ]
+        with self.assertRaises(admission.AdmissionError):
+            self.check()
+
+    def test_existing_same_owner_is_preserved(self):
+        self.data[("agent", "list")]["agents"] = [
+            {
+                "name": "worker",
+                "pane_id": "w1:p1",
+                "cwd": str(self.path),
+            }
+        ]
+        self.assertEqual(self.check(), str(self.path))
+
+    def test_orchestrators_and_help_need_no_worker_probes(self):
+        for name in (
+            "host_orchestrator",
+            "host_co_orchestrator",
+            "host_co_orchestrator_fallback",
+        ):
+            self.assertIsNone(self.check([name, "--kind", "codex", "--pane", "w1:p1"]))
+        self.assertIsNone(self.check(["--help"]))
+        self.assertEqual(self.calls, [])
+
+    def test_dynamic_or_implicit_worker_pane_is_refused(self):
+        for args in (["worker"], ["worker", "--pane", "$PANE"]):
+            with self.assertRaises(admission.AdmissionError):
+                self.check(args)
+
+    def test_agent_help_after_separator_does_not_bypass_admission(self):
+        self.data[("workspace", "get", "w1")]["workspace"]["worktree"] = None
+        with self.assertRaises(admission.AdmissionError):
+            self.check(self.args + ["--", "--help"])
+
+    def test_options_before_name_remain_supported(self):
+        self.assertEqual(
+            self.check(["--kind=codex", "--pane=w1:p1", "worker"]), str(self.path)
+        )
+
+    def test_unreadable_probe_is_refused(self):
+        def unavailable(args):
+            raise admission.AdmissionError("unavailable")
+
+        with self.assertRaises(admission.AdmissionError):
+            admission.require_worker_worktree(self.args, read=unavailable)
+
+    def test_shell_commands_and_quoted_examples_are_distinguished(self):
+        launch = "herdr agent start worker --kind codex --pane w1:p1"
+        for command in (
+            launch,
+            "true && " + launch,
+            "true # comment\n" + launch,
+            "bash -lc " + repr(launch),
+        ):
+            self.assertEqual(list(admission.starts(command)), [self.args])
+        for command in (
+            "echo " + repr(launch),
+            "echo ';' " + launch,
+            "herdr agent read worker",
+            "herdr agent prompt worker 'held'",
+        ):
+            self.assertEqual(list(admission.starts(command)), [])
+
+    def test_open_code_bash_envelope_reaches_existing_shared_hook(self):
+        self.data[("workspace", "get", "w1")]["workspace"]["worktree"] = None
+        fixture = self.home / "responses.json"
+        fixture.write_text(
+            json.dumps(
+                {json.dumps(list(key)): value for key, value in self.data.items()}
+            )
+        )
+        binary_dir = self.home / ".cargo/bin"
+        binary_dir.mkdir(parents=True)
+        binary = binary_dir / "herdr"
+        binary.write_text(
+            "#!/usr/bin/env python3\nimport json,os,sys\n"
+            "data=json.load(open(os.environ['ADMISSION_FIXTURE']))\n"
+            "print(json.dumps({'result':data[json.dumps(sys.argv[1:])]}))\n"
+        )
+        binary.chmod(0o755)
+        env = dict(os.environ, HOME=str(self.home), ADMISSION_FIXTURE=str(fixture))
+        env["PATH"] = str(binary_dir) + os.pathsep + os.environ["PATH"]
+        payload = {
+            "tool_name": "bash",
+            "tool_input": {
+                "command": "herdr agent start worker --kind codex --pane w1:p1",
+            },
+        }
+        result = subprocess.run(
+            [shutil.which("bash"), str(ROOT / "config/shared/hooks/security.sh")],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            env=env,
+        )
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertIn("linked Herdr worktree", result.stderr)
+        config = json.loads((ROOT / "config/opencode/hooks.json").read_text())
+        hook = config["hooks"]["PreToolUse"][0]
+        self.assertEqual(hook["matcher"], "bash")
+        self.assertGreaterEqual(hook["hooks"][0]["timeout"], 5000)
+        self.assertIn("config/shared/hooks/security.sh", hook["hooks"][0]["command"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/spec/herdr_worker_admission_test.py
+++ b/spec/herdr_worker_admission_test.py
@@ -7,6 +7,7 @@ import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[1]
 SPEC = importlib.util.spec_from_file_location(
@@ -217,6 +218,52 @@ class WorkerAdmissionTests(unittest.TestCase):
             "herdr agent prompt worker 'held'",
         ):
             self.assertEqual(list(admission.starts(command)), [])
+
+    def test_env_options_and_assignments_cannot_bypass_or_retarget_admission(self):
+        launch = "herdr agent start worker --kind codex --pane w1:p1"
+        for prefix in (
+            "env -i ",
+            "env --unset=HOME ",
+            "env -u HOME -- ",
+            "HERDR_SOCKET_PATH=/tmp/other.sock ",
+            "env ACTOR=other ",
+        ):
+            with self.subTest(prefix=prefix):
+                with self.assertRaises(admission.AdmissionError):
+                    list(admission.starts(prefix + launch))
+        with self.assertRaises(admission.AdmissionError):
+            list(admission.starts("env -S " + repr(launch)))
+        with self.assertRaises(admission.AdmissionError):
+            list(admission.starts("env -i bash -c " + repr(launch)))
+        for prefix in (
+            "HERDR_SOCKET_PATH=/tmp/other.sock; ",
+            "export HERDR_SOCKET_PATH=/tmp/other.sock; ",
+        ):
+            with self.assertRaises(admission.AdmissionError):
+                list(admission.starts(prefix + launch))
+        self.assertEqual(list(admission.starts("env -- " + launch)), [self.args])
+        self.assertEqual(list(admission.starts("env -i herdr agent list")), [])
+
+    def test_unresolvable_metadata_path_returns_explicit_block(self):
+        require = admission.require_worker_worktree
+
+        def check_with_fixture(args):
+            return require(args, read=self.read, home=self.home, host="host")
+
+        for error in (PermissionError("denied"), RuntimeError("symlink loop")):
+            with self.subTest(error=error):
+                with patch.object(admission.Path, "resolve", side_effect=error):
+                    with patch.object(
+                        admission,
+                        "require_worker_worktree",
+                        side_effect=check_with_fixture,
+                    ):
+                        self.assertEqual(
+                            admission.main(
+                                "herdr agent start worker --kind codex --pane w1:p1"
+                            ),
+                            2,
+                        )
 
     def test_open_code_bash_envelope_reaches_existing_shared_hook(self):
         self.data[("workspace", "get", "w1")]["workspace"]["worktree"] = None


### PR DESCRIPTION
Local shell commands could start Herdr workers in a repository root or an inconsistently associated workspace. OpenCode also reports the lowercase bash tool name, which the existing Claude matcher does not match.

Route OpenCode shell hooks through the shared security hook and check pane, workspace, linked-worktree, cwd, and existing ownership before admitting a local worker start. Preserve canonical main/co-orchestrator seats, help, and read-only commands. The checks use only read-only Herdr probes. Environment-changing launch prefixes are rejected so the probes and launch cannot target different Herdr servers; filesystem resolution errors explicitly block.

Validation: 20 Python admission tests and 36 ShellSpec integration examples passed; focused Ruff, ShellCheck, Nix formatting, and diff checks passed. Nix evaluation resolves the new managed hook file. The installed OpenCode hook executor rejected a live root pane and admitted a live linked-worktree pane with no adapter errors; none of the submitted launch commands was executed. The adapter also blocked cleared-environment and alternate-socket prefixes.

Independent Standards and Spec re-reviews of commit c7c7f0e06c3066e7ad34a5eb7d742613db9840e1 found no remaining concrete blockers after the two admission fixes. Hosted CI remains pending.

This is source-only. Host activation and an actual launch through a refreshed OpenCode session remain unproven. The hook is a local shell guard, not native server enforcement or proof of task/PR ownership.
