### PR TITLE
feat(herdr): package herdr from the upstream herdr-nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -357,6 +357,24 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "foundry": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -440,6 +458,28 @@
         "type": "github"
       }
     },
+    "herdr": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1789079180,
+        "narHash": "sha256-O053NDbbTcBElVEQ6N6Kfyb8uLEaL47VHw4YqltkXI4=",
+        "owner": "herdrdev",
+        "repo": "herdr-nix",
+        "rev": "90bc56abd306bcc5dc7471717fa7aafb8205b451",
+        "type": "github"
+      },
+      "original": {
+        "owner": "herdrdev",
+        "repo": "herdr-nix",
+        "rev": "90bc56abd306bcc5dc7471717fa7aafb8205b451",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -482,7 +522,7 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_3",
+        "systems": "systems_4",
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
@@ -850,6 +890,7 @@
         "flake-parts": "flake-parts_2",
         "foundry": "foundry",
         "handy": "handy",
+        "herdr": "herdr",
         "home-manager": "home-manager",
         "llm-agents": "llm-agents",
         "mk-shell-bin": "mk-shell-bin",
@@ -922,6 +963,21 @@
       }
     },
     "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_4": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,14 @@
       url = "github:gastownhall/beads";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    # Pinned to the bot branch: herdr-nix main still ships 0.8.0 because the
+    # 0.9.0 bump was stranded when a PR-less publish workflow replaced the bot
+    # PR flow. Repoint at main once it carries >= 0.9.0.
+    herdr = {
+      url = "github:herdrdev/herdr-nix/90bc56abd306bcc5dc7471717fa7aafb8205b451";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -76,7 +76,7 @@ with pkgs;
   gping
   grc
   gron
-  pkgs.llm-agents.herdr
+  pkgs.herdr
   pkgs.llm-agents.grok
   pkgs.llm-agents.muse-code
   hexyl

--- a/home-manager/services/herdr/default.nix
+++ b/home-manager/services/herdr/default.nix
@@ -14,7 +14,7 @@ in
       ProgramArguments = [
         "${pkgs.bash}/bin/bash"
         "${./start.sh}"
-        "${pkgs.llm-agents.herdr}/bin/herdr"
+        "${pkgs.herdr}/bin/herdr"
       ];
       WorkingDirectory = homeDir;
       RunAtLoad = true;

--- a/named-hosts/kamino/default.nix
+++ b/named-hosts/kamino/default.nix
@@ -100,7 +100,7 @@ inputs.home-manager.lib.homeManagerConfiguration {
             X-SwitchMethod = "restart";
           };
           Service = {
-            ExecStart = "${pkgs.llm-agents.herdr}/bin/herdr server";
+            ExecStart = "${pkgs.herdr}/bin/herdr server";
             Restart = "on-failure";
             RestartSec = "5s";
             Environment = [

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -127,7 +127,7 @@ home-manager.lib.homeManagerConfiguration {
           };
           Service = {
             Type = "simple";
-            ExecStart = "${pkgs.llm-agents.herdr}/bin/herdr server";
+            ExecStart = "${pkgs.herdr}/bin/herdr server";
             Restart = "on-failure";
             RestartSec = "30s";
             Slice = "herdr.slice";

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -125,26 +125,6 @@
       # https://github.com/numtide/llm-agents.nix
       llm-agents =
         (prev.llm-agents or { })
-        // {
-          # Keep every managed client and server on the same released protocol.
-          # The upstream recipe retains native Linux/Darwin build dependencies.
-          herdr = prev.llm-agents.herdr.overrideAttrs (
-            finalAttrs: _: {
-              version = "0.9.0";
-              src = prev.fetchFromGitHub {
-                owner = "herdrdev";
-                repo = "herdr";
-                tag = "v${finalAttrs.version}";
-                hash = "sha256-SUYF4bbaYwNgoe498VoCUzuLPcjBLQXR0o0DWjjoSnI=";
-              };
-              cargoDeps = prev.rustPlatform.fetchCargoVendor {
-                inherit (finalAttrs) src;
-                name = "herdr-${finalAttrs.version}-vendor";
-                hash = "sha256-CW/SF/cAPDv47gS5B7XbVZEE6LC9F1a2I1TLTJ4AWdw=";
-              };
-            }
-          );
-        }
         // linuxGrokOverrides
         // prev.lib.optionalAttrs (prev.llm-agents ? bernstein) {
           # bernstein 2.8.2 requires reportlab<5,>=4.0 but nixpkgs now provides
@@ -209,6 +189,11 @@
   )
   inputs.noctalia-shell.overlays.default
   inputs.beads.overlays.default
+  (_: prev: {
+    # Upstream packages the official release binaries, so clients and servers
+    # stay on one published protocol without a local Rust build.
+    herdr = inputs.herdr.packages.${prev.system}.herdr;
+  })
   (_: prev: {
     # Keep the Dolt archive-integrity fix independent from the shared nixpkgs
     # pin so storage recovery does not upgrade unrelated host packages.


### PR DESCRIPTION
## What

Packages `herdr` from the upstream [herdrdev/herdr-nix](https://github.com/herdrdev/herdr-nix) flake instead of a locally patched `llm-agents.herdr`.

- New flake input `herdr`, with `inputs.nixpkgs.follows = "nixpkgs"`.
- New overlay entry mapping `pkgs.herdr` to `inputs.herdr.packages.${prev.system}.herdr`. Upstream exposes only `packages.<system>`, no overlay output, so the mapping lives here alongside the existing `dolt` one.
- Drops the hand-rolled `llm-agents.herdr` override: a `fetchFromGitHub` source pin plus a `rustPlatform.fetchCargoVendor` hash that had to be regenerated on every bump.
- Repoints the four consumers to `pkgs.herdr`: the shared package set, the darwin launchd agent, and the kamino and kyber systemd units.

## Why the rev pin, not a branch

`herdr-nix` `main` still ships **0.8.0**. The 0.9.0 bump landed on `bot/update-herdr` (`90bc56ab`) and was stranded an hour later when `e7fcb207` ("ci: validate and publish stable updates without prs") replaced the bot PR flow. Pinning that rev keeps the exact version already deployed here, so this is a packaging change with **no version change**. Repoint the input at `main` once it carries >= 0.9.0.

## Cachix

0.9.0 is not in the herdr cachix; deployments only fire on `main`. That is immaterial: the derivation is `fetchurl` of a prebuilt release binary plus `install -Dm755` (and `autoPatchelfHook` on Linux). A cache miss is one download, strictly cheaper than the Rust source build this replaces.

## Test

- `nix build .#darwinConfigurations.galactica.pkgs.herdr` -> `herdr-0.9.0`, seconds on a cold cache.
- `herdr --version` on the built store path reports `herdr 0.9.0`, matching the currently installed binary exactly.
- `nix fmt --fail-on-change` clean.

Linux hosts (kyber, kamino, matic) are not buildable from this darwin machine; the `autoPatchelfHook` path is exercised only in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Packages `herdr` from the upstream `herdr-nix` flake as `pkgs.herdr`, replacing the locally patched `llm-agents.herdr` override. The version stays at 0.9.0, so this is a packaging change only.

- Adds the `herdr` flake input pinned to a bot-branch rev because `herdr-nix` `main` still ships 0.8.0; repoint at `main` once it carries 0.9.0 or newer.
- Adds an overlay entry mapping `pkgs.herdr` to the upstream package.
- Drops the hand-rolled override, which required regenerating its `fetchCargoVendor` hash on every version bump.
- Repoints the shared package set, the darwin launchd agent, and the kamino and kyber systemd units to `pkgs.herdr`.
- Upstream's derivation fetches a prebuilt release binary, so a cache miss is one download instead of a full Rust source build.

<sup>Written for commit 30d7a2394179960e1e4672489121ff4fc323a306. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

