### PR TITLE
fix(systemd): preserve Herdr children across handoff

### DIFF
--- a/config/shared/hooks/herdr-worker-admission.py
+++ b/config/shared/hooks/herdr-worker-admission.py
@@ -50,6 +50,10 @@ def invocations(command):
             index += 1
             continue
         if quote == '"':
+            if char == "`" or (
+                char == "$" and index + 1 < len(command) and command[index + 1] == "("
+            ):
+                raise AdmissionError("command substitutions cannot be verified")
             segment.append(char)
             if char == "\\" and index + 1 < len(command):
                 if command[index + 1] == "\n":
@@ -81,6 +85,10 @@ def invocations(command):
             token_start = False
             index += 1
             continue
+        if char == "`" or (
+            char == "$" and index + 1 < len(command) and command[index + 1] == "("
+        ):
+            raise AdmissionError("command substitutions cannot be verified")
         if char == "#" and token_start:
             comment = True
             index += 1

--- a/config/shared/hooks/herdr-worker-admission.py
+++ b/config/shared/hooks/herdr-worker-admission.py
@@ -54,6 +54,16 @@ def invocations(command):
                 char == "$" and index + 1 < len(command) and command[index + 1] == "("
             ):
                 raise AdmissionError("command substitutions cannot be verified")
+            if (
+                char == "$"
+                and index + 1 < len(command)
+                and command[index + 1]
+                in {
+                    "'",
+                    '"',
+                }
+            ):
+                raise AdmissionError("Bash quoting cannot be verified")
             segment.append(char)
             if char == "\\" and index + 1 < len(command):
                 if command[index + 1] == "\n":
@@ -85,6 +95,16 @@ def invocations(command):
             token_start = False
             index += 1
             continue
+        if (
+            char == "$"
+            and index + 1 < len(command)
+            and command[index + 1]
+            in {
+                "'",
+                '"',
+            }
+        ):
+            raise AdmissionError("Bash quoting cannot be verified")
         if char == "`" or (
             char == "$" and index + 1 < len(command) and command[index + 1] == "("
         ):
@@ -112,6 +132,8 @@ def invocations(command):
 def launch_words(words):
     environment_changed = False
     while words:
+        if Path(words[0]).name == "eval":
+            raise AdmissionError("eval command cannot be verified")
         if words[0] in {"command", "exec", "do", "then", "else"}:
             words = words[1:]
         elif re.fullmatch(r"[A-Za-z_][A-Za-z_0-9]*=.*", words[0]):

--- a/config/shared/hooks/herdr-worker-admission.py
+++ b/config/shared/hooks/herdr-worker-admission.py
@@ -16,29 +16,89 @@ class AdmissionError(Exception):
 
 
 def invocations(command):
-    # Non-POSIX lexing retains quotes around punctuation-only arguments. The
-    # second pass removes quoting only after command boundaries are known.
-    lexer = shlex.shlex(command, posix=False, punctuation_chars=";&|()\n")
-    lexer.whitespace = " \t\r"
-    lexer.whitespace_split = True
-    lexer.commenters = ""
-    pending = []
+    # Find shell command boundaries while preserving quoting for one POSIX
+    # parse per command. A non-POSIX pass followed by shlex.split() reparses
+    # quote concatenation and escaped punctuation as malformed input.
+    segment = []
+    quote = None
     comment = False
-    for token in lexer:
-        if comment and "\n" not in token:
+    token_start = True
+
+    def boundary():
+        text = "".join(segment)
+        segment.clear()
+        if not text.strip():
+            return None
+        return shlex.split(text, posix=True)
+
+    index = 0
+    while index < len(command):
+        char = command[index]
+        if comment:
+            if char == "\n":
+                comment = False
+                words = boundary()
+                if words:
+                    yield words
+                token_start = True
+            index += 1
             continue
-        if token.startswith("#"):
+        if quote == "'":
+            segment.append(char)
+            if char == "'":
+                quote = None
+            index += 1
+            continue
+        if quote == '"':
+            segment.append(char)
+            if char == "\\" and index + 1 < len(command):
+                if command[index + 1] == "\n":
+                    segment.pop()
+                    index += 2
+                    continue
+                segment.append(command[index + 1])
+                index += 2
+                continue
+            if char == '"':
+                quote = None
+            index += 1
+            continue
+        if char == "\\":
+            if index + 1 < len(command) and command[index + 1] == "\n":
+                index += 2
+                continue
+            segment.append(char)
+            if index + 1 < len(command):
+                segment.append(command[index + 1])
+                index += 2
+            else:
+                index += 1
+            token_start = False
+            continue
+        if char in {"'", '"'}:
+            segment.append(char)
+            quote = char
+            token_start = False
+            index += 1
+            continue
+        if char == "#" and token_start:
             comment = True
+            index += 1
             continue
-        comment = False
-        if token and all(char in ";&|()\n" for char in token):
-            if pending:
-                yield shlex.split(" ".join(pending))
-                pending = []
-        else:
-            pending.append(token)
-    if pending:
-        yield shlex.split(" ".join(pending))
+        if char in ";&|()\n":
+            words = boundary()
+            if words:
+                yield words
+            token_start = True
+            index += 1
+            continue
+        segment.append(char)
+        token_start = char in " \t\r"
+        index += 1
+
+    words = boundary()
+    if words:
+        yield words
 
 
 def launch_words(words):

--- a/named-hosts/kamino/default.nix
+++ b/named-hosts/kamino/default.nix
@@ -97,7 +97,7 @@ inputs.home-manager.lib.homeManagerConfiguration {
         systemd.user.services.herdr-server = {
           Unit = {
             Description = "Herdr headless server";
-            X-SwitchMethod = "restart";
+            X-SwitchMethod = "keep-old";
           };
           Service = {
             ExitType = "cgroup";

--- a/named-hosts/kamino/default.nix
+++ b/named-hosts/kamino/default.nix
@@ -100,6 +100,7 @@ inputs.home-manager.lib.homeManagerConfiguration {
             X-SwitchMethod = "restart";
           };
           Service = {
+            ExitType = "cgroup";
             ExecStart = "${pkgs.llm-agents.herdr}/bin/herdr server";
             Restart = "on-failure";
             RestartSec = "5s";

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -124,7 +124,7 @@ home-manager.lib.homeManagerConfiguration {
           Unit = {
             Description = "Herdr headless server (coding-agent multiplexer)";
             After = [ "install-npm-globals.service" ];
-            X-SwitchMethod = "restart";
+            X-SwitchMethod = "keep-old";
           };
           Service = {
             Type = "simple";

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -128,6 +128,7 @@ home-manager.lib.homeManagerConfiguration {
           };
           Service = {
             Type = "simple";
+            ExitType = "cgroup";
             ExecStart = "${pkgs.bash}/bin/bash ${../../home-manager/services/herdr/start.sh} herdr";
             Restart = "on-failure";
             RestartSec = "30s";

--- a/spec/herdr_worker_admission_test.py
+++ b/spec/herdr_worker_admission_test.py
@@ -270,6 +270,19 @@ class WorkerAdmissionTests(unittest.TestCase):
             with self.subTest(command=command):
                 self.assertEqual(list(admission.starts(command)), [])
 
+    def test_unsupported_reconstructing_shell_forms_are_refused(self):
+        launch = "herdr agent start worker --kind codex --pane w1:p1"
+        for command in (
+            "eval " + repr(launch),
+            "$'herdr' agent start worker --kind codex --pane w1:p1",
+            '$"herdr" agent start worker --kind codex --pane w1:p1',
+        ):
+            with self.subTest(command=command):
+                with self.assertRaisesRegex(
+                    admission.AdmissionError, "cannot be verified"
+                ):
+                    list(admission.starts(command))
+
     def test_env_options_and_assignments_cannot_bypass_or_retarget_admission(self):
         launch = "herdr agent start worker --kind codex --pane w1:p1"
         for prefix in (

--- a/spec/herdr_worker_admission_test.py
+++ b/spec/herdr_worker_admission_test.py
@@ -219,6 +219,42 @@ class WorkerAdmissionTests(unittest.TestCase):
         ):
             self.assertEqual(list(admission.starts(command)), [])
 
+    def test_quoted_words_and_escaped_punctuation_are_inert(self):
+        literal = "herdr"
+        cases = (
+            ('printf "he""rdr"', ["printf", literal]),
+            (f"printf {literal}\\(literal\\)", ["printf", f"{literal}(literal)"]),
+            (f"printf {literal}\\;literal", ["printf", f"{literal};literal"]),
+            (f"printf {literal}\\&literal", ["printf", f"{literal}&literal"]),
+            (f"printf {literal}\\|literal", ["printf", f"{literal}|literal"]),
+            (f"printf '{literal};literal'", ["printf", f"{literal};literal"]),
+        )
+        for command, expected in cases:
+            with self.subTest(command=command):
+                self.assertEqual(list(admission.invocations(command)), [expected])
+                self.assertEqual(list(admission.starts(command)), [])
+
+    def test_shell_continuations_preserve_direct_and_nested_launches(self):
+        continuation = chr(92) + chr(10)
+        launch = "herdr agent start worker --kind codex --pane w1:p1"
+        self.assertEqual(
+            list(admission.starts("herdr agent " + continuation + launch[11:])),
+            [self.args],
+        )
+        self.assertEqual(
+            list(
+                admission.starts(
+                    'bash -c "herdr agent ' + continuation + launch[11:] + '"'
+                )
+            ),
+            [self.args],
+        )
+
+    def test_non_shell_whitespace_does_not_start_a_comment(self):
+        launch = "herdr agent start worker --kind codex --pane w1:p1"
+        command = "printf literal\u00a0#literal; " + launch
+        self.assertEqual(list(admission.starts(command)), [self.args])
+
     def test_env_options_and_assignments_cannot_bypass_or_retarget_admission(self):
         launch = "herdr agent start worker --kind codex --pane w1:p1"
         for prefix in (

--- a/spec/herdr_worker_admission_test.py
+++ b/spec/herdr_worker_admission_test.py
@@ -255,6 +255,21 @@ class WorkerAdmissionTests(unittest.TestCase):
         command = "printf literal\u00a0#literal; " + launch
         self.assertEqual(list(admission.starts(command)), [self.args])
 
+    def test_command_substitutions_are_refused_without_inspection(self):
+        launch = "herdr agent start worker --kind codex --pane w1:p1"
+        for command in (
+            'echo "$(' + launch + ')"',
+            'echo "`' + launch + '`"',
+        ):
+            with self.subTest(command=command):
+                with self.assertRaisesRegex(
+                    admission.AdmissionError, "command substitutions"
+                ):
+                    list(admission.starts(command))
+        for command in ("printf '$(literal)'", "printf '`literal`'"):
+            with self.subTest(command=command):
+                self.assertEqual(list(admission.starts(command)), [])
+
     def test_env_options_and_assignments_cannot_bypass_or_retarget_admission(self):
         launch = "herdr agent start worker --kind codex --pane w1:p1"
         for prefix in (


### PR DESCRIPTION
Herdr live handoff starts the replacement server before the old server exits. Keep the Linux user service alive while its cgroup still contains the replacement, and preserve a running server during Home Manager switches so activation can use the controlled handoff.

Validation: a disposable systemd service proved that daemon-reload changed ExitType from main to cgroup without changing its MainPID, and that the service and child remained alive after the parent exited. This is component lifecycle proof; production native handoff has not run. No aggregate CI or signoff success is claimed.

The operator authorized admin merge of this recovery prerequisite without CI waits. Native managed-worktree admission and live parser removal remain separate delivery and runtime-proof steps.
