### PR TITLE
feat(cliproxyapi): serve Luna through OpenRouter as a second provider

### DIFF
--- a/config/cliproxyapi/config.template.yaml
+++ b/config/cliproxyapi/config.template.yaml
@@ -519,6 +519,10 @@ openai-compatibility:
         alias: "gpt-image-2"
       - name: "@preset/deepseek-v4-1-flash"
         alias: "deepseek-v4.1-flash"
+      # Second provider for Luna: surplus is otherwise the only one that
+      # serves it, so an empty surplus wallet takes the whole model down.
+      - name: "openai/gpt-5.6-luna"
+        alias: "gpt-5.6-luna"
       - name: "openrouter/free"
         alias: "free"
   - name: "z-ai"

--- a/config/cliproxyapi/config.tpl.yaml
+++ b/config/cliproxyapi/config.tpl.yaml
@@ -519,6 +519,10 @@ openai-compatibility:
         alias: "__GPT_IMAGE__"
       - name: "@preset/__DEEPSEEK_FLASH_NONDOT__"
         alias: "__DEEPSEEK_FLASH__"
+      # Second provider for Luna: surplus is otherwise the only one that
+      # serves it, so an empty surplus wallet takes the whole model down.
+      - name: "__GPT_LUNA_OPENROUTER__"
+        alias: "__GPT_LUNA__"
       - name: "openrouter/free"
         alias: "free"
   - name: "z-ai"

--- a/scripts/llm-update.sh
+++ b/scripts/llm-update.sh
@@ -80,6 +80,7 @@ done <<<"$model_rows"
 # Provider-specific upstream slugs that intentionally differ from the canonical
 # alias stored in models.json.
 add_model_override "gpt-image" "openrouter" "openai/gpt-5.4-image-2"
+add_model_override "gpt-luna" "openrouter" "openai/gpt-5.6-luna"
 add_model_override "deepseek-flash" "0731" "deepseek-v4-flash-0731"
 
 # Template → output pairs


### PR DESCRIPTION
## Why

`surplus` was the only provider in `config.tpl.yaml` declaring `gpt-5.6-luna`. When its wallet hit `$0.00` and the pooled codex credential's refresh token expired within the same minute, the proxy had no route left and returned:

```
503 auth_unavailable: no auth available
    (providers=codex,openai-compatible-surplus, model=gpt-5.6-luna)
```

That candidate set is the whole problem — OpenRouter sat at priority 100 the entire time but never declared the model, so it could not be selected. On 2026-09-11 surplus returned `402 Insufficient balance` at 04:03, 06:59, 07:33, 08:03, 08:34, 11:51, 13:41, 14:23, 16:57 and 17:13, so this was not a one-off.

## What

- `scripts/llm-update.sh`: register the OpenRouter upstream slug via the existing `add_model_override` pattern, alongside `gpt-image`.
- `config/cliproxyapi/config.tpl.yaml`: add `__GPT_LUNA_OPENROUTER__` to the `openrouter` provider's model list.
- `config/cliproxyapi/config.template.yaml`: regenerated, resolves to `openai/gpt-5.6-luna` aliased to `gpt-5.6-luna`.

OpenRouter stays at priority 100, below surplus (150) and the codex OAuth credentials (300), so it only takes traffic when both are suspended.

## Verification

- `shellspec spec/cliproxyapi_spec.sh spec/llm_update_spec.sh` — 147 examples, 0 failures
- `openai/gpt-5.6-luna` probed live on OpenRouter: HTTP 200

## Note

The live probe came back `"is_byok": true, "cost": 0` — OpenRouter routes Luna through the linked OpenAI BYOK key, so this hop bills the upstream OpenAI account rather than OpenRouter credits. It is a real second route, not a free one.

Rollout needs a home-manager switch plus a `cliproxyapi` restart to re-render `config.yaml`; that restart drops in-flight requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenRouter as a second provider for `gpt-5.6-luna` so the model keeps serving when the surplus wallet is empty.

- Registers `openai/gpt-5.6-luna` as an OpenRouter override in `scripts/llm-update.sh` and adds it to the OpenRouter provider's model list in both config templates.
- OpenRouter stays at priority 100, below surplus and codex, so it only takes traffic when both are unavailable.
- OpenRouter routes Luna through the linked OpenAI BYOK key, so this hop bills the upstream OpenAI account, not OpenRouter credits.
- Rollout needs a home-manager switch plus a `cliproxyapi` restart; the restart drops in-flight requests.

<sup>Written for commit b981d8f3893b2178d1974f9390b11565d724a662. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

