### PR TITLE
fix(t3): verify native runtimes before updates

### DIFF
--- a/home-manager/services/t3-connect/connect.sh
+++ b/home-manager/services/t3-connect/connect.sh
@@ -6,21 +6,16 @@
 # that deadline; npm then gets SIGTERM'd mid-reify and leaves a partial tree
 # that poisons every later attempt. Warming the cache keeps startup ~2s.
 #
-# node-pty ships no linux-x64 prebuild, so it needs its install script to
-# compile pty.node. Global ignore-scripts=true blocks that, and npm has no
-# per-package allowlist, so rebuild just that one package with a scoped
-# override rather than weakening the default.
+# Native preparation uses a per-package allowlist in the runtime itself.
+# The global npm script policy stays unchanged.
 
 set -euo pipefail
 
 TAG="${T3_CONNECT_TAG:-nightly}"
 
 # A native addon must be built by a compiler whose libc matches the node that
-# loads it: a nix-gcc build needs the nix glibc and fails dlopen under a
-# generic node (`GLIBC_2.42 not found`), and vice versa. Everything here is
-# nix -- the unit's PATH supplies both nix gcc and nix nodejs, and `t3 service`
-# is installed against the same nix node -- so the pair stays consistent with
-# no distro toolchain involved.
+# loads it; a mismatched pair can fail with `GLIBC_2.42 not found`. Home Manager
+# supplies the same Nix toolchain to preparation and the service launcher.
 #
 # npx keys its cache dir on the literal spec string, not the resolved version,
 # so `t3@nightly` and `t3@0.0.33-nightly.20260809.1041` land in different dirs.
@@ -35,15 +30,9 @@ npx --yes "$spec" --version >/dev/null
 # client's SSH launch, and the runtime `t3 service` installs for its systemd
 # unit.
 #
-# Gate on loading, not on the file existing. A build with the wrong toolchain
-# still drops pty.node, so a presence check would treat a binary that fails
-# dlopen as done and skip it forever.
-for dir in "$HOME"/.npm/_npx/*/ "$HOME"/.t3/runtime/versions/*/; do
+# The helper verifies a terminal spawn both before and after rebuilding.
+for dir in "${npm_config_cache:-$HOME/.npm}"/_npx/*/ "${T3CODE_HOME:-$HOME/.t3}"/runtime/versions/*/; do
   pty="${dir}node_modules/node-pty"
   [ -d "$pty" ] || continue
-  if node -e 'require(process.argv[1])' "$pty" >/dev/null 2>&1; then
-    continue
-  fi
-  rm -rf "${pty:?}/build"
-  (cd "$dir" && npm rebuild --ignore-scripts=false node-pty >/dev/null)
+  "${T3_PREPARE_RUNTIME:?}" "$dir"
 done

--- a/home-manager/services/t3-connect/default.nix
+++ b/home-manager/services/t3-connect/default.nix
@@ -1,8 +1,72 @@
 { pkgs, ... }:
 let
   inherit (pkgs) lib;
+  # Compile and load native addons with one libc/Node toolchain. Keep the
+  # caller's remaining PATH available to provider CLIs in the server.
+  toolchain = lib.makeBinPath [
+    pkgs.bash
+    pkgs.coreutils
+    pkgs.findutils
+    pkgs.gawk
+    pkgs.gcc
+    pkgs.gnugrep
+    pkgs.gnumake
+    pkgs.gnused
+    pkgs.nodejs
+    pkgs.python3
+    pkgs.util-linux
+    pkgs.which
+  ];
+  prepareRuntime = pkgs.writeShellScript "t3-prepare-runtime" ''
+    export PATH=${toolchain}:$PATH
+    export T3_PTY_PROBE=${./pty-probe.cjs}
+    ${builtins.readFile ./prepare-runtime.sh}
+  '';
+  runtimeNpm = pkgs.writeShellScriptBin "npm" ''
+    export T3_REAL_NPM=${pkgs.nodejs}/bin/npm
+    export T3_PREPARE_RUNTIME=${prepareRuntime}
+    ${builtins.readFile ./runtime-npm.sh}
+  '';
+  launcher = pkgs.writeShellScript "t3-launch-service" ''
+    export PATH=${runtimeNpm}/bin:${toolchain}:$PATH
+    export T3_PREPARE_RUNTIME=${prepareRuntime}
+    ${builtins.readFile ./launch-service.sh}
+  '';
+  shellInstallerPath = ''
+    if [ "''${T3_BOOT_SERVICE_UNIT:-}" = t3code.service ]; then
+      export PATH=${runtimeNpm}/bin:$PATH
+    fi
+  '';
 in
 {
+  # T3 prefers PATH read from an interactive login shell to its inherited PATH.
+  # Run after fnm's shell setup so that hydration retains the scoped installer.
+  programs.fish.interactiveShellInit = lib.mkIf pkgs.stdenv.hostPlatform.isLinux (
+    lib.mkOrder 2000 ''
+      if test "$T3_BOOT_SERVICE_UNIT" = t3code.service
+        set -gx PATH ${runtimeNpm}/bin $PATH
+      end
+    ''
+  );
+  programs.bash.profileExtra = lib.mkIf pkgs.stdenv.hostPlatform.isLinux (
+    lib.mkOrder 2000 shellInstallerPath
+  );
+  programs.zsh.initContent = lib.mkIf pkgs.stdenv.hostPlatform.isLinux (
+    lib.mkOrder 2000 shellInstallerPath
+  );
+
+  # T3 owns the main unit. A drop-in survives `t3 service install/update` and
+  # prevents the interactive shell's fnm Node from changing the runtime ABI.
+  xdg.configFile."systemd/user/t3code.service.d/native-runtime.conf" =
+    lib.mkIf pkgs.stdenv.hostPlatform.isLinux
+      {
+        text = ''
+          [Service]
+          ExecStart=
+          ExecStart=${launcher}
+        '';
+      };
+
   systemd.user.services.t3-connect = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {
       Description = "Keep the T3 remote server ready to accept connections";
@@ -10,24 +74,8 @@ in
     Service = {
       Type = "oneshot";
       Environment = [
-        # node-gyp's generated Makefile shells out to sed/grep/awk/which, so a
-        # minimal PATH fails the compile with `sed: command not found` rather
-        # than anything that names the real dependency.
-        "PATH=${
-          lib.makeBinPath [
-            pkgs.bash
-            pkgs.coreutils
-            pkgs.findutils
-            pkgs.gawk
-            pkgs.gcc
-            pkgs.gnugrep
-            pkgs.gnumake
-            pkgs.gnused
-            pkgs.nodejs
-            pkgs.python3
-            pkgs.which
-          ]
-        }"
+        "PATH=${toolchain}"
+        "T3_PREPARE_RUNTIME=${prepareRuntime}"
       ];
       Nice = 19;
       IOSchedulingPriority = 7;

--- a/home-manager/services/t3-connect/launch-service.sh
+++ b/home-manager/services/t3-connect/launch-service.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base="${T3CODE_HOME:-$HOME/.t3}"
+version="$(node -e '
+  const state = require(process.argv[1]);
+  if (!/^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(state.activeVersion)) {
+    throw new Error("Invalid active T3 runtime version");
+  }
+  process.stdout.write(state.activeVersion);
+' "$base/runtime/service-state.json")"
+
+"${T3_PREPARE_RUNTIME:?}" "$base/runtime/versions/$version"
+exec node "$base/runtime/service-launcher.mjs"

--- a/home-manager/services/t3-connect/prepare-runtime.sh
+++ b/home-manager/services/t3-connect/prepare-runtime.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runtime="$(realpath -e -- "${1:?runtime directory required}")"
+pty="$runtime/node_modules/node-pty"
+[ -d "$pty" ] || { echo "T3 runtime has no node-pty: $runtime" >&2; exit 1; }
+
+# The updater and cache warmer may prepare the same runtime concurrently.
+exec 9>"$runtime/.native-prepare.lock"
+flock 9
+
+if node "${T3_PTY_PROBE:?}" "$pty" >/dev/null 2>&1; then
+  exit 0
+fi
+
+echo "Preparing T3 native terminal: $runtime" >&2
+cd "$runtime"
+# npm's project policy must live in package.json, not a CLI flag or env var.
+# Rebuild only node-pty; do not enable lifecycle scripts for the whole tree.
+npm pkg set 'allowScripts.node-pty=true' --json
+npm rebuild --ignore-scripts=false --foreground-scripts node-pty
+
+# npm can exit zero even when it skips install scripts. A usable terminal,
+# checked under the service's Node runtime, is the success criterion.
+node "${T3_PTY_PROBE:?}" "$pty"

--- a/home-manager/services/t3-connect/pty-probe.cjs
+++ b/home-manager/services/t3-connect/pty-probe.cjs
@@ -1,0 +1,20 @@
+const pty = require(process.argv[2]);
+const marker = "t3-native-terminal-ready";
+const terminal = pty.spawn(process.execPath, ["-e", `process.stdout.write(${JSON.stringify(marker)})`], {
+  cwd: process.cwd(),
+  env: process.env,
+});
+let output = "";
+const timeout = setTimeout(() => {
+  console.error("T3 native terminal probe timed out");
+  terminal.kill();
+  process.exit(1);
+}, 5000);
+terminal.onData((data) => { output += data; });
+terminal.onExit(({ exitCode }) => {
+  clearTimeout(timeout);
+  if (exitCode !== 0 || !output.includes(marker)) {
+    console.error("T3 native terminal probe failed");
+    process.exitCode = 1;
+  }
+});

--- a/home-manager/services/t3-connect/runtime-npm.sh
+++ b/home-manager/services/t3-connect/runtime-npm.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# T3 installs candidates in a private staging directory, then publishes them
+# only after npm returns. Prepare the terminal before that handoff. All other
+# npm calls, including those made by agent subprocesses, keep their policy.
+runtime=""
+prefix=""
+if [ "${1:-}" = install ]; then
+  args=("$@")
+  for ((index = 1; index < ${#args[@]}; index++)); do
+    case "${args[index]}" in
+      --prefix)
+        ((index += 1))
+        prefix="${args[index]:-}"
+        ;;
+      --prefix=*) prefix="${args[index]#--prefix=}" ;;
+      --) break ;;
+    esac
+  done
+fi
+if [ -n "$prefix" ]; then
+  candidate="$(realpath -m -- "$prefix")"
+  versions="$(realpath -m -- "${T3CODE_HOME:-$HOME/.t3}/runtime/versions")"
+  if [ "$(dirname -- "$candidate")" = "$versions" ] &&
+    [[ "$(basename -- "$candidate")" == .staging-* ]]; then
+    runtime="$candidate"
+  fi
+fi
+
+if [ -z "$runtime" ]; then
+  exec "${T3_REAL_NPM:?}" "$@"
+fi
+
+"${T3_REAL_NPM:?}" "$@" --ignore-scripts=true
+"${T3_PREPARE_RUNTIME:?}" "$runtime"

--- a/spec/t3_connect_spec.sh
+++ b/spec/t3_connect_spec.sh
@@ -1,172 +1,227 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2329
 
-Describe 't3-connect/connect.sh'
+Describe 'T3 native runtime preparation'
 SCRIPT="$PWD/home-manager/services/t3-connect/connect.sh"
+PREPARE="$PWD/home-manager/services/t3-connect/prepare-runtime.sh"
+WRAPPER="$PWD/home-manager/services/t3-connect/runtime-npm.sh"
+LAUNCHER="$PWD/home-manager/services/t3-connect/launch-service.sh"
 
 setup() {
-  mock_bin_setup npx npm
-  FAKE_HOME="$(mktemp -d)"
-  export HOME="$FAKE_HOME"
+  mock_bin_setup npm npx prepare node
+  T3_TEST_ROOT="$(mktemp -d)"
+  export T3_TEST_ROOT
+  export T3CODE_HOME="$T3_TEST_ROOT/t3"
+  export npm_config_cache="$T3_TEST_ROOT/npm-cache"
+  export T3_PREPARE_RUNTIME="$MOCK_BIN/prepare"
+  export T3_REAL_NPM="$MOCK_BIN/npm"
+  export T3_PTY_PROBE=pty-probe.cjs
+  mkdir -p "$T3CODE_HOME/runtime/versions/.staging-test" "$npm_config_cache/_npx"
 }
 
 cleanup() {
   mock_bin_cleanup
-  rm -rf "$FAKE_HOME"
+  rm -rf "$T3_TEST_ROOT"
+  unset T3_TEST_ROOT T3CODE_HOME npm_config_cache T3_PREPARE_RUNTIME T3_REAL_NPM T3_PTY_PROBE
 }
 
 Before 'setup'
 After 'cleanup'
 
-Describe 'cache warming'
-# npx keys its cache dir on the literal spec string, so the script must warm
-# the resolved version the client uses, not the tag.
-mock_npm_view() {
-  cat >"$MOCK_BIN/npm" <<'EOF'
+mock_registry() {
+  cat >"$MOCK_BIN/npm" <<'MOCK'
 #!/usr/bin/env bash
-printf '%s\n' "$0 $*" >>"$MOCK_LOG"
-if [ "${1:-}" = view ]; then echo "0.0.33-nightly.20260809.1041"; fi
-exit 0
-EOF
-  chmod +x "$MOCK_BIN/npm"
+printf '%s\n' "npm $*" >>"$MOCK_LOG"
+if [ "${1:-}" = view ]; then echo 1.2.3; fi
+MOCK
 }
 
-It 'resolves the tag to an exact version before warming'
-When run bash -c "$(declare -f mock_npm_view); mock_npm_view; bash '$SCRIPT' >/dev/null 2>&1; cat '$MOCK_LOG'"
+warm_cache() {
+  mock_registry
+  mkdir -p "$npm_config_cache/_npx/cache/node_modules/node-pty"
+  mkdir -p "$T3CODE_HOME/runtime/versions/1.2.3/node_modules/node-pty"
+  bash "$SCRIPT"
+  cat "$MOCK_LOG"
+}
+
+It 'warms the exact version and prepares cache and service runtimes'
+When call warm_cache
+The status should be success
 The output should include 'npm view t3@nightly version'
-The output should include 'npx --yes t3@0.0.33-nightly.20260809.1041 --version'
-The status should be success
+The output should include 'npx --yes t3@1.2.3 --version'
+The output should include "prepare $npm_config_cache/_npx/cache/"
+The output should include "prepare $T3CODE_HOME/runtime/versions/1.2.3/"
 End
 
-It 'honors T3_CONNECT_TAG override'
-When run bash -c "$(declare -f mock_npm_view); mock_npm_view; T3_CONNECT_TAG=latest bash '$SCRIPT' >/dev/null 2>&1; cat '$MOCK_LOG'"
+It 'honors the release channel override'
+export T3_CONNECT_TAG=latest
+When call warm_cache
+The status should be success
 The output should include 'npm view t3@latest version'
-The status should be success
 End
 
-It 'falls back to the tag when resolution fails'
-When run bash -c "bash '$SCRIPT' >/dev/null 2>&1; cat '$MOCK_LOG'"
-The output should include 'npx --yes t3@nightly --version'
-The status should be success
-End
-End
-
-Describe 'node-pty rebuild'
-make_cache_dir() {
-  mkdir -p "$HOME/.npm/_npx/abc123/node_modules/node-pty"
-}
-
-It 'rebuilds node-pty with a scoped ignore-scripts override'
-When run bash -c "$(declare -f make_cache_dir); make_cache_dir; bash '$SCRIPT' >/dev/null 2>&1; cat '$MOCK_LOG'"
-The output should include 'npm rebuild --ignore-scripts=false node-pty'
-The status should be success
-End
-
-# A wrong-toolchain build still drops pty.node, so presence must NOT count as
-# done -- only a successful require() may skip the rebuild.
-It 'rebuilds anyway when pty.node exists but does not load'
-When run bash -c "$(declare -f make_cache_dir); make_cache_dir; mkdir -p \"\$HOME/.npm/_npx/abc123/node_modules/node-pty/build/Release\"; touch \"\$HOME/.npm/_npx/abc123/node_modules/node-pty/build/Release/pty.node\"; bash '$SCRIPT' >/dev/null 2>&1; cat '$MOCK_LOG'"
-The output should include 'npm rebuild --ignore-scripts=false node-pty'
-The status should be success
-End
-
-mock_node_loads() {
-  cat >"$MOCK_BIN/node" <<'EOF'
-#!/usr/bin/env bash
-printf '%s\n' "$0 $*" >>"$MOCK_LOG"
-exit 0
-EOF
-  chmod +x "$MOCK_BIN/node"
-}
-
-It 'skips rebuild when node-pty already loads'
-When run bash -c "$(declare -f make_cache_dir mock_node_loads); make_cache_dir; mock_node_loads; bash '$SCRIPT' >/dev/null 2>&1; cat '$MOCK_LOG'"
-The output should not include 'npm rebuild'
-The status should be success
-End
-
-It 'succeeds when no npx cache dirs exist'
+It 'does not mask preparation failures'
+mkdir -p "$T3CODE_HOME/runtime/versions/1.2.3/node_modules/node-pty"
+printf '#!/usr/bin/env bash\nexit 23\n' >"$MOCK_BIN/prepare"
 When run bash "$SCRIPT"
-The status should be success
+The status should equal 23
 End
 
-make_runtime_dir() {
-  mkdir -p "$HOME/.t3/runtime/versions/1.2.3/node_modules/node-pty"
+Describe 'native build verification'
+make_runtime() {
+  mkdir -p "$T3CODE_HOME/runtime/versions/1.2.3/node_modules/node-pty"
+  printf '{}\n' >"$T3CODE_HOME/runtime/versions/1.2.3/package.json"
+}
+Before 'make_runtime'
+
+mock_build() {
+  cat >"$MOCK_BIN/node" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "probe $*" >>"$MOCK_LOG"
+[ -f "$T3_TEST_ROOT/built" ] && [ "${T3_TEST_PROBE_FAIL:-0}" = 0 ]
+MOCK
+  cat >"$MOCK_BIN/npm" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "npm $*" >>"$MOCK_LOG"
+if [ "$1" = rebuild ]; then
+  touch "$T3_TEST_ROOT/built"
+  exit "${T3_TEST_BUILD_EXIT:-0}"
+fi
+MOCK
 }
 
-It 'also builds node-pty in the t3 service runtime tree'
-When run bash -c "$(declare -f make_runtime_dir); make_runtime_dir; bash '$SCRIPT' >/dev/null 2>&1; cat '$MOCK_LOG'"
-The output should include 'npm rebuild --ignore-scripts=false node-pty'
+prepare_runtime() {
+  bash "$PREPARE" "$T3CODE_HOME/runtime/versions/1.2.3"
+}
+
+run_build() {
+  mock_build
+  prepare_runtime
+}
+
+It 'approves only node-pty and validates the rebuilt terminal'
+When call run_build
 The status should be success
+The stderr should include 'Preparing T3 native terminal'
+The contents of file "$MOCK_LOG" should include 'npm pkg set allowScripts.node-pty=true --json'
+The contents of file "$MOCK_LOG" should include 'npm rebuild --ignore-scripts=false --foreground-scripts node-pty'
+The contents of file "$MOCK_LOG" should include 'probe pty-probe.cjs'
+End
+
+It 'fails when npm returns success but the terminal still fails'
+export T3_TEST_PROBE_FAIL=1
+When call run_build
+The status should be failure
+The stderr should include 'Preparing T3 native terminal'
+End
+
+It 'preserves the native build exit status'
+export T3_TEST_BUILD_EXIT=17
+When call run_build
+The status should equal 17
+The stderr should include 'Preparing T3 native terminal'
+End
+
+It 'skips rebuilding a working terminal'
+When call prepare_runtime
+The status should be success
+The contents of file "$MOCK_LOG" should not include 'npm'
+End
+
+It 'rejects a runtime missing node-pty'
+When run bash "$PREPARE" "$T3CODE_HOME/runtime/versions/.staging-test"
+The status should be failure
+The stderr should include 'T3 runtime has no node-pty'
 End
 End
 
-Describe 'systemd unit PATH'
-UNIT="$PWD/home-manager/services/t3-connect/default.nix"
+Describe 'synchronous update preparation'
+install_candidate() {
+  bash "$WRAPPER" install --prefix "$T3CODE_HOME/runtime/versions/.staging-test" --no-fund --no-audit t3@1.2.3
+}
 
-# node-gyp's generated Makefile shells out to these. Omitting them fails the
-# build with `sed: command not found`, which names none of the real cause.
-It 'includes the build tools node-gyp shells out to'
-When run bash -c "cat '$UNIT'"
-The output should include 'pkgs.gnused'
-The output should include 'pkgs.gnugrep'
-The output should include 'pkgs.gawk'
-The output should include 'pkgs.which'
-End
-
-It 'includes a compiler, make and python for node-gyp'
-When run bash -c "cat '$UNIT'"
-The output should include 'pkgs.gcc'
-The output should include 'pkgs.gnumake'
-The output should include 'pkgs.python3'
+It 'prepares a staged update before returning success'
+When call install_candidate
+The status should be success
+The contents of file "$MOCK_LOG" should include 't3@1.2.3 --ignore-scripts=true'
+The contents of file "$MOCK_LOG" should include "prepare $T3CODE_HOME/runtime/versions/.staging-test"
 End
 
-# nix gcc and nix nodejs must come from the same PATH so the addon it builds is
-# loadable by the node that will require it.
-It 'supplies nodejs from nix alongside the nix compiler'
-When run bash -c "cat '$UNIT'"
-The output should include 'pkgs.nodejs'
-End
+It 'fails the update when terminal preparation fails'
+printf '#!/usr/bin/env bash\nexit 23\n' >"$MOCK_BIN/prepare"
+When call install_candidate
+The status should equal 23
 End
 
-Describe 'service node pinning'
-MAKEFILE="$PWD/Makefile"
-
-# t3 bakes the node it finds on PATH into t3code.service ExecStart. If that is a
-# generic (fnm) node it cannot load the nix-built addon, so the install must run
-# with the nix node first.
-It 'installs the t3 service against the nix node'
-When run bash -c "sed -n '/^t3-service:/,/service status/p' '$MAKEFILE'"
-The output should include 'NIX_NODE_BIN'
-The output should include '.nix-profile/bin/node'
-End
+It 'prepares updates with reordered flags and an equals-form prefix'
+When run bash "$WRAPPER" install --no-audit t3@1.2.3 "--prefix=$T3CODE_HOME/runtime/versions/.staging-test" --no-fund
+The status should be success
+The contents of file "$MOCK_LOG" should include "prepare $T3CODE_HOME/runtime/versions/.staging-test"
 End
 
-Describe 'toolchain selection'
-# A native addon must be built by a compiler whose libc matches the node that
-# loads it. Everything here is nix, so no distro compiler may be pinned in.
-It 'documents the libc/loader pairing'
-When run bash -c "cat '$SCRIPT'"
-The output should include 'GLIBC'
+It 'does not prepare a failed installation'
+printf '#!/usr/bin/env bash\nexit 19\n' >"$MOCK_BIN/npm"
+When call install_candidate
+The status should equal 19
+The contents of file "$MOCK_LOG" should not include 'prepare'
 End
 
-It 'pins no distro toolchain'
-When run bash -c "cat '$SCRIPT'"
-The output should not include '/usr/bin/g++'
-The output should not include '/etc/NIXOS'
-End
-End
-
-Describe 'script properties'
-It 'uses strict mode (set -euo pipefail)'
-When run bash -c "head -20 '$SCRIPT'"
-The output should include 'set -euo pipefail'
+It 'forwards unrelated npm calls unchanged'
+When run bash "$WRAPPER" view t3@nightly version
+The status should be success
+The contents of file "$MOCK_LOG" should include 'npm view t3@nightly version'
+The contents of file "$MOCK_LOG" should not include 'prepare'
+The contents of file "$MOCK_LOG" should not include 'ignore-scripts'
 End
 
-It 'documents why the scoped override is needed'
-When run bash -c "cat '$SCRIPT'"
-The output should include 'per-package allowlist'
+It 'does not change npm policy for projects outside the T3 runtime'
+When run bash "$WRAPPER" install --prefix "$T3_TEST_ROOT" --no-fund --no-audit t3@1.2.3
+The status should be success
+The contents of file "$MOCK_LOG" should not include 'prepare'
+The contents of file "$MOCK_LOG" should not include 'ignore-scripts'
+End
+
+It 'does not follow a staging symlink outside the runtime'
+ln -s "$T3_TEST_ROOT" "$T3CODE_HOME/runtime/versions/.staging-link"
+When run bash "$WRAPPER" install --prefix "$T3CODE_HOME/runtime/versions/.staging-link" --no-fund --no-audit t3@1.2.3
+The status should be success
+The contents of file "$MOCK_LOG" should not include 'prepare'
+The contents of file "$MOCK_LOG" should not include 'ignore-scripts'
+End
+
+It 'forwards installs into new unrelated directories unchanged'
+When run bash "$WRAPPER" install --prefix "$T3_TEST_ROOT/new-project" --no-fund --no-audit t3@1.2.3
+The status should be success
+The contents of file "$MOCK_LOG" should not include 'prepare'
+The contents of file "$MOCK_LOG" should not include 'ignore-scripts'
 End
 End
 
+Describe 'service startup'
+mock_active_version() {
+  cat >"$MOCK_BIN/node" <<'MOCK'
+#!/usr/bin/env bash
+if [ "$1" = -e ]; then
+  echo 1.2.3
+else
+  printf '%s\n' "launcher $*" >>"$MOCK_LOG"
+fi
+MOCK
+}
+Before 'mock_active_version'
+
+It 'prepares the active runtime before starting the service launcher'
+When run bash "$LAUNCHER"
+The status should be success
+The contents of file "$MOCK_LOG" should include "prepare $T3CODE_HOME/runtime/versions/1.2.3"
+The contents of file "$MOCK_LOG" should include "launcher $T3CODE_HOME/runtime/service-launcher.mjs"
+End
+
+It 'does not launch a broken active runtime'
+printf '#!/usr/bin/env bash\nexit 23\n' >"$MOCK_BIN/prepare"
+When run bash "$LAUNCHER"
+The status should equal 23
+The contents of file "$MOCK_LOG" should not include 'launcher'
+End
+End
 End


### PR DESCRIPTION
T3 updates can finish downloading without a usable Linux `node-pty` binary, causing the candidate server to crash and roll back. The cache warmer also reports success when npm skips unapproved native build scripts.

Prepare and verify native terminals before staged runtime installs return to the updater. Each runtime explicitly approves `node-pty`, and preparation requires a successful terminal spawn after rebuilding. A Home Manager service drop-in uses the same Nix Node toolchain for builds and server startup; T3-specific Fish, Bash, and Zsh hooks preserve the installer through login-shell PATH hydration. The global npm script policy is unchanged.

Validation:
- 18 focused ShellSpec examples passed, including skipped-build failures, install failures, and unrelated npm calls.
- ShellCheck, nixfmt, and diff checks passed.
- Evaluated the merged Home Manager configuration and built the generated Nix scripts and drop-in.
- Installed a real T3 runtime in a disposable directory, compiled its native addon, verified a working terminal, and confirmed a second preparation skips rebuilding.
- Verified the generated launcher uses Nix Node and shell hooks preserve ordinary shell PATH behavior.

Not activated on the running server. After applying Home Manager, run `t3-connect.service` once to prepare already-cached runtimes, then restart `t3code.service`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes T3 updates finishing without a usable Linux `node-pty` binary, which crashed the candidate server and forced a rollback on next start. Preparation now explicitly allows `node-pty`'s build script per runtime, rebuilds it, and requires a successful terminal spawn before a staged install returns success. The global npm script policy is unchanged.

**Bug Fixes**
- The cache warmer now fails when npm skips the native build instead of reporting success.
- A systemd drop-in keeps the main `t3code.service` on the Nix Node toolchain used for builds.
- Fish, Bash, and Zsh hooks keep the scoped npm wrapper available through login-shell PATH hydration.

**Migration**
- Run `t3-connect.service` once after applying Home Manager, then restart `t3code.service`.

<sup>Written for commit 42761a2ccaf445ef97eda92fd82339cfc332a18d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

