### PR TITLE
fix(home-manager): use generation manifest for cleanup

### DIFF
--- a/hosts/linux/activate-backup-files.sh
+++ b/hosts/linux/activate-backup-files.sh
@@ -3,22 +3,24 @@
 # Manager checks the targets it is about to link.
 set -euo pipefail
 
-# Activation snapshots are durable rollback state, not active home files. Keep
-# their links intact while cleaning the live home tree.
+home_files=${1:?Home Manager home-files path is required}
+
+# Inspect only paths in the new generation manifest. This avoids traversing
+# user data and durable activation snapshots while still replacing links from
+# any previous Home Manager generation.
 while IFS= read -r -d '' link; do
-  target=$(readlink -- "$link")
-  case "$target" in
+  target_path=${link#"$home_files/"}
+  target="$HOME/$target_path"
+  [ -L "$target" ] || continue
+  link_target=$(readlink -- "$target")
+  case "$link_target" in
   /nix/store/*-home-manager-generation/* | /nix/store/*-home-manager-files/*)
-    relative=${link#"$HOME/"}
+    relative=${target#"$HOME/"}
     echo "Removing stale Home Manager link $relative"
-    rm -f -- "$link"
+    rm -f -- "$target"
     ;;
   esac
-done < <(
-  find "$HOME" \
-    \( -path "$HOME/.beads" -o -path "$HOME/.cache" -o -path "$HOME/.git" \) -prune \
-    -o -type l -print0 2>/dev/null
-)
+done < <(find -L "$home_files" -type f -print0)
 
 for file in .bashrc .profile .bash_profile; do
   if [ -f "$HOME/$file" ] && [ ! -L "$HOME/$file" ]; then

--- a/hosts/linux/default.nix
+++ b/hosts/linux/default.nix
@@ -36,7 +36,7 @@ home-manager.lib.homeManagerConfiguration {
           before = [ "checkLinkTargets" ];
           after = [ ];
           data = ''
-            ${pkgs.bash}/bin/bash "${./activate-backup-files.sh}"
+            ${pkgs.bash}/bin/bash "${./activate-backup-files.sh}" "$newGenPath/home-files"
           '';
         };
       };

--- a/named-hosts/kyber/activate-backup-files.sh
+++ b/named-hosts/kyber/activate-backup-files.sh
@@ -3,22 +3,24 @@
 # Manager checks the targets it is about to link.
 set -euo pipefail
 
-# Activation snapshots are durable rollback state, not active home files. Keep
-# their links intact while cleaning the live home tree.
+home_files=${1:?Home Manager home-files path is required}
+
+# Inspect only paths in the new generation manifest. This avoids traversing
+# user data and durable activation snapshots while still replacing links from
+# any previous Home Manager generation.
 while IFS= read -r -d '' link; do
-  target=$(readlink -- "$link")
-  case "$target" in
+  target_path=${link#"$home_files/"}
+  target="$HOME/$target_path"
+  [ -L "$target" ] || continue
+  link_target=$(readlink -- "$target")
+  case "$link_target" in
   /nix/store/*-home-manager-generation/* | /nix/store/*-home-manager-files/*)
-    relative=${link#"$HOME/"}
+    relative=${target#"$HOME/"}
     echo "Removing stale Home Manager link $relative"
-    rm -f -- "$link"
+    rm -f -- "$target"
     ;;
   esac
-done < <(
-  find "$HOME" \
-    \( -path "$HOME/.beads" -o -path "$HOME/.cache" -o -path "$HOME/.git" \) -prune \
-    -o -type l -print0 2>/dev/null
-)
+done < <(find -L "$home_files" -type f -print0)
 
 for file in .bashrc .profile .bash_profile; do
   if [ -f "$HOME/$file" ] && [ ! -L "$HOME/$file" ]; then

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -50,7 +50,7 @@ home-manager.lib.homeManagerConfiguration {
             before = [ "checkLinkTargets" ];
             after = [ ];
             data = ''
-              ${pkgs.bash}/bin/bash ${./activate-backup-files.sh}
+              ${pkgs.bash}/bin/bash ${./activate-backup-files.sh} "$newGenPath/home-files"
             '';
           };
         };

--- a/spec/activate_hosts_spec.sh
+++ b/spec/activate_hosts_spec.sh
@@ -76,8 +76,8 @@ When run bash -c "grep -F 'home-manager-generation' '$SCRIPT' >/dev/null && grep
 The status should be success
 End
 
-It 'preserves activation snapshot links'
-When run bash -c "grep -F '\$HOME/.beads' '$SCRIPT' >/dev/null && grep -F '\$HOME/.cache' '$SCRIPT' >/dev/null"
+It 'uses the new generation manifest instead of scanning the home directory'
+When run bash -c "grep -F 'home_files=' '$SCRIPT' >/dev/null && grep -F 'find -L \"\$home_files\"' '$SCRIPT' >/dev/null && grep -F '\"\$newGenPath/home-files\"' '$PWD/hosts/linux/default.nix' >/dev/null"
 The status should be success
 End
 End

--- a/spec/activate_kyber_spec.sh
+++ b/spec/activate_kyber_spec.sh
@@ -33,12 +33,12 @@ The status should be success
 End
 
 It 'preserves unrelated symlinks'
-When run bash -c "grep -F 'case \"\$target\"' '$SCRIPT' >/dev/null && grep -F '/nix/store/*-home-manager-generation/*' '$SCRIPT' >/dev/null"
+When run bash -c "grep -F 'case \"\$link_target\"' '$SCRIPT' >/dev/null && grep -F '/nix/store/*-home-manager-generation/*' '$SCRIPT' >/dev/null"
 The status should be success
 End
 
-It 'preserves activation snapshot links'
-When run bash -c "grep -F '\$HOME/.beads' '$SCRIPT' >/dev/null && grep -F '\$HOME/.cache' '$SCRIPT' >/dev/null"
+It 'uses the new generation manifest instead of scanning the home directory'
+When run bash -c "grep -F 'home_files=' '$SCRIPT' >/dev/null && grep -F 'find -L \"\$home_files\"' '$SCRIPT' >/dev/null && grep -F '\"\$newGenPath/home-files\"' '$PWD/named-hosts/kyber/default.nix' >/dev/null"
 The status should be success
 End
 End


### PR DESCRIPTION
## Summary

Use the new Home Manager generation's `home-files` manifest to identify destination paths before `checkLinkTargets`. This removes stale prior-generation links without scanning user data or rollback snapshots.

### Tracker linkage
- Linear: none — no Linear issue was created for this incident fix.
- Bead: df-cmwed

## Contract diagram

```mermaid
flowchart LR
  A[New generation home-files] --> B[Enumerate managed paths]
  B --> C[Inspect matching live destinations]
  C --> D[Remove stale Home Manager links]
  C --> E[Preserve snapshots and unrelated paths]
  D --> F[Home Manager target checks]
  E --> F
```

## Before / after

| Surface | Before | After |
| --- | --- | --- |
| Activation cleanup | A recursive home scan was slow and could touch rollback snapshots. | Only paths present in `$newGenPath/home-files` are inspected. |
| Kyber switch | Stale prior-generation links blocked activation. | Matching stale links are removed and the new generation can link them. |

## Breaking and irreversible changes

### Behavioral

The cleanup is limited to current-generation destination paths and prior Home Manager store links. Unrelated symlinks and activation snapshots remain untouched.

### Compile-time

None.

### Durable state and rollback

No schema or migration. The interrupted broad-scan activation was stopped and the two affected Kyber snapshot trees were restored from their generation roots before this change.

## Deliberate boundaries

This does not change Nix trust configuration or force-overwrite arbitrary user files.

## Verification

- `make nix-format` — 0 files changed after formatting.
- `shellspec spec/activate_kyber_spec.sh spec/activate_hosts_spec.sh` — 79 examples, 0 failures.
- `shellcheck named-hosts/kyber/activate-backup-files.sh hosts/linux/activate-backup-files.sh` — passed.
- Temp-home generation-manifest test — removed a stale managed link and preserved a synthetic `.beads` snapshot link.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes activation cleanup that blocked Kyber switches by using the new generation's `home-files` manifest instead of recursively scanning the home directory. The old scan was slow and could touch rollback snapshots; now only manifest-listed paths are inspected and stale Home Manager store links are removed.

**Behavior**
- Cleanup inspects only destinations listed in the new generation's `home-files` manifest.
- Unrelated symlinks and activation snapshots remain untouched.
- Both `hosts/linux` and `named-hosts/kyber` activation scripts now require the manifest path as an argument.
- No migration or schema changes needed.

<sup>Written for commit a658a088e31c602e28c072b6e4d32a05070fe5e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

