### PR TITLE
fix(home-manager): pass generation manifest to Linux cleanup

### DIFF
--- a/named-hosts/andor/default.nix
+++ b/named-hosts/andor/default.nix
@@ -48,7 +48,7 @@ home-manager.lib.homeManagerConfiguration {
             before = [ "checkLinkTargets" ];
             after = [ ];
             data = ''
-              ${pkgs.bash}/bin/bash "${../../hosts/linux/activate-backup-files.sh}"
+              ${pkgs.bash}/bin/bash "${../../hosts/linux/activate-backup-files.sh}" "$newGenPath/home-files"
             '';
           };
         };

--- a/named-hosts/kamino/default.nix
+++ b/named-hosts/kamino/default.nix
@@ -51,7 +51,7 @@ inputs.home-manager.lib.homeManagerConfiguration {
           before = [ "checkLinkTargets" ];
           after = [ ];
           data = ''
-            ${pkgs.bash}/bin/bash "${../../hosts/linux/activate-backup-files.sh}"
+            ${pkgs.bash}/bin/bash "${../../hosts/linux/activate-backup-files.sh}" "$newGenPath/home-files"
           '';
         };
         programs.home-manager.enable = true;

--- a/named-hosts/pod/default.nix
+++ b/named-hosts/pod/default.nix
@@ -36,7 +36,7 @@ home-manager.lib.homeManagerConfiguration {
             before = [ "checkLinkTargets" ];
             after = [ ];
             data = ''
-              ${pkgs.bash}/bin/bash "${../../hosts/linux/activate-backup-files.sh}"
+              ${pkgs.bash}/bin/bash "${../../hosts/linux/activate-backup-files.sh}" "$newGenPath/home-files"
             '';
           };
         };


### PR DESCRIPTION
Pass the new Home Manager generation manifest to the shared Linux cleanup helper for Andor, Kamino, and Pod. The helper now requires this path to avoid traversing user data and activation snapshots.

Validation: git diff --check; shellcheck; shellspec spec/activate_hosts_spec.sh spec/activate_kyber_spec.sh (79 examples); make nix-format.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Passes the new Home Manager generation manifest to the Linux cleanup helper for Andor, Kamino, and Pod so it no longer traverses user data and activation snapshots.

<sup>Written for commit 68bba9a38036dc36c852e61a8d387599adf4d4d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

