### PR TITLE
refactor(home-manager): drop force from beads local bin entries

### DIFF
--- a/home-manager/modules/beads/default.nix
+++ b/home-manager/modules/beads/default.nix
@@ -3,17 +3,6 @@
   # ~/.local/bin precedes every nix profile dir in PATH (see programs/fish),
   # so the flake-managed bd only wins if it also owns the ~/.local/bin entry
   # that update-local-binaries.sh used to create.
-  #
-  # force is required to take that entry over: backupFileExtension only moves
-  # regular files aside, so the leftover ulb symlink would abort activation
-  # (check-link-targets.sh skips both backup branches when the target is a
-  # symlink) on every host that still has one.
-  home.file.".local/bin/bd" = {
-    source = "${pkgs.beads}/bin/bd";
-    force = true;
-  };
-  home.file.".local/bin/beads" = {
-    source = "${pkgs.beads}/bin/beads";
-    force = true;
-  };
+  home.file.".local/bin/bd".source = "${pkgs.beads}/bin/bd";
+  home.file.".local/bin/beads".source = "${pkgs.beads}/bin/beads";
 }

--- a/spec/beads_spec.sh
+++ b/spec/beads_spec.sh
@@ -29,11 +29,6 @@ When run bash -c "grep -qF 'home.file.\".local/bin/bd\"' \"$MODULE\" && grep -qF
 The status should be success
 End
 
-It 'forces the takeover so a leftover ulb symlink cannot abort activation'
-When run bash -c "test \"\$(grep -cF 'force = true;' \"$MODULE\")\" -eq 2"
-The status should be success
-End
-
 It 'imports the beads module'
 When run grep -Fx '  ./beads' "$MODULES"
 The output should include './beads'


### PR DESCRIPTION
## What

Reverts the `force = true` blocks added in #2702, restoring the concise one-line `home.file.<name>.source` form.

`force` was only needed to clobber the stale `ulb` symlinks at `~/.local/bin/bd`. Those have now been removed by hand on galactica, kyber, matic and kamino1-4, so nothing is left for activation to collide with and the escape hatch is dead weight.

## Risk

Hosts that were unreachable during the cleanup (viper, andor, pod) will still fail activation with `Existing file '~/.local/bin/bd' would be clobbered` if they carry the old symlink. `check-link-targets.sh` guards both of its backup branches with `[[ ! -L "$targetPath" ]]`, so `backupFileExtension` does not cover a symlink. Remove `~/.local/bin/bd` on those hosts before the next `hm switch`.

## Test

`shellspec spec/beads_spec.sh` - 6 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the `force = true` blocks on the `beads` local bin entries so the concise one-line `source` form is used again, now that the stale `ulb` symlinks they were clobbering have been removed from most hosts.

**Migration**
Hosts that were unreachable during cleanup (viper, andor, pod) still have the old symlink at `~/.local/bin/bd` and will fail activation. Remove it before the next `hm switch`.

<sup>Written for commit afbcf45be935d8285bbd97b4980119408848397c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

