### PR TITLE
fix(kyber): keep recovery panes available and services startable

### DIFF
--- a/home-manager/modules/cargo-globals/default.nix
+++ b/home-manager/modules/cargo-globals/default.nix
@@ -35,7 +35,7 @@ in
     install-cargo-globals = {
       Unit = {
         Description = "Install cargo global packages";
-        After = [ "default.target" ];
+        # default.target wants this service and orders itself after it.
       };
       Service = {
         Type = "simple";

--- a/home-manager/modules/npm-globals/default.nix
+++ b/home-manager/modules/npm-globals/default.nix
@@ -21,7 +21,8 @@ in
     install-npm-globals = {
       Unit = {
         Description = "Install npm global packages";
-        After = [ "default.target" ];
+        # default.target also wants services ordered after this installer.
+        # Ordering the installer after that target creates a startup cycle.
       };
       Service = {
         Type = "simple";

--- a/home-manager/modules/uv-globals/default.nix
+++ b/home-manager/modules/uv-globals/default.nix
@@ -23,7 +23,7 @@ in
     install-uv-globals = {
       Unit = {
         Description = "Install uv global tools";
-        After = [ "default.target" ];
+        # default.target wants this service and orders itself after it.
       };
       Service = {
         Type = "simple";

--- a/named-hosts/kyber/README.md
+++ b/named-hosts/kyber/README.md
@@ -185,7 +185,7 @@ cleaner:
 
 The Herdr server runs in `herdr.slice`, which is never frozen: it is the
 control plane for every lane and must keep answering API calls. Its pane
-shells re-exec themselves into `orchestration.slice` through the kyber fish
+ordinary pane shells re-exec themselves into `orchestration.slice` through the kyber fish
 init, so lane work, RoboRev, and their child processes share one disposable
 slice that caps aggregate writes to 20 MB/s and aggregate tasks to 2,048.
 When sustained host I/O PSI or D-state pressure crosses the health threshold
@@ -199,6 +199,27 @@ pressure-free samples with a healthy CRI probe. Three freezes within an hour
 raise `orchestration-circuit-breaker-flapping`, which means the slice re-trips
 after every thaw and its top writers in the evidence captures need attention
 rather than another auto-thaw.
+
+For an operator-authorized recovery pane, set `HERDR_PANE_ROLE=recovery` when
+creating the tab, before its shell starts:
+
+```sh
+herdr tab create --workspace <workspace-id> --label recovery --env HERDR_PANE_ROLE=recovery
+```
+
+That shell enters a separate `herdr-recovery-<pid>.scope` in `herdr.slice`.
+Ordinary panes keep their disposable placement, and unknown role values refuse
+launch. The role changes placement only; it does not grant authority to thaw
+workloads, alter permissions, or replace another worker. Verify the native
+worker's `/proc/<pid>/cgroup` and its scope's `FreezerState` before handing it
+recovery work. An already frozen pane requires an explicit operator-led move;
+setting an environment variable in its stopped shell cannot recover it.
+
+The managed server resolves `herdr` through the same user-local binary paths as
+the client, with the declared package available on PATH for fresh hosts. Its
+existing dotenv startup wrapper loads the shared environment. The npm, Cargo,
+and uv global package installers are not ordered after `default.target`, since
+that target also starts services ordered after those installers.
 
 Coding-agent hooks are the usual writer behind a flapping slice: every hook
 event goes through `config/shared/hooks/traces-agent-hook.sh`, which bounds

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -112,7 +112,8 @@ home-manager.lib.homeManagerConfiguration {
         # frozen by the host health circuit breaker without interrupting
         # production services. The Herdr server itself is the control plane
         # for every lane, so it lives in its own never-frozen slice and only
-        # the panes it spawns are moved into orchestration.slice.
+        # ordinary panes are moved into orchestration.slice. Explicit recovery
+        # panes stay outside the workload slice they must be able to repair.
         home.file.".config/systemd/user/orchestration.slice".source = ./orchestration.slice;
         home.file.".config/systemd/user/herdr.slice".source = ./herdr.slice;
         home.file.".config/systemd/user/roborev.service.d/10-orchestration.conf".source =
@@ -127,11 +128,20 @@ home-manager.lib.homeManagerConfiguration {
           };
           Service = {
             Type = "simple";
-            ExecStart = "${pkgs.llm-agents.herdr}/bin/herdr server";
+            ExecStart = "${pkgs.bash}/bin/bash ${../../home-manager/services/herdr/start.sh} herdr";
             Restart = "on-failure";
             RestartSec = "30s";
             Slice = "herdr.slice";
-            Environment = [ "HERDR_ENV=1" ];
+            Environment = [
+              "HERDR_ENV=1"
+              "PATH=${config.home.homeDirectory}/.local/bin:${config.home.homeDirectory}/.bun/bin:${config.home.homeDirectory}/.nix-profile/bin:/etc/profiles/per-user/${username}/bin:${
+                lib.makeBinPath [
+                  pkgs.llm-agents.herdr
+                  pkgs.bash
+                  pkgs.coreutils
+                ]
+              }:/usr/local/bin:/usr/bin:/bin"
+            ];
           };
           Install.WantedBy = [ "default.target" ];
         };
@@ -151,16 +161,9 @@ home-manager.lib.homeManagerConfiguration {
           set -gx GPG_TTY (tty)
         '';
 
-        # Herdr pane shells inherit herdr.slice from the server. Re-exec them
-        # into orchestration.slice so the circuit breaker can freeze lane work
-        # without freezing the server that owns the panes.
+        # Select placement before the interactive shell starts the native agent.
         programs.fish.shellInit = lib.mkAfter ''
-          if set -q HERDR_ENV; and status is-interactive; and not set -q HERDR_PANE_SCOPED; and test -r /proc/self/cgroup; and not string match -q '*/orchestration.slice/*' (cat /proc/self/cgroup)
-            set -gx HERDR_PANE_SCOPED 1
-            exec ${pkgs.systemd}/bin/systemd-run --user --quiet --scope --collect \
-              --slice=orchestration.slice --unit=herdr-pane-$fish_pid \
-              ${pkgs.fish}/bin/fish
-          end
+          source ${./herdr-pane-scope.fish} ${pkgs.systemd}/bin/systemd-run ${pkgs.fish}/bin/fish ${pkgs.coreutils}/bin/false
         '';
 
         # Enable XDG directories

--- a/named-hosts/kyber/herdr-pane-scope.fish
+++ b/named-hosts/kyber/herdr-pane-scope.fish
@@ -1,0 +1,42 @@
+# Called by managed shell init with systemd-run, fish and false binaries.
+if not set -q HERDR_ENV; or not status is-interactive
+    return
+end
+
+if set -q HERDR_PANE_ROLE; and test "$HERDR_PANE_ROLE" != recovery
+    echo 'Unknown Herdr pane role; refusing pane launch.' >&2
+    exec $argv[3]
+end
+
+if set -q HERDR_PANE_SCOPED
+    return
+end
+
+if not test -r /proc/self/cgroup
+    echo 'Herdr pane cgroup is unavailable; refusing unverified placement.' >&2
+    exec $argv[3]
+end
+set -l current_cgroup (cat /proc/self/cgroup)
+
+# An operator-moved recovery worker may predate the launch-role variable.
+if string match -q '*/herdr.slice/herdr-recovery-*.scope' $current_cgroup
+    set -gx HERDR_PANE_ROLE recovery
+    set -gx HERDR_PANE_SCOPED 1
+    return
+end
+
+set -l pane_slice orchestration.slice
+set -l pane_unit herdr-pane
+if set -q HERDR_PANE_ROLE
+    set pane_slice herdr.slice
+    set pane_unit herdr-recovery
+end
+
+# Existing scoped panes keep their placement when their shell is replaced.
+if string match -q "*/$pane_slice/$pane_unit-*.scope" $current_cgroup
+    return
+end
+
+set -gx HERDR_PANE_SCOPED 1
+exec $argv[1] --user --quiet --scope --collect \
+    --slice=$pane_slice --unit=$pane_unit-$fish_pid $argv[2]

--- a/spec/activate_kyber_spec.sh
+++ b/spec/activate_kyber_spec.sh
@@ -110,12 +110,12 @@ The output should include 'activate-user-service-priority.sh'
 End
 
 It 'declaratively owns Herdr in its own slice and places review daemons in the orchestration slice'
-When run bash -c "unit=\$(sed -n '/systemd.user.services.herdr-server =/,/Install.WantedBy/p' '$PWD/named-hosts/kyber/default.nix'); grep -q 'xdg.configFile.\"systemd/user/herdr-server.service\".force = true' '$PWD/named-hosts/kyber/default.nix' && grep -q 'xdg.configFile.\"systemd/user/default.target.wants/herdr-server.service\".force = true' '$PWD/named-hosts/kyber/default.nix' && grep -q 'ExecStart = \"\${pkgs.llm-agents.herdr}/bin/herdr server\"' <<<\"\$unit\" && grep -q 'Slice = \"herdr.slice\"' <<<\"\$unit\" && ! grep -q 'orchestration.slice' <<<\"\$unit\" && grep -q 'systemd/user/herdr.slice\".source = ./herdr.slice' '$PWD/named-hosts/kyber/default.nix' && grep -q 'roborev.service.d/10-orchestration.conf' '$PWD/named-hosts/kyber/default.nix' && grep -qxF 'Slice=orchestration.slice' '$PWD/named-hosts/kyber/orchestration-service.conf'"
+When run bash -c "unit=\$(sed -n '/systemd.user.services.herdr-server =/,/Install.WantedBy/p' '$PWD/named-hosts/kyber/default.nix'); grep -q 'xdg.configFile.\"systemd/user/herdr-server.service\".force = true' '$PWD/named-hosts/kyber/default.nix' && grep -q 'xdg.configFile.\"systemd/user/default.target.wants/herdr-server.service\".force = true' '$PWD/named-hosts/kyber/default.nix' && grep -q 'services/herdr/start.sh} herdr' <<<\"\$unit\" && grep -q 'Slice = \"herdr.slice\"' <<<\"\$unit\" && ! grep -q 'orchestration.slice' <<<\"\$unit\" && grep -q 'systemd/user/herdr.slice\".source = ./herdr.slice' '$PWD/named-hosts/kyber/default.nix' && grep -q 'roborev.service.d/10-orchestration.conf' '$PWD/named-hosts/kyber/default.nix' && grep -qxF 'Slice=orchestration.slice' '$PWD/named-hosts/kyber/orchestration-service.conf'"
 The status should be success
 End
 
-It 'keeps the Herdr slice unfrozen and moves only pane shells into the orchestration slice'
-When run bash -c "grep -qxF 'IOAccounting=yes' '$PWD/named-hosts/kyber/herdr.slice' && ! grep -q 'IOWriteBandwidthMax' '$PWD/named-hosts/kyber/herdr.slice' && grep -q 'systemd-run --user --quiet --scope --collect' '$PWD/named-hosts/kyber/default.nix' && grep -q -- '--slice=orchestration.slice --unit=herdr-pane-' '$PWD/named-hosts/kyber/default.nix' && grep -q 'set -q HERDR_ENV; and status is-interactive; and not set -q HERDR_PANE_SCOPED' '$PWD/named-hosts/kyber/default.nix'"
+It 'keeps the Herdr slice unfrozen and installs the pane placement entrypoint'
+When run bash -c "grep -qxF 'IOAccounting=yes' '$PWD/named-hosts/kyber/herdr.slice' && ! grep -q 'IOWriteBandwidthMax' '$PWD/named-hosts/kyber/herdr.slice' && grep -q 'source .*herdr-pane-scope.fish' '$PWD/named-hosts/kyber/default.nix'"
 The status should be success
 End
 

--- a/spec/herdr_pane_scope_spec.sh
+++ b/spec/herdr_pane_scope_spec.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+Describe 'Herdr pane placement'
+It 'preserves recovery scopes and isolates ordinary workers before launch'
+When run python3 "$PWD/spec/herdr_pane_scope_test.py"
+The status should be success
+The stderr should include 'OK'
+End
+End

--- a/spec/herdr_pane_scope_test.py
+++ b/spec/herdr_pane_scope_test.py
@@ -1,0 +1,132 @@
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "named-hosts/kyber/herdr-pane-scope.fish"
+
+
+@unittest.skipUnless(
+    sys.platform == "linux" and shutil.which("fish"), "Linux fish placement"
+)
+class HerdrPaneScopeTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.directory = Path(temporary.name)
+        self.runner = self.directory / "systemd-run"
+        self.runner.write_text('#!/bin/sh\nprintf "%s\\n" "$HERDR_PANE_SCOPED" "$@"\n')
+        self.runner.chmod(0o755)
+        cat = self.directory / "cat"
+        cat.write_text('#!/bin/sh\nprintf "%s\\n" "$TEST_HERDR_CGROUP"\n')
+        cat.chmod(0o755)
+        self.environment = {
+            "HOME": str(self.directory),
+            "PATH": str(self.directory) + os.pathsep + os.environ["PATH"],
+            "TERM": "dumb",
+            "HERDR_ENV": "1",
+            "TEST_HERDR_CGROUP": (
+                "0::/user.slice/user@1000.service/herdr.slice/herdr-server.service"
+            ),
+        }
+
+    def launch(self, interactive=True):
+        command = [shutil.which("fish"), "--no-config"]
+        if interactive:
+            command.append("--interactive")
+        command.extend(
+            [
+                "-c",
+                'source "$argv[1]" "$argv[2]" /managed/fish "$argv[3]"; echo returned',
+                "--",
+                str(SCRIPT),
+                str(self.runner),
+                shutil.which("false"),
+            ]
+        )
+        return subprocess.run(
+            command, env=self.environment, capture_output=True, text=True, timeout=5
+        )
+
+    def test_ordinary_pane_enters_disposable_scope_before_agent_shell(self):
+        result = self.launch()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.stdout.splitlines()[:6],
+            [
+                "1",
+                "--user",
+                "--quiet",
+                "--scope",
+                "--collect",
+                "--slice=orchestration.slice",
+            ],
+        )
+        self.assertRegex(result.stdout, r"--unit=herdr-pane-\d+\n/managed/fish\n$")
+        self.assertNotIn("returned", result.stdout)
+
+    def test_explicit_recovery_uses_separate_control_scope(self):
+        self.environment["HERDR_PANE_ROLE"] = "recovery"
+        result = self.launch()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--slice=herdr.slice\n", result.stdout)
+        self.assertRegex(result.stdout, r"--unit=herdr-recovery-\d+\n/managed/fish\n$")
+        self.assertNotIn("orchestration.slice", result.stdout)
+
+    def test_unknown_role_refuses_launch(self):
+        self.environment["HERDR_PANE_ROLE"] = "recovery-typo"
+        for placement in (
+            {},
+            {
+                "TEST_HERDR_CGROUP": (
+                    "0::/user.slice/user@1000.service/herdr.slice/herdr-recovery-123.scope"
+                )
+            },
+            {"HERDR_PANE_SCOPED": "1"},
+        ):
+            with self.subTest(placement=placement):
+                self.environment.update(placement)
+                result = self.launch()
+                self.assertEqual(result.returncode, 1)
+                self.assertIn("Unknown Herdr pane role", result.stderr)
+                self.assertEqual(result.stdout, "")
+
+    def test_scoped_shell_does_not_reenter_systemd(self):
+        self.environment["HERDR_PANE_SCOPED"] = "1"
+        result = self.launch()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "returned\n")
+
+    def test_existing_recovery_scope_survives_shell_replacement(self):
+        self.environment["HERDR_PANE_ROLE"] = "recovery"
+        self.environment["TEST_HERDR_CGROUP"] = (
+            "0::/user.slice/user@1000.service/herdr.slice/herdr-recovery-123.scope"
+        )
+        result = self.launch()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "returned\n")
+
+    def test_noninteractive_and_nonherdr_shells_keep_their_owner(self):
+        result = self.launch(interactive=False)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "returned\n")
+        del self.environment["HERDR_ENV"]
+        result = self.launch()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "returned\n")
+
+    def test_operator_moved_recovery_scope_survives_without_role_environment(self):
+        self.environment["TEST_HERDR_CGROUP"] = (
+            "0::/user.slice/user@1000.service/herdr.slice/herdr-recovery-123.scope"
+        )
+        result = self.launch()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "returned\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/spec/herdr_service_spec.sh
+++ b/spec/herdr_service_spec.sh
@@ -32,4 +32,27 @@ The line 1 of output should equal 'value with spaces'
 The line 2 of output should equal '$(touch should-not-exist)'
 The line 3 of output should equal 'server'
 End
+
+It 'resolves the same user-local binary as the client before the packaged binary'
+mkdir -p "$TEMP_HOME/.local/bin" "$TEMP_HOME/package/bin"
+cp -f "$TEMP_HOME/herdr" "$TEMP_HOME/.local/bin/herdr"
+cat >"$TEMP_HOME/package/bin/herdr" <<'CLI'
+#!/bin/sh
+echo 'stale packaged binary'
+CLI
+chmod +x "$TEMP_HOME/package/bin/herdr"
+When run env -u DOTFILES_ENV_FILE -u HM_PRINT_ENV_FILE HOME="$TEMP_HOME" PATH="$TEMP_HOME/.local/bin:$TEMP_HOME/package/bin:$PATH" bash "$SCRIPT" herdr
+The status should be success
+The line 1 of output should equal 'value with spaces'
+The line 3 of output should equal 'server'
+End
+
+It 'uses the packaged binary on a fresh host without a local override'
+mkdir -p "$TEMP_HOME/package/bin"
+cp -f "$TEMP_HOME/herdr" "$TEMP_HOME/package/bin/herdr"
+When run env -u DOTFILES_ENV_FILE -u HM_PRINT_ENV_FILE HOME="$TEMP_HOME" PATH="$TEMP_HOME/.local/bin:$TEMP_HOME/package/bin:$PATH" bash "$SCRIPT" herdr
+The status should be success
+The line 1 of output should equal 'value with spaces'
+The line 3 of output should equal 'server'
+End
 End


### PR DESCRIPTION
Recovery shells currently enter the same disposable slice they may need to recover, so freezing that slice also stops the repair worker. Explicit recovery panes now enter a separate scope, preserve an existing operator-moved recovery scope across shell replacement, and reject unknown roles before placement shortcuts.

The managed Herdr server uses the existing environment wrapper and the same binary search paths as its client. Removing the npm, Cargo, and uv installers' `After=default.target` edges also removes startup cycles that could discard dependent service starts.

Validation at `e3882a4b0a8b8593c045d0edfb87d0147bdb9122`: the Kyber activation package built successfully. 179 focused ShellSpec examples passed, including seven real-fish placement tests. Nix service and shell-init evaluation, formatter/linter checks, and an actual recovery-scope preservation check passed. Both independent specification and standards reviews cleared the final diff. The final role-validation correction passed its focused ShellSpec adapter again. GitHub Shell, Python, Nix evaluation, formatting and Nix tests have passed; remaining aggregate checks are running. Runtime installation remains pending merge.
