### PR TITLE
fix(home-manager): clear stale links before Linux activation

### DIFF
--- a/hosts/linux/activate-backup-files.sh
+++ b/hosts/linux/activate-backup-files.sh
@@ -6,11 +6,11 @@ set -euo pipefail
 while IFS= read -r -d '' link; do
   target=$(readlink -- "$link")
   case "$target" in
-    /nix/store/*-home-manager-generation/* | /nix/store/*-home-manager-files/*)
-      relative=${link#"$HOME/"}
-      echo "Removing stale Home Manager link $relative"
-      rm -f -- "$link"
-      ;;
+  /nix/store/*-home-manager-generation/* | /nix/store/*-home-manager-files/*)
+    relative=${link#"$HOME/"}
+    echo "Removing stale Home Manager link $relative"
+    rm -f -- "$link"
+    ;;
   esac
 done < <(find "$HOME" -type l -print0)
 

--- a/hosts/linux/activate-backup-files.sh
+++ b/hosts/linux/activate-backup-files.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
-# Backup existing configuration files before home-manager links
+# Remove stale Home Manager links and backup user-owned files before Home
+# Manager checks the targets it is about to link.
 set -euo pipefail
+
+while IFS= read -r -d '' link; do
+  target=$(readlink -- "$link")
+  case "$target" in
+    /nix/store/*-home-manager-generation/* | /nix/store/*-home-manager-files/*)
+      relative=${link#"$HOME/"}
+      echo "Removing stale Home Manager link $relative"
+      rm -f -- "$link"
+      ;;
+  esac
+done < <(find "$HOME" -type l -print0)
 
 for file in .bashrc .profile .bash_profile; do
   if [ -f "$HOME/$file" ] && [ ! -L "$HOME/$file" ]; then

--- a/named-hosts/kyber/activate-backup-files.sh
+++ b/named-hosts/kyber/activate-backup-files.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
-# Backup existing bash configuration files before home-manager links
+# Remove stale Home Manager links and backup user-owned files before Home
+# Manager checks the targets it is about to link.
 set -euo pipefail
+
+while IFS= read -r -d '' link; do
+  target=$(readlink -- "$link")
+  case "$target" in
+    /nix/store/*-home-manager-generation/* | /nix/store/*-home-manager-files/*)
+      relative=${link#"$HOME/"}
+      echo "Removing stale Home Manager link $relative"
+      rm -f -- "$link"
+      ;;
+  esac
+done < <(find "$HOME" -type l -print0)
 
 for file in .bashrc .profile .bash_profile; do
   if [ -f "$HOME/$file" ] && [ ! -L "$HOME/$file" ]; then

--- a/named-hosts/kyber/activate-backup-files.sh
+++ b/named-hosts/kyber/activate-backup-files.sh
@@ -6,11 +6,11 @@ set -euo pipefail
 while IFS= read -r -d '' link; do
   target=$(readlink -- "$link")
   case "$target" in
-    /nix/store/*-home-manager-generation/* | /nix/store/*-home-manager-files/*)
-      relative=${link#"$HOME/"}
-      echo "Removing stale Home Manager link $relative"
-      rm -f -- "$link"
-      ;;
+  /nix/store/*-home-manager-generation/* | /nix/store/*-home-manager-files/*)
+    relative=${link#"$HOME/"}
+    echo "Removing stale Home Manager link $relative"
+    rm -f -- "$link"
+    ;;
   esac
 done < <(find "$HOME" -type l -print0)
 

--- a/spec/activate_hosts_spec.sh
+++ b/spec/activate_hosts_spec.sh
@@ -70,5 +70,10 @@ It 'cleans up codex backups'
 When run bash -c "grep 'codex' '$SCRIPT'"
 The output should include 'hm-backup'
 End
+
+It 'removes stale Home Manager generation links'
+When run bash -c "grep -F 'home-manager-generation' '$SCRIPT' >/dev/null && grep -F 'home-manager-files' '$SCRIPT' >/dev/null && grep -F 'rm -f --' '$SCRIPT' >/dev/null"
+The status should be success
+End
 End
 End

--- a/spec/activate_kyber_spec.sh
+++ b/spec/activate_kyber_spec.sh
@@ -26,6 +26,16 @@ It 'skips symlinks'
 When run bash -c "grep -- '! -L' '$SCRIPT'"
 The output should include '! -L'
 End
+
+It 'removes stale Home Manager generation links'
+When run bash -c "grep -F 'home-manager-generation' '$SCRIPT' >/dev/null && grep -F 'home-manager-files' '$SCRIPT' >/dev/null && grep -F 'rm -f --' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
+It 'preserves unrelated symlinks'
+When run bash -c "grep -F 'case \"\$target\"' '$SCRIPT' >/dev/null && grep -F '/nix/store/*-home-manager-generation/*' '$SCRIPT' >/dev/null"
+The status should be success
+End
 End
 End
 


### PR DESCRIPTION
## Summary

Clear stale Home Manager store symlinks before `checkLinkTargets` runs during Linux Home Manager activation. This prevents prior generations from blocking Kyber and other Linux host switches while preserving unrelated symlinks and backing up regular startup files.

### Tracker linkage
- Linear: none — no Linear issue was created for this incident fix.
- Bead: df-cmwed

## Contract diagram

```mermaid
flowchart LR
  A[Existing home links] --> B[Pre-check cleanup]
  B --> C[Remove only Home Manager store links]
  B --> D[Preserve unrelated links and backup regular files]
  C --> E[Home Manager target checks]
  D --> E
```

## Before / after

| Surface | Before | After |
| --- | --- | --- |
| Linux Home Manager activation | Symlinks from prior Home Manager generations are reported as clobbers and abort the switch. | Only stale links targeting Home Manager store outputs are removed before target checks, allowing the new generation to link. |
| User-owned files and symlinks | Regular startup files are backed up; unrelated symlinks remain untouched. | Same behavior, covered by the narrowed target pattern. |

## Breaking and irreversible changes

### Behavioral

Home Manager-owned symlinks from prior generations are unlinked during activation so the new generation can replace them. Unrelated symlinks are not changed.

### Compile-time

None.

### Durable state and rollback

No migration or persistent schema change. Reverting the commit restores the previous cleanup behavior; a later switch may again fail on stale Home Manager links until the fix is reapplied.

## Deliberate boundaries

This change does not alter Nix trust configuration or force-overwrite arbitrary user files. The untrusted Cachix messages remain warnings and are not the activation failure.

## Verification

- `shellspec spec/activate_kyber_spec.sh spec/activate_hosts_spec.sh` — 77 examples, 0 failures.
- `shellcheck named-hosts/kyber/activate-backup-files.sh hosts/linux/activate-backup-files.sh` — passed.
- Temp-home execution — removed synthetic Home Manager links, preserved an unrelated symlink, and backed up `.profile`.
- Local Kyber activation-package build — blocked by the local `aarch64-darwin` host attempting to build an `x86_64-linux` Obsidian dependency; native Kyber build remains required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears stale Home Manager store symlinks before Linux activation so prior generations no longer block Kyber and other host switches. Previously, symlinks from old generations caused Home Manager's target checks to fail and aborted the switch; now they are removed beforehand. Unrelated symlinks are preserved, and regular startup files are still backed up as before. Adds shellspec tests covering the new cleanup behavior.

<sup>Written for commit 6ae64a283dd7252005715eea5ba38ed1a3f2695c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

