### PR TITLE
fix(dcg): Fail closed when guard is unavailable

### DIFF
--- a/config/copilot/config.json
+++ b/config/copilot/config.json
@@ -10,7 +10,7 @@
       },
       {
         "type": "command",
-        "command": "command -v dcg >/dev/null 2>&1 && dcg",
+        "command": "$HOME/dotfiles/config/shared/hooks/dcg-guard.sh",
         "timeout": 5
       },
       {

--- a/config/shared/hooks/dcg-guard.sh
+++ b/config/shared/hooks/dcg-guard.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Fail closed when the destructive command guard is unavailable or cannot
+# complete normally. Hook runners only treat exit status 2 as a hard refusal.
+
+set -u
+
+dcg_bin="$(type -P dcg 2>/dev/null || true)"
+if [[ -z $dcg_bin || ! -x $dcg_bin ]]; then
+  printf '%s\n' \
+    'BLOCKED by dcg-guard.sh: dcg is unavailable; refusing to run an unguarded shell command' \
+    >&2
+  exit 2
+fi
+
+DCG_FAIL_CLOSED=1 "$dcg_bin"
+dcg_status=$?
+
+case "$dcg_status" in
+0 | 2) exit "$dcg_status" ;;
+*)
+  printf 'BLOCKED by dcg-guard.sh: dcg failed with status %s; refusing to run an unguarded shell command\n' \
+    "$dcg_status" >&2
+  exit 2
+  ;;
+esac

--- a/generated/hooks/moshi/claude/settings.json
+++ b/generated/hooks/moshi/claude/settings.json
@@ -216,7 +216,7 @@
       {
         "hooks": [
           {
-            "command": "dcg",
+            "command": "$HOME/dotfiles/config/shared/hooks/dcg-guard.sh",
             "type": "command"
           }
         ],
@@ -230,7 +230,7 @@
             "type": "command"
           },
           {
-            "command": "command -v dcg \u003e/dev/null 2\u003e\u00261 \u0026\u0026 dcg",
+            "command": "$HOME/dotfiles/config/shared/hooks/dcg-guard.sh",
             "timeout": 5,
             "type": "command"
           },
@@ -292,7 +292,7 @@
       {
         "hooks": [
           {
-            "command": "command -v dcg \u003e/dev/null 2\u003e\u00261 \u0026\u0026 dcg",
+            "command": "$HOME/dotfiles/config/shared/hooks/dcg-guard.sh",
             "timeout": 5,
             "type": "command"
           }

--- a/generated/hooks/moshi/codex/hooks.json
+++ b/generated/hooks/moshi/codex/hooks.json
@@ -76,7 +76,7 @@
             "type": "command"
           },
           {
-            "command": "command -v dcg \u003e/dev/null 2\u003e\u00261 \u0026\u0026 dcg",
+            "command": "$HOME/dotfiles/config/shared/hooks/dcg-guard.sh",
             "timeout": 5,
             "type": "command"
           },

--- a/scripts/update-moshi-hooks.sh
+++ b/scripts/update-moshi-hooks.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016 # The generated hook command must contain literal $HOME.
 # Sync moshi-hook generated files into tracked dotfiles.
 # Runs `moshi-hook install` to ensure all agents are current,
 # then copies the generated TypeScript plugins back into the repo.
@@ -8,6 +9,62 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 GENERATED_ROOT="${GENERATED_ROOT:-$REPO_ROOT/generated/hooks/moshi}"
+
+normalize_dcg_hooks() {
+  local hook_config tmp_file
+
+  for hook_config in "$@"; do
+    if [[ ! -f $hook_config ]]; then
+      echo "error: hook config not found: $hook_config" >&2
+      return 1
+    fi
+
+    tmp_file="$(mktemp "${hook_config}.tmp.XXXXXX")"
+    if ! sed \
+      -e 's|"command": "dcg"|"command": "$HOME/dotfiles/config/shared/hooks/dcg-guard.sh"|g' \
+      -e 's|"command": "[^"[:space:]]*/dcg"|"command": "$HOME/dotfiles/config/shared/hooks/dcg-guard.sh"|g' \
+      -e 's|"command": "command -v dcg >/dev/null 2>&1 && dcg"|"command": "$HOME/dotfiles/config/shared/hooks/dcg-guard.sh"|g' \
+      -e 's|"command": "command -v dcg \\u003e/dev/null 2\\u003e\\u00261 \\u0026\\u0026 dcg"|"command": "$HOME/dotfiles/config/shared/hooks/dcg-guard.sh"|g' \
+      "$hook_config" >"$tmp_file"; then
+      rm -f "$tmp_file"
+      return 1
+    fi
+
+    if ! jq empty "$tmp_file"; then
+      echo "error: dcg hook normalization produced invalid JSON: $hook_config" >&2
+      rm -f "$tmp_file"
+      return 1
+    fi
+
+    if jq -e '
+      .. | objects | .command? // empty
+      | select(
+          . == "command -v dcg >/dev/null 2>&1 && dcg"
+          or test("(^|/)dcg$")
+        )
+    ' "$tmp_file" >/dev/null; then
+      echo "error: unguarded dcg hook remains in $hook_config" >&2
+      rm -f "$tmp_file"
+      return 1
+    fi
+    mv -f "$tmp_file" "$hook_config"
+  done
+}
+
+if [[ ${1:-} == "--normalize-only" ]]; then
+  shift
+  if (( $# == 0 )); then
+    echo "error: --normalize-only requires at least one hook config" >&2
+    exit 1
+  fi
+  normalize_dcg_hooks "$@"
+  exit 0
+fi
+
+if (( $# != 0 )); then
+  echo "usage: $0 [--normalize-only HOOK_CONFIG ...]" >&2
+  exit 1
+fi
 
 echo "Installing latest moshi-hook configs..."
 moshi-hook install
@@ -56,6 +113,17 @@ for generated_file in \
     "$generated_file" >"$generated_file.tmp"
   mv -f "$generated_file.tmp" "$generated_file"
 done
+
+# dcg's installer may emit a resolved path, a bare invocation, or a conditional
+# lookup. Route all three through the tracked fail-closed wrapper after the
+# portability pass so missing installations cannot degrade shell execution to
+# an unguarded, non-blocking hook failure.
+normalize_dcg_hooks \
+  "$GENERATED_ROOT/claude/settings.json" \
+  "$GENERATED_ROOT/codex/hooks.json" \
+  "$GENERATED_ROOT/cursor/hooks.json" \
+  "$GENERATED_ROOT/gemini/settings.json" \
+  "$GENERATED_ROOT/grok/plugin/hooks/hooks.json"
 
 echo "Formatting..."
 nix fmt -- \

--- a/spec/activate_config_spec.sh
+++ b/spec/activate_config_spec.sh
@@ -181,7 +181,7 @@ End
 
 It 'registers dcg in the Bash pre-tool hook chain'
 When run jq -r '.hooks.PreToolUse[] | select(.matcher == "Bash") | .hooks[].command' "$HOOKS_JSON"
-The output should include 'command -v dcg >/dev/null 2>&1 && dcg'
+The output should include '$HOME/dotfiles/config/shared/hooks/dcg-guard.sh'
 End
 End
 
@@ -218,7 +218,7 @@ End
 
 It 'registers dcg in the pre-tool hook chain'
 When run jq -r '.hooks.preToolUse[].command' "$CONFIG_JSON"
-The output should include 'command -v dcg >/dev/null 2>&1 && dcg'
+The output should include '$HOME/dotfiles/config/shared/hooks/dcg-guard.sh'
 End
 
 It 'registers rtk rewrite in the pre-tool hook chain'
@@ -252,7 +252,7 @@ JSON
 When run bash -c 'HOME="$1" bash "$2" "$3" && jq -r ".disableAllHooks, (.hooks.preToolUse[].command)" "$1/.copilot/config.json"' _ "$TMP_HOME" "$SCRIPT" "$CONFIG_JSON"
 The status should be success
 The output should include 'false'
-The output should include 'command -v dcg >/dev/null 2>&1 && dcg'
+The output should include '$HOME/dotfiles/config/shared/hooks/dcg-guard.sh'
 End
 End
 

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -17,6 +17,10 @@ It 'has spec file for config/shared/hooks/rtk-rewrite.sh'
 The path "spec/rtk_rewrite_spec.sh" should be exist
 End
 
+It 'has spec file for config/shared/hooks/dcg-guard.sh'
+The path "spec/dcg_guard_spec.sh" should be exist
+End
+
 It 'has spec file for config/factory/activate-settings.sh'
 The path "spec/roborev_hooks_spec.sh" should be exist
 End
@@ -528,6 +532,7 @@ config/codex/hooks/notify.sh
 config/codex/hooks/pushover.sh
 config/shared/hooks/block-gh-settings.sh
 config/shared/hooks/block-git-push.sh
+config/shared/hooks/dcg-guard.sh
 config/shared/hooks/traces-agent-hook.sh
 config/shared/hooks/secret-guard.sh
 config/shared/hooks/security.sh

--- a/spec/dcg_guard_spec.sh
+++ b/spec/dcg_guard_spec.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016,SC2329
+
+Describe 'shared hooks/dcg-guard.sh'
+SCRIPT="$PWD/config/shared/hooks/dcg-guard.sh"
+BASH_BIN="$(command -v bash)"
+
+setup() {
+  TEMP_DIR="$(mktemp -d)"
+  MOCK_BIN="$TEMP_DIR/bin"
+  mkdir -p "$MOCK_BIN"
+}
+
+cleanup() {
+  rm -rf "$TEMP_DIR"
+}
+
+BeforeEach 'setup'
+AfterEach 'cleanup'
+
+It 'blocks when dcg is missing'
+When run env -i PATH="$MOCK_BIN" "$BASH_BIN" --noprofile --norc "$SCRIPT"
+The status should eq 2
+The stderr should include 'BLOCKED by dcg-guard.sh: dcg is unavailable'
+End
+
+It 'blocks when dcg is present but not executable'
+printf '%s\n' '#!/bin/sh' 'exit 0' >"$MOCK_BIN/dcg"
+chmod 644 "$MOCK_BIN/dcg"
+When run env -i PATH="$MOCK_BIN" "$BASH_BIN" --noprofile --norc "$SCRIPT"
+The status should eq 2
+The stderr should include 'BLOCKED by dcg-guard.sh: dcg is unavailable'
+End
+
+It 'preserves successful dcg output and enables fail-closed parsing'
+cat >"$MOCK_BIN/dcg" <<'SH'
+#!/bin/sh
+IFS= read -r input || true
+printf 'fail_closed=%s input=%s\n' "${DCG_FAIL_CLOSED:-}" "$input"
+SH
+chmod 755 "$MOCK_BIN/dcg"
+Data '{"tool_name":"Bash","tool_input":{"command":"git status"}}'
+When run env -i PATH="$MOCK_BIN:/usr/bin:/bin" "$BASH_BIN" --noprofile --norc "$SCRIPT"
+The status should be success
+The output should eq 'fail_closed=1 input={"tool_name":"Bash","tool_input":{"command":"git status"}}'
+End
+
+It 'preserves an intentional dcg block'
+cat >"$MOCK_BIN/dcg" <<'SH'
+#!/bin/sh
+echo 'blocked by mock dcg' >&2
+exit 2
+SH
+chmod 755 "$MOCK_BIN/dcg"
+When run env -i PATH="$MOCK_BIN:/usr/bin:/bin" "$BASH_BIN" --noprofile --norc "$SCRIPT"
+The status should eq 2
+The stderr should include 'blocked by mock dcg'
+The stderr should not include 'dcg failed with status'
+End
+
+It 'maps an abnormal dcg failure to a hard refusal'
+cat >"$MOCK_BIN/dcg" <<'SH'
+#!/bin/sh
+exit 1
+SH
+chmod 755 "$MOCK_BIN/dcg"
+When run env -i PATH="$MOCK_BIN:/usr/bin:/bin" "$BASH_BIN" --noprofile --norc "$SCRIPT"
+The status should eq 2
+The stderr should include 'dcg failed with status 1'
+End
+
+It 'routes every tracked dcg hook through the wrapper'
+When run bash -c '
+  commands="$(
+  for config in \
+    generated/hooks/moshi/claude/settings.json \
+    generated/hooks/moshi/codex/hooks.json \
+    config/copilot/config.json; do
+    jq -r ".. | objects | .command? // empty" "$config"
+  done
+  )"
+  grep -Fqx "dcg" <<<"$commands" && exit 1
+  grep -Fqx "command -v dcg >/dev/null 2>&1 && dcg" <<<"$commands" && exit 1
+  printf "%s\n" "$commands"
+'
+The status should be success
+The output should include '$HOME/dotfiles/config/shared/hooks/dcg-guard.sh'
+End
+
+End

--- a/spec/update_moshi_hooks_spec.sh
+++ b/spec/update_moshi_hooks_spec.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2329,SC2034
+# shellcheck disable=SC2016,SC2329,SC2034
 
 Describe 'update-moshi-hooks.sh'
 SCRIPT="$PWD/scripts/update-moshi-hooks.sh"
@@ -35,6 +35,30 @@ It 'runs nix fmt for formatting'
 When run bash -c "grep 'nix fmt' '$SCRIPT'"
 The output should include 'nix fmt'
 The status should be success
+End
+
+It 'normalizes dcg hooks through the fail-closed wrapper without installing'
+TEMP_DIR="$(mktemp -d)"
+HOOKS_JSON="$TEMP_DIR/hooks.json"
+cat >"$HOOKS_JSON" <<'JSON'
+{
+  "hooks": [
+    { "command": "dcg" },
+    { "command": "/nix/store/example-dcg/bin/dcg" },
+    { "command": "command -v dcg >/dev/null 2>&1 && dcg" },
+    { "command": "command -v dcg \u003e/dev/null 2\u003e\u00261 \u0026\u0026 dcg" },
+    { "command": "unrelated-hook" }
+  ]
+}
+JSON
+When run bash -c 'bash "$1" --normalize-only "$2" && jq -r ".hooks[].command" "$2"' _ "$SCRIPT" "$HOOKS_JSON"
+The status should be success
+The output should eq '$HOME/dotfiles/config/shared/hooks/dcg-guard.sh
+$HOME/dotfiles/config/shared/hooks/dcg-guard.sh
+$HOME/dotfiles/config/shared/hooks/dcg-guard.sh
+$HOME/dotfiles/config/shared/hooks/dcg-guard.sh
+unrelated-hook'
+rm -rf "$TEMP_DIR"
 End
 End
 


### PR DESCRIPTION
## Summary

- route existing Claude, Codex, and Copilot DCG hooks through a shared fail-closed wrapper
- refuse shell execution with status 2 when DCG is missing, non-executable, or exits abnormally
- preserve normal allow/deny output and enable DCG's malformed-input fail-closed mode
- normalize generated bare, conditional, and absolute DCG commands so regeneration keeps the guard

## Validation

- `shellspec spec/dcg_guard_spec.sh spec/update_moshi_hooks_spec.sh spec/activate_config_spec.sh spec/coverage_spec.sh` (192 examples, 0 failures)
- `make shell-check`
- JSON validation for every touched hook configuration
- real installed-DCG safe-command smoke test

The repository-wide ShellSpec run still has unrelated environment-sensitive failures. Representative auto-switch, RTK rewrite, and traces hook failures reproduce unchanged from a clean `origin/main` archive.

No Home Manager activation, host provisioning, or runtime hook change was performed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Claude, Codex, and Copilot DCG hooks through a shared fail-closed wrapper so shell execution is refused when `dcg` is missing, non-executable, or exits abnormally.

- Preserves normal allow/deny output and enables `DCG_FAIL_CLOSED=1` for malformed-input blocks.
- `scripts/update-moshi-hooks.sh` normalizes bare, conditional, and absolute DCG commands so regeneration keeps the guard.

<sup>Written for commit ba968474036d40b817c3f3db481cc249dfd6a3d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

