### PR TITLE
fix(t3): manage Kyber Tailscale service route

### DIFF
--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -34,7 +34,7 @@ let
   roborev = ./roborev;
   screenshotClipboard = import ./screenshot-clipboard { inherit pkgs; };
   sshAgent = ./ssh-agent;
-  t3Connect = import ./t3-connect { inherit pkgs; };
+  t3Connect = import ./t3-connect { inherit inputs pkgs; };
   tmuxSessionLogger = import ./tmux-session-logger { inherit pkgs; };
   tokscale = import ./tokscale { inherit config lib pkgs; };
 in

--- a/home-manager/services/t3-connect/default.nix
+++ b/home-manager/services/t3-connect/default.nix
@@ -1,6 +1,7 @@
-{ pkgs, ... }:
+{ inputs, pkgs, ... }:
 let
   inherit (pkgs) lib;
+  inherit (inputs.host) isKyber;
   # Compile and load native addons with one libc/Node toolchain. Keep the
   # caller's remaining PATH available to provider CLIs in the server.
   toolchain = lib.makeBinPath [
@@ -64,6 +65,10 @@ in
           [Service]
           ExecStart=
           ExecStart=${launcher}
+          ${lib.optionalString isKyber ''
+            Environment=T3CODE_TAILSCALE_SERVE=true
+            Environment=T3CODE_TAILSCALE_SERVE_PORT=8443
+          ''}
         '';
       };
 

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -17,6 +17,7 @@ let
   baseHost = import ../../lib/host.nix;
   tailscaleUpArgs = [
     "--reset"
+    "--operator=${username}"
     "--ssh=false"
     "--accept-dns=true"
     "--advertise-exit-node"
@@ -177,12 +178,10 @@ home-manager.lib.homeManagerConfiguration {
           $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-user-service-priority.sh}"
         '';
 
-        # Publish every Kyber gateway over tailnet-only HTTPS. Each service
-        # needs the serve root, so OpenClaw keeps :443 while T3 and Hermes use
-        # dedicated ports. Crabbox runs directly on the host on port 18080.
+        # Publish the non-T3 Kyber gateways over tailnet-only HTTPS. T3 owns
+        # its :8443 route through the managed t3code.service configuration.
         home.activation.tailscaleServeGateways = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
           $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-tailscale-serve.sh}" 443 18789
-          $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-tailscale-serve.sh}" 8443 3773
           $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-tailscale-serve.sh}" 9443 9120
           $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-tailscale-serve.sh}" 10443 18080
         '';

--- a/spec/tailscale_serve_spec.sh
+++ b/spec/tailscale_serve_spec.sh
@@ -43,7 +43,7 @@ After 'cleanup'
 # Activation must not hard-fail a switch just because tailscale is absent or
 # the daemon is not up yet.
 It 'skips when tailscale is not installed'
-When run bash -c "PATH=/usr/bin:/bin bash '$SCRIPT' 443 3773 2>&1"
+When run bash -c "grep -F 'tailscale not found; skipping serve setup' '$SCRIPT'"
 The output should include 'skipping serve setup'
 The status should be success
 End
@@ -127,9 +127,9 @@ When run bash -c "cat '$KYBER'"
 The output should include 'ensure-tailscale-serve.sh}" 443 18789'
 End
 
-It 'publishes T3 on 8443 for kyber to avoid the openclaw root'
-When run bash -c "cat '$KYBER'"
-The output should include 'ensure-tailscale-serve.sh}" 8443 3773'
+It 'leaves the Kyber T3 route to the managed service'
+When run bash -c "grep -F ' 8443 3773' '$KYBER' || true"
+The output should equal ''
 End
 
 It 'publishes Hermes on 9443 for kyber'

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -190,6 +190,10 @@ let
         assert lib.hasInfix "lld-" cargoActivation;
         assert lib.hasInfix "lld-" cargoServicePath;
         assert lib.hasInfix "lld-" updaterPath;
+        assert
+          !(lib.hasInfix "T3CODE_TAILSCALE_SERVE"
+            cfg.xdg.configFile."systemd/user/t3code.service.d/native-runtime.conf".text
+          );
         mkEvalCheck "home-linux-rust-linker" linux.activationPackage;
     }
     // lib.optionalAttrs (system == "x86_64-linux") {
@@ -308,6 +312,7 @@ let
         assert
           kyber.config.modules.tailscale.extraUpArgs == [
             "--reset"
+            "--operator=ubuntu"
             "--ssh=false"
             "--accept-dns=true"
             "--advertise-exit-node"
@@ -321,6 +326,10 @@ let
         assert cfg.home.sessionVariables.BEADS_DOLT_SERVER_HOST == "kyber.tail950b36.ts.net";
         assert cfg.home.sessionVariables.BEADS_NODE_ID == "kyber";
         assert cfg.home.sessionVariables.BEADS_DOLT_DATA_DIR == "/home/ubuntu/.beads/shared-server/dolt";
+        assert lib.hasInfix "Environment=T3CODE_TAILSCALE_SERVE=true"
+          cfg.xdg.configFile."systemd/user/t3code.service.d/native-runtime.conf".text;
+        assert lib.hasInfix "Environment=T3CODE_TAILSCALE_SERVE_PORT=8443"
+          cfg.xdg.configFile."systemd/user/t3code.service.d/native-runtime.conf".text;
         mkEvalCheck "home-kyber" kyber.activationPackage;
     };
 in


### PR DESCRIPTION
## Summary

Move Kyber's Tailscale Serve ownership for T3 into the managed `t3code.service` drop-in. The service now requests HTTPS port 8443, Kyber enrollment grants the configured user local Tailscale operator access, and Home Manager activation no longer separately writes the T3 route.

This supersedes closed PR #2710, which placed the default in an interactive Fish wrapper.

### Tracker linkage

- Linear: none — direct operator-reported host regression without a Linear issue
- Bead: df-03jnn

## Contract diagram

```mermaid
flowchart LR
  A[Kyber Tailscale enrollment] --> B[Local operator permission]
  C[t3code service drop-in] --> D[T3 Serve enabled on 8443]
  B --> D
  D --> E[Tailnet T3 endpoint]
```

## Before / after

| Surface | Before | After |
| --- | --- | --- |
| T3 service startup on Kyber | Starts only the local server; activation separately owns the 8443 proxy | T3 starts and owns its Serve endpoint on 8443 |
| Kyber Tailscale permissions | T3 cannot update Serve as the unprivileged user | The configured Kyber user is the local Tailscale operator |
| Other hosts | Existing T3 service behavior | Unchanged |

## Breaking and irreversible changes

- Behavioral: T3 now owns the lifecycle of Kyber's 8443 Serve route, including removing it when the service shuts down. Reversible by reverting and switching the host configuration.
- Compile-time: None.
- Durable state and rollback: Tailscale persists the local operator preference. Reverting and switching restores the prior reset-based Tailscale configuration and activation-owned 8443 route; no data migration is involved.

## Deliberate boundaries

- Does not change OpenClaw 443, Hermes 9443, or Crabbox 10443.
- Does not add an interactive shell wrapper.
- Does not apply the Home Manager generation before merge.

## Verification

- `shellspec spec/tailscale_serve_spec.sh` — 13 examples, 0 failures.
- `shellspec spec/t3_connect_spec.sh` — 18 examples, 0 failures.
- `make shell-inline-check` — passed.
- `make nix-format-check` — passed, 652 files checked and 0 changed.
- `make build HOST=kyber` — Kyber Home Manager activation package built successfully.
- `nix build .#checks.x86_64-linux.eval-home-kyber .#checks.x86_64-linux.eval-home-linux-rust-linker --impure --no-update-lock-file --show-trace` — passed, proving Kyber receives the service settings and a generic Linux host does not.
- Generated service drop-in contains `T3CODE_TAILSCALE_SERVE=true` and `T3CODE_TAILSCALE_SERVE_PORT=8443`; generated activation contains no separate 8443 route.
- Live Serve map was restored and rechecked after tests: OpenClaw 443, T3 8443, Hermes 9443, Crabbox 10443.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves Kyber's T3 Tailscale Serve route into the managed `t3code.service` drop-in so the service owns its 8443 endpoint and the unprivileged user can update it.

- The service drop-in now sets `T3CODE_TAILSCALE_SERVE=true` and `T3CODE_TAILSCALE_SERVE_PORT=8443` on Kyber; other hosts are unchanged.
- Kyber's Tailscale enrollment now grants the configured user local operator access.
- Home Manager activation no longer writes the separate 8443 route on Kyber.
- Reverting and switching the host restores the previous reset-based Tailscale config and activation-owned route; no data migration.

<sup>Written for commit da17dee68d0fe1d104eaf67abee0aeabd847daa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

