### PR TITLE
feat(fish): add clpri to pin cliproxyapi OAuth priority

### DIFF
--- a/home-manager/programs/fish/default.nix
+++ b/home-manager/programs/fish/default.nix
@@ -136,6 +136,7 @@
       caxe = "_caxe_function";
       caxeh = "_caxeh_function";
       cliproxyapi = "_cliproxyapi_function";
+      clpri = "_cliproxyapi_priority_function";
       clrc = "_clrc_function";
       cltxe = "_cltxe_function";
       cltxeh = "_cltxeh_function";
@@ -274,6 +275,7 @@
         "_caxe_function"
         "_caxeh_function"
         "_cliproxyapi_function"
+        "_cliproxyapi_priority_function"
         "_clrc_function"
         "_cltxe_function"
         "_cltxeh_function"

--- a/home-manager/programs/fish/functions/_cliproxyapi_priority_function.fish
+++ b/home-manager/programs/fish/functions/_cliproxyapi_priority_function.fish
@@ -1,0 +1,67 @@
+function _cliproxyapi_priority_function --description "Pin cliproxyapi OAuth credentials to a routing priority"
+    set -l target 300
+
+    if test (count $argv) -gt 1
+        echo "Usage: clpri [priority]" >&2
+        return 1
+    end
+
+    if test (count $argv) -eq 1
+        if not string match -qr '^[0-9]+$' -- $argv[1]
+            echo "Usage: clpri [priority]" >&2
+            return 1
+        end
+        set target $argv[1]
+    end
+
+    if not command -q jq
+        echo "clpri: jq is required" >&2
+        return 1
+    end
+
+    set -l auth_dir "$HOME/.cli-proxy-api/objectstore/auths"
+    if not test -d "$auth_dir"
+        echo "clpri: auth dir not found: $auth_dir" >&2
+        return 1
+    end
+
+    set -l files $auth_dir/*.json
+    if test (count $files) -eq 0
+        echo "clpri: no credentials in $auth_dir"
+        return 0
+    end
+
+    set -l patched 0
+    set -l failed 0
+
+    for f in $files
+        test -f "$f"; or continue
+
+        if not jq -e 'type == "object"' "$f" >/dev/null 2>&1
+            echo "clpri: skipping unparseable credential: "(basename "$f") >&2
+            set failed (math $failed + 1)
+            continue
+        end
+
+        set -l current (jq -r '.priority // 0' "$f")
+        test "$current" = "$target"; and continue
+
+        set -l tmp (mktemp)
+        if jq --argjson p $target '.priority = $p' "$f" >$tmp
+            # Preserve the credential's mode; mktemp creates 0600 but an
+            # existing file may be looser and cliproxy re-reads it in place.
+            cat $tmp >"$f"
+            rm -f $tmp
+            echo (basename "$f")": $current -> $target"
+            set patched (math $patched + 1)
+        else
+            rm -f $tmp
+            echo "clpri: failed to patch "(basename "$f") >&2
+            set failed (math $failed + 1)
+        end
+    end
+
+    echo "clpri: $patched of "(count $files)" credential(s) updated to priority $target"
+
+    test $failed -eq 0
+end

--- a/spec/fish/_cliproxyapi_priority_function_test.fish
+++ b/spec/fish/_cliproxyapi_priority_function_test.fish
@@ -1,0 +1,51 @@
+set fn (status dirname)/../../home-manager/programs/fish/functions
+source $fn/_cliproxyapi_priority_function.fish
+
+set tmpdir (mktemp -d)
+set -x HOME $tmpdir
+set auth_dir $tmpdir/.cli-proxy-api/objectstore/auths
+mkdir -p $auth_dir
+
+# ── missing auth dir ──────────────────────────────────────
+set -x HOME $tmpdir/absent
+_cliproxyapi_priority_function >/dev/null 2>&1
+@test "missing auth dir returns 1" $status = 1
+set -x HOME $tmpdir
+
+# ── argument validation ───────────────────────────────────
+_cliproxyapi_priority_function abc >/dev/null 2>&1
+@test "non-numeric priority returns 1" $status = 1
+
+_cliproxyapi_priority_function 300 400 >/dev/null 2>&1
+@test "extra arguments return 1" $status = 1
+
+# ── empty auth dir ────────────────────────────────────────
+_cliproxyapi_priority_function >/dev/null 2>&1
+@test "empty auth dir succeeds" $status = 0
+
+# ── bumps unset and zero priorities ───────────────────────
+echo '{"provider":"codex","account":"a@example.com","priority":0}' >$auth_dir/codex-zero.json
+echo '{"provider":"claude","account":"b@example.com"}' >$auth_dir/claude-unset.json
+echo '{"provider":"gemini","account":"c@example.com","priority":300}' >$auth_dir/gemini-set.json
+
+_cliproxyapi_priority_function >/dev/null 2>&1
+@test "sweep succeeds" $status = 0
+@test "zero priority is bumped" (jq -r .priority $auth_dir/codex-zero.json) = 300
+@test "missing priority is added" (jq -r .priority $auth_dir/claude-unset.json) = 300
+@test "already-set priority is kept" (jq -r .priority $auth_dir/gemini-set.json) = 300
+
+# ── other credential fields survive the rewrite ───────────
+@test "account field is preserved" (jq -r .account $auth_dir/codex-zero.json) = a@example.com
+@test "provider field is preserved" (jq -r .provider $auth_dir/claude-unset.json) = claude
+
+# ── explicit priority argument ────────────────────────────
+_cliproxyapi_priority_function 150 >/dev/null 2>&1
+@test "explicit priority is applied" (jq -r .priority $auth_dir/codex-zero.json) = 150
+
+# ── unparseable credential is reported, not silently skipped ─
+echo 'not json' >$auth_dir/broken.json
+_cliproxyapi_priority_function >/dev/null 2>&1
+@test "unparseable credential returns 1" $status = 1
+@test "valid credentials still patched alongside a broken one" (jq -r .priority $auth_dir/codex-zero.json) = 300
+
+rm -rf $tmpdir


### PR DESCRIPTION
## Summary

PR #2652 added `ensure_oauth_priority()` to the cliproxyapi start script, but it only runs at service start. Credentials created later through the live OAuth flow are written by cliproxy itself with no `priority` field, so they sit at 0 and lose routing to openai-compatibility providers like surplus (150) until the next restart.

This happened on kyber: a `codex` credential added at 05:32 UTC ran at priority 0 for hours while the credential from the previous boot was correctly at 300.

`clpri` sweeps the auth dir on demand and pins every credential to the target priority, so a freshly authenticated account can be fixed without restarting the proxy.

```
clpri        # pin all credentials to 300
clpri 150    # or an explicit priority
```

cliproxy hot-reloads the auth dir, so the change takes effect without a restart (verified against the management API on kyber).

## Changes

- `_cliproxyapi_priority_function.fish` - sweeps `~/.cli-proxy-api/objectstore/auths/*.json`, writing `priority` via `jq`. Skips files already at the target, reports unparseable credentials and returns non-zero rather than silently passing over them, and rewrites through `cat >` so an existing credential's mode is preserved instead of inheriting `mktemp`'s 0600.
- Registered as the `clpri` abbreviation in `home-manager/programs/fish/default.nix`.
- 13 fishtape tests: argument validation, missing/empty auth dir, unset and zero priorities, already-set no-op, other credential fields surviving the rewrite, explicit priority argument, and a broken credential not blocking the rest of the sweep.

## Test plan

- [x] `fishtape spec/fish/_cliproxyapi_priority_function_test.fish` - 13/13 pass
- [x] `make fish-test` - full suite passes
- [x] `shellspec spec/fish_functions_coverage_spec.sh` - 101 examples, 0 failures
- [x] `nixfmt --check` and `fish_indent` clean
- [x] Smoke-tested on kyber against real credentials: idempotent no-op, exit 0

## Note

Unrelated, found while verifying on kyber: `~/.cli-proxy-api/config.yaml` has `secret-key: "cliproxyapi"` with `allow-remote: true` - the `__CLIPROXY_MANAGEMENT_PASSWORD__` placeholder was never substituted because the env var is empty, so the management API accepts the literal default password from any remote host. Worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `clpri` to pin `cliproxyapi` OAuth credential priorities on demand, fixing routing loss for credentials created after startup. Previously, credentials written via the live OAuth flow stayed at priority 0 until proxy restart; now `clpri` sweeps the auth dir and pins all credentials to 300 (or an explicit priority), taking effect immediately via hot-reload.

<sup>Written for commit 1039ca363578c375ba23411f94f4bbe93fd8317c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

