### PR TITLE
fix(hooks): preserve native Codex permission flow

### DIFF
--- a/config/shared/hooks/rtk-rewrite.sh
+++ b/config/shared/hooks/rtk-rewrite.sh
@@ -80,8 +80,14 @@ case $EXIT_CODE in
     exit 0
     ;;
   3)
-    # Ask rule matched — rewrite the command but do NOT auto-allow so that
-    # Claude Code prompts the user for confirmation.
+    # Ask rule matched. Native Codex rejects updatedInput without an allow
+    # decision and does not support Claude's ask response, so let its native
+    # permission flow handle the original command.
+    if jq -e 'has("turn_id")' >/dev/null <<<"$INPUT"; then
+      _rtk_audit_log "skip:ask_native" "$CMD"
+      exit 0
+    fi
+    # Claude Code prompts the user for confirmation after this rewrite.
     ;;
   *)
     exit 0

--- a/spec/rtk_rewrite_spec.sh
+++ b/spec/rtk_rewrite_spec.sh
@@ -62,6 +62,28 @@ run_hook_modified_args() {
   fi
 }
 
+# Use a deterministic RTK mock for permission-protocol cases. The regular
+# tests use the installed RTK when available, but its rule set can change.
+PERMISSION_MOCK_BIN="$SHELLSPEC_TMPBASE/permission_mock_bin"
+mkdir -p "$PERMISSION_MOCK_BIN"
+cat >"$PERMISSION_MOCK_BIN/rtk" <<'MOCK'
+#!/bin/bash
+if [ "$1" = "rewrite" ]; then
+  case "$2" in
+    ask\ *) echo "rtk $2"; exit 3 ;;
+    allow\ *) echo "rtk $2"; exit 0 ;;
+    deny\ *) exit 2 ;;
+    *) exit 1 ;;
+  esac
+fi
+exit 1
+MOCK
+chmod +x "$PERMISSION_MOCK_BIN/rtk"
+
+run_permission_mock_hook() {
+  PATH="$PERMISSION_MOCK_BIN:$PATH" bash "$SCRIPT"
+}
+
 Describe 'guards'
 It 'exits silently when no command in input'
 Data '{"tool_input": {}}'
@@ -142,6 +164,39 @@ When run run_hook
 The status should be success
 The output should include '"timeout"'
 The output should include '5000'
+End
+End
+
+Describe 'permission protocol'
+It 'keeps the ask rewrite for Claude payloads'
+Data '{"tool_input": {"command": "ask command"}}'
+When run run_permission_mock_hook
+The status should be success
+The output should include '"updatedInput"'
+The output should include 'rtk ask command'
+The output should not include 'permissionDecision'
+End
+
+It 'passes native Codex ask payloads through unchanged'
+Data '{"turn_id": "turn-1", "tool_input": {"command": "ask command"}}'
+When run run_permission_mock_hook
+The status should be success
+The output should eq ''
+End
+
+It 'allows native Codex rewrites when RTK has no permission rule'
+Data '{"turn_id": "turn-1", "tool_input": {"command": "allow command"}}'
+When run run_permission_mock_hook
+The status should be success
+The output should include '"permissionDecision": "allow"'
+The output should include 'rtk allow command'
+End
+
+It 'passes native Codex deny payloads through unchanged'
+Data '{"turn_id": "turn-1", "tool_input": {"command": "deny command"}}'
+When run run_permission_mock_hook
+The status should be success
+The output should eq ''
 End
 End
 


### PR DESCRIPTION
## Problem

The shared RTK hook emits an `updatedInput` response without `permissionDecision` when RTK returns exit 3. Claude Code accepts that ask-rewrite shape, but native Codex rejects it and reports a hook protocol error before its own permission flow can run.

## Change

- Detect native Codex PreToolUse payloads by their required `turn_id` field.
- Pass RTK ask and deny outcomes through unchanged for Codex so native permission handling remains authoritative.
- Preserve Claude's existing ask rewrite and Codex's allow rewrite response.
- Add deterministic shellspec coverage for the permission protocol cases.

## Validation

- `shellspec spec/rtk_rewrite_spec.sh spec/sync_rtk_rewrite_spec.sh`
- `bash -n config/shared/hooks/rtk-rewrite.sh spec/rtk_rewrite_spec.sh`
- `shellcheck config/shared/hooks/rtk-rewrite.sh spec/rtk_rewrite_spec.sh`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the shared RTK hook so native Codex permission prompts work again. Previously, on RTK exit 3, the hook rewrote the command into an `updatedInput` response without `permissionDecision`, which Claude Code accepts but native Codex rejects as a hook protocol error before its own permission flow can run. The hook now detects native Codex PreToolUse payloads by their required `turn_id` field and passes RTK ask and deny outcomes through unchanged, letting Codex handle permission natively. Claude's existing ask rewrite and Codex's allow rewrite response are preserved. Adds deterministic shellspec coverage for the permission protocol cases.

<sup>Written for commit e1f0e46e881b314b7b5a4ea3fe3e73e9511a54e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

