### PR TITLE
feat(models): bump deepseek-flash to deepseek-v4.1-flash

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -28,7 +28,7 @@ Never hand-edit a generated config. Edit the `.tpl.*` file, regenerate, and comm
 | `__GPT_LUNA__` | `gpt-5.6-luna` |
 | `__GPT_IMAGE__` | `gpt-image-2` |
 | `__GEMINI_FLASH__` | `gemini-3.8-flash` |
-| `__DEEPSEEK_FLASH__` | `deepseek-v4-flash` |
+| `__DEEPSEEK_FLASH__` | `deepseek-v4.1-flash` |
 | `__GEMMA_LOCAL__` | `gemma3:4b` |
 | `__MINIMAX__` | `minimax-m3` |
 | `__KIMI__` | `kimi-k3` |
@@ -38,7 +38,7 @@ Never hand-edit a generated config. Edit the `.tpl.*` file, regenerate, and comm
 
 This table is the complete set of keys in [models.json](models.json). Every key
 also gets two derived forms: `__<KEY>_PRETTY__` for the display name
-("Deepseek V4 Flash") and `__<KEY>_NONDOT__` for the dot-stripped ID, used in
+("Deepseek V4.1 Flash") and `__<KEY>_NONDOT__` for the dot-stripped ID, used in
 OpenRouter `@preset/` names.
 
 Provider-specific slugs remain separate even when they represent the same model
@@ -52,20 +52,20 @@ because the upstream ID differs from the canonical one:
 | Placeholder | Value | Used by |
 | --- | --- | --- |
 | `__GPT_IMAGE_OPENROUTER__` | `openai/gpt-5.4-image-2` | OpenRouter, aliased back to `gpt-image-2` |
-| `__DEEPSEEK_FLASH_0731__` | `deepseek-v4-flash-0731` | Aliyun, aliased back to `deepseek-v4-flash` |
+| `__DEEPSEEK_FLASH_0731__` | `deepseek-v4-flash-0731` | Aliyun, aliased back to `deepseek-v4.1-flash` |
 
 ## The shared fallback chain
 
 Harnesses that support runtime fallback use one chain, in this order:
 
 ```
-deepseek-v4-flash  (primary)
+deepseek-v4.1-flash  (primary)
   -> free           (OpenRouter free router, last resort)
 ```
 
 Rules:
 
-- `deepseek-v4-flash` is the only DeepSeek model on any automatic path.
+- `deepseek-v4.1-flash` is the only DeepSeek model on any automatic path.
 - Every hop resolves through CLIProxy, so provider-level rotation (OpenCode ->
   Aliyun -> OpenRouter) already happens inside a single hop. Do not add a hop
   that repeats the primary model.
@@ -78,10 +78,10 @@ Rules:
 
 | Harness | Default | Fallback chain | Config |
 | --- | --- | --- | --- |
-| OpenCode | `shunkakinoki/deepseek-v4-flash` | shared chain, `shunkakinoki/` prefix | [opencode-fallback.tpl.jsonc](config/opencode/opencode-fallback.tpl.jsonc) |
-| OpenClaw | `cliproxy/deepseek-v4-flash` | shared chain, `cliproxy/` prefix | [openclaw.tpl.json](config/openclaw/openclaw.tpl.json) |
-| Hermes | `cliproxy/deepseek-v4-flash` | shared chain via `fallback_providers` | [config.tpl.yaml](config/hermes/config.tpl.yaml) |
-| OMP | `cliproxyapi/deepseek-v4-flash` | shared chain, `cliproxyapi/` prefix | [config.tpl.yml](config/omp/config.tpl.yml) |
+| OpenCode | `shunkakinoki/deepseek-v4.1-flash` | shared chain, `shunkakinoki/` prefix | [opencode-fallback.tpl.jsonc](config/opencode/opencode-fallback.tpl.jsonc) |
+| OpenClaw | `cliproxy/deepseek-v4.1-flash` | shared chain, `cliproxy/` prefix | [openclaw.tpl.json](config/openclaw/openclaw.tpl.json) |
+| Hermes | `cliproxy/deepseek-v4.1-flash` | shared chain via `fallback_providers` | [config.tpl.yaml](config/hermes/config.tpl.yaml) |
+| OMP | `cliproxyapi/deepseek-v4.1-flash` | shared chain, `cliproxyapi/` prefix | [config.tpl.yml](config/omp/config.tpl.yml) |
 
 OpenCode fallback is driven by the `opencode-runtime-fallback@0.2.3` plugin:
 
@@ -98,34 +98,34 @@ on the `unknown provider for model <prefixed-name>` 400 that OpenCode absorbs.
 OMP uses native `retry.fallbackChains` instead of a plugin.
 
 Hermes also runs a Mixture-of-Agents preset: reference models
-`deepseek-v4-flash` + `minimax-m3`, aggregator `deepseek-v4-flash`.
+`deepseek-v4.1-flash` + `minimax-m3`, aggregator `deepseek-v4.1-flash`.
 
 ### No fallback chain
 
 | Harness | Role | Model | Config |
 | --- | --- | --- | --- |
-| OpenCode | `small_model` | `shunkakinoki/deepseek-v4-flash` | [opencode.tpl.jsonc](config/opencode/opencode.tpl.jsonc) |
-| OpenCode | `code-reviewer` agent | `shunkakinoki/deepseek-v4-flash` | [opencode.tpl.jsonc](config/opencode/opencode.tpl.jsonc) |
+| OpenCode | `small_model` | `shunkakinoki/deepseek-v4.1-flash` | [opencode.tpl.jsonc](config/opencode/opencode.tpl.jsonc) |
+| OpenCode | `code-reviewer` agent | `shunkakinoki/deepseek-v4.1-flash` | [opencode.tpl.jsonc](config/opencode/opencode.tpl.jsonc) |
 | OMP | `smol`, `commit`, `task` | `cliproxyapi/free` | [config.tpl.yml](config/omp/config.tpl.yml) |
-| OMP | `slow`, `vision`, `plan` | `cliproxyapi/deepseek-v4-flash` | |
+| OMP | `slow`, `vision`, `plan` | `cliproxyapi/deepseek-v4.1-flash` | |
 | Codex | default | `gpt-5.6-sol` | [config.tpl.toml](config/codex/config.tpl.toml) |
 | Codex | subagents | `gpt-5.6-luna` | |
 | Codex | `qwen-local` profile | `qwen3.5-0.8b-optiq` (LM Studio) | |
 | Antigravity | default | `gemini-3.8-flash` (native Antigravity provider) | [settings.tpl.json](config/antigravity/settings.tpl.json) |
 | Pi | `defaultModel` | `free` (provider `cliproxyapi`) | [settings.tpl.json](config/pi/settings.tpl.json) |
 | Factory (droid) | session default | `deepseek-v4-flash-0731` (Droid Core) | [settings.tpl.json](config/factory/settings.tpl.json) |
-| Factory (droid) | custom models | `custom:deepseek-v4-flash-0`, `custom:free-1` via `https://cliproxy.shunkakinoki.com/v1` | [settings.tpl.json](config/factory/settings.tpl.json) |
-| aichat | default | `cliproxy:deepseek-v4-flash` | [config.tpl.yaml](config/aichat/config.tpl.yaml) |
-| DSH web | default | `deepseek-v4-flash` via `https://cliproxy.shunkakinoki.com/v1` (native DeepSeek adapter) | [settings.tpl.yaml](config/dsh/settings.tpl.yaml) |
-| llm | default | `deepseek-v4-flash` | [default_model.tpl.txt](config/llm/default_model.tpl.txt) |
-| Handy | transcript post-process | `@preset/deepseek-v4-flash` (OpenRouter) | [settings_store.tpl.json](config/handy/settings_store.tpl.json) |
+| Factory (droid) | custom models | `custom:deepseek-v4.1-flash-0`, `custom:free-1` via `https://cliproxy.shunkakinoki.com/v1` | [settings.tpl.json](config/factory/settings.tpl.json) |
+| aichat | default | `cliproxy:deepseek-v4.1-flash` | [config.tpl.yaml](config/aichat/config.tpl.yaml) |
+| DSH web | default | `deepseek-v4.1-flash` via `https://cliproxy.shunkakinoki.com/v1` (native DeepSeek adapter) | [settings.tpl.yaml](config/dsh/settings.tpl.yaml) |
+| llm | default | `deepseek-v4.1-flash` | [default_model.tpl.txt](config/llm/default_model.tpl.txt) |
+| Handy | transcript post-process | `@preset/deepseek-v4.1-flash` (OpenRouter) | [settings_store.tpl.json](config/handy/settings_store.tpl.json) |
 
 OMP selects only `cliproxyapi/*`. Subagent overrides use
-`deepseek-v4-flash` for the hard-task roles and `free` for the lightweight
+`deepseek-v4.1-flash` for the hard-task roles and `free` for the lightweight
 roles.
 The registry in [models.tpl.yml](config/omp/models.tpl.yml) lists the
 CLIProxy aliases and discovers the rest from remote `/v1/models`.
-OMP fallback uses the shared chain (`deepseek-v4-flash` -> `free`).
+OMP fallback uses the shared chain (`deepseek-v4.1-flash` -> `free`).
 
 ### Fish shortcuts
 
@@ -134,12 +134,12 @@ headless.
 
 | Function | Model |
 | --- | --- |
-| `ocxe`, `ocxeh` | `cliproxyapi/deepseek-v4-flash` |
+| `ocxe`, `ocxeh` | `cliproxyapi/deepseek-v4.1-flash` |
 | `ocxel`, `ocxelh` | `lmstudio/qwen3.5-0.8b-optiq` |
 | `coxe`, `coxeh` | `gpt-5.6-sol` |
 | `coxec`, `coxech` | `gpt-5.6-luna` (`--profile cliproxy`) |
 | `coxel`, `coxelh` | `qwen3.5-0.8b-optiq` (`--oss --local-provider lmstudio`) |
-| `pixe`, `pixeh` | `cliproxyapi/deepseek-v4-flash` |
+| `pixe`, `pixeh` | `cliproxyapi/deepseek-v4.1-flash` |
 | `pixel`, `pixelh` | `lmstudio/qwen3.5-0.8b-optiq` |
 
 ## CLIProxy routing
@@ -161,11 +161,11 @@ Every one of them resolves through
 
 | Provider | Priority | DeepSeek models served |
 | --- | --- | --- |
-| `opencode` | 300 | `deepseek-v4-flash` |
-| `aliyun` | 200 | `deepseek-v4-flash-0731` aliased to `deepseek-v4-flash` |
-| `openrouter` | 100 | `@preset/deepseek-v4-flash` |
+| `opencode` | 300 | `deepseek-v4.1-flash` |
+| `aliyun` | 200 | `deepseek-v4-flash-0731` aliased to `deepseek-v4.1-flash` |
+| `openrouter` | 100 | `@preset/deepseek-v4.1-flash` |
 
-So a single `deepseek-v4-flash` request tries OpenCode Zen, then Aliyun, then
+So a single `deepseek-v4.1-flash` request tries OpenCode Zen, then Aliyun, then
 OpenRouter before the harness-level fallback chain sees a failure.
 
 ## Changing a model

--- a/config/aichat/config.yaml
+++ b/config/aichat/config.yaml
@@ -1,10 +1,10 @@
 # see https://github.com/sigoden/aichat/blob/main/config.example.yaml
-model: cliproxy:deepseek-v4-flash
+model: cliproxy:deepseek-v4.1-flash
 clients:
   - type: openai-compatible
     # Aichat derives CLIPROXY_API_KEY from this client name.
     name: cliproxy
     api_base: https://cliproxy.shunkakinoki.com/v1
     models:
-      - name: deepseek-v4-flash
+      - name: deepseek-v4.1-flash
       - name: gpt-5.6-luna

--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -517,8 +517,8 @@ openai-compatibility:
     models:
       - name: "openai/gpt-5.4-image-2"
         alias: "gpt-image-2"
-      - name: "@preset/deepseek-v4-flash"
-        alias: "deepseek-v4-flash"
+      - name: "@preset/deepseek-v4-1-flash"
+        alias: "deepseek-v4.1-flash"
       - name: "openrouter/free"
         alias: "free"
   - name: "z-ai"
@@ -555,15 +555,15 @@ openai-compatibility:
       - name: "qwen3.6-plus"
         alias: "qwen3.6-plus"
       - name: "deepseek-v4-flash-0731"
-        alias: "deepseek-v4-flash"
+        alias: "deepseek-v4.1-flash"
   - name: "opencode"
     priority: 300
     base-url: "https://opencode.ai/zen/go/v1"
     support-prompt-cache-key: true
     api-key-entries: __OPENCODE_API_KEY_ENTRIES__
     models:
-      - name: "deepseek-v4-flash"
-        alias: "deepseek-v4-flash"
+      - name: "deepseek-v4.1-flash"
+        alias: "deepseek-v4.1-flash"
       - name: "minimax-m3"
         alias: "minimax-m3"
       - name: "kimi-k3"
@@ -576,7 +576,7 @@ openai-compatibility:
       - api-key: "__VERBOO_API_KEY__"
     models:
       - name: "deepseek-v4-flash-0731"
-        alias: "deepseek-v4-flash"
+        alias: "deepseek-v4.1-flash"
   - name: "commandcode"
     priority: 150
     base-url: "https://api.commandcode.ai/provider/v1"
@@ -585,7 +585,7 @@ openai-compatibility:
       - api-key: "__COMMANDCODE_API_KEY__"
     models:
       - name: "deepseek-v4-flash-0731"
-        alias: "deepseek-v4-flash"
+        alias: "deepseek-v4.1-flash"
   - name: "openai"
     base-url: "https://api.openai.com/v1"
     api-key-entries:
@@ -603,7 +603,7 @@ openai-compatibility:
       - name: "gpt-5.6-luna"
         alias: "gpt-5.6-luna"
       - name: "deepseek-v4-flash-0731"
-        alias: "deepseek-v4-flash"
+        alias: "deepseek-v4.1-flash"
 
 # Official OpenAI compatibility provider reference
 # OpenAI compatibility providers

--- a/config/commandcode/settings.json
+++ b/config/commandcode/settings.json
@@ -1,6 +1,6 @@
 {
   "theme": "dark",
-  "model": "deepseek/deepseek-v4-flash",
+  "model": "deepseek/deepseek-v4.1-flash",
   "taste-learning": true,
   "compact-mode": "default"
 }

--- a/config/dsh/settings.yaml
+++ b/config/dsh/settings.yaml
@@ -1,6 +1,6 @@
 agent-default-model:
   provider: deepseek-official
-  model: deepseek-v4-flash
+  model: deepseek-v4.1-flash
 llm-deepseek:
   apiKeyEnv: CLIPROXY_API_KEY
   baseURL: https://cliproxy.shunkakinoki.com/v1

--- a/config/factory/settings.json
+++ b/config/factory/settings.json
@@ -5,12 +5,12 @@
   },
   "customModels": [
     {
-      "model": "deepseek-v4-flash",
-      "id": "custom:deepseek-v4-flash-0",
+      "model": "deepseek-v4.1-flash",
+      "id": "custom:deepseek-v4.1-flash-0",
       "index": 0,
       "baseUrl": "https://cliproxy.shunkakinoki.com/v1",
       "apiKey": "CLIPROXY_API_KEY",
-      "displayName": "Deepseek V4 Flash",
+      "displayName": "Deepseek V4.1 Flash",
       "maxOutputTokens": 64000,
       "noImageSupport": true,
       "provider": "generic-chat-completion-api"

--- a/config/handy/settings_store.template.json
+++ b/config/handy/settings_store.template.json
@@ -69,7 +69,7 @@
       "custom": "",
       "groq": "",
       "openai": "",
-      "openrouter": "@preset/deepseek-v4-flash",
+      "openrouter": "@preset/deepseek-v4-1-flash",
       "zai": ""
     },
     "post_process_prompts": [

--- a/config/hermes/config.template.yaml
+++ b/config/hermes/config.template.yaml
@@ -1,5 +1,5 @@
 model:
-  default: deepseek-v4-flash
+  default: deepseek-v4.1-flash
   provider: cliproxy
   base_url: https://cliproxy.shunkakinoki.com/v1
   api_key: __CLIPROXY_API_KEY__
@@ -18,14 +18,14 @@ moa:
     default:
       reference_models:
         - provider: cliproxy
-          model: deepseek-v4-flash
+          model: deepseek-v4.1-flash
           enabled: true
         - provider: cliproxy
           model: minimax-m3
           enabled: true
       aggregator:
         provider: cliproxy
-        model: deepseek-v4-flash
+        model: deepseek-v4.1-flash
 credential_pool_strategies: {}
 toolsets:
   - hermes-cli
@@ -241,7 +241,7 @@ memory:
   user_char_limit: 1375
   provider: ''
 delegation:
-  model: deepseek-v4-flash
+  model: deepseek-v4.1-flash
   provider: cliproxy
   base_url: ''
   api_key: ''

--- a/config/llm/default_model.txt
+++ b/config/llm/default_model.txt
@@ -1,1 +1,1 @@
-deepseek-v4-flash
+deepseek-v4.1-flash

--- a/config/llm/extra-openai-models.yaml
+++ b/config/llm/extra-openai-models.yaml
@@ -12,7 +12,7 @@
   api_base: https://cliproxy.shunkakinoki.com/v1
   api_key_name: cliproxyapi
 - model_id: deepseek-flash
-  model_name: deepseek-v4-flash
+  model_name: deepseek-v4.1-flash
   api_base: https://cliproxy.shunkakinoki.com/v1
   api_key_name: cliproxyapi
 - model_id: gpt-luna

--- a/config/omp/config.yml
+++ b/config/omp/config.yml
@@ -63,16 +63,16 @@ disabledExtensions: []
 # Examples:
 #   default: cliproxyapi/free
 #   fast:    cliproxyapi/free
-#   slow:    cliproxyapi/deepseek-v4-flash
+#   slow:    cliproxyapi/deepseek-v4.1-flash
 modelRoles:
   # Default model role used as the fallback when no other role is selected.
   default: "cliproxyapi/free"
   # Smaller / dumber model for cheap lightweight work.
   smol: "cliproxyapi/free"
   # Strongest model in the suite for hard tasks.
-  slow: "cliproxyapi/deepseek-v4-flash"
+  slow: "cliproxyapi/deepseek-v4.1-flash"
   # Keep vision on the main default model.
-  vision: "cliproxyapi/deepseek-v4-flash"
+  vision: "cliproxyapi/deepseek-v4.1-flash"
   # Planning / architecture model.
   plan: "cliproxyapi/free"
   # Commit message model.
@@ -316,7 +316,7 @@ retry:
   #   them. Do not put a role on the last hop.
   fallbackChains:
     default:
-      - "cliproxyapi/deepseek-v4-flash"
+      - "cliproxyapi/deepseek-v4.1-flash"
       - "cliproxyapi/free"
   # fallbackRevertPolicy
 
@@ -495,9 +495,9 @@ task:
   maxRecursionDepth: 2
   disabledAgents: []
   agentModelOverrides:
-    code-architect: "deepseek-v4-flash"
+    code-architect: "deepseek-v4.1-flash"
     code-explorer: "free"
-    code-reviewer: "deepseek-v4-flash"
+    code-reviewer: "deepseek-v4.1-flash"
     code-simplifier: "free"
     comment-analyzer: "free"
     pr-test-analyzer: "free"

--- a/config/omp/models.yml
+++ b/config/omp/models.yml
@@ -7,8 +7,8 @@ providers:
     discovery:
       type: openai-models-list
     models:
-      - id: deepseek-v4-flash
-        name: Deepseek V4 Flash (via shunkakinoki's CLIProxy)
+      - id: deepseek-v4.1-flash
+        name: Deepseek V4.1 Flash (via shunkakinoki's CLIProxy)
         reasoning: true
         input:
           - text

--- a/config/openclaw/openclaw.template.json
+++ b/config/openclaw/openclaw.template.json
@@ -116,8 +116,8 @@
             "maxTokens": 40960
           },
           {
-            "id": "deepseek-v4-flash",
-            "name": "Deepseek V4 Flash",
+            "id": "deepseek-v4.1-flash",
+            "name": "Deepseek V4.1 Flash",
             "reasoning": true,
             "input": [
               "text"
@@ -204,7 +204,7 @@
       "model": {
         "primary": "openai/gpt-5.6-luna",
         "fallbacks": [
-          "cliproxy/deepseek-v4-flash",
+          "cliproxy/deepseek-v4.1-flash",
           "cliproxy/free"
         ]
       },

--- a/config/opencode/opencode.jsonc
+++ b/config/opencode/opencode.jsonc
@@ -1,12 +1,12 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "shunkakinoki/deepseek-v4-flash",
-  "small_model": "shunkakinoki/deepseek-v4-flash",
+  "model": "shunkakinoki/deepseek-v4.1-flash",
+  "small_model": "shunkakinoki/deepseek-v4.1-flash",
   "autoupdate": true,
   "agent": {
     "code-reviewer": {
       "description": "Reviews code for best practices and potential issues",
-      "model": "shunkakinoki/deepseek-v4-flash",
+      "model": "shunkakinoki/deepseek-v4.1-flash",
       "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
       "tools": {
         // Disable file modification tools for review-only agent
@@ -40,8 +40,8 @@
         "gemini-3.8-flash": {
           "name": "Gemini 3.8 Flash (via shunkakinoki's CLIProxy)"
         },
-        "deepseek-v4-flash": {
-          "name": "Deepseek V4 Flash (via shunkakinoki's CLIProxy)"
+        "deepseek-v4.1-flash": {
+          "name": "Deepseek V4.1 Flash (via shunkakinoki's CLIProxy)"
         },
         "gpt-5.6-luna": {
           "name": "GPT 5.6 Luna (via shunkakinoki's CLIProxy)"
@@ -81,8 +81,8 @@
         "gemini-3.8-flash": {
           "name": "Gemini 3.8 Flash (via local CLIProxyAPI)"
         },
-        "deepseek-v4-flash": {
-          "name": "Deepseek V4 Flash (via local CLIProxyAPI)"
+        "deepseek-v4.1-flash": {
+          "name": "Deepseek V4.1 Flash (via local CLIProxyAPI)"
         },
         "gpt-5.6-luna": {
           "name": "GPT 5.6 Luna (via local CLIProxyAPI)"

--- a/config/pi/fallback.ts
+++ b/config/pi/fallback.ts
@@ -103,7 +103,7 @@ export function loadFallbackConfig(path: string): FallbackConfig {
   }
 }
 
-/** Model ids may contain slashes (cliproxyapi/deepseek-v4-flash), so split once. */
+/** Model ids may contain slashes (cliproxyapi/deepseek-v4.1-flash), so split once. */
 export function splitModelRef(ref: string): { provider: string; id: string } {
   const index = ref.indexOf("/");
   return index === -1

--- a/home-manager/programs/fish/functions/_ocxe_function.fish
+++ b/home-manager/programs/fish/functions/_ocxe_function.fish
@@ -4,14 +4,14 @@ function _ocxe_function --description "Run OpenCode with a free-form prompt"
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
     if test (count $argv) -gt 1
-      _caam_exec_function opencode -m 'shunkakinoki/deepseek-v4-flash' --session "$argv[2]"
+      _caam_exec_function opencode -m 'shunkakinoki/deepseek-v4.1-flash' --session "$argv[2]"
     else
-      _caam_exec_function opencode -m 'shunkakinoki/deepseek-v4-flash' --continue
+      _caam_exec_function opencode -m 'shunkakinoki/deepseek-v4.1-flash' --continue
     end
   else if test (count $argv) -eq 0
-    _caam_exec_function opencode -m 'shunkakinoki/deepseek-v4-flash'
+    _caam_exec_function opencode -m 'shunkakinoki/deepseek-v4.1-flash'
   else
     set -l prompt (string join " " -- $argv)
-    _caam_exec_function opencode run "$prompt" -m 'shunkakinoki/deepseek-v4-flash'
+    _caam_exec_function opencode run "$prompt" -m 'shunkakinoki/deepseek-v4.1-flash'
   end
 end

--- a/home-manager/programs/fish/functions/_ocxeh_function.fish
+++ b/home-manager/programs/fish/functions/_ocxeh_function.fish
@@ -14,5 +14,5 @@ function _ocxeh_function --description "Run OpenCode headlessly with a prompted 
     return 1
   end
 
-  _caam_exec_function opencode run "$prompt" -m 'shunkakinoki/deepseek-v4-flash'
+  _caam_exec_function opencode run "$prompt" -m 'shunkakinoki/deepseek-v4.1-flash'
 end

--- a/home-manager/programs/fish/functions/_pixe_function.fish
+++ b/home-manager/programs/fish/functions/_pixe_function.fish
@@ -3,11 +3,11 @@ function _pixe_function --description "Run Pi with a free-form prompt"
   # Usage: pixe [<prompt words...>]
 
   if test (count $argv) -gt 0; and contains -- "$argv[1]" --resume -r --continue -c
-    pi --model 'cliproxyapi/deepseek-v4-flash' --resume $argv[2]
+    pi --model 'cliproxyapi/deepseek-v4.1-flash' --resume $argv[2]
   else if test (count $argv) -eq 0
-    pi --model 'cliproxyapi/deepseek-v4-flash'
+    pi --model 'cliproxyapi/deepseek-v4.1-flash'
   else
     set -l prompt (string join " " -- $argv)
-    pi --model 'cliproxyapi/deepseek-v4-flash' "$prompt"
+    pi --model 'cliproxyapi/deepseek-v4.1-flash' "$prompt"
   end
 end

--- a/home-manager/programs/fish/functions/_pixeh_function.fish
+++ b/home-manager/programs/fish/functions/_pixeh_function.fish
@@ -14,5 +14,5 @@ function _pixeh_function --description "Run Pi headlessly with a prompted input"
     return 1
   end
 
-  pi --model 'cliproxyapi/deepseek-v4-flash' -p "$prompt"
+  pi --model 'cliproxyapi/deepseek-v4.1-flash' -p "$prompt"
 end

--- a/models.json
+++ b/models.json
@@ -8,7 +8,7 @@
   "gpt-image": "gpt-image-2",
   "gpt-luna": "gpt-5.6-luna",
   "gemini-flash": "gemini-3.8-flash",
-  "deepseek-flash": "deepseek-v4-flash",
+  "deepseek-flash": "deepseek-v4.1-flash",
   "grok": "grok-4.5",
   "minimax": "minimax-m3",
   "gemma-local": "gemma3:4b",

--- a/scripts/update-moshi-hooks.sh
+++ b/scripts/update-moshi-hooks.sh
@@ -53,7 +53,7 @@ normalize_dcg_hooks() {
 
 if [[ ${1:-} == "--normalize-only" ]]; then
   shift
-  if (( $# == 0 )); then
+  if (($# == 0)); then
     echo "error: --normalize-only requires at least one hook config" >&2
     exit 1
   fi
@@ -61,7 +61,7 @@ if [[ ${1:-} == "--normalize-only" ]]; then
   exit 0
 fi
 
-if (( $# != 0 )); then
+if (($# != 0)); then
   echo "usage: $0 [--normalize-only HOOK_CONFIG ...]" >&2
   exit 1
 fi

--- a/spec/cliproxyapi_spec.sh
+++ b/spec/cliproxyapi_spec.sh
@@ -256,7 +256,7 @@ The output should include 'api-key: "__ALIYUN_TOKEN_PLAN_API_KEY__"'
 The output should include 'priority: 200'
 The output should include 'name: "qwen3.6-plus"'
 The output should include 'name: "deepseek-v4-flash-0731"'
-The output should include 'alias: "deepseek-v4-flash"'
+The output should include 'alias: "deepseek-v4.1-flash"'
 The output should not include 'name: "qwen3.8-max"'
 The output should not include 'name: "glm-5.2"'
 The status should be success
@@ -277,7 +277,7 @@ The output should include 'priority: 150'
 The output should include 'base-url: "https://code.verboo.ai/router/v1"'
 The output should include 'api-key: "__VERBOO_API_KEY__"'
 The output should include 'name: "deepseek-v4-flash-0731"'
-The output should include 'alias: "deepseek-v4-flash"'
+The output should include 'alias: "deepseek-v4.1-flash"'
 The status should be success
 End
 End
@@ -296,7 +296,7 @@ The output should include 'priority: 150'
 The output should include 'base-url: "https://api.commandcode.ai/provider/v1"'
 The output should include 'api-key: "__COMMANDCODE_API_KEY__"'
 The output should include 'name: "deepseek-v4-flash-0731"'
-The output should include 'alias: "deepseek-v4-flash"'
+The output should include 'alias: "deepseek-v4.1-flash"'
 The status should be success
 End
 End
@@ -315,7 +315,7 @@ The output should include 'priority: 150'
 The output should include 'base-url: "https://api.surplusintelligence.ai/v1"'
 The output should include 'api-key: "__SURPLUS_API_KEY__"'
 The output should include 'name: "deepseek-v4-flash-0731"'
-The output should include 'alias: "deepseek-v4-flash"'
+The output should include 'alias: "deepseek-v4.1-flash"'
 The status should be success
 End
 End

--- a/spec/dsh_config_spec.sh
+++ b/spec/dsh_config_spec.sh
@@ -5,9 +5,9 @@ PATCH="$PWD/config/dsh/settings.yaml"
 TEMPLATE="$PWD/config/dsh/settings.tpl.yaml"
 
 It 'selects DeepSeek Flash as the web profile default'
-When run grep -E '^  model: deepseek-v4-flash$' "$PATCH"
+When run grep -E '^  model: deepseek-v4.1-flash$' "$PATCH"
 The status should be success
-The output should include 'model: deepseek-v4-flash'
+The output should include 'model: deepseek-v4.1-flash'
 End
 
 It 'routes the native adapter through remote CLIProxy'
@@ -18,7 +18,7 @@ The output should include 'baseURL: https://cliproxy.shunkakinoki.com/v1'
 End
 
 It 'keeps the generated settings aligned with its template'
-When run bash -c "diff -u <(sed 's/__DEEPSEEK_FLASH__/deepseek-v4-flash/g' '$TEMPLATE') '$PATCH'"
+When run bash -c "diff -u <(sed 's/__DEEPSEEK_FLASH__/deepseek-v4.1-flash/g' '$TEMPLATE') '$PATCH'"
 The status should be success
 End
 

--- a/spec/fish/_ocxe_function_test.fish
+++ b/spec/fish/_ocxe_function_test.fish
@@ -8,7 +8,7 @@ function opencode; echo $argv >> $log1; end
 
 _ocxe_function
 
-@test "no args calls opencode with remote CLIProxy model" (grep -c "shunkakinoki/deepseek-v4-flash" $log1) -ge 1
+@test "no args calls opencode with remote CLIProxy model" (grep -c "shunkakinoki/deepseek-v4.1-flash" $log1) -ge 1
 @test "no args skips run subcommand" (grep -c "^run " $log1) -eq 0
 
 # ── with args: run mode ──────────────────────────────────

--- a/spec/fish/_ocxeh_function_test.fish
+++ b/spec/fish/_ocxeh_function_test.fish
@@ -12,6 +12,6 @@ _ocxeh_function hello world
 
 @test "inline args forwards prompt" (grep -c "hello world" $log1) -ge 1
 @test "inline args uses run subcommand" (grep -c "^run " $log1) -ge 1
-@test "inline args uses remote CLIProxy DeepSeek Flash model" (grep -c "shunkakinoki/deepseek-v4-flash" $log1) -ge 1
+@test "inline args uses remote CLIProxy DeepSeek Flash model" (grep -c "shunkakinoki/deepseek-v4.1-flash" $log1) -ge 1
 
 rm -f $log1

--- a/spec/fish/_pixe_function_test.fish
+++ b/spec/fish/_pixe_function_test.fish
@@ -7,7 +7,7 @@ function pi; echo $argv >> $log1; end
 
 _pixe_function
 
-@test "no args calls pi with cliproxyapi model" (grep -c "cliproxyapi/deepseek-v4-flash" $log1) -ge 1
+@test "no args calls pi with cliproxyapi model" (grep -c "cliproxyapi/deepseek-v4.1-flash" $log1) -ge 1
 
 # ── with args: builds prompt ──────────────────────────────
 set log2 (mktemp)
@@ -16,6 +16,6 @@ function pi; echo $argv >> $log2; end
 _pixe_function hello world
 
 @test "with args builds prompt" (grep -c "hello world" $log2) -ge 1
-@test "with args uses cliproxyapi model" (grep -c "cliproxyapi/deepseek-v4-flash" $log2) -ge 1
+@test "with args uses cliproxyapi model" (grep -c "cliproxyapi/deepseek-v4.1-flash" $log2) -ge 1
 
 rm -f $log1 $log2

--- a/spec/fish/_pixeh_function_test.fish
+++ b/spec/fish/_pixeh_function_test.fish
@@ -10,7 +10,7 @@ function pi; echo $argv >> $log1; end
 echo "hello world" | _pixeh_function
 
 @test "non-empty prompt builds prompt" (grep -c "hello world" $log1) -ge 1
-@test "non-empty prompt uses cliproxyapi model" (grep -c "cliproxyapi/deepseek-v4-flash" $log1) -ge 1
+@test "non-empty prompt uses cliproxyapi model" (grep -c "cliproxyapi/deepseek-v4.1-flash" $log1) -ge 1
 @test "non-empty prompt uses print mode" (grep -c -- "-p" $log1) -ge 1
 
 set log2 (mktemp)

--- a/spec/hermes_hydrate_spec.sh
+++ b/spec/hermes_hydrate_spec.sh
@@ -213,7 +213,7 @@ End
 Describe 'declarative model routing'
 It 'uses the Flash, free fallback convention'
 When run bash -c "sed -n '1,20p' '$PWD/config/hermes/config.template.yaml'"
-The output should include 'default: deepseek-v4-flash'
+The output should include 'default: deepseek-v4.1-flash'
 The output should include 'provider: cliproxy'
 The output should include 'model: free'
 End
@@ -256,7 +256,7 @@ End
 It 'hydrates the default Mixture-of-Agents models from the canonical model list'
 When run bash -c "sed -n '/^moa:/,/^credential_pool_strategies:/p' '$PWD/config/hermes/config.template.yaml'"
 The output should include 'provider: cliproxy'
-The output should include 'model: deepseek-v4-flash'
+The output should include 'model: deepseek-v4.1-flash'
 The output should include 'model: minimax-m3'
 The output should not include 'opus'
 End

--- a/spec/llm_update_spec.sh
+++ b/spec/llm_update_spec.sh
@@ -210,8 +210,8 @@ End
 
 Describe 'OpenCode runtime fallback'
 It 'keeps DeepSeek Flash as the explicit default model'
-When run bash -c "grep '\"model\": \"shunkakinoki/deepseek-v4-flash\"' config/opencode/opencode.jsonc"
-The output should include 'shunkakinoki/deepseek-v4-flash'
+When run bash -c "grep '\"model\": \"shunkakinoki/deepseek-v4.1-flash\"' config/opencode/opencode.jsonc"
+The output should include 'shunkakinoki/deepseek-v4.1-flash'
 End
 
 It 'omits unsupported prompt cache keys for both CLIProxy providers'
@@ -220,8 +220,8 @@ The status should be success
 End
 
 It 'uses the DeepSeek Flash alias for the small model'
-When run bash -c "grep '\"small_model\": \"shunkakinoki/deepseek-v4-flash\"' config/opencode/opencode.jsonc"
-The output should include 'shunkakinoki/deepseek-v4-flash'
+When run bash -c "grep '\"small_model\": \"shunkakinoki/deepseek-v4.1-flash\"' config/opencode/opencode.jsonc"
+The output should include 'shunkakinoki/deepseek-v4.1-flash'
 End
 
 It 'pins the audited OpenCode runtime fallback plugin release'
@@ -235,7 +235,7 @@ The status should be success
 End
 
 It 'generates the CLIProxyAPI DeepSeek Flash model'
-When run bash -c "sed -n '/\"cliproxyapi\"/,/\"lmstudio\"/p' config/opencode/opencode.jsonc | grep -q 'deepseek-v4-flash'"
+When run bash -c "sed -n '/\"cliproxyapi\"/,/\"lmstudio\"/p' config/opencode/opencode.jsonc | grep -q 'deepseek-v4.1-flash'"
 The status should be success
 End
 
@@ -262,7 +262,7 @@ End
 
 It 'uses the free-tier CLIProxy fallback chain for OMP'
 When run bash -c "sed -n '/^  fallbackChains:/,/^  fallbackRevertPolicy/p' config/omp/config.yml"
-The output should include 'cliproxyapi/deepseek-v4-flash'
+The output should include 'cliproxyapi/deepseek-v4.1-flash'
 The output should include 'cliproxyapi/free'
 The output should not include 'openai-codex/'
 End
@@ -326,17 +326,17 @@ End
 
 Describe 'CLIProxyAPI routing'
 It 'hydrates the OMP remote CLIProxyAPI catalog without the retired model'
-When run bash -c "grep -q 'baseUrl: https://cliproxy.shunkakinoki.com/v1' config/omp/models.yml && grep -q 'auth: apiKey' config/omp/models.yml && grep -q 'type: openai-models-list' config/omp/models.yml && grep -q 'id: deepseek-v4-flash' config/omp/models.yml && grep -q 'id: free' config/omp/models.yml && ! grep -q 'id: gemma-4-31b-it' config/omp/models.yml && ! grep -q 'id: glm-4.7' config/omp/models.yml && ! grep -q '__DEEPSEEK_FLASH__' config/omp/models.yml"
+When run bash -c "grep -q 'baseUrl: https://cliproxy.shunkakinoki.com/v1' config/omp/models.yml && grep -q 'auth: apiKey' config/omp/models.yml && grep -q 'type: openai-models-list' config/omp/models.yml && grep -q 'id: deepseek-v4.1-flash' config/omp/models.yml && grep -q 'id: free' config/omp/models.yml && ! grep -q 'id: gemma-4-31b-it' config/omp/models.yml && ! grep -q 'id: glm-4.7' config/omp/models.yml && ! grep -q '__DEEPSEEK_FLASH__' config/omp/models.yml"
 The status should be success
 End
 
 It 'generates the DeepSeek Flash route in CliProxy'
-When run bash -c "sed -n '/name: \"opencode\"/,/name: \"openai\"/p' config/cliproxyapi/config.template.yaml | grep -q 'name: \"deepseek-v4-flash\"'"
+When run bash -c "sed -n '/name: \"opencode\"/,/name: \"openai\"/p' config/cliproxyapi/config.template.yaml | grep -q 'name: \"deepseek-v4.1-flash\"'"
 The status should be success
 End
 
 It 'routes the DeepSeek Flash preset through OpenRouter and OpenCode Go in CliProxy'
-When run bash -c "sed -n '/name: \"openrouter\"/,/name: \"z-ai\"/p' config/cliproxyapi/config.template.yaml | grep -q 'name: \"@preset/deepseek-v4-flash\"' && sed -n '/name: \"opencode\"/,/name: \"openai\"/p' config/cliproxyapi/config.template.yaml | grep -q 'name: \"deepseek-v4-flash\"'"
+When run bash -c "sed -n '/name: \"openrouter\"/,/name: \"z-ai\"/p' config/cliproxyapi/config.template.yaml | grep -q 'name: \"@preset/deepseek-v4.1-flash\"' && sed -n '/name: \"opencode\"/,/name: \"openai\"/p' config/cliproxyapi/config.template.yaml | grep -q 'name: \"deepseek-v4.1-flash\"'"
 The status should be success
 End
 
@@ -351,7 +351,7 @@ The status should be success
 End
 
 It 'hydrates the versioned Aliyun DeepSeek model behind the canonical alias'
-When run bash -c "section=\$(sed -n '/name: \"aliyun\"/,/name: \"opencode\"/p' config/cliproxyapi/config.template.yaml); printf '%s\n' \"\$section\" | grep -q 'name: \"deepseek-v4-flash-0731\"' && printf '%s\n' \"\$section\" | grep -q 'alias: \"deepseek-v4-flash\"'"
+When run bash -c "section=\$(sed -n '/name: \"aliyun\"/,/name: \"opencode\"/p' config/cliproxyapi/config.template.yaml); printf '%s\n' \"\$section\" | grep -q 'name: \"deepseek-v4-flash-0731\"' && printf '%s\n' \"\$section\" | grep -q 'alias: \"deepseek-v4.1-flash\"'"
 The status should be success
 End
 

--- a/spec/openclaw_hydrate_spec.sh
+++ b/spec/openclaw_hydrate_spec.sh
@@ -9,15 +9,15 @@ template_uses_cliproxy_flash_default() {
     .agents.defaults.model == {
       "primary": "openai/gpt-5.6-luna",
       "fallbacks": [
-        "cliproxy/deepseek-v4-flash",
+        "cliproxy/deepseek-v4.1-flash",
         "cliproxy/free"
       ]
     } and
-    (.models.providers.cliproxy.models | any(.id == "deepseek-v4-flash")) and
+    (.models.providers.cliproxy.models | any(.id == "deepseek-v4.1-flash")) and
     (.models.providers.cliproxy.models | any(.id == "free")) and
     (.agents.defaults.model.fallbacks[-1] == "cliproxy/free") and
     (.models.providers.cliproxy.models | all(
-      if (.id == "deepseek-v4-flash" or .id == "gpt-5.6-luna")
+      if (.id == "deepseek-v4.1-flash" or .id == "gpt-5.6-luna")
       then .compat.supportsPromptCacheKey == true
       else .compat.supportsPromptCacheKey? != true
       end

--- a/spec/roborev_hooks_spec.sh
+++ b/spec/roborev_hooks_spec.sh
@@ -17,7 +17,7 @@ The output should include 'dotfiles/config/shared/hooks/roborev-agent.sh'
 End
 
 It 'uses Droid Core DeepSeek Flash as the Factory session default'
-When run jq -e '.sessionDefaultSettings.model == "deepseek-v4-flash-0731" and any(.customModels[]; .id == "custom:deepseek-v4-flash-0" and .baseUrl == "https://cliproxy.shunkakinoki.com/v1" and .apiKey == "CLIPROXY_API_KEY") and any(.customModels[]; .id == "custom:gpt-5.6-luna-1" and .model == "gpt-5.6-luna" and .baseUrl == "https://cliproxy.shunkakinoki.com/v1" and .apiKey == "CLIPROXY_API_KEY") and any(.customModels[]; .id == "custom:free-2" and .model == "free" and .baseUrl == "https://cliproxy.shunkakinoki.com/v1" and .apiKey == "CLIPROXY_API_KEY")' "$SETTINGS"
+When run jq -e '.sessionDefaultSettings.model == "deepseek-v4-flash-0731" and any(.customModels[]; .id == "custom:deepseek-v4.1-flash-0" and .baseUrl == "https://cliproxy.shunkakinoki.com/v1" and .apiKey == "CLIPROXY_API_KEY") and any(.customModels[]; .id == "custom:gpt-5.6-luna-1" and .model == "gpt-5.6-luna" and .baseUrl == "https://cliproxy.shunkakinoki.com/v1" and .apiKey == "CLIPROXY_API_KEY") and any(.customModels[]; .id == "custom:free-2" and .model == "free" and .baseUrl == "https://cliproxy.shunkakinoki.com/v1" and .apiKey == "CLIPROXY_API_KEY")' "$SETTINGS"
 The status should be success
 The output should equal 'true'
 End


### PR DESCRIPTION
Points the `deepseek-flash` alias in `models.json` at `deepseek-v4.1-flash` and re-runs `scripts/llm-update.sh` to hydrate every generated config.

Also updated by hand (not template-driven):
- `config/commandcode/settings.json` - hand-maintained, uses the OpenRouter-style `deepseek/deepseek-v4.1-flash` slug
- `config/pi/fallback.ts` - stale model id in a comment
- `MODELS.md` and the shellspec assertions

`__DEEPSEEK_FLASH_0731__` is left at `deepseek-v4-flash-0731`: that is the Aliyun upstream snapshot slug declared in `scripts/llm-update.sh`, not derived from `models.json`. It still aliases back to the canonical id, which is now `deepseek-v4.1-flash`. If Aliyun publishes a v4.1 snapshot that override needs a separate bump.

## Testing

`shellspec` - 13 failures in `spec/t3_connect_spec.sh` and `spec/herdr_worker_admission_spec.sh`, all pre-existing at HEAD (verified against a clean clone). Every model-related suite passes: `llm_update`, `cliproxyapi`, `dsh_config`, `hermes_hydrate`, `openclaw_hydrate`, `roborev_hooks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Points the `deepseek-flash` alias in `models.json` at `deepseek-v4.1-flash` and re-runs the model update script to regenerate every generated config. `__DEEPSEEK_FLASH_0731__` keeps the `deepseek-v4-flash-0731` Aliyun slug, now aliasing back to the new canonical id.

**Notes**

- Hand-updated outside the template flow: `config/commandcode/settings.json`, `config/pi/fallback.ts`, `MODELS.md`, and the shellspec assertions.
- OpenRouter presets use the dot-stripped `@preset/deepseek-v4-1-flash` form.
- The Aliyun override needs a separate bump once Aliyun publishes a v4.1 snapshot.
- `scripts/update-moshi-hooks.sh` was reformatted with shfmt because treefmt rejects the spaced `(( $# == 0 ))` form.
- All model-related specs pass; 13 failures in `spec/t3_connect_spec.sh` and `spec/herdr_worker_admission_spec.sh` are pre-existing at HEAD.

<sup>Written for commit 0452e7e4327a9c4876d7e735604b3e7e55609cf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

