### PR TITLE
fix(home-manager): preserve activation snapshots

### DIFF
--- a/hosts/linux/activate-backup-files.sh
+++ b/hosts/linux/activate-backup-files.sh
@@ -3,6 +3,8 @@
 # Manager checks the targets it is about to link.
 set -euo pipefail
 
+# Activation snapshots are durable rollback state, not active home files. Keep
+# their links intact while cleaning the live home tree.
 while IFS= read -r -d '' link; do
   target=$(readlink -- "$link")
   case "$target" in
@@ -12,7 +14,11 @@ while IFS= read -r -d '' link; do
     rm -f -- "$link"
     ;;
   esac
-done < <(find "$HOME" -type l -print0)
+done < <(
+  find "$HOME" \
+    \( -path "$HOME/.beads" -o -path "$HOME/.cache" -o -path "$HOME/.git" \) -prune \
+    -o -type l -print0 2>/dev/null
+)
 
 for file in .bashrc .profile .bash_profile; do
   if [ -f "$HOME/$file" ] && [ ! -L "$HOME/$file" ]; then

--- a/named-hosts/kyber/activate-backup-files.sh
+++ b/named-hosts/kyber/activate-backup-files.sh
@@ -3,6 +3,8 @@
 # Manager checks the targets it is about to link.
 set -euo pipefail
 
+# Activation snapshots are durable rollback state, not active home files. Keep
+# their links intact while cleaning the live home tree.
 while IFS= read -r -d '' link; do
   target=$(readlink -- "$link")
   case "$target" in
@@ -12,7 +14,11 @@ while IFS= read -r -d '' link; do
     rm -f -- "$link"
     ;;
   esac
-done < <(find "$HOME" -type l -print0)
+done < <(
+  find "$HOME" \
+    \( -path "$HOME/.beads" -o -path "$HOME/.cache" -o -path "$HOME/.git" \) -prune \
+    -o -type l -print0 2>/dev/null
+)
 
 for file in .bashrc .profile .bash_profile; do
   if [ -f "$HOME/$file" ] && [ ! -L "$HOME/$file" ]; then

--- a/spec/activate_hosts_spec.sh
+++ b/spec/activate_hosts_spec.sh
@@ -75,5 +75,10 @@ It 'removes stale Home Manager generation links'
 When run bash -c "grep -F 'home-manager-generation' '$SCRIPT' >/dev/null && grep -F 'home-manager-files' '$SCRIPT' >/dev/null && grep -F 'rm -f --' '$SCRIPT' >/dev/null"
 The status should be success
 End
+
+It 'preserves activation snapshot links'
+When run bash -c "grep -F '\$HOME/.beads' '$SCRIPT' >/dev/null && grep -F '\$HOME/.cache' '$SCRIPT' >/dev/null"
+The status should be success
+End
 End
 End

--- a/spec/activate_kyber_spec.sh
+++ b/spec/activate_kyber_spec.sh
@@ -36,6 +36,11 @@ It 'preserves unrelated symlinks'
 When run bash -c "grep -F 'case \"\$target\"' '$SCRIPT' >/dev/null && grep -F '/nix/store/*-home-manager-generation/*' '$SCRIPT' >/dev/null"
 The status should be success
 End
+
+It 'preserves activation snapshot links'
+When run bash -c "grep -F '\$HOME/.beads' '$SCRIPT' >/dev/null && grep -F '\$HOME/.cache' '$SCRIPT' >/dev/null"
+The status should be success
+End
 End
 End
 


### PR DESCRIPTION
## Summary

Narrow the Linux Home Manager stale-link cleanup so durable activation snapshots are excluded from the live-home scan. This follow-up preserves rollback state while retaining the Kyber switch fix.

### Tracker linkage
- Linear: none — no Linear issue was created for this incident fix.
- Bead: df-cmwed

## Contract diagram

```mermaid
flowchart LR
  A[Live home tree] --> B[Pre-check cleanup]
  B --> C[Remove stale Home Manager links]
  D[Activation snapshots] --> E[Excluded rollback state]
  C --> F[Home Manager target checks]
```

## Before / after

| Surface | Before | After |
| --- | --- | --- |
| Activation cleanup | Recursive cleanup also traversed `.beads` rollback snapshots. | `.beads`, `.cache`, and `.git` trees are pruned before stale-link cleanup. |
| Kyber activation | Snapshot links could be removed before target checks. | Snapshot links remain available for rollback while active stale links are replaced. |

## Breaking and irreversible changes

### Behavioral

Rollback snapshot trees are preserved. Stale Home Manager links in the active home tree continue to be removed.

### Compile-time

None.

### Durable state and rollback

No schema or migration. The first merged fix was interrupted during Kyber activation; the archived snapshot links removed by that scan were restored from their generation roots before this follow-up was prepared.

## Deliberate boundaries

This does not change Nix trust configuration or force-overwrite arbitrary user files.

## Verification

- `make nix-format` — formatted with 0 files changed after the patch.
- `shellspec spec/activate_kyber_spec.sh spec/activate_hosts_spec.sh` — 79 examples, 0 failures.
- `shellcheck named-hosts/kyber/activate-backup-files.sh hosts/linux/activate-backup-files.sh` — passed.
- Temp-home scope test — preserved a synthetic `.beads` snapshot link and removed an active stale link.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves durable Home Manager activation snapshots during stale-link cleanup on Linux. Cleanup now prunes `.beads`, `.cache`, and `.git` directories, so rollback links are not removed while stale live-home links are still cleaned. Adds ShellSpec tests covering this behavior for both the Kyber and generic activation scripts.

<sup>Written for commit a2cd0181772ffdecd54cdca70e3a04eb54c3b472. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

