### PR TITLE
fix(codex): recover managed hook client selection

### DIFF
--- a/config/codex/config.toml
+++ b/config/codex/config.toml
@@ -10,7 +10,6 @@ sandbox_mode = "danger-full-access"
 personality = "pragmatic"
 model_verbosity = "low"
 model_reasoning_summary = "concise"
-notify = ["turn-ended"]
 oss_provider = "lmstudio"
 
 [features]

--- a/config/codex/config.tpl.toml
+++ b/config/codex/config.tpl.toml
@@ -10,7 +10,6 @@ sandbox_mode = "danger-full-access"
 personality = "pragmatic"
 model_verbosity = "low"
 model_reasoning_summary = "concise"
-notify = ["turn-ended"]
 oss_provider = "lmstudio"
 
 [features]

--- a/config/shared/hooks/security.sh
+++ b/config/shared/hooks/security.sh
@@ -10,7 +10,7 @@
 # Cursor on macOS launches GUI apps with a minimal PATH, so this script
 # self-bootstraps PATH to find jq.
 
-export PATH="$HOME/.cargo/bin:/etc/profiles/per-user/shunkakinoki/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/sbin:/usr/bin:/bin:${PATH:-}"
+export PATH="$HOME/.local/bin:$HOME/.cargo/bin:/etc/profiles/per-user/shunkakinoki/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/opt/homebrew/bin:/usr/local/bin:/usr/sbin:/usr/bin:/bin:${PATH:-}"
 
 set -euo pipefail
 

--- a/home-manager/services/t3-connect/default.nix
+++ b/home-manager/services/t3-connect/default.nix
@@ -17,21 +17,21 @@ let
     pkgs.util-linux
     pkgs.which
   ];
-  prepareRuntime = pkgs.writeShellScript "t3-prepare-runtime" ''
-    export PATH=${toolchain}:$PATH
-    export T3_PTY_PROBE=${./pty-probe.cjs}
-    ${builtins.readFile ./prepare-runtime.sh}
-  '';
-  runtimeNpm = pkgs.writeShellScriptBin "npm" ''
-    export T3_REAL_NPM=${pkgs.nodejs}/bin/npm
-    export T3_PREPARE_RUNTIME=${prepareRuntime}
-    ${builtins.readFile ./runtime-npm.sh}
-  '';
-  launcher = pkgs.writeShellScript "t3-launch-service" ''
-    export PATH=${runtimeNpm}/bin:${toolchain}:$PATH
-    export T3_PREPARE_RUNTIME=${prepareRuntime}
-    ${builtins.readFile ./launch-service.sh}
-  '';
+  prepareRuntime = pkgs.writeShellScript "t3-prepare-runtime" (
+    "export PATH=${toolchain}:$PATH\n"
+    + "export T3_PTY_PROBE=${./pty-probe.cjs}\n"
+    + builtins.readFile ./prepare-runtime.sh
+  );
+  runtimeNpm = pkgs.writeShellScriptBin "npm" (
+    "export T3_REAL_NPM=${pkgs.nodejs}/bin/npm\n"
+    + "export T3_PREPARE_RUNTIME=${prepareRuntime}\n"
+    + builtins.readFile ./runtime-npm.sh
+  );
+  launcher = pkgs.writeShellScript "t3-launch-service" (
+    "export PATH=${runtimeNpm}/bin:${toolchain}:$PATH\n"
+    + "export T3_PREPARE_RUNTIME=${prepareRuntime}\n"
+    + builtins.readFile ./launch-service.sh
+  );
   shellInstallerPath = ''
     if [ "''${T3_BOOT_SERVICE_UNIT:-}" = t3code.service ]; then
       export PATH=${runtimeNpm}/bin:$PATH

--- a/home-manager/services/t3-connect/prepare-runtime.sh
+++ b/home-manager/services/t3-connect/prepare-runtime.sh
@@ -3,7 +3,10 @@ set -euo pipefail
 
 runtime="$(realpath -e -- "${1:?runtime directory required}")"
 pty="$runtime/node_modules/node-pty"
-[ -d "$pty" ] || { echo "T3 runtime has no node-pty: $runtime" >&2; exit 1; }
+[ -d "$pty" ] || {
+  echo "T3 runtime has no node-pty: $runtime" >&2
+  exit 1
+}
 
 # The updater and cache warmer may prepare the same runtime concurrently.
 exec 9>"$runtime/.native-prepare.lock"

--- a/home-manager/services/t3-connect/runtime-npm.sh
+++ b/home-manager/services/t3-connect/runtime-npm.sh
@@ -10,12 +10,12 @@ if [ "${1:-}" = install ]; then
   args=("$@")
   for ((index = 1; index < ${#args[@]}; index++)); do
     case "${args[index]}" in
-      --prefix)
-        ((index += 1))
-        prefix="${args[index]:-}"
-        ;;
-      --prefix=*) prefix="${args[index]#--prefix=}" ;;
-      --) break ;;
+    --prefix)
+      ((index += 1))
+      prefix="${args[index]:-}"
+      ;;
+    --prefix=*) prefix="${args[index]#--prefix=}" ;;
+    --) break ;;
     esac
   done
 fi

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -153,6 +153,18 @@ It 'has spec file for home-manager/services/t3-connect/connect.sh'
 The path "spec/t3_connect_spec.sh" should be exist
 End
 
+It 'has spec file for home-manager/services/t3-connect/launch-service.sh'
+The path "spec/t3_connect_spec.sh" should be exist
+End
+
+It 'has spec file for home-manager/services/t3-connect/prepare-runtime.sh'
+The path "spec/t3_connect_spec.sh" should be exist
+End
+
+It 'has spec file for home-manager/services/t3-connect/runtime-npm.sh'
+The path "spec/t3_connect_spec.sh" should be exist
+End
+
 It 'has spec file for home-manager/services/night-shift/apply-night-shift.sh'
 The path "spec/night_shift_spec.sh" should be exist
 End
@@ -626,6 +638,9 @@ home-manager/services/mempalace-exporter/export.sh
 home-manager/services/neverssl-keepalive/keepalive.sh
 home-manager/services/night-shift/apply-night-shift.sh
 home-manager/services/t3-connect/connect.sh
+home-manager/services/t3-connect/launch-service.sh
+home-manager/services/t3-connect/prepare-runtime.sh
+home-manager/services/t3-connect/runtime-npm.sh
 home-manager/services/tokscale/submit.sh
 hosts/darwin/activate-remove-backups.sh
 hosts/linux/activate-backup-files.sh

--- a/spec/herdr_worker_admission_test.py
+++ b/spec/herdr_worker_admission_test.py
@@ -305,6 +305,33 @@ class WorkerAdmissionTests(unittest.TestCase):
         self.assertGreaterEqual(hook["hooks"][0]["timeout"], 5000)
         self.assertIn("config/shared/hooks/security.sh", hook["hooks"][0]["command"])
 
+    def test_shared_hook_prefers_local_herdr_client(self):
+        local_bin = self.home / ".local/bin"
+        legacy_bin = self.home / ".cargo/bin"
+        local_bin.mkdir(parents=True)
+        legacy_bin.mkdir(parents=True)
+        for directory in (local_bin, legacy_bin):
+            binary = directory / "herdr"
+            binary.write_text("#!/bin/sh\nexit 0\n")
+            binary.chmod(0o755)
+
+        path_export = next(
+            line
+            for line in (ROOT / "config/shared/hooks/security.sh")
+            .read_text()
+            .splitlines()
+            if line.startswith("export PATH=")
+        )
+        env = dict(os.environ, HOME=str(self.home), PATH=str(legacy_bin))
+        result = subprocess.run(
+            [shutil.which("bash"), "-c", f"{path_export}\ntype -P herdr"],
+            text=True,
+            capture_output=True,
+            env=env,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), str(local_bin / "herdr"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -411,6 +411,13 @@ The status should be success
 End
 End
 
+Describe 'Codex notification configuration'
+It 'omits the obsolete turn notifier from the template and hydrated config'
+When run bash -c "for file in config/codex/config.tpl.toml config/codex/config.toml; do ! grep -Eq '^notify[[:space:]]*=' \"\$file\" || exit 1; done"
+The status should be success
+End
+End
+
 Describe 'Codex named profile model hydration'
 It 'propagates independent Astra, Sol, and Luna selections into the named profiles'
 FIXTURE="$(mktemp -d)"


### PR DESCRIPTION
## Summary
- remove the obsolete Codex turn notifier from the managed config and template
- prefer the managed user-local Herdr client in the shared security hook PATH
- add hermetic coverage for client resolution and notifier removal while preserving admission guards

## Validation
- 21/21 spec/herdr_worker_admission_test.py tests
- 120/120 focused ShellSpec examples
- ShellCheck
- Ruff check and format
- git diff --check

Draft-only: no full switch, root reset, admission bypass, floor activity, or undraft/merge action.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the shared security hook’s preference for the managed user-local Herdr client by searching `~/.local/bin` before the legacy Cargo path. Removes the obsolete Codex turn notifier from the managed config and template; no migration is needed.

- Adds hermetic tests for client resolution and notifier removal while preserving admission guards.

<sup>Written for commit 0743b32a7a6e33df02ec383ac17e82a6e5b33652. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

