### PR TITLE
fix(beads): use the scoped SQL client principal

### DIFF
--- a/home-manager/services/dolt/client-environment.sh
+++ b/home-manager/services/dolt/client-environment.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 /bin/launchctl setenv BEADS_DOLT_SERVER_MODE 1
 /bin/launchctl setenv BEADS_DOLT_SERVER_HOST "@doltServerHost@"
 /bin/launchctl setenv BEADS_DOLT_SERVER_PORT 3307
-/bin/launchctl setenv BEADS_DOLT_SERVER_USER root
+/bin/launchctl setenv BEADS_DOLT_SERVER_USER beads
 /bin/launchctl setenv BEADS_NODE_ID kyber
-/bin/launchctl setenv DOLT_CLI_USER root
+/bin/launchctl setenv DOLT_CLI_USER beads
 /bin/launchctl setenv DOLT_CLI_PASSWORD ""

--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -21,9 +21,9 @@ let
     BEADS_DOLT_SERVER_MODE = "1";
     BEADS_DOLT_SERVER_HOST = doltServerHost;
     BEADS_DOLT_SERVER_PORT = "3307";
-    BEADS_DOLT_SERVER_USER = "root";
+    BEADS_DOLT_SERVER_USER = "beads";
     BEADS_NODE_ID = "kyber";
-    DOLT_CLI_USER = "root";
+    DOLT_CLI_USER = "beads";
     DOLT_CLI_PASSWORD = "";
   }
   // lib.optionalAttrs isKyber {

--- a/home-manager/services/dolt/linear-sync.sh
+++ b/home-manager/services/dolt/linear-sync.sh
@@ -43,12 +43,12 @@ fi
 unset BEADS_DOLT_DATA_DIR BEADS_FEDERATION_HUB BEADS_DIR BEADS_DB
 export BEADS_DOLT_SERVER_HOST="kyber.tail950b36.ts.net"
 export BEADS_DOLT_SERVER_PORT="3307"
-export BEADS_DOLT_SERVER_USER="root"
+export BEADS_DOLT_SERVER_USER="beads"
 export BEADS_DOLT_SERVER_MODE="1"
 export BEADS_DOLT_AUTO_START="0"
 export BEADS_NODE_ID="kyber"
 export BEADS_ACTOR="beads-linear-reconciler"
-export DOLT_CLI_USER="root"
+export DOLT_CLI_USER="beads"
 export DOLT_CLI_PASSWORD=""
 
 # An accepted issue completes through the same repository lock and credential
@@ -288,7 +288,7 @@ run_dolt_sql() {
   "$dolt_cli" \
     --host="$BEADS_DOLT_SERVER_HOST" \
     --port="${BEADS_DOLT_SERVER_PORT:-3307}" \
-    --user="${DOLT_CLI_USER:-root}" \
+    --user="${DOLT_CLI_USER:-beads}" \
     --no-tls \
     sql -q "$query" >/dev/null
 }

--- a/spec/beads_authority_spec.sh
+++ b/spec/beads_authority_spec.sh
@@ -18,5 +18,7 @@ The output should include 'unsetenv BEADS_FEDERATION_HUB'
 The output should include 'setenv BEADS_DOLT_SERVER_HOST kyber.tail950b36.ts.net'
 The output should include 'setenv BEADS_DOLT_AUTO_START 0'
 The output should include 'setenv BEADS_NODE_ID kyber'
+The output should include 'setenv BEADS_DOLT_SERVER_USER beads'
+The output should include 'setenv DOLT_CLI_USER beads'
 End
 End

--- a/spec/beads_linear_sync_spec.sh
+++ b/spec/beads_linear_sync_spec.sh
@@ -195,7 +195,7 @@ printf '%s\n' "$*" >>"$COMMAND_LOG"
 if [ "${FAKE_VERIFY_AUTHORITY:-}" = 1 ]; then
   test "${BEADS_DOLT_SERVER_HOST:-}" = kyber.tail950b36.ts.net || exit 98
   test "${BEADS_DOLT_SERVER_PORT:-}" = 3307 || exit 98
-  test "${BEADS_DOLT_SERVER_USER:-}" = root || exit 98
+  test "${BEADS_DOLT_SERVER_USER:-}" = beads || exit 98
   test "${BEADS_NODE_ID:-}" = kyber || exit 98
   test "${BEADS_ACTOR:-}" = beads-linear-reconciler || exit 98
   test -z "${BEADS_DOLT_DATA_DIR:-}${BEADS_FEDERATION_HUB:-}${BEADS_DIR:-}${BEADS_DB:-}" || exit 98

--- a/spec/beads_linear_sync_spec.sh
+++ b/spec/beads_linear_sync_spec.sh
@@ -196,6 +196,7 @@ if [ "${FAKE_VERIFY_AUTHORITY:-}" = 1 ]; then
   test "${BEADS_DOLT_SERVER_HOST:-}" = kyber.tail950b36.ts.net || exit 98
   test "${BEADS_DOLT_SERVER_PORT:-}" = 3307 || exit 98
   test "${BEADS_DOLT_SERVER_USER:-}" = beads || exit 98
+  test "${DOLT_CLI_USER:-}" = beads || exit 98
   test "${BEADS_NODE_ID:-}" = kyber || exit 98
   test "${BEADS_ACTOR:-}" = beads-linear-reconciler || exit 98
   test -z "${BEADS_DOLT_DATA_DIR:-}${BEADS_FEDERATION_HUB:-}${BEADS_DIR:-}${BEADS_DB:-}" || exit 98


### PR DESCRIPTION
## Summary

Use the existing scoped `beads` SQL principal for managed shell, GUI, agent-service, and Linear clients. The root account is restricted by source address and rejects some fleet clients; the scoped account already has access to the task databases. The database daemon retains its administrative identity.

## Verification

- 73 focused ShellSpec examples pass.
- ShellCheck, Nix formatting, and whitespace checks pass.
- Live Kamino native diagnostics and task reads succeed with the existing account; no grants changed.
- Exact revision Nix builds on all seven hosts are running; managed activation remains pending.

Runtime completion requires generated client settings, all-host authority reads, and a concurrent claim canary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches managed shell, GUI, agent-service, and Linear clients to the scoped `beads` SQL principal so they no longer hit root's source-address restrictions. The database daemon keeps its administrative identity. The ShellSpec coverage now asserts the scoped client principal.

<sup>Written for commit be4fd367a13e67db7ef89bff35c462274ad08246. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

