### PR TITLE
feat(codex): raise Astra context window to 400k

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -1,6 +1,8 @@
 suppress_unstable_features_warning = true
 web_search = "cached"
 model = "gpt-5.6-sol"
+model_context_window = 400000
+model_auto_compact_token_limit = 360000
 enabled-reasoning-efforts = ["medium", "high", "max"]
 model_reasoning_effort = "high"
 approval_policy = "never"

--- a/config/codex/config.tpl.toml
+++ b/config/codex/config.tpl.toml
@@ -1,6 +1,8 @@
 suppress_unstable_features_warning = true
 web_search = "cached"
 model = "__GPT__"
+model_context_window = 400000
+model_auto_compact_token_limit = 360000
 enabled-reasoning-efforts = ["medium", "high", "max"]
 model_reasoning_effort = "high"
 approval_policy = "never"

--- a/config/codex/profiles/cliproxy-astra.config.toml
+++ b/config/codex/profiles/cliproxy-astra.config.toml
@@ -1,2 +1,4 @@
 model = "gpt-6-astra"
+model_context_window = 400000
+model_auto_compact_token_limit = 360000
 model_provider = "cliproxyapi"

--- a/config/codex/profiles/cliproxy-astra.config.tpl.toml
+++ b/config/codex/profiles/cliproxy-astra.config.tpl.toml
@@ -1,2 +1,4 @@
 model = "__GPT_ASTRA__"
+model_context_window = 400000
+model_auto_compact_token_limit = 360000
 model_provider = "cliproxyapi"


### PR DESCRIPTION
## Summary
- Raise Codex Astra practical context to ~400k (`model_context_window = 400000`, `model_auto_compact_token_limit = 360000`) on top-level `config/codex/config.toml` + tpl and the `cliproxy-astra` profile.
- Leaves default `model` on `gpt-5.6-sol` (tweet suggested switching to `gpt-6-astra`; say if you want that as the default too).
- `features.context_management.experimental_mode` already true from #2618 / SHUN-4069.

Source: https://x.com/brandon_galang/status/2097067132014211348

Linear: SHUN-4797

## Test plan
- [ ] After home-manager / activate, confirm `~/.codex/config.toml` has the two new keys at top level
- [ ] Astra profile sessions compact near 360k rather than the old ~270k band

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the Astra context window to ~400k tokens so sessions auto-compact near 360k instead of the old ~270k band (SHUN-4797).

- Sets `model_context_window = 400000` and `model_auto_compact_token_limit = 360000` in the base config and the `cliproxy-astra` profile, for both `.toml` and `.tpl.toml` variants.
- Keeps the default model on `gpt-5.6-sol`; `gpt-6-astra` remains the model for the Astra profile only.

<sup>Written for commit e5b3019052ffb17e9a2ded99f21a1833c857c849. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

