### PR TITLE
fix(darwin): make Nix the sole Herdr owner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -446,7 +446,7 @@ llm-update: ## Regenerate tool configs from models.json.
 	@echo "✅ LLM configs updated"
 
 .PHONY: overlays-update
-overlays-update: ## Upgrade all custom overlays to latest versions (CI only).
+overlays-update: ## Upgrade all custom overlay versions and fixed hashes (CI only).
 	@if [ "$$CI" != "true" ]; then \
 		echo "⏭️ Skipping overlay upgrade outside CI"; \
 	elif [ "$$IN_DOCKER" = "true" ]; then \

--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -76,7 +76,6 @@
       "grafana"
       "graphviz"
       "helm"
-      "herdr"
       "infracost"
       "jjui"
       "kimi-cli"

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -48,21 +48,20 @@
     inherit (prev.stdenv.hostPlatform) system;
   })
   (_: prev: {
-    # Use the immutable GitHub CLI preview commit that adds --attach to issue and PR
-    # commands. Remove this override once the feature is released in a tagged version.
+    # Use the first tagged release that includes --attach on issue and PR commands.
     gh = prev.gh.overrideAttrs (_: {
       pname = "gh";
-      version = "2.95.0-unstable-20260828";
+      version = "2.100.0";
       src = prev.fetchFromGitHub {
         owner = "cli";
         repo = "cli";
-        rev = "40b742f76d68e6b1f472942a6368db4b5d765641";
-        hash = "sha256-nGquMOwkEZp6ysFJOw5qa1PqQqw7+WLqpPQiziEAPG0=";
+        rev = "45437bc7eeeb3359bbfddd1742f79de7652fd3e2";
+        hash = "sha256-9tnSQPSqllE+Ke6LKyNbnOF1drzdEwesEuPdmWD1X5c=";
       };
-      vendorHash = "sha256-v9h17XD/fyHasgLsHHkGvoV1qITWpwGDJ6MtlvWnN4c=";
+      vendorHash = "sha256-ZqUs2BnasF3QBX0I2Sxh2A/CnO61Vy6gRn1hkf0n9AY=";
       buildPhase = ''
         runHook preBuild
-        make GO_LDFLAGS="-s -w -X github.com/cli/cli/v2/internal/build.Date=nixpkgs" GH_VERSION=2.95.0-unstable-20260828 bin/gh manpages
+        make GO_LDFLAGS="-s -w -X github.com/cli/cli/v2/internal/build.Date=nixpkgs" GH_VERSION=2.100.0 bin/gh manpages
         runHook postBuild
       '';
     });
@@ -127,14 +126,14 @@
           });
         }
         // (
-          # t3code 0.0.33 pins one pnpm deps hash, but fetchPnpmDeps resolves
+          # t3code 0.0.36 pins one pnpm deps hash, but fetchPnpmDeps resolves
           # platform-specific optional packages, so it only reproduces on the
           # system upstream generated it from. Every x86_64-linux build fails on
           # the fixed-output mismatch; other systems keep the upstream hash.
           # https://github.com/numtide/llm-agents.nix
           let
             pnpmDepsHashes = {
-              x86_64-linux = "sha256-i/K5bj7CS7PGIX5hfayxAJ7ngNib92w3SDKGXTVWccA=";
+              x86_64-linux = "sha256-y/sJIluwbn65APmJ2p07FK1ScXpetCloTHtQzZMchDU=";
             };
             hash = pnpmDepsHashes.${prev.stdenv.hostPlatform.system} or null;
             t3code = prev.llm-agents.t3code.overrideAttrs (
@@ -188,16 +187,16 @@
   (_: prev: {
     ascii-box-cli = prev.stdenvNoCC.mkDerivation rec {
       pname = "ascii-box-cli";
-      version = "0.1.208";
+      version = "0.1.228";
       src = prev.fetchurl {
         url = "https://github.com/ariana-dot-dev/agent-server/releases/download/box-cli-v${version}-ascii-prod1/box-${
           if prev.stdenv.hostPlatform.isDarwin then "darwin" else "linux"
         }-${if prev.stdenv.hostPlatform.isAarch64 then "arm64" else "x64"}";
         sha256 =
           {
-            "aarch64-darwin" = "0p85n67mklxfvvh1v6sj047wcskxsagzmg6r0wdd4kibpvgbxdap";
-            "aarch64-linux" = "1nsfky5jilcg2w87k4dlvkg1bki325j1mmf8qp93m8rjg4zq3sm1";
-            "x86_64-linux" = "0jmp1xvzsnxpgakrd69fiqp2fd8rzcr57s80djlzbdgfs3jr2z60";
+            "aarch64-darwin" = "0zhfrncihahnbln400j0n2bqxnra86q64vf4zf1vblyhwl1zwic2";
+            "aarch64-linux" = "0w89dxyq16rdkxkvl88apxxpivq473ap7r5igrhi0km3k238r5bb";
+            "x86_64-linux" = "1c05jp8jnf3qb7viqgd2fzjgdpmjvrw59wgnrx88q1w7k429iwjb";
           }
           .${prev.stdenv.hostPlatform.system};
       };
@@ -210,20 +209,20 @@
 
     blacksmith-testbox-cli = prev.stdenvNoCC.mkDerivation rec {
       pname = "blacksmith-testbox-cli";
-      version = "0.4.57";
+      version = "0.4.58";
       src = prev.fetchurl {
         url = "https://clireleases.blacksmith.sh/cli/v${version}/${
           if prev.stdenv.hostPlatform.isDarwin then "darwin" else "linux"
         }/${if prev.stdenv.hostPlatform.isAarch64 then "arm64" else "amd64"}/blacksmith";
         sha256 =
           if prev.stdenv.hostPlatform.isLinux && prev.stdenv.hostPlatform.isx86_64 then
-            "7f60f3b9f8d4d7644d9743f5d962acb3b3dbf675f51676702e5f292e02060bca"
+            "0b54a4398e9b35344d8fb32891703d8a393343f5001914d7482f93d068c76822"
           else if prev.stdenv.hostPlatform.isLinux && prev.stdenv.hostPlatform.isAarch64 then
-            "04c8d261526e23c7791f05b8acec8f02b9d1fe67c35a1adcf28076627327270a"
+            "2bf3e7246414e2fd113d3214577bb8951015aeda57579d1f36ec75dc5c05c716"
           else if prev.stdenv.hostPlatform.isDarwin && prev.stdenv.hostPlatform.isAarch64 then
-            "607b0f4413e426574527446c7718ea32587d57b24a3ea0749e1ab4138a426584"
+            "2384984fa9cdb943e9352b4ff6a4adf9e9ac61c194c255887413357fada27d88"
           else
-            "47281f402ff223f85e5165ea9018cd0281a727f19c69af8121ae4b09658ad313";
+            "6dabf51a4e168d7ea1d9379f09fb8e08dc57a5f8c000932b1f9d507c44bc5450";
       };
       dontUnpack = true;
       installPhase = ''
@@ -234,20 +233,20 @@
 
     crabbox = prev.stdenvNoCC.mkDerivation rec {
       pname = "crabbox";
-      version = "0.47.0";
+      version = "0.55.0";
       src = prev.fetchurl {
         url = "https://github.com/openclaw/crabbox/releases/download/v${version}/crabbox_${version}_${
           if prev.stdenv.hostPlatform.isDarwin then "darwin" else "linux"
         }_${if prev.stdenv.hostPlatform.isAarch64 then "arm64" else "amd64"}.tar.gz";
         sha256 =
           if prev.stdenv.hostPlatform.isLinux && prev.stdenv.hostPlatform.isx86_64 then
-            "e513ba473be4eaaadf16f88fe030a03e6a11c0b49a088941fcccdbf3a09247ad"
+            "883e9201c4b508077f092ea3ded99092ea34068e19e9d4dd4812cf50d2134e98"
           else if prev.stdenv.hostPlatform.isLinux && prev.stdenv.hostPlatform.isAarch64 then
-            "94a388cd7301c7ba1d7e42d8c55d68c6b9dd55025e79cf247c58d659aa5039d4"
+            "87711d0002f0a4d034f8a651052ea4244fdcc401aed5fd69759d966953d7c4fa"
           else if prev.stdenv.hostPlatform.isDarwin && prev.stdenv.hostPlatform.isAarch64 then
-            "ef1567083f6bd0d01b2539efdd69ccd205c2642e7d9eefb073d58052e8a7bb91"
+            "5c7c8faf98eb91d64b86b22f859735ae13777c8bdf759e0bd51f9456df5d018e"
           else
-            "642995363f7d6c367859e77f80eb66468ef2ed380d1e7ea4ae737f7deeb986d4";
+            "607d62adda808be29bb9341071b5e7a895f4f1f45a7905d763870b91f56d3b57";
       };
       sourceRoot = ".";
       dontConfigure = true;
@@ -265,20 +264,20 @@
 
     moshi-hook = prev.stdenv.mkDerivation rec {
       pname = "moshi-hook";
-      version = "0.3.16";
+      version = "0.3.21";
       src = prev.fetchurl {
         url = "https://cdn.getmoshi.app/hook/v${version}/moshi-hook_${
           if prev.stdenv.hostPlatform.isDarwin then "Darwin" else "Linux"
         }_${if prev.stdenv.hostPlatform.isAarch64 then "arm64" else "x86_64"}.tar.gz";
         sha256 =
           if prev.stdenv.hostPlatform.isLinux && prev.stdenv.hostPlatform.isx86_64 then
-            "ee96ff3cebe68648a9631976660afa4a7a247cfa2cc8c030d9d5eca784df5a95"
+            "038431d47325ab91e455491873f074df8b804e877e742e22e6b54164dd0dd926"
           else if prev.stdenv.hostPlatform.isLinux && prev.stdenv.hostPlatform.isAarch64 then
-            "8df6d83dcd1aa99c42e7516937f29249f3a8f704d9d9d7eec703fa2287a88666"
+            "e4dec1da4692e7678df70629c27bdda4e620f379ac0f73c6060c0f35d62f8520"
           else if prev.stdenv.hostPlatform.isDarwin && prev.stdenv.hostPlatform.isAarch64 then
-            "173550c6437e6663dbdf43736fc9cbca2a5af8acf7c3d61b2c3a97c4963cf596"
+            "f70b3ee65a159e301c04dbf9528e0a484fd60d54daa2a203678a22a50f0e61a3"
           else
-            "608c8af54a5d7add4e6d58ce2d1b5b3ea0ba536fd8b7e57d947b5f9f244e8311";
+            "5a2883944e4e13584e4e5c6269e9d1b248a3f8e4437ded9d522dc3daa2c85ba6";
       };
       sourceRoot = ".";
       dontConfigure = true;

--- a/scripts/upgrade-overlays.sh
+++ b/scripts/upgrade-overlays.sh
@@ -13,6 +13,9 @@ ASCII_BOX_CLI_URL="${ASCII_BOX_CLI_URL:-https://ascii.dev/api/box/cli/download}"
 ASCII_BOX_CLI_CHANNEL="${ASCII_BOX_CLI_CHANNEL:-ascii-prod}"
 ASCII_BOX_CLI_RELEASE_URL="${ASCII_BOX_CLI_RELEASE_URL:-https://github.com/ariana-dot-dev/agent-server/releases/download}"
 ASCII_BOX_CLI_RELEASE_CHANNEL="${ASCII_BOX_CLI_RELEASE_CHANNEL:-ascii-prod1}"
+CRABBOX_RELEASE_API="${CRABBOX_RELEASE_API:-https://api.github.com/repos/openclaw/crabbox/releases/latest}"
+CRABBOX_RELEASE_CDN="${CRABBOX_RELEASE_CDN:-https://github.com/openclaw/crabbox/releases/download}"
+GH_RELEASE_API="${GH_RELEASE_API:-repos/cli/cli/releases/latest}"
 
 # Colors for output
 RED='\033[0;31m'
@@ -38,7 +41,10 @@ usage() {
   echo "Available overlays:"
   echo "  ascii-box-cli - Upgrade the pinned ASCII Box CLI binaries"
   echo "  blacksmith-testbox-cli - Upgrade the pinned Blacksmith Testbox CLI binaries"
+  echo "  crabbox - Upgrade the pinned Crabbox binaries"
+  echo "  gh - Upgrade the pinned GitHub CLI release and Go vendor hash"
   echo "  moshi-hook - Upgrade the pinned moshi-hook binaries"
+  echo "  t3code - Refresh the platform-specific t3code pnpm dependency hash"
   echo "  all        - Upgrade all overlays"
   echo ""
   echo "Examples:"
@@ -54,8 +60,9 @@ require_command() {
 }
 
 checksum_for() {
-  local asset="$1"
-  awk -v asset="$asset" '$2 == asset { print $1; found = 1; exit } END { if (!found) exit 1 }' "$MOSHI_CHECKSUMS_FILE"
+  local checksums_file="$1"
+  local asset="$2"
+  awk -v asset="$asset" '$2 == asset { print $1; found = 1; exit } END { if (!found) exit 1 }' "$checksums_file"
 }
 
 validate_checksum() {
@@ -133,6 +140,100 @@ validate_nix_checksum() {
     log_error "Invalid Nix checksum for $asset"
     exit 1
   fi
+}
+
+validate_sri_checksum() {
+  local asset="$1"
+  local checksum="$2"
+  if [[ ! $checksum =~ ^sha256-[[:alnum:]+/]{43}=$ ]]; then
+    log_error "Invalid SRI checksum for $asset"
+    exit 1
+  fi
+}
+
+github_cli_vendor_hash() {
+  local expression output
+
+  if [ -n "${GH_VENDOR_HASH:-}" ]; then
+    printf '%s\n' "$GH_VENDOR_HASH"
+    return 0
+  fi
+
+  expression="let flake = builtins.getFlake (toString $REPO_ROOT); pkgs = flake.inputs.nixpkgs.legacyPackages.x86_64-linux; in pkgs.gh.overrideAttrs (_: { version = \"$GH_VERSION\"; src = pkgs.fetchFromGitHub { owner = \"cli\"; repo = \"cli\"; rev = \"$GH_REV\"; hash = \"$GH_SOURCE_HASH\"; }; vendorHash = \"sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\"; })"
+  output="$(nix build --no-link --impure --print-build-logs --expr "$expression" 2>&1 || true)"
+  printf '%s\n' "$output" | sed -n 's/.*got:[[:space:]]*\(sha256-[[:alnum:]+/]*=[=]*\).*/\1/p' | tail -1
+}
+
+upgrade_gh() {
+  local version rev source_hash vendor_hash current_version
+  local source_nix32
+
+  version="${GH_VERSION:-}"
+  if [ -z "$version" ]; then
+    require_command gh
+    version="$(gh api "$GH_RELEASE_API" --jq '.tag_name' | sed 's/^v//' | head -1)"
+  fi
+  if [[ ! $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    log_error "Invalid GitHub CLI version: ${version:-unknown}"
+    exit 1
+  fi
+
+  rev="${GH_REV:-}"
+  if [ -z "$rev" ]; then
+    require_command gh
+    rev="$(gh api "repos/cli/cli/commits/v$version" --jq '.sha')"
+  fi
+  if [[ ! $rev =~ ^[0-9a-f]{40}$ ]]; then
+    log_error "Invalid GitHub CLI revision: ${rev:-unknown}"
+    exit 1
+  fi
+
+  source_hash="${GH_SOURCE_HASH:-}"
+  if [ -z "$source_hash" ]; then
+    source_nix32="$(nix-prefetch-url --unpack "https://github.com/cli/cli/archive/refs/tags/v$version.tar.gz" | tail -1)"
+    source_hash="$(nix hash convert --hash-algo sha256 --from nix32 --to sri "$source_nix32")"
+  fi
+  validate_sri_checksum "gh-$version-source" "$source_hash"
+
+  vendor_hash="$(github_cli_vendor_hash)"
+  validate_sri_checksum "gh-$version-vendor" "$vendor_hash"
+  current_version="$(sed -n '/gh = prev.gh.overrideAttrs/,/^[[:space:]]*});/p' "$OVERLAY_FILE" | sed -n 's/.*version = "\([^"]*\)";.*/\1/p' | head -1)"
+
+  awk \
+    -v version="$version" \
+    -v rev="$rev" \
+    -v source_hash="$source_hash" \
+    -v vendor_hash="$vendor_hash" '
+      /gh = prev\.gh\.overrideAttrs/ { in_gh = 1 }
+      in_gh && /version = "[^"]*";/ {
+        sub(/version = "[^"]*";/, "version = \"" version "\";")
+      }
+      in_gh && /rev = "[^"]*";/ {
+        sub(/rev = "[^"]*";/, "rev = \"" rev "\";")
+      }
+      in_gh && /^[[:space:]]*hash = "[^"]*";/ && !source_updated {
+        sub(/hash = "[^"]*";/, "hash = \"" source_hash "\";")
+        source_updated = 1
+      }
+      in_gh && /vendorHash = "[^"]*";/ {
+        sub(/vendorHash = "[^"]*";/, "vendorHash = \"" vendor_hash "\";")
+        vendor_updated = 1
+      }
+      in_gh && /GH_VERSION=[^ ]+/ {
+        sub(/GH_VERSION=[^ ]+/, "GH_VERSION=" version)
+      }
+      in_gh && /^[[:space:]]*\}\);$/ { in_gh = 0 }
+      { print }
+      END {
+        if (source_updated != 1 || vendor_updated != 1) {
+          print "expected GitHub CLI source and vendor hashes in " FILENAME > "/dev/stderr"
+          exit 1
+        }
+      }
+    ' "$OVERLAY_FILE" >"$OVERLAY_FILE.tmp"
+  mv -f "$OVERLAY_FILE.tmp" "$OVERLAY_FILE"
+
+  log_info "✅ gh upgraded from ${current_version:-unknown} to $version"
 }
 
 upgrade_ascii_box_cli() {
@@ -245,11 +346,6 @@ upgrade_blacksmith_testbox_cli() {
   echo "  Current version: ${current_version:-unknown}"
   echo "  Latest version:  $version"
 
-  if [[ $current_version == "$version" ]]; then
-    log_info "✅ blacksmith-testbox-cli is already on latest version ($version)"
-    return 0
-  fi
-
   linux_x86_64="$(checksum_from_url "$BLACKSMITH_CLI_CDN/v$version/linux/amd64/blacksmith.sha256")"
   linux_arm64="$(checksum_from_url "$BLACKSMITH_CLI_CDN/v$version/linux/arm64/blacksmith.sha256")"
   darwin_arm64="$(checksum_from_url "$BLACKSMITH_CLI_CDN/v$version/darwin/arm64/blacksmith.sha256")"
@@ -293,7 +389,7 @@ upgrade_blacksmith_testbox_cli() {
 }
 
 upgrade_moshi_hook() {
-  local latest_version version current_version
+  local latest_version version current_version checksums_file
   local linux_x86_64 linux_arm64 darwin_arm64 darwin_x86_64
 
   latest_version="$(curl -fsSL "$MOSHI_HOOK_CDN/hook/latest/version.txt" | tr -d '[:space:]')"
@@ -311,23 +407,17 @@ upgrade_moshi_hook() {
   echo "  Current version: ${current_version:-unknown}"
   echo "  Latest version:  $version"
 
-  MOSHI_CHECKSUMS_FILE="$(mktemp)"
-  curl -fsSL "$MOSHI_HOOK_CDN/hook/v$version/checksums.txt" -o "$MOSHI_CHECKSUMS_FILE"
+  checksums_file="$(mktemp)"
+  curl -fsSL "$MOSHI_HOOK_CDN/hook/v$version/checksums.txt" -o "$checksums_file"
 
-  linux_x86_64="$(checksum_for moshi-hook_Linux_x86_64.tar.gz)"
-  linux_arm64="$(checksum_for moshi-hook_Linux_arm64.tar.gz)"
-  darwin_arm64="$(checksum_for moshi-hook_Darwin_arm64.tar.gz)"
-  darwin_x86_64="$(checksum_for moshi-hook_Darwin_x86_64.tar.gz)"
+  linux_x86_64="$(checksum_for "$checksums_file" moshi-hook_Linux_x86_64.tar.gz)"
+  linux_arm64="$(checksum_for "$checksums_file" moshi-hook_Linux_arm64.tar.gz)"
+  darwin_arm64="$(checksum_for "$checksums_file" moshi-hook_Darwin_arm64.tar.gz)"
+  darwin_x86_64="$(checksum_for "$checksums_file" moshi-hook_Darwin_x86_64.tar.gz)"
   validate_checksum moshi-hook_Linux_x86_64.tar.gz "$linux_x86_64"
   validate_checksum moshi-hook_Linux_arm64.tar.gz "$linux_arm64"
   validate_checksum moshi-hook_Darwin_arm64.tar.gz "$darwin_arm64"
   validate_checksum moshi-hook_Darwin_x86_64.tar.gz "$darwin_x86_64"
-
-  if [[ $current_version == "$version" ]]; then
-    rm -f "$MOSHI_CHECKSUMS_FILE"
-    log_info "✅ moshi-hook is already on latest version ($version)"
-    return 0
-  fi
 
   awk \
     -v version="$version" \
@@ -358,9 +448,122 @@ upgrade_moshi_hook() {
       }
     ' "$OVERLAY_FILE" >"$OVERLAY_FILE.tmp"
   mv -f "$OVERLAY_FILE.tmp" "$OVERLAY_FILE"
-  rm -f "$MOSHI_CHECKSUMS_FILE"
+  rm -f "$checksums_file"
 
   log_info "✅ moshi-hook upgraded from ${current_version:-unknown} to $version"
+}
+
+upgrade_crabbox() {
+  local version current_version checksums_file
+  local linux_x86_64 linux_arm64 darwin_arm64 darwin_x86_64
+
+  version="${CRABBOX_VERSION:-}"
+  if [ -z "$version" ]; then
+    require_command gh
+    version="$(gh api "$CRABBOX_RELEASE_API" --jq '.tag_name' | sed 's/^v//' | head -1)"
+  fi
+
+  if [[ ! $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    log_error "Invalid Crabbox version: ${version:-unknown}"
+    exit 1
+  fi
+
+  current_version="$(sed -n '/crabbox = prev.stdenvNoCC.mkDerivation rec {/,/meta.mainProgram = "crabbox"/p' "$OVERLAY_FILE" | sed -n 's/.*version = "\([^"]*\)";.*/\1/p' | head -1)"
+  echo "  Current version: ${current_version:-unknown}"
+  echo "  Latest version:  $version"
+
+  checksums_file="$(mktemp)"
+  curl -fsSL "$CRABBOX_RELEASE_CDN/v$version/checksums.txt" -o "$checksums_file"
+  linux_x86_64="$(checksum_for "$checksums_file" "crabbox_${version}_linux_amd64.tar.gz")"
+  linux_arm64="$(checksum_for "$checksums_file" "crabbox_${version}_linux_arm64.tar.gz")"
+  darwin_arm64="$(checksum_for "$checksums_file" "crabbox_${version}_darwin_arm64.tar.gz")"
+  darwin_x86_64="$(checksum_for "$checksums_file" "crabbox_${version}_darwin_amd64.tar.gz")"
+  rm -f "$checksums_file"
+  validate_checksum "crabbox_${version}_linux_amd64.tar.gz" "$linux_x86_64"
+  validate_checksum "crabbox_${version}_linux_arm64.tar.gz" "$linux_arm64"
+  validate_checksum "crabbox_${version}_darwin_arm64.tar.gz" "$darwin_arm64"
+  validate_checksum "crabbox_${version}_darwin_amd64.tar.gz" "$darwin_x86_64"
+
+  awk \
+    -v version="$version" \
+    -v linux_x86_64="$linux_x86_64" \
+    -v linux_arm64="$linux_arm64" \
+    -v darwin_arm64="$darwin_arm64" \
+    -v darwin_x86_64="$darwin_x86_64" '
+      /crabbox = prev.stdenvNoCC.mkDerivation rec \{/ { in_crabbox = 1 }
+      in_crabbox && /version = "[^"]*";/ {
+        sub(/version = "[^"]*";/, "version = \"" version "\";")
+      }
+      in_crabbox && /isLinux && prev.stdenv.hostPlatform.isx86_64 then/ { pending_hash = linux_x86_64 }
+      in_crabbox && /isLinux && prev.stdenv.hostPlatform.isAarch64 then/ { pending_hash = linux_arm64 }
+      in_crabbox && /isDarwin && prev.stdenv.hostPlatform.isAarch64 then/ { pending_hash = darwin_arm64 }
+      in_crabbox && /^          else$/ { pending_hash = darwin_x86_64 }
+      in_crabbox && pending_hash != "" && $0 ~ /^[[:space:]]*"[^"]*";?$/ {
+        sub(/"[^"]*"/, "\"" pending_hash "\"")
+        pending_hash = ""
+        updated_hashes++
+      }
+      in_crabbox && /meta.mainProgram = "crabbox"/ { in_crabbox = 0 }
+      { print }
+      END {
+        if (updated_hashes != 4) {
+          print "expected four crabbox checksums in " FILENAME > "/dev/stderr"
+          exit 1
+        }
+      }
+    ' "$OVERLAY_FILE" >"$OVERLAY_FILE.tmp"
+  mv -f "$OVERLAY_FILE.tmp" "$OVERLAY_FILE"
+
+  log_info "✅ crabbox upgraded from ${current_version:-unknown} to $version"
+}
+
+t3code_pnpm_hash() {
+  local expression output
+
+  if [ -n "${T3CODE_PNPM_HASH:-}" ]; then
+    printf '%s\n' "$T3CODE_PNPM_HASH"
+    return 0
+  fi
+
+  expression="let flake = builtins.getFlake (toString $REPO_ROOT); package = flake.inputs.llm-agents.packages.x86_64-linux.t3code; in package.pnpmDeps.overrideAttrs (_: { outputHash = \"sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\"; })"
+  output="$(nix build --no-link --impure --print-build-logs --expr "$expression" 2>&1 || true)"
+  printf '%s\n' "$output" | sed -n 's/.*got:[[:space:]]*\(sha256-[[:alnum:]+/]*=[=]*\).*/\1/p' | tail -1
+}
+
+upgrade_t3code() {
+  local version current_hash latest_hash
+
+  version="${T3CODE_VERSION:-}"
+  if [ -z "$version" ]; then
+    version="$(nix eval --impure --raw --expr "let flake = builtins.getFlake (toString $REPO_ROOT); in flake.inputs.llm-agents.packages.x86_64-linux.t3code.version")"
+  fi
+  current_hash="$(sed -n '/# t3code [0-9][0-9.]* pins one pnpm deps hash/,/outputHash = hash;/p' "$OVERLAY_FILE" | sed -n 's/.*# t3code \([0-9][0-9.]*\) pins.*/\1/p' | head -1)"
+  latest_hash="$(t3code_pnpm_hash)"
+  validate_sri_checksum "t3code-${version}-x86_64-linux" "$latest_hash"
+
+  awk \
+    -v version="$version" \
+    -v hash="$latest_hash" '
+      /# t3code [0-9][0-9.]* pins one pnpm deps hash/ {
+        sub(/# t3code [0-9][0-9.]*/, "# t3code " version)
+      }
+      /x86_64-linux = "[^"]*";/ && in_t3code {
+        sub(/"[^"]*"/, "\"" hash "\"")
+        updated_hashes++
+      }
+      /# t3code [0-9][0-9.]* pins one pnpm deps hash/ { in_t3code = 1 }
+      in_t3code && /outputHash = hash;/ { in_t3code = 0 }
+      { print }
+      END {
+        if (updated_hashes != 1) {
+          print "expected one t3code platform hash in " FILENAME > "/dev/stderr"
+          exit 1
+        }
+      }
+    ' "$OVERLAY_FILE" >"$OVERLAY_FILE.tmp"
+  mv -f "$OVERLAY_FILE.tmp" "$OVERLAY_FILE"
+
+  log_info "✅ t3code pnpm hash refreshed for ${version} (was ${current_hash:-unknown})"
 }
 
 main() {
@@ -385,6 +588,19 @@ main() {
     require_command sed
     upgrade_blacksmith_testbox_cli
     ;;
+  crabbox)
+    require_command awk
+    require_command curl
+    require_command sed
+    upgrade_crabbox
+    ;;
+  gh)
+    require_command awk
+    require_command nix
+    require_command nix-prefetch-url
+    require_command sed
+    upgrade_gh
+    ;;
   moshi-hook)
     require_command awk
     require_command curl
@@ -392,15 +608,25 @@ main() {
     require_command tr
     upgrade_moshi_hook
     ;;
+  t3code)
+    require_command awk
+    require_command nix
+    require_command sed
+    upgrade_t3code
+    ;;
   all)
     require_command awk
     require_command curl
     require_command nix-prefetch-url
+    require_command nix
     require_command sed
     require_command tr
     upgrade_ascii_box_cli
     upgrade_blacksmith_testbox_cli
+    upgrade_crabbox
+    upgrade_gh
     upgrade_moshi_hook
+    upgrade_t3code
     ;;
   -h | --help)
     usage

--- a/spec/crabbox_spec.sh
+++ b/spec/crabbox_spec.sh
@@ -17,7 +17,7 @@ HEALTH_CHECK="$PWD/home-manager/services/crabbox/health-check.sh"
 
 It 'packages the CLI independently in the shared overlay'
 When run bash -c "sed -n '/crabbox = prev.stdenvNoCC.mkDerivation rec {/,/meta.mainProgram = \"crabbox\"/p' '$OVERLAY'"
-The output should include 'version = "0.47.0"'
+The output should include 'version = "0.55.0"'
 The output should include 'crabbox_${version}'
 The output should include 'crabbox-apple-vm-helper'
 The output should include 'meta.mainProgram = "crabbox"'
@@ -31,7 +31,7 @@ End
 
 It 'packages the official Blacksmith Testbox CLI outside npm'
 When run bash -c "sed -n '/blacksmith-testbox-cli = prev.stdenvNoCC.mkDerivation rec {/,/meta.mainProgram = \"blacksmith\"/p' '$OVERLAY'; grep -Fx '  blacksmith-testbox-cli' '$PACKAGES'; grep -F '\"blacksmith-cli\"' '$PACKAGE_JSON' || true"
-The output should include 'version = "0.4.57"'
+The output should include 'version = "0.4.58"'
 The output should include 'clireleases.blacksmith.sh'
 The output should include 'meta.mainProgram = "blacksmith"'
 The output should include '  blacksmith-testbox-cli'

--- a/spec/herdr_service_spec.sh
+++ b/spec/herdr_service_spec.sh
@@ -1,6 +1,9 @@
-# shellcheck shell=bash
+# shellcheck shell=bash disable=SC2016
 Describe 'Herdr server environment'
 SCRIPT="$PWD/home-manager/services/herdr/start.sh"
+PACKAGE_CONFIG="$PWD/home-manager/packages/default.nix"
+SERVICE_CONFIG="$PWD/home-manager/services/herdr/default.nix"
+HOMEBREW_CONFIG="$PWD/nix-darwin/config/homebrew.nix"
 
 setup() {
   TEMP_HOME=$(mktemp -d)
@@ -31,5 +34,22 @@ The line 1 of output should equal 'value with spaces'
 # shellcheck disable=SC2016
 The line 2 of output should equal '$(touch should-not-exist)'
 The line 3 of output should equal 'server'
+End
+
+Describe 'Herdr package ownership'
+It 'keeps Herdr in the Nix Home Manager package set'
+When run grep -Fx '  pkgs.llm-agents.herdr' "$PACKAGE_CONFIG"
+The output should include '  pkgs.llm-agents.herdr'
+End
+
+It 'does not declare Herdr as a Homebrew formula'
+When run grep -Fx '      "herdr"' "$HOMEBREW_CONFIG"
+The status should not be success
+End
+
+It 'launches the Nix-backed Herdr package on Darwin'
+When run grep -F '"${pkgs.llm-agents.herdr}/bin/herdr"' "$SERVICE_CONFIG"
+The output should include '"${pkgs.llm-agents.herdr}/bin/herdr"'
+End
 End
 End

--- a/spec/upgrade_overlays_spec.sh
+++ b/spec/upgrade_overlays_spec.sh
@@ -10,7 +10,9 @@ When run bash "$SCRIPT"
 The output should include 'Usage:'
 The output should include 'upgrade-overlays.sh'
 The output should include 'blacksmith-testbox-cli'
+The output should include 'crabbox'
 The output should include 'moshi-hook'
+The output should include 't3code'
 The output should include 'all'
 The status should be failure
 End
@@ -41,7 +43,16 @@ End
 Describe 'moshi-hook overlay target'
 setup() {
   TEMP_DIR=$(mktemp -d)
-  mkdir -p "$TEMP_DIR/bin" "$TEMP_DIR/cdn/hook/latest" "$TEMP_DIR/cdn/hook/v0.2.69" "$TEMP_DIR/overlays"
+  mkdir -p \
+    "$TEMP_DIR/bin" \
+    "$TEMP_DIR/cdn/hook/latest" \
+    "$TEMP_DIR/cdn/hook/v0.2.69" \
+    "$TEMP_DIR/cdn/blacksmith/v0.4.57/linux/amd64" \
+    "$TEMP_DIR/cdn/blacksmith/v0.4.57/linux/arm64" \
+    "$TEMP_DIR/cdn/blacksmith/v0.4.57/darwin/amd64" \
+    "$TEMP_DIR/cdn/blacksmith/v0.4.57/darwin/arm64" \
+    "$TEMP_DIR/cdn/crabbox/v0.55.0" \
+    "$TEMP_DIR/overlays"
   cat >"$TEMP_DIR/bin/nix-prefetch-url" <<'EOF'
 #!/usr/bin/env bash
 case "$*" in
@@ -60,10 +71,35 @@ EOF
 0a30e081399543551bbd0ba3320f3b28be814a585e5c591e168f8fd6d9565f07  moshi-hook_Linux_arm64.tar.gz
 3903e2e5d1dba02f9e1f53df8cea6e2b3260e1581461b9a07ca65f18814b8b08  moshi-hook_Linux_x86_64.tar.gz
 EOF
+  for asset in \
+    linux/amd64 \
+    linux/arm64 \
+    darwin/amd64 \
+    darwin/arm64; do
+    printf '%s  blacksmith\n' 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' \
+      >"$TEMP_DIR/cdn/blacksmith/v0.4.57/$asset/blacksmith.sha256"
+  done
+  cat >"$TEMP_DIR/cdn/crabbox/v0.55.0/checksums.txt" <<'EOF'
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  crabbox_0.55.0_linux_amd64.tar.gz
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  crabbox_0.55.0_linux_arm64.tar.gz
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  crabbox_0.55.0_darwin_arm64.tar.gz
+dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd  crabbox_0.55.0_darwin_amd64.tar.gz
+EOF
   cat >"$TEMP_DIR/overlays/default.nix" <<'EOF'
 { inputs }:
 [
   (_: prev: {
+    gh = prev.gh.overrideAttrs (_: {
+      version = "2.98.0";
+      src = prev.fetchFromGitHub {
+        rev = "0000000000000000000000000000000000000000";
+        hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+      };
+      vendorHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+      buildPhase = ''
+        make GH_VERSION=2.98.0 bin/gh
+      '';
+    });
     moshi-hook = prev.stdenv.mkDerivation rec {
       pname = "moshi-hook";
       version = "0.2.55";
@@ -95,7 +131,43 @@ EOF
     blacksmith-testbox-cli = prev.stdenvNoCC.mkDerivation rec {
       pname = "blacksmith-testbox-cli";
       version = "0.4.57";
+      src = prev.fetchurl {
+        sha256 =
+          if prev.stdenv.hostPlatform.isLinux && prev.stdenv.hostPlatform.isx86_64 then
+            "old-linux-x86"
+          else if prev.stdenv.hostPlatform.isLinux && prev.stdenv.hostPlatform.isAarch64 then
+            "old-linux-arm"
+          else if prev.stdenv.hostPlatform.isDarwin && prev.stdenv.hostPlatform.isAarch64 then
+            "old-darwin-arm"
+          else
+            "old-darwin-x86";
+      };
       meta.mainProgram = "blacksmith";
+    };
+    crabbox = prev.stdenvNoCC.mkDerivation rec {
+      pname = "crabbox";
+      version = "0.46.0";
+      src = prev.fetchurl {
+        sha256 =
+          if prev.stdenv.hostPlatform.isLinux && prev.stdenv.hostPlatform.isx86_64 then
+            "old-linux-x86"
+          else if prev.stdenv.hostPlatform.isLinux && prev.stdenv.hostPlatform.isAarch64 then
+            "old-linux-arm"
+          else if prev.stdenv.hostPlatform.isDarwin && prev.stdenv.hostPlatform.isAarch64 then
+            "old-darwin-arm"
+          else
+            "old-darwin-x86";
+      };
+      meta.mainProgram = "crabbox";
+    };
+    # t3code 0.0.33 pins one pnpm deps hash
+    t3code-test = let
+      pnpmDepsHashes = {
+        x86_64-linux = "old-t3code-hash";
+      };
+      hash = pnpmDepsHashes.x86_64-linux;
+    in {
+      outputHash = hash;
     };
   })
 ]
@@ -109,9 +181,16 @@ cleanup() {
 Before 'setup'
 After 'cleanup'
 
-It 'updates moshi-hook from the all target'
-When run env OVERLAY_FILE="$TEMP_DIR/overlays/default.nix" ASCII_BOX_CLI_VERSION="0.1.208" MOSHI_HOOK_CDN="file://$TEMP_DIR/cdn" BLACKSMITH_CLI_VERSION="0.4.57" bash "$SCRIPT" all
+It 'updates every overlay hash from the all target'
+When run bash -c "env OVERLAY_FILE='$TEMP_DIR/overlays/default.nix' ASCII_BOX_CLI_VERSION='0.1.208' MOSHI_HOOK_CDN='file://$TEMP_DIR/cdn' BLACKSMITH_CLI_CDN='file://$TEMP_DIR/cdn/blacksmith' BLACKSMITH_CLI_VERSION='0.4.57' CRABBOX_RELEASE_CDN='file://$TEMP_DIR/cdn/crabbox' CRABBOX_VERSION='0.55.0' GH_VERSION='2.100.0' GH_REV='45437bc7eeeb3359bbfddd1742f79de7652fd3e2' GH_SOURCE_HASH='sha256-9tnSQPSqllE+Ke6LKyNbnOF1drzdEwesEuPdmWD1X5c=' GH_VENDOR_HASH='sha256-ZqUs2BnasF3QBX0I2Sxh2A/CnO61Vy6gRn1hkf0n9AY=' T3CODE_VERSION='0.0.36' T3CODE_PNPM_HASH='sha256-y/sJIluwbn65APmJ2p07FK1ScXpetCloTHtQzZMchDU=' bash '$SCRIPT' all && cat '$TEMP_DIR/overlays/default.nix'"
 The output should include 'moshi-hook upgraded from 0.2.55 to 0.2.69'
+The output should include 'crabbox upgraded from 0.46.0 to 0.55.0'
+The output should include 't3code pnpm hash refreshed for 0.0.36'
+The output should include 'gh upgraded from 2.98.0 to 2.100.0'
+The output should include '45437bc7eeeb3359bbfddd1742f79de7652fd3e2'
+The output should include 'version = "0.55.0"'
+The output should include 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+The output should include 'sha256-9tnSQPSqllE+Ke6LKyNbnOF1drzdEwesEuPdmWD1X5c='
 The status should be success
 End
 

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -50,6 +50,7 @@ let
         };
         activation = galactica.config.system.activationScripts.tailscaleDns.text;
         beads = galactica.config.home-manager.users.shunkakinoki;
+        packageNames = map lib.getName beads.home.packages;
       in
       assert !galactica.config.home-manager.users.shunkakinoki.nix.enable;
       assert !galactica.config.home-manager.users.shunkakinoki.nix.gc.automatic;
@@ -59,7 +60,9 @@ let
       assert !(beads.launchd.agents ? dolt);
       assert !(beads.launchd.agents ? dolt-backup-main);
       assert beads.launchd.agents.beads-dolt-client-environment.enable;
+      assert lib.elem "herdr" packageNames;
       assert lib.elem "openclaw/tap/crabbox" (map (brew: brew.name) galactica.config.homebrew.brews);
+      assert !(lib.elem "herdr" (map (brew: brew.name) galactica.config.homebrew.brews));
       assert !(lib.elem "crabbox" (map (brew: brew.name) galactica.config.homebrew.brews));
       assert !(lib.elem "crabbox" (map (cask: cask.name) galactica.config.homebrew.casks));
       assert lib.hasInfix "--accept-dns=true" activation;


### PR DESCRIPTION
Remove the duplicate Homebrew Herdr formula. Keep the Nix Home Manager package and launchd service.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Nix Home Manager the sole owner of the Herdr service on macOS and refreshes several pinned overlay versions.

**Bug Fixes**
- Removes `herdr` from the Homebrew formula list so the Nix Home Manager package is the only installation source.
- Existing Homebrew `herdr` installs should be removed manually to avoid duplicate binaries.

**Dependencies**
- Moves `gh` from an unstable preview commit to the tagged `2.100.0` release, which includes `--attach` support.
- Updates `ascii-box-cli` to `0.1.228`, `blacksmith-testbox-cli` to `0.4.58`, `crabbox` to `0.55.0`, and `moshi-hook` to `0.3.21`.
- Refreshes the `t3code` x86_64-linux pnpm dependency hash.
- `upgrade-overlays.sh` adds `crabbox`, `gh`, and `t3code` targets and runs them from `all`.
- `blacksmith-testbox-cli` and `moshi-hook` upgrades now refresh checksums even when the version hasn't changed.

<sup>Written for commit 3a6c73d24e519c09582e566a06eb71fe5124568f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

