### PR TITLE
fix(home-manager): expose Muse Code on Galactica

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -71,15 +71,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1784665499,
-        "narHash": "sha256-9BMxlTxCCDAeoNLtb1a/st7udtTIJep+wpUzquA29VU=",
-        "owner": "nix-community",
+        "lastModified": 1788011267,
+        "narHash": "sha256-mEq2kU+ljompTToZ44Afvm7d/rHJ5iMBl0tjZuyShJs=",
+        "owner": "Mic92",
         "repo": "bun2nix",
-        "rev": "0f2a1f0b6f42cebe3b149bf62d38754c5e0e9729",
+        "rev": "5765b0614591f75ee8ba5596e81ae85c167d1071",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
+        "owner": "Mic92",
+        "ref": "fix-structured-attrs-hook",
         "repo": "bun2nix",
         "type": "github"
       }
@@ -266,11 +267,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787559586,
-        "narHash": "sha256-onL0VLf9vPllmT0H/OlURIU5r5t5WIEl7t4tVNKT0Nw=",
+        "lastModified": 1788450739,
+        "narHash": "sha256-glZLQlzIn1fXH6PazR2iUmTo7kzzyYSshrWhLS9TqCU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9d0d87172c374f89da73c1cfe6d81ae62feac1f1",
+        "rev": "31729ca8cbdb4fa927b34e5f4353e6a83f39e993",
         "type": "github"
       },
       "original": {
@@ -465,11 +466,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1788150365,
-        "narHash": "sha256-m2gPtFZRPdD5uhXoHii410PWCJrUZKh+JYAfQz/3Cpo=",
+        "lastModified": 1789098369,
+        "narHash": "sha256-ziCSBMAFEeJzhwNpxydECUpiB391Ci4A2sc99bvBpKg=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "589f676e56d5de0bc300cada69e93ab3bc8c0841",
+        "rev": "d26c4af29f2375eecb7f3e76ac36acb892227a50",
         "type": "github"
       },
       "original": {

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -77,6 +77,7 @@ with pkgs;
   gron
   pkgs.llm-agents.herdr
   pkgs.llm-agents.grok
+  pkgs.llm-agents.muse-code
   hexyl
   htop
   httpie

--- a/spec/llm_agents_packages_spec.sh
+++ b/spec/llm_agents_packages_spec.sh
@@ -14,6 +14,11 @@ When run bash -c "line=\$(grep -nF 'pkgs.llm-agents.grok' \"$PACKAGES\" | cut -d
 The status should be success
 End
 
+It 'includes Muse Code in the shared package set'
+When run grep -Fx '  pkgs.llm-agents.muse-code' "$PACKAGES"
+The output should include '  pkgs.llm-agents.muse-code'
+End
+
 It 'does not retain the separate nixpkgs Cursor CLI'
 When run grep -Fx '  cursor-cli' "$PACKAGES"
 The status should not be success


### PR DESCRIPTION
## Summary
Expose Meta Muse Code through the shared `llm-agents.nix` package set used by Galactica. The locked input is refreshed because the previous revision did not expose the `muse-code` package for the target host.

### Tracker linkage
- Linear: none — no Linear issue was provided or associated with this scoped dotfiles task.
- Bead: df-llbuz

## Before / after

| Surface | Before | After |
| --- | --- | --- |
| Galactica Home Manager packages | Muse Code was absent from the package set. | `muse-code-1.1.1-R2514.1` is included and evaluates for `aarch64-darwin`. |

## Breaking and irreversible changes

- **Behavioral:** Adds the Muse Code executable to the declarative user package set; reverting the commit removes it on the next activation.
- **Compile-time:** No public code contracts change.
- **Durable state and rollback:** No migrations or persisted records. Rollback is a normal revert followed by Home Manager activation.

## Deliberate boundaries

This PR only exposes the package; it does not activate Galactica or configure Muse credentials, accounts, or service behavior.

## Verification

- `shellspec spec/llm_agents_packages_spec.sh` — 4 examples, 0 failures
- `nix eval` of the locked `llm-agents` input — `muse-code` present on `aarch64-darwin`, version `1.1.1-R2514.1`
- `nix eval .#darwinConfigurations.galactica.config.home-manager.users.shunkakinoki.home.packages` — includes `muse-code-1.1.1-R2514.1`
- `make nix-test` — passed
- `make nix-format-check` — passed
- `make nix-lint` — passed with existing dead-code warnings
- `git diff --check` — passed

Evidence safety: Not applicable; this is a configuration/package change with no rendered UI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes Muse Code on Galactica by adding `pkgs.llm-agents.muse-code` to the shared Home Manager package set and refreshing the locked `llm-agents.nix` input to a revision that provides it.

- Adds `muse-code-1.1.1-R2514.1` for `aarch64-darwin`; reverting the commit removes it on the next activation.
- Also updates locked `bun2nix` and `flake-parts` inputs as part of the lockfile refresh.
- Adds a spec test asserting Muse Code is in the package set.
- Only exposes the package; it does not activate Galactica or configure Muse credentials, accounts, or service behavior.

<sup>Written for commit de0b920b5f07ade8c8cb08267123b07c134f47bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

