### PR TITLE
fix(darwin): make Nix the sole Herdr owner

### DIFF
--- a/nix-darwin/config/homebrew.nix
+++ b/nix-darwin/config/homebrew.nix
@@ -76,7 +76,6 @@
       "grafana"
       "graphviz"
       "helm"
-      "herdr"
       "infracost"
       "jjui"
       "kimi-cli"

--- a/spec/herdr_service_spec.sh
+++ b/spec/herdr_service_spec.sh
@@ -1,6 +1,9 @@
-# shellcheck shell=bash
+# shellcheck shell=bash disable=SC2016
 Describe 'Herdr server environment'
 SCRIPT="$PWD/home-manager/services/herdr/start.sh"
+PACKAGE_CONFIG="$PWD/home-manager/packages/default.nix"
+SERVICE_CONFIG="$PWD/home-manager/services/herdr/default.nix"
+HOMEBREW_CONFIG="$PWD/nix-darwin/config/homebrew.nix"
 
 setup() {
   TEMP_HOME=$(mktemp -d)
@@ -31,5 +34,22 @@ The line 1 of output should equal 'value with spaces'
 # shellcheck disable=SC2016
 The line 2 of output should equal '$(touch should-not-exist)'
 The line 3 of output should equal 'server'
+End
+
+Describe 'Herdr package ownership'
+It 'keeps Herdr in the Nix Home Manager package set'
+When run grep -Fx '  pkgs.llm-agents.herdr' "$PACKAGE_CONFIG"
+The output should include '  pkgs.llm-agents.herdr'
+End
+
+It 'does not declare Herdr as a Homebrew formula'
+When run grep -Fx '      "herdr"' "$HOMEBREW_CONFIG"
+The status should not be success
+End
+
+It 'launches the Nix-backed Herdr package on Darwin'
+When run grep -F '"${pkgs.llm-agents.herdr}/bin/herdr"' "$SERVICE_CONFIG"
+The output should include '"${pkgs.llm-agents.herdr}/bin/herdr"'
+End
 End
 End

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -50,6 +50,7 @@ let
         };
         activation = galactica.config.system.activationScripts.tailscaleDns.text;
         beads = galactica.config.home-manager.users.shunkakinoki;
+        packageNames = map lib.getName beads.home.packages;
       in
       assert !galactica.config.home-manager.users.shunkakinoki.nix.enable;
       assert !galactica.config.home-manager.users.shunkakinoki.nix.gc.automatic;
@@ -59,7 +60,9 @@ let
       assert !(beads.launchd.agents ? dolt);
       assert !(beads.launchd.agents ? dolt-backup-main);
       assert beads.launchd.agents.beads-dolt-client-environment.enable;
+      assert lib.elem "herdr" packageNames;
       assert lib.elem "openclaw/tap/crabbox" (map (brew: brew.name) galactica.config.homebrew.brews);
+      assert !(lib.elem "herdr" (map (brew: brew.name) galactica.config.homebrew.brews));
       assert !(lib.elem "crabbox" (map (brew: brew.name) galactica.config.homebrew.brews));
       assert !(lib.elem "crabbox" (map (cask: cask.name) galactica.config.homebrew.casks));
       assert lib.hasInfix "--accept-dns=true" activation;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removes the Homebrew formula for herdr on Darwin so the only way it gets installed is through Nix Home Manager. Adds test coverage that verifies the Nix package is present, the Homebrew formula is gone, and the Darwin service still launches the Nix-backed binary.

<sup>Written for commit 0f438bc1c2c32264f74eeb77b6e4269e0ce3a5f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

