### PR TITLE
perf(git): enable fsmonitor and manyFiles for large repos

### DIFF
--- a/home-manager/programs/git/default.nix
+++ b/home-manager/programs/git/default.nix
@@ -23,6 +23,11 @@
           precomposeunicode = true;
           ignorecase = false;
           notesRef = "refs/notes/ai";
+          fsmonitor = true;
+          untrackedcache = true;
+        };
+        feature = {
+          manyFiles = true;
         };
         color = {
           diff = "auto";


### PR DESCRIPTION
## Summary

- Adds `core.fsmonitor`, `core.untrackedcache`, and `feature.manyFiles` to the global git config via home-manager
- Prevents VCS checkpoint timeouts on large worktrees (5.7GB+ monorepo worktrees were hitting 30s timeout)

## Test plan

- [ ] `home-manager switch` applies the new gitconfig values
- [ ] `git config --get core.fsmonitor` returns `true`
- [ ] t3code worktree operations complete within timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TgiA2EppJB6WfteFSAobCG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Git's fsmonitor, untracked cache, and manyFiles features via home-manager to stop VCS checkpoint timeouts on large worktrees (5.7GB+).

<sup>Written for commit 1dccd48611689f87fd7ba8c969b5f1d6ea441543. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

