### PR TITLE
fix: parse quoted admission commands safely

### DIFF
--- a/config/shared/hooks/herdr-worker-admission.py
+++ b/config/shared/hooks/herdr-worker-admission.py
@@ -52,6 +52,10 @@ def invocations(command):
         if quote == '"':
             segment.append(char)
             if char == "\\" and index + 1 < len(command):
+                if command[index + 1] == "\n":
+                    segment.pop()
+                    index += 2
+                    continue
                 segment.append(command[index + 1])
                 index += 2
                 continue
@@ -60,6 +64,9 @@ def invocations(command):
             index += 1
             continue
         if char == "\\":
+            if index + 1 < len(command) and command[index + 1] == "\n":
+                index += 2
+                continue
             segment.append(char)
             if index + 1 < len(command):
                 segment.append(command[index + 1])
@@ -86,7 +93,7 @@ def invocations(command):
             index += 1
             continue
         segment.append(char)
-        token_start = char.isspace()
+        token_start = char in " \t\r"
         index += 1
 
     words = boundary()

--- a/config/shared/hooks/herdr-worker-admission.py
+++ b/config/shared/hooks/herdr-worker-admission.py
@@ -16,29 +16,82 @@ class AdmissionError(Exception):
 
 
 def invocations(command):
-    # Non-POSIX lexing retains quotes around punctuation-only arguments. The
-    # second pass removes quoting only after command boundaries are known.
-    lexer = shlex.shlex(command, posix=False, punctuation_chars=";&|()\n")
-    lexer.whitespace = " \t\r"
-    lexer.whitespace_split = True
-    lexer.commenters = ""
-    pending = []
+    # Find shell command boundaries while preserving quoting for one POSIX
+    # parse per command. A non-POSIX pass followed by shlex.split() reparses
+    # quote concatenation and escaped punctuation as malformed input.
+    segment = []
+    quote = None
     comment = False
-    for token in lexer:
-        if comment and "\n" not in token:
+    token_start = True
+
+    def boundary():
+        text = "".join(segment)
+        segment.clear()
+        if not text.strip():
+            return None
+        return shlex.split(text, posix=True)
+
+    index = 0
+    while index < len(command):
+        char = command[index]
+        if comment:
+            if char == "\n":
+                comment = False
+                words = boundary()
+                if words:
+                    yield words
+                token_start = True
+            index += 1
             continue
-        if token.startswith("#"):
+        if quote == "'":
+            segment.append(char)
+            if char == "'":
+                quote = None
+            index += 1
+            continue
+        if quote == '"':
+            segment.append(char)
+            if char == "\\" and index + 1 < len(command):
+                segment.append(command[index + 1])
+                index += 2
+                continue
+            if char == '"':
+                quote = None
+            index += 1
+            continue
+        if char == "\\":
+            segment.append(char)
+            if index + 1 < len(command):
+                segment.append(command[index + 1])
+                index += 2
+            else:
+                index += 1
+            token_start = False
+            continue
+        if char in {"'", '"'}:
+            segment.append(char)
+            quote = char
+            token_start = False
+            index += 1
+            continue
+        if char == "#" and token_start:
             comment = True
+            index += 1
             continue
-        comment = False
-        if token and all(char in ";&|()\n" for char in token):
-            if pending:
-                yield shlex.split(" ".join(pending))
-                pending = []
-        else:
-            pending.append(token)
-    if pending:
-        yield shlex.split(" ".join(pending))
+        if char in ";&|()\n":
+            words = boundary()
+            if words:
+                yield words
+            token_start = True
+            index += 1
+            continue
+        segment.append(char)
+        token_start = char.isspace()
+        index += 1
+
+    words = boundary()
+    if words:
+        yield words
 
 
 def launch_words(words):

--- a/spec/herdr_worker_admission_test.py
+++ b/spec/herdr_worker_admission_test.py
@@ -234,6 +234,27 @@ class WorkerAdmissionTests(unittest.TestCase):
                 self.assertEqual(list(admission.invocations(command)), [expected])
                 self.assertEqual(list(admission.starts(command)), [])
 
+    def test_shell_continuations_preserve_direct_and_nested_launches(self):
+        continuation = chr(92) + chr(10)
+        launch = "herdr agent start worker --kind codex --pane w1:p1"
+        self.assertEqual(
+            list(admission.starts("herdr agent " + continuation + launch[11:])),
+            [self.args],
+        )
+        self.assertEqual(
+            list(
+                admission.starts(
+                    'bash -c "herdr agent ' + continuation + launch[11:] + '"'
+                )
+            ),
+            [self.args],
+        )
+
+    def test_non_shell_whitespace_does_not_start_a_comment(self):
+        launch = "herdr agent start worker --kind codex --pane w1:p1"
+        command = "printf literal\u00a0#literal; " + launch
+        self.assertEqual(list(admission.starts(command)), [self.args])
+
     def test_env_options_and_assignments_cannot_bypass_or_retarget_admission(self):
         launch = "herdr agent start worker --kind codex --pane w1:p1"
         for prefix in (

--- a/spec/herdr_worker_admission_test.py
+++ b/spec/herdr_worker_admission_test.py
@@ -219,6 +219,21 @@ class WorkerAdmissionTests(unittest.TestCase):
         ):
             self.assertEqual(list(admission.starts(command)), [])
 
+    def test_quoted_words_and_escaped_punctuation_are_inert(self):
+        literal = "herdr"
+        cases = (
+            ('printf "he""rdr"', ["printf", literal]),
+            (f"printf {literal}\\(literal\\)", ["printf", f"{literal}(literal)"]),
+            (f"printf {literal}\\;literal", ["printf", f"{literal};literal"]),
+            (f"printf {literal}\\&literal", ["printf", f"{literal}&literal"]),
+            (f"printf {literal}\\|literal", ["printf", f"{literal}|literal"]),
+            (f"printf '{literal};literal'", ["printf", f"{literal};literal"]),
+        )
+        for command, expected in cases:
+            with self.subTest(command=command):
+                self.assertEqual(list(admission.invocations(command)), [expected])
+                self.assertEqual(list(admission.starts(command)), [])
+
     def test_env_options_and_assignments_cannot_bypass_or_retarget_admission(self):
         launch = "herdr agent start worker --kind codex --pane w1:p1"
         for prefix in (


### PR DESCRIPTION
## Summary

- parse command boundaries with quote- and escape-aware scanning
- retain one POSIX lexer per command segment while keeping malformed input fail-closed
- add inert regressions for quoted-word concatenation, escaped literal punctuation, shell continuations, and lexical whitespace

## Validation

- focused admission unittest/pytest: 24 passed
- Ruff check and format check passed
- repository Python test target: 19 passed; 12 unrelated host-environment failures because /bin/bash and tr are unavailable in the inherited PATH

This is a dependent draft on #2672. Preserve the existing merge order and operational activation ownership.