### PR TITLE
fix(herdr): pin shared package to version 0.9.0

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -109,6 +109,26 @@
       # https://github.com/numtide/llm-agents.nix
       llm-agents =
         (prev.llm-agents or { })
+        // {
+          # Keep every managed client and server on the same released protocol.
+          # The upstream recipe retains native Linux/Darwin build dependencies.
+          herdr = prev.llm-agents.herdr.overrideAttrs (
+            finalAttrs: _: {
+              version = "0.9.0";
+              src = prev.fetchFromGitHub {
+                owner = "herdrdev";
+                repo = "herdr";
+                tag = "v${finalAttrs.version}";
+                hash = "sha256-SUYF4bbaYwNgoe498VoCUzuLPcjBLQXR0o0DWjjoSnI=";
+              };
+              cargoDeps = prev.rustPlatform.fetchCargoVendor {
+                inherit (finalAttrs) src;
+                name = "herdr-${finalAttrs.version}-vendor";
+                hash = "sha256-CW/SF/cAPDv47gS5B7XbVZEE6LC9F1a2I1TLTJ4AWdw=";
+              };
+            }
+          );
+        }
         // prev.lib.optionalAttrs (prev.llm-agents ? grok) {
           grok = prev.llm-agents.grok.overrideAttrs (old: {
             doInstallCheck = false;


### PR DESCRIPTION
## Summary

Pin the shared Herdr package to released 0.9.0 so managed clients and servers use the same package version on Linux and macOS. The override keeps the upstream source build, platform dependencies, shell completions and bundled integration assets.

### Tracker linkage

- Linear: none — direct operator request tracked in Beads.
- Bead: df-hji6t

## Validation

- Evaluated the overlay for x86_64/aarch64 Linux and macOS. Intel macOS uses the repository's existing `nixpkgs-darwin-legacy` input because current Nixpkgs dropped that target.
- Built the x86_64 Linux package; its install check and a direct `herdr --version` invocation report `herdr 0.9.0`.
- `nixfmt --check`, Statix and Deadnix pass for the changed overlay.
- Broader `nix flake check --no-build` is blocked by an invalid Docker Postgres wrapper derivation. The same failure reproduces at the pinned base `cb1409e4000a463e0a5736979a06a7f8ba440221`.

This PR is draft for review. Host activation and service restarts are outside this change; other-platform runtime builds remain unproven.
