### PR TITLE
refactor(home-manager): drop redundant beads local bin shim

### DIFF
--- a/home-manager/modules/beads/default.nix
+++ b/home-manager/modules/beads/default.nix
@@ -1,8 +1,0 @@
-{ pkgs, ... }:
-{
-  # ~/.local/bin precedes every nix profile dir in PATH (see programs/fish),
-  # so the flake-managed bd only wins if it also owns the ~/.local/bin entry
-  # that update-local-binaries.sh used to create.
-  home.file.".local/bin/bd".source = "${pkgs.beads}/bin/bd";
-  home.file.".local/bin/beads".source = "${pkgs.beads}/bin/beads";
-}

--- a/home-manager/modules/default.nix
+++ b/home-manager/modules/default.nix
@@ -1,5 +1,4 @@
 [
-  ./beads
   ./bin-shells
   ./cargo-globals
   ./dotenv

--- a/spec/beads_spec.sh
+++ b/spec/beads_spec.sh
@@ -5,7 +5,6 @@ Describe 'Nix-managed beads'
 FLAKE="$PWD/flake.nix"
 OVERLAY="$PWD/overlays/default.nix"
 PACKAGES="$PWD/home-manager/packages/default.nix"
-MODULE="$PWD/home-manager/modules/beads/default.nix"
 MODULES="$PWD/home-manager/modules/default.nix"
 LOCAL_BINARIES="$PWD/.local-binaries.txt"
 
@@ -24,14 +23,11 @@ When run bash -c "line=\$(grep -nFx '  beads' \"$PACKAGES\" | cut -d: -f1); boun
 The status should be success
 End
 
-It 'owns the ~/.local/bin entries that outrank the nix profile'
-When run bash -c "grep -qF 'home.file.\".local/bin/bd\"' \"$MODULE\" && grep -qF 'home.file.\".local/bin/beads\"' \"$MODULE\" && grep -qF '\${pkgs.beads}/bin/bd' \"$MODULE\" && grep -qF '\${pkgs.beads}/bin/beads' \"$MODULE\""
-The status should be success
-End
-
-It 'imports the beads module'
+# home.packages already puts bd and beads on PATH. A ~/.local/bin shim would
+# only matter to outrank the nix profile, and nothing writes there any more.
+It 'does not shim beads into ~/.local/bin'
 When run grep -Fx '  ./beads' "$MODULES"
-The output should include './beads'
+The status should not be success
 End
 
 It 'no longer builds bd through update-local-binaries.sh'


### PR DESCRIPTION
## What

Deletes `home-manager/modules/beads`, its import, and the spec examples that asserted it.

## Why

The module existed only to win a PATH fight. `~/.local/bin` sits ahead of `/etc/profiles/per-user/<user>/bin` in `fish_user_paths`, so while `ulb` owned `~/.local/bin/bd` the nix build was shadowed. Both halves of that premise are now gone:

- `.local-binaries.txt` no longer lists `steveyegge/beads`, so nothing recreates the entry.
- The stale entries were removed on galactica, kyber, matic and kamino1-4.

`beads` in `home.packages` already installs **both** binaries:

```
/nix/store/xx0ylk3y9pnvbagnpxzh90x33r8l8r6a-beads-1.2.2/bin/  ->  bd, beads
```

Verified on galactica after the cleanup: `which -a bd` resolves to `/etc/profiles/per-user/shunkakinoki/bin/bd` and `bd version` reports `1.2.2`.

## Note

Hosts unreachable during the cleanup (viper, andor, pod) may still carry the old `ulb` symlink at `~/.local/bin/bd`. With this module gone they will no longer fail activation, but the stale binary would silently shadow the nix one until removed.

## Test

`shellspec spec/beads_spec.sh` - 5 examples, 0 failures.
`nix fmt --fail-on-change` - clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `home-manager` `beads` shim module that linked `bd` and `beads` into `~/.local/bin` to outrank the nix profile. That PATH fight is gone: nothing writes the local entry anymore, and stale entries were removed from most hosts. `home.packages` already installs both binaries, so the shim is redundant.

Hosts unreachable during cleanup (viper, andor, pod) may still have the old `~/.local/bin/bd` symlink, which will silently shadow the nix binary until removed. Activation won't fail.

<sup>Written for commit 5cc7f63e55b69d20afcff4e47e04da7a392e061a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

