### PR TITLE
fix: add Chromium runtime libraries for Playwright

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -22,6 +22,7 @@ with pkgs;
   angle-grinder
   argocd
   ast-grep
+  atk
   ascii-box-cli
   awscli
   azure-cli
@@ -165,6 +166,7 @@ with pkgs;
   fwupd
   gcc
   glib
+  gtk3
   keychain
   libiconv
   libsecret

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -398,8 +398,10 @@ import ../../hosts/nixos {
         # Enable nix-ld for running dynamically linked binaries
         programs.nix-ld.enable = true;
         programs.nix-ld.libraries = with pkgs; [
+          atk
           curl
           glibc
+          gtk3
           libgcc
           libnl
           openssl


### PR DESCRIPTION
## Changes
- Add `atk` and `gtk3` to the managed Linux desktop package set.
- Add both libraries to `programs.nix-ld.libraries` for dynamically linked Playwright Chromium.

## Technical Details
This supplies the missing `libatk-1.0.so.0` runtime dependency through the existing NixOS matic host configuration.

## Testing
- `make nix-format-check`
- `make build`

Host activation was attempted separately; the configuration built successfully, while the service restart phase encountered the existing read-only Docker unit path.

Linear: none — host configuration maintenance request


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `atk` and `gtk3` to the managed packages and to `programs.nix-ld.libraries` on `matic` so Playwright Chromium no longer fails to find `libatk-1.0.so.0`.

<sup>Written for commit 4cd73cb5940c5e79719bdd7e298569998c21e5cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

