### PR TITLE
Document safe Beads upgrades

### DIFF
--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -1,0 +1,53 @@
+# Upgrade guide
+
+This guide covers upgrades that change the Beads client or its Dolt schema.
+Routine Home Manager activation must not perform an implicit database migration.
+
+## Before the upgrade
+
+1. Announce a maintenance window and quiesce Beads writers, Linear sync, and
+   orchestration clients.
+2. Confirm the authoritative Dolt service is the only writable server and that
+   clients route to it with `BEADS_NODE_ID=kyber`.
+3. Capture a restorable snapshot of the database and record its identity,
+   current revision, schema version, and timestamp.
+4. Build the candidate Home Manager generation and run its Nix checks without
+   switching any host.
+
+## Apply the upgrade
+
+Run the migration as an explicit, serialized operation owned by the Beads
+maintainer:
+
+```text
+snapshot -> migrate -> commit Dolt working set -> verify schema -> resume clients
+```
+
+Do not run `bd` from an unrelated checkout with its own `.beads` prefix. Use the
+canonical repository checkout so the intended database name and authority are
+selected. Never point clients at a local replica to work around a failed
+migration.
+
+## Verify before resuming
+
+The upgrade is successful only when all of these pass:
+
+- the Dolt user service is active and its configured database is reachable;
+- `bd doctor` completes without schema or transaction errors;
+- a temporary Beads record can be created, read back, and closed;
+- Linear sync reports either a clean result or an explicitly owned hold;
+- orchestration clients can read the same authority through the fleet monitor.
+
+Keep the previous Home Manager generation and database snapshot until these
+checks pass on every client. A listening SQL port alone is not readiness.
+
+## Failure and rollback
+
+If migration or verification fails, stop dependent clients, preserve the dirty
+working set and logs, and do not retry blindly. Roll back the Home Manager
+generation only after reconciling any writes made after the snapshot. Restore a
+database snapshot only through the Beads maintainer's documented recovery
+operation; never delete a store or start a second writable server.
+
+Record the exact client version, migration result, database revision, and
+verification commands with the upgrade change.


### PR DESCRIPTION
Adds UPGRADE_GUIDE.md with the quiesce, snapshot, migration, verification, and rollback sequence for authorized Beads/Dolt upgrades. Emphasizes canonical authority routing and readiness beyond a listening SQL port.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `UPGRADE_GUIDE.md` documenting the explicit upgrade sequence for Beads/Dolt, covering quiesce, snapshot, migration, verification, and rollback. Stops routine Home Manager activation from implicitly migrating the database and clarifies that a listening SQL port alone is not readiness.

<sup>Written for commit 6dc7bf4957372014661c7d08fabbe3871952fa86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

