### PR TITLE
fix(home-manager): expose llm-agents on Galactica

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -40,7 +40,7 @@ with pkgs;
   croc
   curl
   curlie
-  cursor-cli
+  pkgs.llm-agents.cursor-agent
   dasel
   delta
   difftastic
@@ -76,6 +76,7 @@ with pkgs;
   grc
   gron
   pkgs.llm-agents.herdr
+  pkgs.llm-agents.grok
   hexyl
   htop
   httpie
@@ -162,7 +163,6 @@ with pkgs;
   fwupd
   gcc
   glib
-  pkgs.llm-agents.grok
   keychain
   libiconv
   libsecret

--- a/spec/llm_agents_packages_spec.sh
+++ b/spec/llm_agents_packages_spec.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+Describe 'Cross-platform llm-agents packages'
+
+PACKAGES="$PWD/home-manager/packages/default.nix"
+
+It 'uses the upstream Cursor Agent package'
+When run grep -Fx '  pkgs.llm-agents.cursor-agent' "$PACKAGES"
+The output should include '  pkgs.llm-agents.cursor-agent'
+End
+
+It 'keeps Grok in the shared package set'
+When run bash -c "line=\$(grep -nF 'pkgs.llm-agents.grok' \"$PACKAGES\" | cut -d: -f1); boundary=\$(grep -nF '++ lib.optionals stdenv.hostPlatform.isDarwin' \"$PACKAGES\" | cut -d: -f1); test -n \"\$line\" -a -n \"\$boundary\" -a \"\$line\" -lt \"\$boundary\""
+The status should be success
+End
+
+It 'does not retain the separate nixpkgs Cursor CLI'
+When run grep -Fx '  cursor-cli' "$PACKAGES"
+The status should not be success
+End
+
+End


### PR DESCRIPTION
## Summary
Expose the Darwin-supported Grok and Cursor Agent packages through the shared Home Manager package set so Galactica receives the expected agent CLIs.

### Tracker linkage
- Linear: SHUN-4989
- Bead: df-dvopn

Fixes SHUN-4989

## Before / after

| Surface | Before | After |
| --- | --- | --- |
| Galactica Home Manager packages | Grok omitted; nixpkgs `cursor-cli` selected | `pkgs.llm-agents.grok` and `pkgs.llm-agents.cursor-agent` selected |
| CLI availability after activation | No `grok` / `agent`; Cursor package source was separate | `grok`, Grok `agent`, and `cursor-agent` are provided by `llm-agents.nix` |
| Linux package behavior | Grok selected from a Linux-only block | Grok is shared because the locked upstream package supports Darwin and keeps `wrapBuddy` Linux-only |

## Breaking and irreversible changes

- Behavioral: adds the requested Grok and Cursor Agent CLIs to Galactica; removes the separate nixpkgs Cursor CLI selection.
- Compile-time: no public API or type changes.
- Durable state and rollback: no migrations or durable state changes; reverting the commit restores the previous package set.

## Deliberate boundaries

This PR does not install every helper derivation exposed by the upstream `llm-agents.nix` flake, and it does not change the Linux-only GUI package group. It adds the supported agent CLIs requested for Galactica while preserving platform guards for unrelated packages.

## Verification

- `shellspec spec/llm_agents_packages_spec.sh spec/caam_config_spec.sh` — 16 examples, 0 failures
- Darwin evaluation of `darwinConfigurations.galactica.config.home-manager.users.shunkakinoki.home.packages` — includes `cursor-agent-2026.08.25-3e8eec8` and `grok-1.0.13`
- `git diff --check` — passed
- Clean `origin/main` reproduction — existing Herdr worker-admission test failures are unrelated to this PR

## Review notes

Non-UI configuration change; screenshots and accessibility evidence are not applicable.