### PR TITLE
feat(herdr): package structured admission repair

### DIFF
--- a/config/shared/hooks/herdr-worker-admission.py
+++ b/config/shared/hooks/herdr-worker-admission.py
@@ -50,6 +50,10 @@ def invocations(command):
             index += 1
             continue
         if quote == '"':
+            if char == "`" or (
+                char == "$" and index + 1 < len(command) and command[index + 1] == "("
+            ):
+                raise AdmissionError("command substitutions cannot be verified")
             segment.append(char)
             if char == "\\" and index + 1 < len(command):
                 if command[index + 1] == "\n":
@@ -81,6 +85,10 @@ def invocations(command):
             token_start = False
             index += 1
             continue
+        if char == "`" or (
+            char == "$" and index + 1 < len(command) and command[index + 1] == "("
+        ):
+            raise AdmissionError("command substitutions cannot be verified")
         if char == "#" and token_start:
             comment = True
             index += 1

--- a/config/shared/hooks/herdr-worker-admission.py
+++ b/config/shared/hooks/herdr-worker-admission.py
@@ -54,6 +54,16 @@ def invocations(command):
                 char == "$" and index + 1 < len(command) and command[index + 1] == "("
             ):
                 raise AdmissionError("command substitutions cannot be verified")
+            if (
+                char == "$"
+                and index + 1 < len(command)
+                and command[index + 1]
+                in {
+                    "'",
+                    '"',
+                }
+            ):
+                raise AdmissionError("Bash quoting cannot be verified")
             segment.append(char)
             if char == "\\" and index + 1 < len(command):
                 if command[index + 1] == "\n":
@@ -85,6 +95,16 @@ def invocations(command):
             token_start = False
             index += 1
             continue
+        if (
+            char == "$"
+            and index + 1 < len(command)
+            and command[index + 1]
+            in {
+                "'",
+                '"',
+            }
+        ):
+            raise AdmissionError("Bash quoting cannot be verified")
         if char == "`" or (
             char == "$" and index + 1 < len(command) and command[index + 1] == "("
         ):
@@ -112,6 +132,8 @@ def invocations(command):
 def launch_words(words):
     environment_changed = False
     while words:
+        if Path(words[0]).name == "eval":
+            raise AdmissionError("eval command cannot be verified")
         if words[0] in {"command", "exec", "do", "then", "else"}:
             words = words[1:]
         elif re.fullmatch(r"[A-Za-z_][A-Za-z_0-9]*=.*", words[0]):

--- a/config/shared/hooks/herdr-worker-admission.py
+++ b/config/shared/hooks/herdr-worker-admission.py
@@ -16,29 +16,89 @@ class AdmissionError(Exception):
 
 
 def invocations(command):
-    # Non-POSIX lexing retains quotes around punctuation-only arguments. The
-    # second pass removes quoting only after command boundaries are known.
-    lexer = shlex.shlex(command, posix=False, punctuation_chars=";&|()\n")
-    lexer.whitespace = " \t\r"
-    lexer.whitespace_split = True
-    lexer.commenters = ""
-    pending = []
+    # Find shell command boundaries while preserving quoting for one POSIX
+    # parse per command. A non-POSIX pass followed by shlex.split() reparses
+    # quote concatenation and escaped punctuation as malformed input.
+    segment = []
+    quote = None
     comment = False
-    for token in lexer:
-        if comment and "\n" not in token:
+    token_start = True
+
+    def boundary():
+        text = "".join(segment)
+        segment.clear()
+        if not text.strip():
+            return None
+        return shlex.split(text, posix=True)
+
+    index = 0
+    while index < len(command):
+        char = command[index]
+        if comment:
+            if char == "\n":
+                comment = False
+                words = boundary()
+                if words:
+                    yield words
+                token_start = True
+            index += 1
             continue
-        if token.startswith("#"):
+        if quote == "'":
+            segment.append(char)
+            if char == "'":
+                quote = None
+            index += 1
+            continue
+        if quote == '"':
+            segment.append(char)
+            if char == "\\" and index + 1 < len(command):
+                if command[index + 1] == "\n":
+                    segment.pop()
+                    index += 2
+                    continue
+                segment.append(command[index + 1])
+                index += 2
+                continue
+            if char == '"':
+                quote = None
+            index += 1
+            continue
+        if char == "\\":
+            if index + 1 < len(command) and command[index + 1] == "\n":
+                index += 2
+                continue
+            segment.append(char)
+            if index + 1 < len(command):
+                segment.append(command[index + 1])
+                index += 2
+            else:
+                index += 1
+            token_start = False
+            continue
+        if char in {"'", '"'}:
+            segment.append(char)
+            quote = char
+            token_start = False
+            index += 1
+            continue
+        if char == "#" and token_start:
             comment = True
+            index += 1
             continue
-        comment = False
-        if token and all(char in ";&|()\n" for char in token):
-            if pending:
-                yield shlex.split(" ".join(pending))
-                pending = []
-        else:
-            pending.append(token)
-    if pending:
-        yield shlex.split(" ".join(pending))
+        if char in ";&|()\n":
+            words = boundary()
+            if words:
+                yield words
+            token_start = True
+            index += 1
+            continue
+        segment.append(char)
+        token_start = char in " \t\r"
+        index += 1
+
+    words = boundary()
+    if words:
+        yield words
 
 
 def launch_words(words):

--- a/named-hosts/kamino/default.nix
+++ b/named-hosts/kamino/default.nix
@@ -97,7 +97,7 @@ inputs.home-manager.lib.homeManagerConfiguration {
         systemd.user.services.herdr-server = {
           Unit = {
             Description = "Herdr headless server";
-            X-SwitchMethod = "restart";
+            X-SwitchMethod = "keep-old";
           };
           Service = {
             ExitType = "cgroup";

--- a/named-hosts/kamino/default.nix
+++ b/named-hosts/kamino/default.nix
@@ -100,6 +100,7 @@ inputs.home-manager.lib.homeManagerConfiguration {
             X-SwitchMethod = "restart";
           };
           Service = {
+            ExitType = "cgroup";
             ExecStart = "${pkgs.llm-agents.herdr}/bin/herdr server";
             Restart = "on-failure";
             RestartSec = "5s";

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -124,7 +124,7 @@ home-manager.lib.homeManagerConfiguration {
           Unit = {
             Description = "Herdr headless server (coding-agent multiplexer)";
             After = [ "install-npm-globals.service" ];
-            X-SwitchMethod = "restart";
+            X-SwitchMethod = "keep-old";
           };
           Service = {
             Type = "simple";

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -128,6 +128,7 @@ home-manager.lib.homeManagerConfiguration {
           };
           Service = {
             Type = "simple";
+            ExitType = "cgroup";
             ExecStart = "${pkgs.bash}/bin/bash ${../../home-manager/services/herdr/start.sh} herdr";
             Restart = "on-failure";
             RestartSec = "30s";

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -126,6 +126,32 @@
             dontCheckRuntimeDeps = true;
           });
         }
+        // prev.lib.optionalAttrs (prev.llm-agents ? herdr) {
+          # Keep the native structured admission repair in the package used by
+          # the managed Linux services. The source patch is applied to the
+          # pinned v0.9.0 tag and retains the existing build hooks.
+          herdr = prev.llm-agents.herdr.overrideAttrs (
+            old:
+            let
+              herdrSrc = prev.fetchFromGitHub {
+                owner = "herdrdev";
+                repo = "herdr";
+                rev = "b99002ac99b09e00b4ca692436cb15a6b0d676f1";
+                hash = "sha256-SUYF4bbaYwNgoe498VoCUzuLPcjBLQXR0o0DWjjoSnI=";
+              };
+            in
+            {
+              version = "0.9.0";
+              src = herdrSrc;
+              patches = [ ./patches/herdr-structured-admission.patch ];
+              cargoDeps = prev.rustPlatform.fetchCargoVendor {
+                src = herdrSrc;
+                hash = "sha256-CW/SF/cAPDv47gS5B7XbVZEE6LC9F1a2I1TLTJ4AWdw=";
+              };
+              cargoHash = "sha256-CW/SF/cAPDv47gS5B7XbVZEE6LC9F1a2I1TLTJ4AWdw=";
+            }
+          );
+        }
         // (
           # t3code 0.0.33 pins one pnpm deps hash, but fetchPnpmDeps resolves
           # platform-specific optional packages, so it only reproduces on the

--- a/overlays/patches/herdr-structured-admission.patch
+++ b/overlays/patches/herdr-structured-admission.patch
@@ -1,0 +1,1588 @@
+diff --git a/src/api/schema/agents.rs b/src/api/schema/agents.rs
+index ee496d5..badc690 100644
+--- a/src/api/schema/agents.rs
++++ b/src/api/schema/agents.rs
+@@ -173,6 +173,15 @@ pub struct AgentStartParams {
+     /// Startup timeout in milliseconds. Values must be greater than 3000 and at most 300000.
+     #[serde(default, skip_serializing_if = "Option::is_none")]
+     pub timeout_ms: Option<u64>,
++    /// Canonical Git common directory expected by a managed launch.
++    #[serde(default, skip_serializing_if = "Option::is_none")]
++    pub repo_key: Option<String>,
++    /// Canonical linked-worktree checkout expected by a managed launch.
++    #[serde(default, skip_serializing_if = "Option::is_none")]
++    pub checkout_key: Option<String>,
++    /// Optional branch expected by a managed launch.
++    #[serde(default, skip_serializing_if = "Option::is_none")]
++    pub branch: Option<String>,
+ }
+ 
+ #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+diff --git a/src/api/schema/tests.rs b/src/api/schema/tests.rs
+index b566e8f..17e9390 100644
+--- a/src/api/schema/tests.rs
++++ b/src/api/schema/tests.rs
+@@ -100,6 +100,9 @@ fn agent_start_and_prompt_requests_round_trip() {
+             pane_id: "w1:p2".into(),
+             args: vec!["--no-session".into()],
+             timeout_ms: Some(30_000),
++            repo_key: None,
++            checkout_key: None,
++            branch: None,
+         }),
+     };
+     let start_json = serde_json::to_value(&start).unwrap();
+diff --git a/src/app/agent_resume.rs b/src/app/agent_resume.rs
+index 2cbd93a..31d73be 100644
+--- a/src/app/agent_resume.rs
++++ b/src/app/agent_resume.rs
+@@ -216,7 +216,6 @@ impl App {
+         if host_terminal_theme.is_empty() && !allow_empty_theme {
+             return false;
+         }
+-
+         let Some(resume_command) = shell_command_from_argv(&plan.argv) else {
+             tracing::warn!(
+                 pane = pane_id.raw(),
+@@ -226,6 +225,34 @@ impl App {
+             );
+             return false;
+         };
++
++        let Some((ws_idx, _)) = self.find_pane(pane_id) else {
++            return false;
++        };
++        let saved_identity = self
++            .state
++            .terminals
++            .get(&terminal_id)
++            .and_then(|terminal| terminal.managed_checkout_identity.clone());
++        let managed_checkout = match self.validate_managed_admission(
++            ws_idx,
++            &terminal_id,
++            &cwd,
++            saved_identity.as_ref().map(|identity| identity.0.as_str()),
++            saved_identity.as_ref().map(|identity| identity.1.as_str()),
++            None,
++        ) {
++            Ok(identity) => identity,
++            Err(err) => {
++                tracing::warn!(
++                    pane = pane_id.raw(),
++                    terminal = %terminal_id,
++                    ?err,
++                    "refused deferred agent resume at managed admission boundary"
++                );
++                return false;
++            }
++        };
+         let Some(launch_env) = self
+             .find_pane(pane_id)
+             .and_then(|(ws_idx, _)| self.pane_launch_env(ws_idx, pane_id, Vec::new()))
+@@ -233,6 +260,31 @@ impl App {
+             return false;
+         };
+ 
++        // Build every fallible launch input before taking ownership. A
++        // missing pane identity must not leave a checkout lease held forever.
++        if let Some(identity) = managed_checkout.as_ref() {
++            match self.acquire_managed_checkout_lease(identity, &terminal_id) {
++                Ok(true) => {}
++                Ok(false) => {
++                    tracing::warn!(
++                        pane = pane_id.raw(),
++                        terminal = %terminal_id,
++                        "deferred agent resume lost managed checkout lease"
++                    );
++                    return false;
++                }
++                Err(err) => {
++                    tracing::warn!(
++                        pane = pane_id.raw(),
++                        terminal = %terminal_id,
++                        ?err,
++                        "deferred agent resume could not acquire managed checkout lease"
++                    );
++                    return false;
++                }
++            }
++        }
++
+         let runtime = match crate::terminal::TerminalRuntime::spawn(
+             pane_id,
+             rows,
+@@ -259,6 +311,10 @@ impl App {
+                 if let Some(terminal) = self.state.terminals.get_mut(&terminal_id) {
+                     terminal.clear_agent_runtime_identity_after_respawn();
+                 }
++                if let Some(identity) = managed_checkout.as_ref() {
++                    self.release_managed_checkout_lease(&terminal_id);
++                    let _ = identity;
++                }
+                 return false;
+             }
+         };
+@@ -274,6 +330,9 @@ impl App {
+                 "failed to send deferred agent resume command to shell"
+             );
+             runtime.shutdown();
++            if managed_checkout.is_some() {
++                self.release_managed_checkout_lease(&terminal_id);
++            }
+             return false;
+         }
+ 
+diff --git a/src/app/agents.rs b/src/app/agents.rs
+index 5033505..c66ec3d 100644
+--- a/src/app/agents.rs
++++ b/src/app/agents.rs
+@@ -1,4 +1,9 @@
++use std::path::Path;
+ use std::time::{Duration, Instant};
++use std::{fs, io};
++
++#[cfg(unix)]
++use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+ 
+ use bytes::Bytes;
+ 
+@@ -11,6 +16,9 @@ pub(crate) const AGENT_START_SETTLE_DELAY: Duration = Duration::from_secs(3);
+ const INVALID_AGENT_TIMEOUT_MESSAGE: &str =
+     "agent start timeout must be greater than 3000ms and at most 300000ms";
+ const INVALID_AGENT_NAME_MESSAGE: &str = "agent name must start with a lowercase letter and contain only lowercase letters, digits, '-' or '_' (1-32 characters)";
++const MANAGED_ADMISSION_REQUIRED_MESSAGE: &str =
++    "linked-worktree agent starts require canonical repo_key and checkout_key";
++const MANAGED_CHECKOUT_LOCK_DIR: &str = "/var/tmp/herdr/managed-checkouts";
+ 
+ fn valid_agent_name(name: &str) -> bool {
+     let mut chars = name.chars();
+@@ -146,22 +154,27 @@ impl App {
+         &mut self,
+         params: AgentStartParams,
+     ) -> Result<(crate::api::schema::AgentInfo, Vec<String>), AgentStartError> {
+-        let name = params.name;
++        let AgentStartParams {
++            name,
++            kind: kind_name,
++            pane_id: pane_id_arg,
++            args,
++            timeout_ms,
++            repo_key,
++            checkout_key,
++            branch,
++        } = params;
+         if !valid_agent_name(&name) {
+             return Err(AgentStartError::InvalidName);
+         }
+-        let Some(kind) = crate::detect::parse_agent_label(&params.kind) else {
+-            return Err(AgentStartError::UnsupportedKind(params.kind));
++        let Some(kind) = crate::detect::parse_agent_label(&kind_name) else {
++            return Err(AgentStartError::UnsupportedKind(kind_name));
+         };
+-        if params
+-            .args
+-            .iter()
+-            .any(|arg| arg.chars().any(char::is_control))
+-        {
++        if args.iter().any(|arg| arg.chars().any(char::is_control)) {
+             return Err(AgentStartError::InvalidArgument);
+         }
+         let persisted_agent_session =
+-            crate::agent_resume::persisted_session_from_launch_args(kind, &params.args);
++            crate::agent_resume::persisted_session_from_launch_args(kind, &args);
+         let conflicts = self.agent_name_conflicts(&name, "");
+         if !conflicts.is_empty() {
+             return Err(AgentStartError::DuplicateName {
+@@ -169,8 +182,8 @@ impl App {
+                 candidates: conflicts,
+             });
+         }
+-        let Some((ws_idx, pane_id)) = self.parse_current_public_pane_id(&params.pane_id) else {
+-            return Err(AgentStartError::TargetNotFound(params.pane_id));
++        let Some((ws_idx, pane_id)) = self.parse_current_public_pane_id(&pane_id_arg) else {
++            return Err(AgentStartError::TargetNotFound(pane_id_arg));
+         };
+         let terminal_id = self
+             .state
+@@ -178,44 +191,125 @@ impl App {
+             .get(ws_idx)
+             .and_then(|workspace| workspace.terminal_id(pane_id))
+             .cloned()
+-            .ok_or_else(|| AgentStartError::TargetNotFound(params.pane_id.clone()))?;
+-        let terminal = self
++            .ok_or_else(|| AgentStartError::TargetNotFound(pane_id_arg.clone()))?;
++        let terminal_is_busy = self
+             .state
+             .terminals
+             .get(&terminal_id)
+-            .ok_or_else(|| AgentStartError::TargetNotFound(params.pane_id.clone()))?;
+-        if terminal.is_agent_terminal() || terminal.managed_agent_kind().is_some() {
+-            return Err(AgentStartError::TargetBusy(params.pane_id));
++            .ok_or_else(|| AgentStartError::TargetNotFound(pane_id_arg.clone()))
++            .map(|terminal| {
++                terminal.is_agent_terminal() || terminal.managed_agent_kind().is_some()
++            })?;
++        if terminal_is_busy {
++            return Err(AgentStartError::TargetBusy(pane_id_arg.clone()));
+         }
+-        let runtime = self
++        let live_cwd = self
+             .terminal_runtimes
+             .get(&terminal_id)
+-            .ok_or_else(|| AgentStartError::TargetUnavailable(params.pane_id.clone()))?;
+-        let shell_name = available_shell_name(runtime)
+-            .ok_or_else(|| AgentStartError::TargetBusy(params.pane_id.clone()))?;
+-
+-        let mut argv = vec![crate::detect::interactive_agent_executable(kind).to_string()];
+-        argv.extend(params.args);
+-        let command = crate::platform::interactive_shell_command(&argv, &shell_name)
+-            .ok_or(AgentStartError::InvalidArgument)?;
+-        let bytes = crate::app::api_helpers::encode_api_submission(runtime, &command);
++            .ok_or_else(|| AgentStartError::TargetUnavailable(pane_id_arg.clone()))?
++            .follow_cwd()
++            .or_else(|| {
++                self.state
++                    .terminals
++                    .get(&terminal_id)
++                    .map(|terminal| terminal.cwd.clone())
++            })
++            .ok_or_else(|| AgentStartError::ManagedAdmissionRequired {
++                reason: "pane live cwd is unavailable".into(),
++            })?;
++        let managed_checkout = self.validate_managed_admission(
++            ws_idx,
++            &terminal_id,
++            &live_cwd,
++            repo_key.as_deref(),
++            checkout_key.as_deref(),
++            branch.as_deref(),
++        )?;
+         let timeout = Duration::from_millis(
+-            params
+-                .timeout_ms
+-                .unwrap_or(DEFAULT_AGENT_START_TIMEOUT.as_millis() as u64),
++            timeout_ms.unwrap_or(DEFAULT_AGENT_START_TIMEOUT.as_millis() as u64),
+         );
+         if timeout <= AGENT_START_SETTLE_DELAY || timeout > MAX_AGENT_START_TIMEOUT {
+             return Err(AgentStartError::InvalidTimeout);
+         }
++        let (argv, bytes) = {
++            let runtime = self
++                .terminal_runtimes
++                .get(&terminal_id)
++                .ok_or_else(|| AgentStartError::TargetUnavailable(pane_id_arg.clone()))?;
++            let shell_name = available_shell_name(runtime)
++                .ok_or_else(|| AgentStartError::TargetBusy(pane_id_arg.clone()))?;
++            let mut argv = vec![crate::detect::interactive_agent_executable(kind).to_string()];
++            argv.extend(args);
++            let command = crate::platform::interactive_shell_command(&argv, &shell_name)
++                .ok_or(AgentStartError::InvalidArgument)?;
++            let bytes = crate::app::api_helpers::encode_api_submission(runtime, &command);
++            (argv, bytes)
++        };
+ 
++        let lease_key = managed_checkout.as_ref().map(ManagedCheckout::key);
++        let lease_preexisting = lease_key
++            .as_ref()
++            .and_then(|key| self.managed_checkout_leases.get(key))
++            .is_some_and(|(owner, _)| owner == &terminal_id);
++        if let Some(identity) = managed_checkout.as_ref() {
++            if !self.acquire_managed_checkout_lease(identity, &terminal_id)? {
++                return Err(AgentStartError::DuplicateCheckout {
++                    repo_key: identity.repo_key.clone(),
++                    checkout_key: identity.checkout_key.clone(),
++                });
++            }
++        }
++        let runtime = self
++            .terminal_runtimes
++            .get(&terminal_id)
++            .ok_or_else(|| AgentStartError::TargetUnavailable(pane_id_arg.clone()))?;
++        if let Some(identity) = managed_checkout.as_ref() {
++            let launch_cwd = runtime
++                .follow_cwd()
++                .or_else(|| {
++                    self.state
++                        .terminals
++                        .get(&terminal_id)
++                        .map(|terminal| terminal.cwd.clone())
++                })
++                .ok_or_else(|| AgentStartError::ManagedAdmissionRequired {
++                    reason: "pane live cwd disappeared before launch".into(),
++                });
++            let current = launch_cwd
++                .ok()
++                .and_then(|cwd| crate::workspace::git_space_metadata(&cwd));
++            if !current.is_some_and(|space| {
++                space.is_linked_worktree
++                    && space.key == identity.repo_key
++                    && space.checkout_key == identity.checkout_key
++            }) {
++                if !lease_preexisting {
++                    self.release_managed_checkout_lease(&terminal_id);
++                }
++                return Err(AgentStartError::ManagedAdmissionMismatch {
++                    reason: "pane cwd changed after managed admission".into(),
++                });
++            }
++        }
+         let now = Instant::now();
+         let terminal = self
+             .state
+             .terminals
+             .get_mut(&terminal_id)
+-            .ok_or_else(|| AgentStartError::TargetUnavailable(params.pane_id.clone()))?;
++            .ok_or_else(|| AgentStartError::TargetUnavailable(pane_id_arg.clone()))?;
+         terminal.begin_managed_agent(name.clone(), kind, now, AGENT_START_SETTLE_DELAY, timeout);
++        if let Some(identity) = managed_checkout.as_ref() {
++            terminal.set_managed_checkout_identity(
++                identity.repo_key.clone(),
++                identity.checkout_key.clone(),
++            );
++        }
+         if let Err(err) = runtime.try_send_bytes(Bytes::from(bytes)) {
++            if !lease_preexisting {
++                if let Some(lease_key) = lease_key {
++                    self.managed_checkout_leases.remove(&lease_key);
++                }
++            }
+             terminal.clear_agent_name();
+             return Err(AgentStartError::InputFailed(err.to_string()));
+         }
+@@ -227,10 +321,450 @@ impl App {
+ 
+         let agent = self
+             .agent_info(ws_idx, pane_id)
+-            .ok_or(AgentStartError::TargetUnavailable(params.pane_id))?;
++            .ok_or(AgentStartError::TargetUnavailable(pane_id_arg))?;
+         Ok((agent, argv))
+     }
+ 
++    pub(super) fn validate_managed_admission(
++        &self,
++        ws_idx: usize,
++        terminal_id: &crate::terminal::TerminalId,
++        live_cwd: &Path,
++        expected_repo_key: Option<&str>,
++        expected_checkout_key: Option<&str>,
++        expected_branch: Option<&str>,
++    ) -> Result<Option<ManagedCheckout>, AgentStartError> {
++        let cached_linked = self.state.workspaces.get(ws_idx).is_some_and(|workspace| {
++            workspace
++                .git_space()
++                .is_some_and(|space| space.is_linked_worktree)
++                || workspace
++                    .worktree_space()
++                    .is_some_and(|space| space.is_linked_worktree)
++        });
++        let actual = crate::workspace::git_space_metadata(live_cwd);
++        let typed = match (expected_repo_key, expected_checkout_key) {
++            (Some(repo_key), Some(checkout_key)) => Some(ManagedCheckout {
++                repo_key: repo_key.to_string(),
++                checkout_key: checkout_key.to_string(),
++            }),
++            (None, None) if expected_branch.is_some() => {
++                return Err(AgentStartError::ManagedAdmissionMismatch {
++                    reason: "branch requires repo_key and checkout_key".into(),
++                });
++            }
++            (None, None) => None,
++            _ => {
++                return Err(AgentStartError::ManagedAdmissionMismatch {
++                    reason: "repo_key and checkout_key must be supplied together".into(),
++                });
++            }
++        };
++
++        let Some(actual) = actual else {
++            if cached_linked {
++                return Err(AgentStartError::ManagedAdmissionRequired {
++                    reason: "live Git identity could not be recomputed for linked workspace".into(),
++                });
++            }
++            if typed.is_some() || expected_branch.is_some() {
++                return Err(AgentStartError::ManagedAdmissionMismatch {
++                    reason: "expected Git identity does not describe the live pane cwd".into(),
++                });
++            }
++            return Ok(None);
++        };
++
++        let workspace = self.state.workspaces.get(ws_idx).ok_or_else(|| {
++            AgentStartError::ManagedAdmissionRequired {
++                reason: "target workspace is unavailable".into(),
++            }
++        })?;
++        let workspace_space = workspace.git_space();
++        if let Some(space) = workspace_space {
++            if space.key != actual.key || space.checkout_key != actual.checkout_key {
++                return Err(AgentStartError::ManagedAdmissionMismatch {
++                    reason: "workspace Git metadata is stale or points at another checkout".into(),
++                });
++            }
++        }
++        if let Some(membership) = workspace.worktree_space() {
++            let membership_checkout =
++                crate::worktree::canonical_or_original(&membership.checkout_path);
++            if !membership.is_linked_worktree
++                || membership.key != actual.key
++                || membership_checkout.display().to_string() != actual.checkout_key
++            {
++                return Err(AgentStartError::ManagedAdmissionMismatch {
++                    reason: "workspace linked-worktree metadata does not match live Git identity"
++                        .into(),
++                });
++            }
++        }
++
++        if actual.is_linked_worktree && typed.is_none() {
++            return Err(AgentStartError::ManagedAdmissionRequired {
++                reason: MANAGED_ADMISSION_REQUIRED_MESSAGE.into(),
++            });
++        }
++        if !actual.is_linked_worktree {
++            if typed.is_some() || expected_branch.is_some() {
++                return Err(AgentStartError::ManagedAdmissionMismatch {
++                    reason: "managed identity is not valid for the source-controller root route"
++                        .into(),
++                });
++            }
++            return Ok(None);
++        }
++        if workspace_space.is_none() && workspace.worktree_space().is_none() {
++            return Err(AgentStartError::ManagedAdmissionRequired {
++                reason: "linked workspace has no trusted worktree association".into(),
++            });
++        }
++        let identity = typed;
++        if let Some(identity) = identity {
++            if identity.repo_key != actual.key || identity.checkout_key != actual.checkout_key {
++                return Err(AgentStartError::ManagedAdmissionMismatch {
++                    reason: "expected Git identity does not match live pane cwd".into(),
++                });
++            }
++            if let Some(expected_branch) = expected_branch {
++                if crate::workspace::git_branch(live_cwd).as_deref() != Some(expected_branch) {
++                    return Err(AgentStartError::ManagedAdmissionMismatch {
++                        reason: "expected branch does not match live pane cwd".into(),
++                    });
++                }
++            }
++            if self.managed_checkout_is_owned(&identity, terminal_id) {
++                return Err(AgentStartError::DuplicateCheckout {
++                    repo_key: identity.repo_key,
++                    checkout_key: identity.checkout_key,
++                });
++            }
++            return Ok(Some(identity));
++        }
++        Ok(None)
++    }
++
++    fn managed_checkout_is_owned(
++        &self,
++        identity: &ManagedCheckout,
++        target_terminal_id: &crate::terminal::TerminalId,
++    ) -> bool {
++        self.state.workspaces.iter().any(|workspace| {
++            workspace.tabs.iter().any(|tab| {
++                tab.layout.pane_ids().into_iter().any(|pane_id| {
++                    let Some(terminal_id) = workspace.terminal_id(pane_id) else {
++                        return false;
++                    };
++                    if terminal_id == target_terminal_id {
++                        return false;
++                    }
++                    let Some(terminal) = self.state.terminals.get(terminal_id) else {
++                        return false;
++                    };
++                    if !terminal.is_agent_terminal() && terminal.managed_agent_kind().is_none() {
++                        return false;
++                    }
++                    let cwd = self
++                        .terminal_runtimes
++                        .get(terminal_id)
++                        .and_then(|runtime| runtime.follow_cwd())
++                        .unwrap_or_else(|| terminal.cwd.clone());
++                    crate::workspace::git_space_metadata(&cwd).is_some_and(|space| {
++                        space.key == identity.repo_key
++                            && space.checkout_key == identity.checkout_key
++                    })
++                })
++            })
++        })
++    }
++
++    pub(super) fn acquire_managed_checkout_lease(
++        &mut self,
++        identity: &ManagedCheckout,
++        terminal_id: &crate::terminal::TerminalId,
++    ) -> Result<bool, AgentStartError> {
++        let key = identity.key();
++        if let Some((owner, _)) = self.managed_checkout_leases.get(&key) {
++            // A deferred resume or retry for the same terminal already owns
++            // the open file description. Opening the path again would contend
++            // with our own flock.
++            return Ok(owner == terminal_id);
++        }
++        // The lease namespace must be shared by all same-user Herdr servers.
++        // XDG_RUNTIME_DIR (and TMPDIR) can differ between a systemd service,
++        // a handoff child, and a manually started contender, so neither may
++        // select the lock directory.
++        let lock_dir = Path::new(MANAGED_CHECKOUT_LOCK_DIR);
++        fs::create_dir_all(&lock_dir).map_err(|err| AgentStartError::ManagedAdmissionRequired {
++            reason: format!("managed checkout lease directory unavailable: {err}"),
++        })?;
++        let mut digest = sha2::Sha256::new();
++        use sha2::Digest;
++        digest.update(identity.key());
++        let lock_path = lock_dir.join(format!("{:x}.lock", digest.finalize()));
++        let file = fs::OpenOptions::new()
++            .create(true)
++            .read(true)
++            .write(true)
++            .open(lock_path)
++            .map_err(|err| AgentStartError::ManagedAdmissionRequired {
++                reason: format!("managed checkout lease unavailable: {err}"),
++            })?;
++        #[cfg(unix)]
++        {
++            let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
++            if result != 0 {
++                let err = io::Error::last_os_error();
++                if err.raw_os_error() == Some(libc::EWOULDBLOCK) {
++                    return Ok(false);
++                }
++                return Err(AgentStartError::ManagedAdmissionRequired {
++                    reason: format!("managed checkout lease failed: {err}"),
++                });
++            }
++        }
++        #[cfg(not(unix))]
++        {
++            return Err(AgentStartError::ManagedAdmissionRequired {
++                reason: "managed checkout admission requires a platform lock implementation".into(),
++            });
++        }
++        self.managed_checkout_leases
++            .insert(key, (terminal_id.clone(), file));
++        Ok(true)
++    }
++
++    #[cfg(unix)]
++    pub(crate) fn managed_checkout_leases_for_handoff(
++        &self,
++        pane_by_terminal: &std::collections::HashMap<crate::terminal::TerminalId, u32>,
++    ) -> io::Result<Vec<crate::server::handoff::HandoffManagedCheckoutLease>> {
++        let mut entries = Vec::new();
++        for (key, (terminal_id, _file)) in &self.managed_checkout_leases {
++            let pane_id = pane_by_terminal.get(terminal_id).copied().ok_or_else(|| {
++                io::Error::other(format!(
++                    "managed checkout lease {key:?} has no live pane during handoff"
++                ))
++            })?;
++            let identity = self
++                .state
++                .terminals
++                .get(terminal_id)
++                .and_then(|terminal| terminal.managed_checkout_identity.clone())
++                .or_else(|| {
++                    ManagedCheckout::from_key(key)
++                        .map(|identity| (identity.repo_key, identity.checkout_key))
++                })
++                .ok_or_else(|| io::Error::other("managed checkout lease identity is malformed"))?;
++            entries.push(crate::server::handoff::HandoffManagedCheckoutLease {
++                pane_id,
++                repo_key: identity.0,
++                checkout_key: identity.1,
++            });
++        }
++        Ok(entries)
++    }
++
++    #[cfg(unix)]
++    pub(crate) fn duplicate_managed_checkout_leases_for_handoff(
++        &self,
++        pane_by_terminal: &std::collections::HashMap<crate::terminal::TerminalId, u32>,
++        entries: &[crate::server::handoff::HandoffManagedCheckoutLease],
++    ) -> io::Result<Vec<RawFd>> {
++        entries
++            .iter()
++            .map(|entry| {
++                let terminal_id = pane_by_terminal
++                    .iter()
++                    .find_map(|(terminal_id, pane_id)| {
++                        (*pane_id == entry.pane_id).then_some(terminal_id)
++                    })
++                    .ok_or_else(|| io::Error::other("managed checkout lease pane disappeared"))?;
++                let identity = ManagedCheckout {
++                    repo_key: entry.repo_key.clone(),
++                    checkout_key: entry.checkout_key.clone(),
++                };
++                let (owner, file) = self
++                    .managed_checkout_leases
++                    .get(&identity.key())
++                    .ok_or_else(|| io::Error::other("managed checkout lease disappeared"))?;
++                if owner != terminal_id {
++                    return Err(io::Error::other(
++                        "managed checkout lease owner changed during handoff",
++                    ));
++                }
++                crate::pty::fd::duplicate_cloexec_fd(file.as_raw_fd())
++            })
++            .collect()
++    }
++
++    #[cfg(unix)]
++    pub(super) fn install_handoff_managed_checkout_lease(
++        &mut self,
++        terminal_id: crate::terminal::TerminalId,
++        identity: ManagedCheckout,
++        fd: RawFd,
++    ) -> io::Result<()> {
++        let key = identity.key();
++        // SAFETY: the descriptor was received through SCM_RIGHTS and is
++        // consumed exactly once by this File.
++        let file = unsafe { std::fs::File::from_raw_fd(fd) };
++        if let Some((owner, _)) = self.managed_checkout_leases.get(&key) {
++            if owner == &terminal_id {
++                drop(file);
++                return Ok(());
++            }
++            return Err(io::Error::new(
++                io::ErrorKind::AddrInUse,
++                format!("managed checkout lease already owned: {key}"),
++            ));
++        }
++        self.managed_checkout_leases
++            .insert(key, (terminal_id, file));
++        Ok(())
++    }
++
++    #[cfg(unix)]
++    pub(super) fn prepare_handoff_managed_checkout_leases(
++        &mut self,
++        imported: &mut std::collections::HashMap<
++            u32,
++            crate::handoff_runtime::ImportedManagedCheckoutLease,
++        >,
++        pane_aliases: &std::collections::HashMap<u32, crate::layout::PaneId>,
++    ) -> io::Result<()> {
++        // Snapshots written before the identity field existed can still hold
++        // managed agents. Recompute their identity from the retained pane's
++        // canonical cwd before the replacement reports restored.
++        let mut legacy = Vec::new();
++        for workspace in &self.state.workspaces {
++            let cached_linked = workspace
++                .git_space()
++                .is_some_and(|space| space.is_linked_worktree)
++                || workspace
++                    .worktree_space()
++                    .is_some_and(|space| space.is_linked_worktree);
++            for pane_id in workspace.tabs.iter().flat_map(|tab| tab.layout.pane_ids()) {
++                let Some(terminal_id) = workspace.terminal_id(pane_id) else {
++                    continue;
++                };
++                let Some(terminal) = self.state.terminals.get(&terminal_id) else {
++                    continue;
++                };
++                if terminal.managed_agent_kind().is_none()
++                    || terminal.managed_checkout_identity.is_some()
++                {
++                    continue;
++                }
++                legacy.push((terminal_id, terminal.cwd.clone(), cached_linked));
++            }
++        }
++        for (terminal_id, cwd, cached_linked) in legacy {
++            let Some(space) = crate::workspace::git_space_metadata(&cwd) else {
++                if cached_linked {
++                    return Err(io::Error::other(
++                        "cannot adopt managed writer: live Git identity could not be recomputed",
++                    ));
++                }
++                continue;
++            };
++            if cached_linked != space.is_linked_worktree {
++                return Err(io::Error::other(
++                    "cannot adopt managed writer: cached and live worktree routes differ",
++                ));
++            }
++            if space.is_linked_worktree {
++                self.state
++                    .terminals
++                    .get_mut(&terminal_id)
++                    .expect("terminal collected from state")
++                    .set_managed_checkout_identity(space.key, space.checkout_key);
++            }
++        }
++
++        for (old_pane_id, imported_lease) in std::mem::take(imported) {
++            let new_pane_id = pane_aliases.get(&old_pane_id).copied().ok_or_else(|| {
++                io::Error::other(format!(
++                    "handoff lease references unknown pane {old_pane_id}"
++                ))
++            })?;
++            let terminal_id = self
++                .state
++                .workspaces
++                .iter()
++                .find_map(|workspace| workspace.terminal_id(new_pane_id).cloned())
++                .ok_or_else(|| io::Error::other("handoff lease pane was not restored"))?;
++            let identity = ManagedCheckout {
++                repo_key: imported_lease.repo_key,
++                checkout_key: imported_lease.checkout_key,
++            };
++            let expected = self
++                .state
++                .terminals
++                .get(&terminal_id)
++                .and_then(|terminal| terminal.managed_checkout_identity.clone())
++                .ok_or_else(|| {
++                    io::Error::other("handoff lease has no admitted terminal identity")
++                })?;
++            if expected != (identity.repo_key.clone(), identity.checkout_key.clone()) {
++                return Err(io::Error::other(
++                    "handoff lease identity does not match restored pane",
++                ));
++            }
++            self.install_handoff_managed_checkout_lease(terminal_id, identity, imported_lease.fd)?;
++        }
++
++        let required: Vec<_> = self
++            .state
++            .terminals
++            .values()
++            .filter_map(|terminal| {
++                terminal
++                    .managed_checkout_identity
++                    .clone()
++                    .map(|(repo_key, checkout_key)| {
++                        (
++                            terminal.id.clone(),
++                            ManagedCheckout {
++                                repo_key,
++                                checkout_key,
++                            },
++                        )
++                    })
++            })
++            .collect();
++        for (terminal_id, identity) in required {
++            if self.managed_checkout_leases.contains_key(&identity.key()) {
++                continue;
++            }
++            match self.acquire_managed_checkout_lease(&identity, &terminal_id) {
++                Ok(true) => {}
++                Ok(false) => {
++                    return Err(io::Error::new(
++                        io::ErrorKind::AddrInUse,
++                        format!("managed checkout lease is still owned: {}", identity.key()),
++                    ));
++                }
++                Err(err) => {
++                    return Err(io::Error::other(format!(
++                        "managed handoff admission failed: {err:?}"
++                    )))
++                }
++            }
++        }
++        Ok(())
++    }
++
++    pub(super) fn release_managed_checkout_lease(
++        &mut self,
++        terminal_id: &crate::terminal::TerminalId,
++    ) {
++        self.managed_checkout_leases
++            .retain(|_, (owner, _)| owner != terminal_id);
++    }
++
+     pub(super) fn agent_start_error_body(
+         &self,
+         err: AgentStartError,
+@@ -287,6 +821,23 @@ impl App {
+                         .join("; ")
+                 ),
+             },
++            AgentStartError::ManagedAdmissionRequired { reason } => crate::api::schema::ErrorBody {
++                code: "managed_admission_required".into(),
++                message: reason,
++            },
++            AgentStartError::ManagedAdmissionMismatch { reason } => crate::api::schema::ErrorBody {
++                code: "managed_admission_mismatch".into(),
++                message: reason,
++            },
++            AgentStartError::DuplicateCheckout {
++                repo_key,
++                checkout_key,
++            } => crate::api::schema::ErrorBody {
++                code: "managed_checkout_taken".into(),
++                message: format!(
++                    "managed checkout is already owned: repo_key={repo_key} checkout_key={checkout_key}"
++                ),
++            },
+         }
+     }
+ 
+@@ -445,6 +996,7 @@ fn live_runtime_agent(runtime: &crate::terminal::TerminalRuntime) -> Option<crat
+         })
+ }
+ 
++#[derive(Debug)]
+ pub(super) enum AgentStartError {
+     InvalidName,
+     UnsupportedKind(String),
+@@ -458,6 +1010,39 @@ pub(super) enum AgentStartError {
+         name: String,
+         candidates: Vec<crate::api::schema::AgentInfo>,
+     },
++    ManagedAdmissionRequired {
++        reason: String,
++    },
++    ManagedAdmissionMismatch {
++        reason: String,
++    },
++    DuplicateCheckout {
++        repo_key: String,
++        checkout_key: String,
++    },
++}
++
++#[derive(Debug, Clone, PartialEq, Eq)]
++pub(super) struct ManagedCheckout {
++    repo_key: String,
++    checkout_key: String,
++}
++
++impl ManagedCheckout {
++    fn key(&self) -> String {
++        format!("{}\n{}", self.repo_key, self.checkout_key)
++    }
++
++    fn from_key(key: &str) -> Option<Self> {
++        let (repo_key, checkout_key) = key.split_once('\n')?;
++        if repo_key.is_empty() || checkout_key.is_empty() || checkout_key.contains('\n') {
++            return None;
++        }
++        Some(Self {
++            repo_key: repo_key.to_string(),
++            checkout_key: checkout_key.to_string(),
++        })
++    }
+ }
+ 
+ pub(super) enum AgentRenameError {
+@@ -493,4 +1078,89 @@ mod tests {
+             assert!(!valid_agent_name(name), "expected {name:?} to be invalid");
+         }
+     }
++
++    #[cfg(unix)]
++    #[test]
++    fn same_terminal_resume_reuses_its_existing_checkout_lease() {
++        let (_api_tx, api_rx) = tokio::sync::mpsc::unbounded_channel();
++        let mut app = crate::app::App::new(
++            &crate::config::Config::default(),
++            crate::app::AppPolicy::TEST,
++            None,
++            api_rx,
++            crate::api::EventHub::default(),
++        );
++        let terminal_id = crate::terminal::TerminalId::alloc();
++        let identity = super::ManagedCheckout {
++            repo_key: format!("/tmp/herdr-test-repo-{}", std::process::id()),
++            checkout_key: format!("/tmp/herdr-test-checkout-{}", std::process::id()),
++        };
++
++        assert!(app
++            .acquire_managed_checkout_lease(&identity, &terminal_id)
++            .expect("first lease acquisition should succeed"));
++        assert!(app
++            .acquire_managed_checkout_lease(&identity, &terminal_id)
++            .expect("same-terminal lease acquisition should be resumable"));
++        assert_eq!(app.managed_checkout_leases.len(), 1);
++    }
++
++    #[cfg(unix)]
++    #[test]
++    fn another_process_cannot_acquire_an_owned_checkout_lease() {
++        let _env_guard = crate::config::test_config_env_lock().lock().unwrap();
++        let identity = super::ManagedCheckout {
++            repo_key: "/tmp/herdr-cross-process-repo".into(),
++            checkout_key: "/tmp/herdr-cross-process-checkout".into(),
++        };
++        let owner_runtime_dir =
++            std::env::temp_dir().join(format!("herdr-lease-owner-runtime-{}", std::process::id()));
++        let contender_runtime_dir = std::env::temp_dir().join(format!(
++            "herdr-lease-contender-runtime-{}",
++            std::process::id()
++        ));
++        std::fs::create_dir_all(&owner_runtime_dir).expect("owner runtime directory");
++        std::fs::create_dir_all(&contender_runtime_dir).expect("contender runtime directory");
++        if std::env::var_os("HERDR_LEASE_CHILD").is_some() {
++            let (_api_tx, api_rx) = tokio::sync::mpsc::unbounded_channel();
++            let mut app = crate::app::App::new(
++                &crate::config::Config::default(),
++                crate::app::AppPolicy::TEST,
++                None,
++                api_rx,
++                crate::api::EventHub::default(),
++            );
++            assert!(!app
++                .acquire_managed_checkout_lease(&identity, &crate::terminal::TerminalId::alloc())
++                .expect("competing lease check should be handled"));
++            return;
++        }
++
++        let (_api_tx, api_rx) = tokio::sync::mpsc::unbounded_channel();
++        std::env::set_var("XDG_RUNTIME_DIR", &owner_runtime_dir);
++        let mut app = crate::app::App::new(
++            &crate::config::Config::default(),
++            crate::app::AppPolicy::TEST,
++            None,
++            api_rx,
++            crate::api::EventHub::default(),
++        );
++        assert!(app
++            .acquire_managed_checkout_lease(&identity, &crate::terminal::TerminalId::alloc())
++            .expect("owner lease acquisition should succeed"));
++        let status = std::process::Command::new(std::env::current_exe().expect("test executable"))
++            .args([
++                "--exact",
++                "app::agents::tests::another_process_cannot_acquire_an_owned_checkout_lease",
++                "--nocapture",
++            ])
++            .env("HERDR_LEASE_CHILD", "1")
++            .env("XDG_RUNTIME_DIR", &contender_runtime_dir)
++            .status()
++            .expect("spawn competing lease test");
++        assert!(
++            status.success(),
++            "competing process must be refused: {status}"
++        );
++    }
+ }
+diff --git a/src/app/api.rs b/src/app/api.rs
+index 8470818..930613d 100644
+--- a/src/app/api.rs
++++ b/src/app/api.rs
+@@ -310,8 +310,27 @@ impl App {
+                 None
+             };
+         let terminal_cwd_reported = matches!(ev, AppEvent::TerminalCwdReported { .. });
++        let pane_died_terminal = if let AppEvent::PaneDied { pane_id, .. } = &ev {
++            self.find_pane(*pane_id)
++                .and_then(|(ws_idx, _)| self.state.terminal_id_for_pane(ws_idx, *pane_id))
++        } else {
++            None
++        };
+         let previous_toast = self.state.toast.clone();
+         let mut pane_updates = self.state.handle_app_event(ev);
++        if let Some(terminal_id) = pane_died_terminal {
++            self.release_managed_checkout_lease(&terminal_id);
++        }
++        for update in &pane_updates {
++            if update.agent_released {
++                if let Some(terminal_id) = self
++                    .state
++                    .terminal_id_for_pane(update.ws_idx, update.pane_id)
++                {
++                    self.release_managed_checkout_lease(&terminal_id);
++                }
++            }
++        }
+         if update_ready.is_some() {
+             self.state.latest_release_notes = crate::release_notes::load_latest();
+         }
+diff --git a/src/app/mod.rs b/src/app/mod.rs
+index b327b5b..3429ccb 100644
+--- a/src/app/mod.rs
++++ b/src/app/mod.rs
+@@ -123,6 +123,8 @@ pub struct App {
+     pub(crate) git_refresh_due_after_in_flight: bool,
+     pub(crate) git_identity_refresh_requested: bool,
+     pub(crate) git_status_cache: HashMap<std::path::PathBuf, crate::workspace::GitStatusCacheEntry>,
++    pub(crate) managed_checkout_leases:
++        HashMap<String, (crate::terminal::TerminalId, std::fs::File)>,
+     pub(crate) pending_api_worktree_creates: HashMap<std::path::PathBuf, u64>,
+     pub(crate) pending_api_worktree_removes: HashMap<String, u64>,
+     pub(crate) pending_api_worktree_remove_paths: HashMap<std::path::PathBuf, u64>,
+@@ -582,6 +584,7 @@ impl App {
+             git_refresh_due_after_in_flight: false,
+             git_identity_refresh_requested: false,
+             git_status_cache: HashMap::new(),
++            managed_checkout_leases: HashMap::new(),
+             pending_api_worktree_creates: HashMap::new(),
+             pending_api_worktree_removes: HashMap::new(),
+             pending_api_worktree_remove_paths: HashMap::new(),
+@@ -637,6 +640,10 @@ impl App {
+             u32,
+             crate::handoff_runtime::ImportedHandoffRuntime,
+         >,
++        managed_checkout_leases: &mut std::collections::HashMap<
++            u32,
++            crate::handoff_runtime::ImportedManagedCheckoutLease,
++        >,
+     ) -> io::Result<Self> {
+         let mut app = Self::new(
+             config,
+@@ -678,6 +685,8 @@ impl App {
+                 .get(idx)
+                 .and_then(|ws| ws.focused_pane_id().map(|pane_id| (idx, pane_id)))
+         });
++        let pane_id_aliases = app.state.pane_id_aliases.clone();
++        app.prepare_handoff_managed_checkout_leases(managed_checkout_leases, &pane_id_aliases)?;
+         Ok(app)
+     }
+ 
+@@ -2795,6 +2804,9 @@ mod tests {
+                 pane_id,
+                 args: Vec::new(),
+                 timeout_ms: Some(1_000),
++                repo_key: None,
++                checkout_key: None,
++                branch: None,
+             }),
+         });
+         let response: serde_json::Value = serde_json::from_str(&response).unwrap();
+@@ -2837,6 +2849,9 @@ mod tests {
+                 pane_id: pane_id.clone(),
+                 args: vec!["resume".into(), "codex-session".into()],
+                 timeout_ms: Some(4_000),
++                repo_key: None,
++                checkout_key: None,
++                branch: None,
+             }),
+         };
+         let response = app.handle_api_request(request());
+diff --git a/src/app/runtime.rs b/src/app/runtime.rs
+index 99769e7..9d39c00 100644
+--- a/src/app/runtime.rs
++++ b/src/app/runtime.rs
+@@ -28,6 +28,7 @@ impl App {
+     }
+ 
+     pub(crate) fn shutdown_terminal_runtime(&mut self, terminal_id: crate::terminal::TerminalId) {
++        self.release_managed_checkout_lease(&terminal_id);
+         if let Some(runtime) = self.terminal_runtimes.remove(&terminal_id) {
+             runtime.shutdown();
+         }
+diff --git a/src/cli/agent.rs b/src/cli/agent.rs
+index 1af3e0d..e3e69ab 100644
+--- a/src/cli/agent.rs
++++ b/src/cli/agent.rs
+@@ -4,6 +4,7 @@ use crate::api::schema::{
+     AgentPromptParams, AgentPromptWaitOptions, AgentReadParams, AgentRenameParams,
+     AgentSendKeysParams, AgentStartParams, AgentTarget, AgentWaitParams, EmptyParams, ErrorBody,
+     ErrorResponse, Method, PaneProcessInfoParams, PaneTarget, ReadFormat, ReadSource, Request,
++    WorkspaceTarget,
+ };
+ 
+ const AGENT_START_POLL_INTERVAL: Duration = Duration::from_millis(100);
+@@ -356,6 +357,7 @@ fn agent_start(args: &[String]) -> std::io::Result<i32> {
+     let retryable_timeout = timeout > crate::app::AGENT_START_SETTLE_DELAY
+         && timeout <= crate::app::MAX_AGENT_START_TIMEOUT;
+     let pinned_terminal_id = pane_terminal_id(&pane_id)?;
++    let managed_identity = pane_managed_identity(&pane_id)?;
+     let mut retry_deadline = None;
+     let mut previous_busy_response = None;
+     let mut response = loop {
+@@ -377,6 +379,15 @@ fn agent_start(args: &[String]) -> std::io::Result<i32> {
+                 pane_id: pane_id.clone(),
+                 args: agent_args.clone(),
+                 timeout_ms,
++                repo_key: managed_identity
++                    .as_ref()
++                    .map(|identity| identity.repo_key.clone()),
++                checkout_key: managed_identity
++                    .as_ref()
++                    .map(|identity| identity.checkout_key.clone()),
++                branch: managed_identity
++                    .as_ref()
++                    .and_then(|identity| identity.branch.clone()),
+             }),
+         })?;
+         if response.get("error").is_none() {
+@@ -643,6 +654,46 @@ fn pane_terminal_id(pane_id: &str) -> std::io::Result<Option<String>> {
+         .map(str::to_owned))
+ }
+ 
++#[derive(Debug, Clone)]
++struct ManagedIdentity {
++    repo_key: String,
++    checkout_key: String,
++    branch: Option<String>,
++}
++
++fn pane_managed_identity(pane_id: &str) -> std::io::Result<Option<ManagedIdentity>> {
++    let response = super::send_request(&Request {
++        id: "cli:agent:start:workspace".into(),
++        method: Method::PaneGet(PaneTarget {
++            pane_id: pane_id.to_owned(),
++        }),
++    })?;
++    let Some(workspace_id) = response["result"]["pane"]["workspace_id"].as_str() else {
++        return Ok(None);
++    };
++    let response = super::send_request(&Request {
++        id: "cli:agent:start:workspace:get".into(),
++        method: Method::WorkspaceGet(WorkspaceTarget {
++            workspace_id: workspace_id.to_owned(),
++        }),
++    })?;
++    let worktree = &response["result"]["workspace"]["worktree"];
++    if !worktree["is_linked_worktree"].as_bool().unwrap_or(false) {
++        return Ok(None);
++    }
++    let (Some(repo_key), Some(checkout_key)) = (
++        worktree["repo_key"].as_str(),
++        worktree["checkout_path"].as_str(),
++    ) else {
++        return Ok(None);
++    };
++    Ok(Some(ManagedIdentity {
++        repo_key: repo_key.to_owned(),
++        checkout_key: checkout_key.to_owned(),
++        branch: None,
++    }))
++}
++
+ fn pane_shell_is_initializing(pane_id: &str) -> std::io::Result<bool> {
+     let response = super::send_request(&Request {
+         id: "cli:agent:start:process_info".into(),
+diff --git a/src/handoff_runtime.rs b/src/handoff_runtime.rs
+index 29ba85f..2edd096 100644
+--- a/src/handoff_runtime.rs
++++ b/src/handoff_runtime.rs
+@@ -44,3 +44,14 @@ pub(crate) struct ImportedHandoffRuntime {
+     #[cfg(unix)]
+     pub state: HandoffRuntimeState,
+ }
++
++/// A checkout lease descriptor transferred with a live handoff. The lock is
++/// already held by the source server; the replacement must retain this exact
++/// open file description instead of opening the path again.
++#[cfg(unix)]
++#[derive(Debug)]
++pub(crate) struct ImportedManagedCheckoutLease {
++    pub repo_key: String,
++    pub checkout_key: String,
++    pub fd: std::os::fd::RawFd,
++}
+diff --git a/src/pane.rs b/src/pane.rs
+index aa6acb5..7c9cdc1 100644
+--- a/src/pane.rs
++++ b/src/pane.rs
+@@ -2078,7 +2078,9 @@ impl PaneRuntime {
+         render_notify: Arc<Notify>,
+         render_dirty: Arc<RenderSignal>,
+     ) -> std::io::Result<Self> {
+-        let crate::handoff_runtime::ImportedHandoffRuntime { master_fd, state } = import;
++        let crate::handoff_runtime::ImportedHandoffRuntime {
++            master_fd, state, ..
++        } = import;
+         let crate::handoff_runtime::HandoffRuntimeState {
+             pane_id,
+             child_pid,
+diff --git a/src/persist/restore.rs b/src/persist/restore.rs
+index 3c5775c..7d1251f 100644
+--- a/src/persist/restore.rs
++++ b/src/persist/restore.rs
+@@ -495,6 +495,8 @@ fn restore_tab(
+         let saved_managed_agent = saved_pane
+             .and_then(|pane| pane.managed_agent_kind.as_deref())
+             .and_then(crate::detect::parse_canonical_agent_label);
++        let saved_managed_checkout_identity =
++            saved_pane.and_then(|pane| pane.managed_checkout_identity.clone());
+         let saved_launch_argv = saved_pane.and_then(|p| p.launch_argv.clone());
+         let saved_agent_session = saved_pane.and_then(|p| p.agent_session.as_ref());
+         let saved_history =
+@@ -543,6 +545,9 @@ fn restore_tab(
+             if let Some(session) = restored_agent_session {
+                 terminal.set_persisted_agent_session(session);
+             }
++            if let Some((repo_key, checkout_key)) = saved_managed_checkout_identity.clone() {
++                terminal.set_managed_checkout_identity(repo_key, checkout_key);
++            }
+             match (saved_agent_name, saved_managed_agent) {
+                 (Some(agent_name), Some(agent)) => {
+                     terminal.restore_managed_agent(agent_name, agent)
+@@ -640,6 +645,9 @@ fn restore_tab(
+                 if let Some(session) = restored_agent_session {
+                     terminal.set_persisted_agent_session(session);
+                 }
++                if let Some((repo_key, checkout_key)) = saved_managed_checkout_identity {
++                    terminal.set_managed_checkout_identity(repo_key, checkout_key);
++                }
+                 match (saved_agent_name, saved_managed_agent) {
+                     (Some(agent_name), Some(agent)) if was_imported => {
+                         terminal.restore_managed_agent(agent_name, agent)
+@@ -1191,6 +1199,7 @@ mod tests {
+                             label: Some("reviewer".into()),
+                             agent_name: Some("reviewer".into()),
+                             managed_agent_kind: Some("opencode".into()),
++                            managed_checkout_identity: None,
+                             agent_session: Some(super::super::snapshot::PaneAgentSessionSnapshot {
+                                 source: "herdr:opencode".into(),
+                                 agent: "opencode".into(),
+@@ -1277,6 +1286,7 @@ mod tests {
+                                 label: None,
+                                 agent_name: None,
+                                 managed_agent_kind: None,
++                                managed_checkout_identity: None,
+                                 agent_session: None,
+                                 launch_argv: None,
+                             },
+@@ -1288,6 +1298,7 @@ mod tests {
+                                 label: None,
+                                 agent_name: None,
+                                 managed_agent_kind: None,
++                                managed_checkout_identity: None,
+                                 agent_session: None,
+                                 launch_argv: None,
+                             },
+@@ -1341,6 +1352,7 @@ mod tests {
+                     label: None,
+                     agent_name: None,
+                     managed_agent_kind: None,
++                    managed_checkout_identity: None,
+                     agent_session: None,
+                     launch_argv: None,
+                 },
+@@ -1351,6 +1363,7 @@ mod tests {
+             label: Some("planner".into()),
+             agent_name: Some("planner".into()),
+             managed_agent_kind: None,
++            managed_checkout_identity: None,
+             agent_session: Some(super::super::snapshot::PaneAgentSessionSnapshot {
+                 source: "herdr:codex".into(),
+                 agent: "codex".into(),
+@@ -1502,6 +1515,7 @@ mod tests {
+                             label: None,
+                             agent_name: None,
+                             managed_agent_kind: None,
++                            managed_checkout_identity: None,
+                             agent_session: Some(super::super::snapshot::PaneAgentSessionSnapshot {
+                                 source: "herdr:codex".into(),
+                                 agent: "codex".into(),
+@@ -1668,6 +1682,7 @@ mod tests {
+                 label: None,
+                 agent_name: None,
+                 managed_agent_kind: None,
++                managed_checkout_identity: None,
+                 agent_session: None,
+                 launch_argv: None,
+             },
+diff --git a/src/persist/snapshot.rs b/src/persist/snapshot.rs
+index e6ca70f..ebd2a42 100644
+--- a/src/persist/snapshot.rs
++++ b/src/persist/snapshot.rs
+@@ -104,6 +104,8 @@ pub struct PaneSnapshot {
+     #[serde(default, skip_serializing_if = "Option::is_none")]
+     pub managed_agent_kind: Option<String>,
+     #[serde(default, skip_serializing_if = "Option::is_none")]
++    pub managed_checkout_identity: Option<(String, String)>,
++    #[serde(default, skip_serializing_if = "Option::is_none")]
+     pub agent_session: Option<PaneAgentSessionSnapshot>,
+     #[serde(default, skip_serializing_if = "Option::is_none")]
+     pub launch_argv: Option<Vec<String>>,
+@@ -335,6 +337,8 @@ fn capture_tab(
+             })
+             .unwrap_or_default();
+         let launch_argv = terminal.and_then(|terminal| terminal.launch_argv.clone());
++        let managed_checkout_identity =
++            terminal.and_then(|terminal| terminal.managed_checkout_identity.clone());
+         let agent_session = terminal.and_then(|terminal| {
+             if let Some(authority) = terminal.hook_authority.as_ref() {
+                 if let Some(session_ref) = authority.session_ref.as_ref() {
+@@ -363,6 +367,7 @@ fn capture_tab(
+                 label,
+                 agent_name,
+                 managed_agent_kind,
++                managed_checkout_identity,
+                 agent_session,
+                 launch_argv,
+             },
+@@ -640,6 +645,7 @@ mod tests {
+                 label: None,
+                 agent_name: None,
+                 managed_agent_kind: None,
++                managed_checkout_identity: None,
+                 agent_session: None,
+                 launch_argv: None,
+             },
+@@ -651,6 +657,7 @@ mod tests {
+                 label: Some("website".into()),
+                 agent_name: None,
+                 managed_agent_kind: None,
++                managed_checkout_identity: None,
+                 agent_session: None,
+                 launch_argv: None,
+             },
+@@ -1204,6 +1211,7 @@ mod tests {
+                 label: None,
+                 agent_name: None,
+                 managed_agent_kind: None,
++                managed_checkout_identity: None,
+                 agent_session: None,
+                 launch_argv: None,
+             },
+@@ -1217,6 +1225,7 @@ mod tests {
+                 label: None,
+                 agent_name: None,
+                 managed_agent_kind: None,
++                managed_checkout_identity: None,
+                 agent_session: None,
+                 launch_argv: None,
+             },
+diff --git a/src/server/handoff.rs b/src/server/handoff.rs
+index 2cd1714..80e5ce4 100644
+--- a/src/server/handoff.rs
++++ b/src/server/handoff.rs
+@@ -44,12 +44,26 @@ pub(crate) struct HandoffManifest {
+     /// Absent from manifests written before this field existed.
+     #[serde(default)]
+     pub api_window_title: Option<String>,
++    /// Lease descriptors are sent in the same order as these entries after
++    /// the pane descriptors. Keeping them separate avoids counting a lease
++    /// against the 64-pane handoff limit.
++    #[serde(default)]
++    pub managed_checkout_leases: Vec<HandoffManagedCheckoutLease>,
++}
++
++#[cfg(unix)]
++#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
++pub(crate) struct HandoffManagedCheckoutLease {
++    pub pane_id: u32,
++    pub repo_key: String,
++    pub checkout_key: String,
+ }
+ 
+ #[cfg(unix)]
+ pub(crate) struct ReceivedHandoff {
+     pub manifest: HandoffManifest,
+     pub fds: Vec<RawFd>,
++    pub lease_fds: Vec<RawFd>,
+     pub stream: UnixStream,
+ }
+ 
+@@ -173,7 +187,11 @@ pub(crate) fn accept_and_validate_on(
+ }
+ 
+ #[cfg(unix)]
+-pub(crate) fn send_fds_and_wait_restored(stream: &mut UnixStream, fds: &[RawFd]) -> io::Result<()> {
++pub(crate) fn send_fds_and_wait_restored(
++    stream: &mut UnixStream,
++    fds: &[RawFd],
++    lease_fds: &[RawFd],
++) -> io::Result<()> {
+     if fds.len() > MAX_FDS_PER_HANDOFF {
+         return Err(io::Error::new(
+             io::ErrorKind::InvalidInput,
+@@ -181,6 +199,7 @@ pub(crate) fn send_fds_and_wait_restored(stream: &mut UnixStream, fds: &[RawFd])
+         ));
+     }
+     send_fds(stream, fds)?;
++    send_fds(stream, lease_fds)?;
+ 
+     stream.set_read_timeout(Some(READY_TIMEOUT))?;
+     let restored = read_line_unbuffered(&mut *stream)?;
+@@ -268,9 +287,11 @@ pub(crate) fn receive(socket_path: &Path, token: &str) -> io::Result<ReceivedHan
+     stream.write_all(b"validated\n")?;
+     stream.flush()?;
+     let fds = recv_fds(&stream, manifest.panes.len())?;
++    let lease_fds = recv_fds(&stream, manifest.managed_checkout_leases.len())?;
+     Ok(ReceivedHandoff {
+         manifest,
+         fds,
++        lease_fds,
+         stream,
+     })
+ }
+@@ -310,6 +331,7 @@ pub(crate) fn manifest_for(
+     expected_protocol: Option<u32>,
+     expected_version: Option<String>,
+     api_window_title: Option<String>,
++    managed_checkout_leases: Vec<HandoffManagedCheckoutLease>,
+ ) -> HandoffManifest {
+     HandoffManifest {
+         version: HANDOFF_VERSION,
+@@ -320,6 +342,7 @@ pub(crate) fn manifest_for(
+         snapshot,
+         panes,
+         api_window_title,
++        managed_checkout_leases,
+     }
+ }
+ 
+@@ -496,6 +519,7 @@ mod tests {
+             None,
+             None,
+             Some("deploying".to_string()),
++            Vec::new(),
+         );
+ 
+         assert_eq!(manifest.api_window_title.as_deref(), Some("deploying"));
+@@ -509,6 +533,7 @@ mod tests {
+             None,
+             None,
+             Some("deploying".to_string()),
++            Vec::new(),
+         );
+         let mut value = serde_json::to_value(&manifest).expect("manifest should serialize");
+         value
+diff --git a/src/server/headless/bootstrap.rs b/src/server/headless/bootstrap.rs
+index 638b1b2..a4f5caf 100644
+--- a/src/server/headless/bootstrap.rs
++++ b/src/server/headless/bootstrap.rs
+@@ -127,6 +127,23 @@ fn run_handoff_import_server(socket_path: &Path, token: &str) -> io::Result<()>
+     let should_quit = Arc::new(AtomicBool::new(false));
+ 
+     let mut imports = HashMap::new();
++    let mut managed_checkout_leases = HashMap::new();
++    for (entry, fd) in received
++        .manifest
++        .managed_checkout_leases
++        .iter()
++        .cloned()
++        .zip(received.lease_fds.drain(..))
++    {
++        managed_checkout_leases.insert(
++            entry.pane_id,
++            crate::handoff_runtime::ImportedManagedCheckoutLease {
++                repo_key: entry.repo_key,
++                checkout_key: entry.checkout_key,
++                fd,
++            },
++        );
++    }
+     for (pane, fd) in received.manifest.panes.into_iter().zip(received.fds) {
+         let pane_id = pane.pane_id;
+         imports.insert(
+@@ -137,7 +154,6 @@ fn run_handoff_import_server(socket_path: &Path, token: &str) -> io::Result<()>
+             },
+         );
+     }
+-
+     let rt = tokio::runtime::Builder::new_multi_thread()
+         .enable_all()
+         .build()
+@@ -151,6 +167,7 @@ fn run_handoff_import_server(socket_path: &Path, token: &str) -> io::Result<()>
+             event_hub.clone(),
+             &received.manifest.snapshot,
+             &mut imports,
++            &mut managed_checkout_leases,
+         )?;
+         crate::server::handoff::report_restored(&mut received.stream)?;
+         if std::env::var("HERDR_TEST_HANDOFF_IMPORT_FAIL").as_deref() == Ok("after_restored") {
+diff --git a/src/server/headless/lifecycle.rs b/src/server/headless/lifecycle.rs
+index ab1448c..277ede8 100644
+--- a/src/server/headless/lifecycle.rs
++++ b/src/server/headless/lifecycle.rs
+@@ -63,6 +63,9 @@ impl HeadlessServer {
+                 ),
+             ));
+         }
++        let managed_checkout_leases = self
++            .app
++            .managed_checkout_leases_for_handoff(&pane_by_terminal)?;
+ 
+         self.handoff_in_progress = true;
+         self.disconnect_all_clients_for_handoff();
+@@ -115,6 +118,7 @@ impl HeadlessServer {
+             params.expected_protocol,
+             params.expected_version,
+             self.api_window_title.clone(),
++            managed_checkout_leases.clone(),
+         );
+         let mut import_child = match crate::server::handoff::spawn_handoff_import(
+             import_exe.as_deref(),
+@@ -131,6 +135,7 @@ impl HeadlessServer {
+         info!(pid = child_pid, socket = %socket_path.display(), "spawned handoff import server");
+ 
+         let mut fds = Vec::new();
++        let mut lease_fds = Vec::new();
+         let duplicate_result = (|| {
+             for (terminal_id, _) in &handoff_entries {
+                 let Some(runtime) = self.app.terminal_runtimes.get(terminal_id) else {
+@@ -138,12 +143,19 @@ impl HeadlessServer {
+                 };
+                 fds.push(runtime.duplicate_handoff_fd()?);
+             }
++            lease_fds = self.app.duplicate_managed_checkout_leases_for_handoff(
++                &pane_by_terminal,
++                &managed_checkout_leases,
++            )?;
+             Ok::<(), io::Error>(())
+         })();
+         if let Err(err) = duplicate_result {
+             for fd in fds {
+                 let _ = unsafe { libc::close(fd) };
+             }
++            for fd in lease_fds {
++                let _ = unsafe { libc::close(fd) };
++            }
+             crate::server::handoff::cleanup_failed_import_child(&mut import_child);
+             self.rollback_handoff_before_commit(&socket_path, &paused_terminal_ids);
+             return Err(err);
+@@ -160,16 +172,23 @@ impl HeadlessServer {
+                 for fd in fds {
+                     let _ = unsafe { libc::close(fd) };
+                 }
++                for fd in lease_fds {
++                    let _ = unsafe { libc::close(fd) };
++                }
+                 crate::server::handoff::cleanup_failed_import_child(&mut import_child);
+                 self.rollback_handoff_before_commit(&socket_path, &paused_terminal_ids);
+                 return Err(err);
+             }
+         };
+ 
+-        let send_result = crate::server::handoff::send_fds_and_wait_restored(&mut stream, &fds);
++        let send_result =
++            crate::server::handoff::send_fds_and_wait_restored(&mut stream, &fds, &lease_fds);
+         for fd in fds {
+             let _ = unsafe { libc::close(fd) };
+         }
++        for fd in lease_fds {
++            let _ = unsafe { libc::close(fd) };
++        }
+         if let Err(err) = send_result {
+             crate::server::handoff::cleanup_failed_import_child(&mut import_child);
+             self.rollback_handoff_before_commit(&socket_path, &paused_terminal_ids);
+diff --git a/src/terminal/state.rs b/src/terminal/state.rs
+index dc28af1..cd607b2 100644
+--- a/src/terminal/state.rs
++++ b/src/terminal/state.rs
+@@ -131,6 +131,9 @@ pub struct TerminalState {
+     pub terminal_title: Option<String>,
+     pub manual_label: Option<String>,
+     pub agent_name: Option<String>,
++    /// Canonical checkout identity admitted for the current managed agent.
++    /// This remains stable if the agent changes its foreground cwd.
++    pub managed_checkout_identity: Option<(String, String)>,
+     agent_name_owner: Option<AgentNameOwner>,
+     managed_agent: Option<ManagedAgent>,
+     managed_agent_launch_session: Option<crate::agent_resume::PersistedAgentSession>,
+@@ -166,6 +169,7 @@ impl TerminalState {
+             terminal_title: None,
+             manual_label: None,
+             agent_name: None,
++            managed_checkout_identity: None,
+             agent_name_owner: None,
+             managed_agent: None,
+             managed_agent_launch_session: None,
+@@ -2068,6 +2072,11 @@ impl TerminalState {
+         self.agent_name = None;
+         self.agent_name_owner = None;
+         self.managed_agent = None;
++        self.managed_checkout_identity = None;
++    }
++
++    pub fn set_managed_checkout_identity(&mut self, repo_key: String, checkout_key: String) {
++        self.managed_checkout_identity = Some((repo_key, checkout_key));
+     }
+ 
+     pub fn clear_agent_runtime_identity_after_respawn(&mut self) {
+

--- a/spec/herdr_worker_admission_test.py
+++ b/spec/herdr_worker_admission_test.py
@@ -270,6 +270,19 @@ class WorkerAdmissionTests(unittest.TestCase):
             with self.subTest(command=command):
                 self.assertEqual(list(admission.starts(command)), [])
 
+    def test_unsupported_reconstructing_shell_forms_are_refused(self):
+        launch = "herdr agent start worker --kind codex --pane w1:p1"
+        for command in (
+            "eval " + repr(launch),
+            "$'herdr' agent start worker --kind codex --pane w1:p1",
+            '$"herdr" agent start worker --kind codex --pane w1:p1',
+        ):
+            with self.subTest(command=command):
+                with self.assertRaisesRegex(
+                    admission.AdmissionError, "cannot be verified"
+                ):
+                    list(admission.starts(command))
+
     def test_env_options_and_assignments_cannot_bypass_or_retarget_admission(self):
         launch = "herdr agent start worker --kind codex --pane w1:p1"
         for prefix in (

--- a/spec/herdr_worker_admission_test.py
+++ b/spec/herdr_worker_admission_test.py
@@ -219,6 +219,42 @@ class WorkerAdmissionTests(unittest.TestCase):
         ):
             self.assertEqual(list(admission.starts(command)), [])
 
+    def test_quoted_words_and_escaped_punctuation_are_inert(self):
+        literal = "herdr"
+        cases = (
+            ('printf "he""rdr"', ["printf", literal]),
+            (f"printf {literal}\\(literal\\)", ["printf", f"{literal}(literal)"]),
+            (f"printf {literal}\\;literal", ["printf", f"{literal};literal"]),
+            (f"printf {literal}\\&literal", ["printf", f"{literal}&literal"]),
+            (f"printf {literal}\\|literal", ["printf", f"{literal}|literal"]),
+            (f"printf '{literal};literal'", ["printf", f"{literal};literal"]),
+        )
+        for command, expected in cases:
+            with self.subTest(command=command):
+                self.assertEqual(list(admission.invocations(command)), [expected])
+                self.assertEqual(list(admission.starts(command)), [])
+
+    def test_shell_continuations_preserve_direct_and_nested_launches(self):
+        continuation = chr(92) + chr(10)
+        launch = "herdr agent start worker --kind codex --pane w1:p1"
+        self.assertEqual(
+            list(admission.starts("herdr agent " + continuation + launch[11:])),
+            [self.args],
+        )
+        self.assertEqual(
+            list(
+                admission.starts(
+                    'bash -c "herdr agent ' + continuation + launch[11:] + '"'
+                )
+            ),
+            [self.args],
+        )
+
+    def test_non_shell_whitespace_does_not_start_a_comment(self):
+        launch = "herdr agent start worker --kind codex --pane w1:p1"
+        command = "printf literal\u00a0#literal; " + launch
+        self.assertEqual(list(admission.starts(command)), [self.args])
+
     def test_env_options_and_assignments_cannot_bypass_or_retarget_admission(self):
         launch = "herdr agent start worker --kind codex --pane w1:p1"
         for prefix in (

--- a/spec/herdr_worker_admission_test.py
+++ b/spec/herdr_worker_admission_test.py
@@ -255,6 +255,21 @@ class WorkerAdmissionTests(unittest.TestCase):
         command = "printf literal\u00a0#literal; " + launch
         self.assertEqual(list(admission.starts(command)), [self.args])
 
+    def test_command_substitutions_are_refused_without_inspection(self):
+        launch = "herdr agent start worker --kind codex --pane w1:p1"
+        for command in (
+            'echo "$(' + launch + ')"',
+            'echo "`' + launch + '`"',
+        ):
+            with self.subTest(command=command):
+                with self.assertRaisesRegex(
+                    admission.AdmissionError, "command substitutions"
+                ):
+                    list(admission.starts(command))
+        for command in ("printf '$(literal)'", "printf '`literal`'"):
+            with self.subTest(command=command):
+                self.assertEqual(list(admission.starts(command)), [])
+
     def test_env_options_and_assignments_cannot_bypass_or_retarget_admission(self):
         launch = "herdr agent start worker --kind codex --pane w1:p1"
         for prefix in (


### PR DESCRIPTION
## Summary

Package the pinned Herdr v0.9.0 structured managed-admission repair through the existing llm-agents overlay. The patch enforces canonical linked-worktree identity and single-writer checkout leases at the native boundary, including lifecycle cleanup, resume, and live-handoff FD ownership. Existing Python hook wiring remains in place pending equivalent runtime proof.

The Linux Herdr service prerequisite is already merged separately in #2680.

## Validation

- Pinned Nix build succeeded and versionCheckHook found `herdr 0.9.0`.
- The native cross-process lease regression passed with different XDG_RUNTIME_DIR values.
- API agent-start smoke and six native agent/schema tests passed.
- Serial CLI agent-start coverage passed 5 of 8 cases; three existing behavior cases remain failing with timeout/expected-status mismatches and are recorded for follow-up.

This PR records validation actually run; no live service activation is performed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Packages the pinned Herdr v0.9.0 structured managed-admission repair through the existing llm-agents overlay, enforcing canonical linked-worktree identity and single-writer checkout leases at the native boundary. It also hardens the worker-admission hook's shell parsing and changes systemd service behavior to preserve live checkouts across switches and handoffs.

**What changed**
- Applies the structured admission patch to the pinned Herdr source, adding lifecycle cleanup, resume validation, and live-handoff FD ownership for checkout leases.
- Updates the Python admission hook to parse quoted and escaped arguments correctly and refuse command substitutions, `eval`, and other unverifiable shell forms.
- Sets `X-SwitchMethod = "keep-old"` and `ExitType = "cgroup"` for Herdr services on kamino and kyber so checkouts survive service switches and handoffs.

**Validation**
- Pinned Nix build succeeds and versionCheckHook finds herdr 0.9.0.
- Cross-process lease regression passes with different `XDG_RUNTIME_DIR` values.
- API agent-start smoke and six native agent/schema tests pass.
- Serial CLI agent-start passes 5 of 8 cases; three existing failures are recorded for follow-up.

<sup>Written for commit 3935233803c4ddb0133e1ba1ed0d6b948cf797a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

