### PR TITLE
fix(home-manager): force beads takeover of ~/.local/bin

### DIFF
--- a/home-manager/modules/beads/default.nix
+++ b/home-manager/modules/beads/default.nix
@@ -3,6 +3,17 @@
   # ~/.local/bin precedes every nix profile dir in PATH (see programs/fish),
   # so the flake-managed bd only wins if it also owns the ~/.local/bin entry
   # that update-local-binaries.sh used to create.
-  home.file.".local/bin/bd".source = "${pkgs.beads}/bin/bd";
-  home.file.".local/bin/beads".source = "${pkgs.beads}/bin/beads";
+  #
+  # force is required to take that entry over: backupFileExtension only moves
+  # regular files aside, so the leftover ulb symlink would abort activation
+  # (check-link-targets.sh skips both backup branches when the target is a
+  # symlink) on every host that still has one.
+  home.file.".local/bin/bd" = {
+    source = "${pkgs.beads}/bin/bd";
+    force = true;
+  };
+  home.file.".local/bin/beads" = {
+    source = "${pkgs.beads}/bin/beads";
+    force = true;
+  };
 }

--- a/spec/beads_spec.sh
+++ b/spec/beads_spec.sh
@@ -25,7 +25,12 @@ The status should be success
 End
 
 It 'owns the ~/.local/bin entries that outrank the nix profile'
-When run bash -c "grep -F 'home.file.\".local/bin/bd\".source = \"\${pkgs.beads}/bin/bd\"' \"$MODULE\" >/dev/null && grep -F 'home.file.\".local/bin/beads\".source = \"\${pkgs.beads}/bin/beads\"' \"$MODULE\" >/dev/null"
+When run bash -c "grep -qF 'home.file.\".local/bin/bd\"' \"$MODULE\" && grep -qF 'home.file.\".local/bin/beads\"' \"$MODULE\" && grep -qF '\${pkgs.beads}/bin/bd' \"$MODULE\" && grep -qF '\${pkgs.beads}/bin/beads' \"$MODULE\""
+The status should be success
+End
+
+It 'forces the takeover so a leftover ulb symlink cannot abort activation'
+When run bash -c "test \"\$(grep -cF 'force = true;' \"$MODULE\")\" -eq 2"
 The status should be success
 End
 


### PR DESCRIPTION
## Problem

`#2701` gave home-manager ownership of `~/.local/bin/bd` and `~/.local/bin/beads`, but without `force`. Every host that still has the `ulb` symlinks there will abort activation:

`check-link-targets.sh` only applies `backupFileExtension` / `HOME_MANAGER_BACKUP_COMMAND` when the existing target is **not** a symlink. Both backup branches are guarded by `[[ ! -L "$targetPath" ... ]]`, so a leftover symlink falls through to the hard error `Existing file '...' would be clobbered`.

That affects every host, including kyber and kamino, which are standalone `homeManagerConfiguration`s with no `backupFileExtension` at all.

## Fix

Set `force = true` on both entries so activation replaces the stale `ulb` symlinks instead of failing. No manual per-machine cleanup is required.

## Test

`shellspec spec/beads_spec.sh` - 7 examples, 0 failures (new example asserts both entries carry `force = true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes home-manager activation failures on hosts that still have `ulb`-created symlinks in `~/.local/bin` by setting `force = true` on the `bd` and `beads` entries.

- Activation now replaces the stale symlinks instead of aborting.
- Adds a spec example asserting both entries set `force = true`.

<sup>Written for commit 1a84d72cdc2222e2cfb1adf36a7a330cf97b430f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

