### PR TITLE
fix(overlay): guard Linux-only wrapBuddy on Darwin

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -83,24 +83,41 @@
   (
     _: prev:
     let
-      wrapBuddy = prev.llm-agents.wrapBuddy;
-      wrapBuddyBinary = builtins.head wrapBuddy.propagatedBuildInputs;
-      fixedWrapBuddy = wrapBuddy.overrideAttrs (_: {
-        propagatedBuildInputs = [
-          (wrapBuddyBinary.overrideAttrs (old: {
-            postPatch = (old.postPatch or "") + ''
-              # grep -q exits as soon as it finds the match. With pipefail, the
-              # upstream echo producer can then receive SIGPIPE and fail the
-              # otherwise-successful install check under loaded CI runners.
-              substituteInPlace tests/test.sh \
-                --replace-fail 'echo "$output" | grep -q "Hello from patched binary!" ||' \
-                'grep -q "Hello from patched binary!" <<< "$output" ||' \
-                --replace-fail 'echo "$output" | grep -q "NEEDED_LOADED=yes" ||' \
-                'grep -q "NEEDED_LOADED=yes" <<< "$output" ||'
-            '';
-          }))
-        ];
-      });
+      linuxGrokOverrides =
+        prev.lib.optionalAttrs
+          (prev.stdenv.hostPlatform.isLinux && prev.llm-agents ? grok && prev.llm-agents ? wrapBuddy)
+          (
+            let
+              wrapBuddy = prev.llm-agents.wrapBuddy;
+              wrapBuddyBinary = builtins.head wrapBuddy.propagatedBuildInputs;
+              fixedWrapBuddy = wrapBuddy.overrideAttrs (_: {
+                propagatedBuildInputs = [
+                  (wrapBuddyBinary.overrideAttrs (old: {
+                    postPatch = (old.postPatch or "") + ''
+                      # grep -q exits as soon as it finds the match. With pipefail, the
+                      # upstream echo producer can then receive SIGPIPE and fail the
+                      # otherwise-successful install check under loaded CI runners.
+                      substituteInPlace tests/test.sh \
+                        --replace-fail 'echo "$output" | grep -q "Hello from patched binary!" ||' \
+                        'grep -q "Hello from patched binary!" <<< "$output" ||' \
+                        --replace-fail 'echo "$output" | grep -q "NEEDED_LOADED=yes" ||' \
+                        'grep -q "NEEDED_LOADED=yes" <<< "$output" ||'
+                    '';
+                  }))
+                ];
+              });
+            in
+            {
+              # wrap-buddy-hook is Linux-only; keep its fix off Darwin evaluation.
+              grok = prev.llm-agents.grok.overrideAttrs (old: {
+                doInstallCheck = false;
+                nativeBuildInputs = map (
+                  input: if (input.outPath or "") == wrapBuddy.outPath then fixedWrapBuddy else input
+                ) (old.nativeBuildInputs or [ ]);
+              });
+              wrapBuddy = fixedWrapBuddy;
+            }
+          );
     in
     {
       # Upstream grok 0.1.218 fails versionCheckHook because `grok --version`/`--help`
@@ -128,15 +145,7 @@
             }
           );
         }
-        // prev.lib.optionalAttrs (prev.llm-agents ? grok) {
-          grok = prev.llm-agents.grok.overrideAttrs (old: {
-            doInstallCheck = false;
-            nativeBuildInputs = map (
-              input: if (input.outPath or "") == wrapBuddy.outPath then fixedWrapBuddy else input
-            ) (old.nativeBuildInputs or [ ]);
-          });
-          wrapBuddy = fixedWrapBuddy;
-        }
+        // linuxGrokOverrides
         // prev.lib.optionalAttrs (prev.llm-agents ? bernstein) {
           # bernstein 2.8.2 requires reportlab<5,>=4.0 but nixpkgs now provides
           # reportlab 5.0.0, failing pythonRuntimeDepsCheckHook.

--- a/spec/llm_agents_packages_spec.sh
+++ b/spec/llm_agents_packages_spec.sh
@@ -3,6 +3,7 @@
 Describe 'Cross-platform llm-agents packages'
 
 PACKAGES="$PWD/home-manager/packages/default.nix"
+OVERLAY="$PWD/overlays/default.nix"
 
 It 'uses the upstream Cursor Agent package'
 When run grep -Fx '  pkgs.llm-agents.cursor-agent' "$PACKAGES"
@@ -17,6 +18,11 @@ End
 It 'includes Muse Code in the shared package set'
 When run grep -Fx '  pkgs.llm-agents.muse-code' "$PACKAGES"
 The output should include '  pkgs.llm-agents.muse-code'
+End
+
+It 'guards the Linux-only Grok wrapBuddy override'
+When run bash -c "grep -F 'linuxGrokOverrides' \"$OVERLAY\" >/dev/null && grep -F 'prev.stdenv.hostPlatform.isLinux' \"$OVERLAY\" >/dev/null"
+The status should be success
 End
 
 It 'does not retain the separate nixpkgs Cursor CLI'


### PR DESCRIPTION
## Summary
Follow up the Muse Code rollout by fixing Galactica's Darwin evaluation failure. The existing Grok overlay forced the Linux-only `wrap-buddy-hook` derivation while evaluating `aarch64-darwin`; the override is now constructed only on Linux hosts.

### Tracker linkage
- Linear: none — no Linear issue was provided or associated with this scoped dotfiles task.
- Bead: df-13yhz

## Before / after

 | Surface | Before | After |
| --- | --- | --- |
| Galactica Darwin system evaluation | Evaluation failed because `wrap-buddy-hook` is unsupported on `aarch64-darwin`. | The Linux-only Grok/WrapBuddy override is skipped on Darwin and the Galactica system derivation evaluates successfully. |

## Breaking and irreversible changes

- **Behavioral:** Darwin no longer evaluates a Linux-only build override; Linux keeps the existing WrapBuddy fix.
- **Compile-time:** No public contracts change.
- **Durable state and rollback:** No migrations or persisted state. Revert the commit to restore the previous overlay behavior.

## Deliberate boundaries

This PR fixes configuration evaluation only. It does not change Muse credentials, service configuration, or activate a host.

## Verification

- `NIXPKGS_ALLOW_UNFREE=1 nix eval .#darwinConfigurations.galactica.system.drvPath --impure` — returned the Darwin system derivation without the unsupported-system error
- `NIXPKGS_ALLOW_UNFREE=1 nix build .#checks.aarch64-darwin.eval-darwin-galactica --no-link --impure --no-update-lock-file --offline` — passed
- `shellspec spec/llm_agents_packages_spec.sh` — 5 examples, 0 failures
- `nix fmt -- --fail-on-change` — passed
- `make nix-lint` — passed with existing dead-code warnings
- `git diff --check` — passed

Evidence safety: Not applicable; this is a configuration evaluation fix with no rendered UI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Galactica Darwin evaluation failure by guarding the Linux-only Grok `wrapBuddy` override to Linux hosts. Darwin previously tried to evaluate the unsupported `wrap-buddy-hook` and failed; now the override is skipped on `aarch64-darwin`, while Linux keeps the existing WrapBuddy fix.

- Adds a spec check that the override is guarded by `prev.stdenv.hostPlatform.isLinux`.

<sup>Written for commit 9cdc8627e5d80bf80b1d666f8810ee1f717005bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

