### PR TITLE
fix(beads): classify rejected Linear result shapes

### DIFF
--- a/home-manager/services/dolt/linear-sync.sh
+++ b/home-manager/services/dolt/linear-sync.sh
@@ -171,10 +171,13 @@ wait_for_beads() {
 }
 
 run_linear() {
+  local operation="$1"
   local output
   local status
   local category
   local cause
+  local diagnostic
+  shift
 
   if output="$("$@" --json 2>/dev/null)"; then
     status=0
@@ -225,7 +228,38 @@ run_linear() {
     category="command-timeout"
     cause="timeout"
   fi
-  log "Linear result rejected: category=$category exit=$status cause=$cause"
+  # Summarize the rejected contract without copying any payload values. The
+  # warning prefixes identify native sync operations, not their private causes.
+  if ! diagnostic="$(@jq@/bin/jq -r -s '
+    def counter:
+      if type == "number" and . >= 0 and . == floor then tostring else type end;
+    def family:
+      if type != "string" then "invalid"
+      elif test("^Failed to (build dependency resolver:|resolve dependency |create dependency )") then "dependency"
+      elif startswith("Failed to update last_sync:") then "cursor"
+      elif startswith("Failed to update external_ref ") then "external-ref"
+      elif startswith("Failed to record push hash ") then "push-hash"
+      elif startswith("Failed to update ") then "update"
+      elif startswith("Failed to create ") then "create"
+      elif startswith("Failed to fetch ") then "fetch"
+      elif test("^Failed to (prepare |generate ID )") then "prepare"
+      elif startswith("Failed to push ") then "push"
+      else "unknown" end;
+    if length != 1 then "shape=result-count count=\(length)"
+    elif (.[0] | type) != "object" then "shape=\(.[0] | type)"
+    else .[0] |
+      (if (.warnings | type) == "array" then .warnings else [] end) as $warnings |
+      (if (.error | type) == "string" and .error != "" then [.error] else [] end) as $errors |
+      "shape=object success=\(.success | if type == "boolean" then tostring else type end)" +
+      " stats=\(.stats | type) errors=\((if (.stats | type) == "object" then .stats.errors else null end) | counter)" +
+      " warnings=\(.warnings | if type == "array" then length else type end)" +
+      " error=\(.error | if . == null or . == "" then "none" elif type == "string" then "present" else type end)" +
+      " families=\([$warnings[], $errors[] | family] | unique | join(","))"
+    end
+  ' <<<"$output" 2>/dev/null)"; then
+    diagnostic="shape=invalid-json"
+  fi
+  log "Linear result rejected: category=$category exit=$status cause=$cause operation=$operation $diagnostic"
   if [ "$status" -ne 0 ]; then
     return "$status"
   fi
@@ -264,7 +298,7 @@ push_issue_batches() {
     )"
     log "Pushing $description Beads batch $batch_number/$batch_count"
 
-    if run_linear @coreutils@/bin/timeout 120 "$bd_cli" -C "$repo_dir" linear sync --push --issues "$batch_ids" --no-wait; then
+    if run_linear push @coreutils@/bin/timeout 120 "$bd_cli" -C "$repo_dir" linear sync --push --issues "$batch_ids" --no-wait; then
       if [ -n "$progress_file" ] && [ -n "$progress_entries" ]; then
         printf '%s\n' "$progress_entries" |
           @coreutils@/bin/tail -n +"$((batch_start + 1))" |
@@ -586,7 +620,7 @@ run_dolt_sql "USE \`$linear_database\`; DELETE FROM local_metadata WHERE \`key\`
 # failure is deferred to the next scheduled run instead of making launchd
 # hot-loop a failed job.
 log "Pulling complete Linear state"
-if run_linear @coreutils@/bin/timeout 720 "$bd_cli" -C "$repo_dir" linear sync \
+if run_linear pull @coreutils@/bin/timeout 720 "$bd_cli" -C "$repo_dir" linear sync \
   --pull \
   --state all \
   --relations \

--- a/spec/beads_linear_sync_spec.sh
+++ b/spec/beads_linear_sync_spec.sh
@@ -109,7 +109,7 @@ The status should be success
 End
 
 It 'bounds inbound pull and small outbound batches'
-When run bash -c "grep -F 'run_linear @coreutils@/bin/timeout 720 \"\$bd_cli\"' '$SCRIPT' >/dev/null && grep -F 'local batch_size=10' '$SCRIPT' >/dev/null && grep -F 'run_linear @coreutils@/bin/timeout 120 \"\$bd_cli\"' '$SCRIPT' >/dev/null"
+When run bash -c "grep -F 'run_linear pull @coreutils@/bin/timeout 720 \"\$bd_cli\"' '$SCRIPT' >/dev/null && grep -F 'local batch_size=10' '$SCRIPT' >/dev/null && grep -F 'run_linear push @coreutils@/bin/timeout 120 \"\$bd_cli\"' '$SCRIPT' >/dev/null"
 The status should be success
 End
 
@@ -451,6 +451,7 @@ When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MOD
 The status should equal 65
 The output should include 'category=unclean-result exit=0 cause=unknown'
 The output should include 'Linear push failed with status 65'
+The output should include 'operation=push shape=object success=true stats=object errors=1 warnings=null error=none'
 The contents of file "$progress_file" should equal 'preserved-entry 2026-01-01T00:00:00Z'
 The file "$CHECKPOINT_FILE" should not be exist
 End
@@ -460,6 +461,7 @@ When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MOD
 The status should equal 65
 The output should include 'category=unclean-result exit=0 cause=unknown'
 The output should include 'Linear pull failed with status 65'
+The output should include 'operation=pull shape=object success=true stats=object errors=1 warnings=null error=none'
 The contents of file "$DOLT_LOG" should include 'REPLACE INTO local_metadata'
 The contents of file "$DOLT_LOG" should include '2026-08-24T10:39:54Z'
 The file "$CHECKPOINT_FILE" should not be exist
@@ -469,6 +471,7 @@ It 'rejects a warning-only result without leaking the warning'
 When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MODE=warning-only XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
 The status should equal 65
 The output should include 'category=unclean-result exit=0 cause=unknown'
+The output should include 'warnings=1 error=none families=unknown'
 The output should not include 'PRIVATE_LINEAR_PAYLOAD'
 The file "$CHECKPOINT_FILE" should not be exist
 End
@@ -477,6 +480,7 @@ It 'rejects malformed JSON without leaking its payload'
 When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MODE=invalid-json XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
 The status should equal 65
 The output should include 'category=unclean-result exit=0 cause=unknown'
+The output should include 'shape=invalid-json'
 The output should not include 'PRIVATE_LINEAR_PAYLOAD'
 The file "$CHECKPOINT_FILE" should not be exist
 End
@@ -485,6 +489,7 @@ It 'rejects an empty JSON result'
 When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MODE=empty-json XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
 The status should equal 65
 The output should include 'category=unclean-result exit=0 cause=unknown'
+The output should include 'shape=result-count count=0'
 The file "$CHECKPOINT_FILE" should not be exist
 End
 
@@ -492,6 +497,7 @@ It 'requires exactly one JSON document'
 When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MODE=multiple-json XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
 The status should equal 65
 The output should include 'category=unclean-result exit=0 cause=unknown'
+The output should include 'shape=result-count count=2'
 The file "$CHECKPOINT_FILE" should not be exist
 End
 
@@ -499,6 +505,7 @@ It 'rejects a false success result'
 When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MODE=success-false XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
 The status should equal 65
 The output should include 'category=unclean-result exit=0 cause=unknown'
+The output should include 'shape=object success=false'
 The file "$CHECKPOINT_FILE" should not be exist
 End
 
@@ -506,8 +513,37 @@ It 'rejects a nonempty structured error without leaking it'
 When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_MODE=error-field XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
 The status should equal 65
 The output should include 'category=unclean-result exit=0 cause=unknown'
+The output should include 'error=present families=unknown'
 The output should not include 'PRIVATE_LINEAR_PAYLOAD'
 The file "$CHECKPOINT_FILE" should not be exist
+End
+
+It 'reports distinct native operation families without their private messages'
+linear_result='{"success":true,"stats":{"errors":2},"warnings":["Failed to create issue for PRIVATE_LINEAR_PAYLOAD","Failed to update PRIVATE_LINEAR_PAYLOAD","Failed to update PRIVATE_LINEAR_PAYLOAD again","Failed to fetch PRIVATE_LINEAR_PAYLOAD","Failed to prepare PRIVATE_LINEAR_PAYLOAD","Failed to push PRIVATE_LINEAR_PAYLOAD","Failed to record push hash for PRIVATE_LINEAR_PAYLOAD","Failed to update external_ref for PRIVATE_LINEAR_PAYLOAD","Failed to build dependency resolver: PRIVATE_LINEAR_PAYLOAD","Failed to resolve dependency target PRIVATE_LINEAR_PAYLOAD","Failed to create dependency PRIVATE_LINEAR_PAYLOAD","Failed to update last_sync: PRIVATE_LINEAR_PAYLOAD"]}'
+When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_RESULT="$linear_result" XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
+The status should equal 65
+The output should include 'operation=pull shape=object success=true stats=object errors=2 warnings=12 error=none'
+The output should include 'families=create,cursor,dependency,external-ref,fetch,prepare,push,push-hash,update'
+The output should not include 'PRIVATE_LINEAR_PAYLOAD'
+The file "$CHECKPOINT_FILE" should not be exist
+End
+
+Describe 'malformed result shapes'
+Parameters:dynamic
+%data '"PRIVATE_LINEAR_PAYLOAD"' 'shape=string'
+%data '["PRIVATE_LINEAR_PAYLOAD"]' 'shape=array'
+%data 'null' 'shape=null'
+%data '{"success":"PRIVATE_LINEAR_PAYLOAD","stats":{"errors":"PRIVATE_LINEAR_PAYLOAD"},"warnings":{"text":"PRIVATE_LINEAR_PAYLOAD"},"error":["PRIVATE_LINEAR_PAYLOAD"]}' 'shape=object success=string stats=object errors=string warnings=object error=array families='
+%data '{"success":false,"stats":"PRIVATE_LINEAR_PAYLOAD","warnings":[{"text":"PRIVATE_LINEAR_PAYLOAD"}]}' 'shape=object success=false stats=string errors=null warnings=1 error=none families=invalid'
+End
+
+It 'reports only shape information and preserves failure'
+When run env COMMAND_LOG="$COMMAND_LOG" SYNC_COUNT="$SYNC_COUNT" FAKE_LINEAR_RESULT="$1" XDG_STATE_HOME="$STATE_HOME" HOME="$TEST_ROOT" LINEAR_API_KEY=test bash "$RENDERED_SCRIPT"
+The status should equal 65
+The output should include "$2"
+The output should not include 'PRIVATE_LINEAR_PAYLOAD'
+The file "$CHECKPOINT_FILE" should not be exist
+End
 End
 
 It 'defers a plain circuit-breaker result without appending JSON'


### PR DESCRIPTION
## Summary

When Linear synchronization exits successfully but reports partial failures, the reconciler rejects the run without enough detail to distinguish malformed output, issue errors, and warnings. Add a privacy-safe rejection summary containing the pull/push direction, JSON shape, error and warning counts, and recognized operation families.

### Tracker linkage
- Linear: none — this operator-directed recovery has no linked Linear issue.
- Bead: shunkakinokisoftware-l3r8

## Before / after

| Surface | Before | After |
| --- | --- | --- |
| Rejected sync result | Broad category, process exit, and cause | Also reports contract shape, counts, and fixed operation families |
| Private payloads | Kept in memory and excluded from logs | Preserved; malformed fields emit only type names |
| Failed sync progress | Strict rejection preserves prior progress/cursor | Unchanged |

## Boundaries and rollback

This changes diagnostics only. Success criteria, rate-limit deferral, deadlines, cursor restoration, and progress writes are unchanged. No public API or persisted-state change; rollback removes the additional log fields. Operation families classify known native message prefixes and do not establish the underlying failure cause.

Managed activation and a successful scheduled reconciliation checkpoint remain separate acceptance work. This PR does not retry syncs or control services.

## Verification

- `shellspec spec/beads_linear_sync_spec.sh`: 76 examples, 0 failures.
- Changed-file ShellCheck and `make shell-check`: passed.
- `git diff --check`: passed.
- `make nix-format-check`: 648 files checked, 0 changed.

Regression coverage includes invalid JSON, empty/multiple results, malformed nested fields, fixed operation-family classification, private-payload exclusion, and unchanged partial-push/pull safeguards.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves rejection logs for unsuccessful Linear syncs so operators can distinguish malformed output, issue errors, and warnings without seeing private payload values.

`run_linear` now takes a pull/push operation name and summarizes the rejected JSON contract with its shape, error and warning counts, and recognized operation families. The diagnostic emits only type names for malformed fields and never copies payload content. This is a diagnostics-only change; success criteria, rate-limit deferral, deadlines, cursor restoration, and progress writes are unchanged.

<sup>Written for commit f0e1602d58dbd800adc0bdf5aa5e1cacbae74f35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

