### PR TITLE
feat(beads): manage bd through the upstream beads flake

### DIFF
--- a/.local-binaries.txt
+++ b/.local-binaries.txt
@@ -34,5 +34,4 @@
 ~/ghq/github.com/nwiizo/ccswarm/target/release/ccswarm
 ~/ghq/github.com/openai/symphony/elixir/bin/symphony
 ~/ghq/github.com/roborev-dev/roborev/bin/roborev
-~/ghq/github.com/steveyegge/beads/bd
 ~/ghq/github.com/steveyegge/gastown/gt

--- a/flake.lock
+++ b/flake.lock
@@ -25,6 +25,26 @@
         "type": "github"
       }
     },
+    "beads": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788916595,
+        "narHash": "sha256-2OaA2zFY9wrPPBo7WplVc7Hcwt90c/uQ1jiMTVm+Xo4=",
+        "owner": "gastownhall",
+        "repo": "beads",
+        "rev": "a690b0a8c4d1ddc4f0bd9bf767499625dd71bc96",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gastownhall",
+        "repo": "beads",
+        "type": "github"
+      }
+    },
     "bun2nix": {
       "inputs": {
         "flake-parts": "flake-parts_3",
@@ -825,6 +845,7 @@
     "root": {
       "inputs": {
         "agenix": "agenix",
+        "beads": "beads",
         "devenv": "devenv",
         "flake-parts": "flake-parts_2",
         "foundry": "foundry",

--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,10 @@
       url = "github:cjpais/Handy";
       inputs.nixpkgs.follows = "nixpkgs-darwin-legacy";
     };
+    beads = {
+      url = "github:gastownhall/beads";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/home-manager/modules/beads/default.nix
+++ b/home-manager/modules/beads/default.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }:
+{
+  # ~/.local/bin precedes every nix profile dir in PATH (see programs/fish),
+  # so the flake-managed bd only wins if it also owns the ~/.local/bin entry
+  # that update-local-binaries.sh used to create.
+  home.file.".local/bin/bd".source = "${pkgs.beads}/bin/bd";
+  home.file.".local/bin/beads".source = "${pkgs.beads}/bin/beads";
+}

--- a/home-manager/modules/default.nix
+++ b/home-manager/modules/default.nix
@@ -1,4 +1,5 @@
 [
+  ./beads
   ./bin-shells
   ./cargo-globals
   ./dotenv

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -27,6 +27,7 @@ with pkgs;
   azure-cli
   bandwhich
   bat
+  beads
   blacksmith-testbox-cli
   pkgs.llm-agents.bernstein
   broot

--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -39,7 +39,7 @@ let
     inherit (pkgs) dolt;
   };
   linearSyncScript = pkgs.replaceVars ./linear-sync.sh {
-    bd = "${homeDir}/.local/bin/bd";
+    bd = "${pkgs.beads}/bin/bd";
     linear = "${homeDir}/.bun/install/global/node_modules/.bin/linear";
     inherit linearWorkspace linearTeamId;
     utilLinux = pkgs.util-linux;

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -208,6 +208,7 @@
     }
   )
   inputs.noctalia-shell.overlays.default
+  inputs.beads.overlays.default
   (_: prev: {
     # Keep the Dolt archive-integrity fix independent from the shared nixpkgs
     # pin so storage recovery does not upgrade unrelated host packages.

--- a/spec/beads_spec.sh
+++ b/spec/beads_spec.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+Describe 'Nix-managed beads'
+
+FLAKE="$PWD/flake.nix"
+OVERLAY="$PWD/overlays/default.nix"
+PACKAGES="$PWD/home-manager/packages/default.nix"
+MODULE="$PWD/home-manager/modules/beads/default.nix"
+MODULES="$PWD/home-manager/modules/default.nix"
+LOCAL_BINARIES="$PWD/.local-binaries.txt"
+
+It 'tracks the upstream beads flake'
+When run grep -F 'url = "github:gastownhall/beads"' "$FLAKE"
+The output should include 'github:gastownhall/beads'
+End
+
+It 'applies the beads overlay'
+When run grep -Fx '  inputs.beads.overlays.default' "$OVERLAY"
+The output should include 'inputs.beads.overlays.default'
+End
+
+It 'installs beads on every host'
+When run bash -c "line=\$(grep -nFx '  beads' \"$PACKAGES\" | cut -d: -f1); boundary=\$(grep -nF '++ lib.optionals stdenv.hostPlatform.isDarwin' \"$PACKAGES\" | cut -d: -f1); test -n \"\$line\" -a -n \"\$boundary\" -a \"\$line\" -lt \"\$boundary\""
+The status should be success
+End
+
+It 'owns the ~/.local/bin entries that outrank the nix profile'
+When run bash -c "grep -F 'home.file.\".local/bin/bd\".source = \"\${pkgs.beads}/bin/bd\"' \"$MODULE\" >/dev/null && grep -F 'home.file.\".local/bin/beads\".source = \"\${pkgs.beads}/bin/beads\"' \"$MODULE\" >/dev/null"
+The status should be success
+End
+
+It 'imports the beads module'
+When run grep -Fx '  ./beads' "$MODULES"
+The output should include './beads'
+End
+
+It 'no longer builds bd through update-local-binaries.sh'
+When run grep -F 'steveyegge/beads' "$LOCAL_BINARIES"
+The status should not be success
+End
+
+End


### PR DESCRIPTION
`bd` was built from a ghq checkout by `update-local-binaries.sh` (`ulb`). It is now a nix flake input, installed on every host.

## Changes

- `beads` flake input: `github:gastownhall/beads`, `nixpkgs` follows the shared pin
- `inputs.beads.overlays.default` registered in `overlays/default.nix`
- `beads` added to the shared (all-host) package set
- New `home-manager/modules/beads` owns `~/.local/bin/{bd,beads}`
- `~/ghq/github.com/steveyegge/beads/bd` removed from `.local-binaries.txt`
- dolt linear-sync now calls `${pkgs.beads}/bin/bd` instead of `~/.local/bin/bd`

## Why the `~/.local/bin` ownership

`fish_add_path` puts `~/.local/bin` ahead of every nix profile directory. Dropping the `ulb` manifest entry alone would leave the stale symlink in place, still shadowing the nix `bd`. Having home-manager own those two entries makes the flake build win on all hosts and lets the generation manifest clean them up.

## Verification

- `nix eval .#darwinConfigurations.galactica...toplevel.drvPath` - ok
- `pkgs.beads` evaluates for `x86_64-linux` and `aarch64-linux` (beads-1.2.2)
- `nix fmt --fail-on-change` - 0 changed
- `shellspec spec/beads_spec.sh` - 6 examples, 0 failures

`nixosConfigurations.matic` cannot be evaluated on darwin (pre-existing IFD platform mismatch on `docker.service`); CI covers Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `bd` from a ghq checkout built by `update-local-binaries.sh` to a nix flake input (`github:gastownhall/beads`) so it's consistently installed on every host via the shared package set.

- Adds `beads` as a flake input with `nixpkgs` following the shared pin and registers its overlay.
- Installs `beads` in the all-host package set and adds a new `home-manager` module that owns the `~/.local/bin/bd` and `~/.local/bin/beads` symlinks.
- The symlink ownership is needed because `~/.local/bin` precedes nix profile directories in PATH, so without it the stale symlink would still shadow the nix version.
- Removes the `bd` entry from `.local-binaries.txt`.
- Updates dolt's linear-sync to use `${pkgs.beads}/bin/bd` directly.

<sup>Written for commit 3536d5f324a21460680054e9e8a99e757d8f3917. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

