### PR TITLE
docs: preserve cross-host SSH provisioning consistency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ cp -rf source dest          # NOT: cp -r source dest
 - Repair one-off host or database incidents directly in place, with appropriate backups and verification.
 - Keep Home Manager configuration and managed scripts focused on durable, declarative behavior and general fixes that prevent recurrence.
 - Do not embed incident-specific migrations, recovery commands, or temporary repair workarounds into recurring services or activation scripts.
+- Before adding cross-host SSH access, verify the existing trust and provisioning model. Inbound `authorized_keys` does not provide an outbound private identity. Keep reverse access machine-local when existing trust is machine-local unless declarative management is explicitly requested. Approval for access does not imply approval to expand its persistence or scope.
 
 ## Repository Privacy Guidance
 


### PR DESCRIPTION
Cross-host SSH changes must follow the existing provisioning model. The agent instructions now require checking how existing trust was established, keeping reverse access machine-local when that is the existing model unless declarative management is explicitly requested, and distinguishing inbound public-key authorization from an outbound private identity.

This changes instructions only. Validation: `git diff --check` and the commit secret scan passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds guidance to `AGENTS.md` so cross-host SSH changes follow the existing trust and provisioning model.

- Inbound `authorized_keys` does not imply an outbound private identity.
- Keep reverse access machine-local when existing trust is machine-local unless declarative management is explicitly requested.

<sup>Written for commit 21b9ca69505915163ec29fee6b2dee52a0dc275a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

