### PR TITLE
fix: parse quoted admission commands safely

### DIFF
--- a/config/shared/hooks/herdr-worker-admission.py
+++ b/config/shared/hooks/herdr-worker-admission.py
@@ -50,6 +50,10 @@ def invocations(command):
             index += 1
             continue
         if quote == '"':
+            if char == "`" or (
+                char == "$" and index + 1 < len(command) and command[index + 1] == "("
+            ):
+                raise AdmissionError("command substitutions cannot be verified")
             segment.append(char)
             if char == "\\" and index + 1 < len(command):
                 if command[index + 1] == "\n":
@@ -81,6 +85,10 @@ def invocations(command):
             token_start = False
             index += 1
             continue
+        if char == "`" or (
+            char == "$" and index + 1 < len(command) and command[index + 1] == "("
+        ):
+            raise AdmissionError("command substitutions cannot be verified")
         if char == "#" and token_start:
             comment = True
             index += 1

--- a/config/shared/hooks/herdr-worker-admission.py
+++ b/config/shared/hooks/herdr-worker-admission.py
@@ -54,6 +54,16 @@ def invocations(command):
                 char == "$" and index + 1 < len(command) and command[index + 1] == "("
             ):
                 raise AdmissionError("command substitutions cannot be verified")
+            if (
+                char == "$"
+                and index + 1 < len(command)
+                and command[index + 1]
+                in {
+                    "'",
+                    '"',
+                }
+            ):
+                raise AdmissionError("Bash quoting cannot be verified")
             segment.append(char)
             if char == "\\" and index + 1 < len(command):
                 if command[index + 1] == "\n":
@@ -85,6 +95,16 @@ def invocations(command):
             token_start = False
             index += 1
             continue
+        if (
+            char == "$"
+            and index + 1 < len(command)
+            and command[index + 1]
+            in {
+                "'",
+                '"',
+            }
+        ):
+            raise AdmissionError("Bash quoting cannot be verified")
         if char == "`" or (
             char == "$" and index + 1 < len(command) and command[index + 1] == "("
         ):
@@ -112,6 +132,8 @@ def invocations(command):
 def launch_words(words):
     environment_changed = False
     while words:
+        if Path(words[0]).name == "eval":
+            raise AdmissionError("eval command cannot be verified")
         if words[0] in {"command", "exec", "do", "then", "else"}:
             words = words[1:]
         elif re.fullmatch(r"[A-Za-z_][A-Za-z_0-9]*=.*", words[0]):

--- a/config/shared/hooks/herdr-worker-admission.py
+++ b/config/shared/hooks/herdr-worker-admission.py
@@ -16,29 +16,89 @@ class AdmissionError(Exception):
 
 
 def invocations(command):
-    # Non-POSIX lexing retains quotes around punctuation-only arguments. The
-    # second pass removes quoting only after command boundaries are known.
-    lexer = shlex.shlex(command, posix=False, punctuation_chars=";&|()\n")
-    lexer.whitespace = " \t\r"
-    lexer.whitespace_split = True
-    lexer.commenters = ""
-    pending = []
+    # Find shell command boundaries while preserving quoting for one POSIX
+    # parse per command. A non-POSIX pass followed by shlex.split() reparses
+    # quote concatenation and escaped punctuation as malformed input.
+    segment = []
+    quote = None
     comment = False
-    for token in lexer:
-        if comment and "\n" not in token:
+    token_start = True
+
+    def boundary():
+        text = "".join(segment)
+        segment.clear()
+        if not text.strip():
+            return None
+        return shlex.split(text, posix=True)
+
+    index = 0
+    while index < len(command):
+        char = command[index]
+        if comment:
+            if char == "\n":
+                comment = False
+                words = boundary()
+                if words:
+                    yield words
+                token_start = True
+            index += 1
             continue
-        if token.startswith("#"):
+        if quote == "'":
+            segment.append(char)
+            if char == "'":
+                quote = None
+            index += 1
+            continue
+        if quote == '"':
+            segment.append(char)
+            if char == "\\" and index + 1 < len(command):
+                if command[index + 1] == "\n":
+                    segment.pop()
+                    index += 2
+                    continue
+                segment.append(command[index + 1])
+                index += 2
+                continue
+            if char == '"':
+                quote = None
+            index += 1
+            continue
+        if char == "\\":
+            if index + 1 < len(command) and command[index + 1] == "\n":
+                index += 2
+                continue
+            segment.append(char)
+            if index + 1 < len(command):
+                segment.append(command[index + 1])
+                index += 2
+            else:
+                index += 1
+            token_start = False
+            continue
+        if char in {"'", '"'}:
+            segment.append(char)
+            quote = char
+            token_start = False
+            index += 1
+            continue
+        if char == "#" and token_start:
             comment = True
+            index += 1
             continue
-        comment = False
-        if token and all(char in ";&|()\n" for char in token):
-            if pending:
-                yield shlex.split(" ".join(pending))
-                pending = []
-        else:
-            pending.append(token)
-    if pending:
-        yield shlex.split(" ".join(pending))
+        if char in ";&|()\n":
+            words = boundary()
+            if words:
+                yield words
+            token_start = True
+            index += 1
+            continue
+        segment.append(char)
+        token_start = char in " \t\r"
+        index += 1
+
+    words = boundary()
+    if words:
+        yield words
 
 
 def launch_words(words):

--- a/spec/herdr_worker_admission_test.py
+++ b/spec/herdr_worker_admission_test.py
@@ -270,6 +270,19 @@ class WorkerAdmissionTests(unittest.TestCase):
             with self.subTest(command=command):
                 self.assertEqual(list(admission.starts(command)), [])
 
+    def test_unsupported_reconstructing_shell_forms_are_refused(self):
+        launch = "herdr agent start worker --kind codex --pane w1:p1"
+        for command in (
+            "eval " + repr(launch),
+            "$'herdr' agent start worker --kind codex --pane w1:p1",
+            '$"herdr" agent start worker --kind codex --pane w1:p1',
+        ):
+            with self.subTest(command=command):
+                with self.assertRaisesRegex(
+                    admission.AdmissionError, "cannot be verified"
+                ):
+                    list(admission.starts(command))
+
     def test_env_options_and_assignments_cannot_bypass_or_retarget_admission(self):
         launch = "herdr agent start worker --kind codex --pane w1:p1"
         for prefix in (

--- a/spec/herdr_worker_admission_test.py
+++ b/spec/herdr_worker_admission_test.py
@@ -219,6 +219,42 @@ class WorkerAdmissionTests(unittest.TestCase):
         ):
             self.assertEqual(list(admission.starts(command)), [])
 
+    def test_quoted_words_and_escaped_punctuation_are_inert(self):
+        literal = "herdr"
+        cases = (
+            ('printf "he""rdr"', ["printf", literal]),
+            (f"printf {literal}\\(literal\\)", ["printf", f"{literal}(literal)"]),
+            (f"printf {literal}\\;literal", ["printf", f"{literal};literal"]),
+            (f"printf {literal}\\&literal", ["printf", f"{literal}&literal"]),
+            (f"printf {literal}\\|literal", ["printf", f"{literal}|literal"]),
+            (f"printf '{literal};literal'", ["printf", f"{literal};literal"]),
+        )
+        for command, expected in cases:
+            with self.subTest(command=command):
+                self.assertEqual(list(admission.invocations(command)), [expected])
+                self.assertEqual(list(admission.starts(command)), [])
+
+    def test_shell_continuations_preserve_direct_and_nested_launches(self):
+        continuation = chr(92) + chr(10)
+        launch = "herdr agent start worker --kind codex --pane w1:p1"
+        self.assertEqual(
+            list(admission.starts("herdr agent " + continuation + launch[11:])),
+            [self.args],
+        )
+        self.assertEqual(
+            list(
+                admission.starts(
+                    'bash -c "herdr agent ' + continuation + launch[11:] + '"'
+                )
+            ),
+            [self.args],
+        )
+
+    def test_non_shell_whitespace_does_not_start_a_comment(self):
+        launch = "herdr agent start worker --kind codex --pane w1:p1"
+        command = "printf literal\u00a0#literal; " + launch
+        self.assertEqual(list(admission.starts(command)), [self.args])
+
     def test_env_options_and_assignments_cannot_bypass_or_retarget_admission(self):
         launch = "herdr agent start worker --kind codex --pane w1:p1"
         for prefix in (

--- a/spec/herdr_worker_admission_test.py
+++ b/spec/herdr_worker_admission_test.py
@@ -255,6 +255,21 @@ class WorkerAdmissionTests(unittest.TestCase):
         command = "printf literal\u00a0#literal; " + launch
         self.assertEqual(list(admission.starts(command)), [self.args])
 
+    def test_command_substitutions_are_refused_without_inspection(self):
+        launch = "herdr agent start worker --kind codex --pane w1:p1"
+        for command in (
+            'echo "$(' + launch + ')"',
+            'echo "`' + launch + '`"',
+        ):
+            with self.subTest(command=command):
+                with self.assertRaisesRegex(
+                    admission.AdmissionError, "command substitutions"
+                ):
+                    list(admission.starts(command))
+        for command in ("printf '$(literal)'", "printf '`literal`'"):
+            with self.subTest(command=command):
+                self.assertEqual(list(admission.starts(command)), [])
+
     def test_env_options_and_assignments_cannot_bypass_or_retarget_admission(self):
         launch = "herdr agent start worker --kind codex --pane w1:p1"
         for prefix in (


### PR DESCRIPTION
## Summary

- parse managed admission command boundaries with quote- and escape-aware scanning
- use one POSIX parse per command segment while preserving fail-closed malformed-input handling
- cover quoted-word concatenation, escaped punctuation, shell continuations, and lexical whitespace with inert fixtures

## Validation

- focused admission unittest and pytest: 23 passed
- Ruff check and format check passed
- diff check passed

This is a fresh successor change from current main; the previously closed draft remains closed. No live hook activation is included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes admission command parsing so quoted words, escaped punctuation, and shell continuations are handled without re-parsing or misinterpreting boundaries, and refuses unverified shell substitutions and reconstructing shell forms to keep verification fail-closed.

**Bug Fixes**
- Replaces the old two-pass lexing that broke quoted concatenation and escaped punctuation.
- Handles shell line continuations and lexical whitespace (e.g., non-breaking space) correctly.
- Rejects command substitutions (`$()`, backticks) and Bash quoting (`$'...'`, `$"..."`) as unverifiable.
- Refuses `eval` commands instead of attempting to resolve them.
- Adds tests for these cases; no live hook activation is included.

<sup>Written for commit 4ecaf7efd55d7e5c6f57b6eecbbf91001858f836. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

