### PR TITLE
fix: complete Chromium runtime libraries

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -398,13 +398,37 @@ import ../../hosts/nixos {
         # Enable nix-ld for running dynamically linked binaries
         programs.nix-ld.enable = true;
         programs.nix-ld.libraries = with pkgs; [
+          alsa-lib
           atk
+          at-spi2-atk
+          cairo
+          cups
           curl
+          dbus
           glibc
+          gdk-pixbuf
           gtk3
+          libdrm
+          libgbm
           libgcc
+          libxkbcommon
           libnl
+          mesa
+          nspr
+          nss
           openssl
+          pango
+          xorg.libX11
+          xorg.libXcomposite
+          xorg.libXdamage
+          xorg.libXext
+          xorg.libXfixes
+          xorg.libXi
+          xorg.libXrandr
+          xorg.libXrender
+          xorg.libXtst
+          xorg.libxcb
+          xorg.libxshmfence
           zlib
         ];
 


### PR DESCRIPTION
## Changes
- Complete the Chromium runtime library set exposed through `programs.nix-ld.libraries` for Playwright's downloaded browser.
- Add DBus, GTK, X11, Mesa/GBM, NSS, audio, and graphics dependencies.

## Testing
- `make nix-format-check`
- `make build`
- Host switch applied the prior merged change; Chromium advanced from missing `libatk-1.0.so.0` to the next missing runtime library, confirming nix-ld was being used.

This remains a draft while the host activation service phase reports the existing read-only Docker unit warning.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the Chromium runtime libraries exposed through `programs.nix-ld.libraries` on the `matic` host so Playwright's downloaded browser can launch without missing shared library errors.

<sup>Written for commit c4aa1ec262469157cfd91dd5c49baad982200ddd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

