### PR TITLE
refactor(tailscale): centralize Serve route inventory

### DIFF
--- a/home-manager/activation/ensure-tailscale-serve.sh
+++ b/home-manager/activation/ensure-tailscale-serve.sh
@@ -86,7 +86,7 @@ ensure_route() {
       }
       next
     }
-    active && index($0, "proxy " target) { found = 1 }
+    active && $2 == "/" && $3 == "proxy" && $4 == target { found = 1 }
     END { exit found ? 0 : 1 }
   '; then
     return 0

--- a/home-manager/activation/ensure-tailscale-serve.sh
+++ b/home-manager/activation/ensure-tailscale-serve.sh
@@ -1,19 +1,22 @@
 #!/usr/bin/env bash
 # Publish a local HTTP port over Tailscale Serve (tailnet-only HTTPS).
 #
-# Usage: ensure-tailscale-serve.sh <https-port> <local-port>
+# Usage: ensure-tailscale-serve.sh <https-port> <local-port> [<https-port> <local-port>...]
 #
 # Services that need the serve root must use distinct HTTPS ports rather than
-# path prefixes. The helper reconciles one exact HTTPS-port-to-local-port
-# mapping without disturbing other routes on the same node.
+# path prefixes. The helper reconciles exact HTTPS-port-to-local-port mappings
+# without disturbing other routes on the same node.
 #
 # `tailscale serve` persists in tailscaled state, so this is a no-op on every
 # activation after the first.
 set -euo pipefail
 
-HTTPS_PORT="${1:?https port required}"
-LOCAL_PORT="${2:?local port required}"
-TARGET="http://127.0.0.1:${LOCAL_PORT}"
+: "${1:?https port required}"
+: "${2:?local port required}"
+if [ $(($# % 2)) -ne 0 ]; then
+  echo "serve routes require HTTPS/local port pairs" >&2
+  exit 2
+fi
 
 # Home Manager activation runs with a minimal PATH, so `command -v` alone finds
 # nothing. Search where each host actually keeps it, and prefer the installed
@@ -33,32 +36,18 @@ for candidate in \
 done
 
 if [ -z "$TS" ]; then
-  echo "tailscale not found; skipping serve setup for :${HTTPS_PORT}" >&2
+  echo "tailscale not found; skipping serve setup" >&2
   exit 0
 fi
 
 # Not logged in / daemon down: leave the config alone rather than erroring the
 # whole activation.
 if ! "$TS" status >/dev/null 2>&1; then
-  echo "tailscale not running; skipping serve setup for :${HTTPS_PORT}" >&2
+  echo "tailscale not running; skipping serve setup" >&2
   exit 0
 fi
 
 SERVE_STATUS="$("$TS" serve status 2>/dev/null || true)"
-if printf '%s\n' "$SERVE_STATUS" | awk -v port="$HTTPS_PORT" -v target="$TARGET" '
-  /^https:\/\// {
-    if (port == "443") {
-      active = ($0 !~ /:[0-9]+ \(tailnet only\)$/)
-    } else {
-      active = ($0 ~ (":" port " \\(tailnet only\\)$"))
-    }
-    next
-  }
-  active && index($0, "proxy " target) { found = 1 }
-  END { exit found ? 0 : 1 }
-'; then
-  exit 0
-fi
 
 # Same minimal-PATH problem as above: fall back to absolute paths.
 SUDO_CMD=""
@@ -79,13 +68,39 @@ fi
 # `tailscale serve` needs root unless the user is a tailscale operator. Skipping
 # beats aborting the whole switch over an endpoint that can be set up later.
 if [ -z "$SUDO_CMD" ] && [ "$(id -u)" -ne 0 ]; then
-  echo "no sudo/doas available; skipping serve setup for :${HTTPS_PORT}" >&2
+  echo "no sudo/doas available; skipping serve setup" >&2
   exit 0
 fi
 
-echo "Publishing ${TARGET} over Tailscale Serve on :${HTTPS_PORT}..."
-if [ -n "$SUDO_CMD" ]; then
-  "$SUDO_CMD" "$TS" serve --yes --bg --https="${HTTPS_PORT}" "${TARGET}"
-else
-  "$TS" serve --yes --bg --https="${HTTPS_PORT}" "${TARGET}"
-fi
+ensure_route() {
+  local https_port="$1"
+  local local_port="$2"
+  local target="http://127.0.0.1:${local_port}"
+
+  if printf '%s\n' "$SERVE_STATUS" | awk -v port="$https_port" -v target="$target" '
+    /^https:\/\// {
+      if (port == "443") {
+        active = ($0 !~ /:[0-9]+ \(tailnet only\)$/)
+      } else {
+        active = ($0 ~ (":" port " \\(tailnet only\\)$"))
+      }
+      next
+    }
+    active && index($0, "proxy " target) { found = 1 }
+    END { exit found ? 0 : 1 }
+  '; then
+    return 0
+  fi
+
+  echo "Publishing ${target} over Tailscale Serve on :${https_port}..."
+  if [ -n "$SUDO_CMD" ]; then
+    "$SUDO_CMD" "$TS" serve --yes --bg --https="${https_port}" "${target}"
+  else
+    "$TS" serve --yes --bg --https="${https_port}" "${target}"
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  ensure_route "$1" "$2"
+  shift 2
+done

--- a/home-manager/modules/default.nix
+++ b/home-manager/modules/default.nix
@@ -7,5 +7,6 @@
   ./npm-globals
   ./secure-dotenv
   ./tailscale
+  ./tailscale/serve-routes.nix
   ./uv-globals
 ]

--- a/home-manager/modules/tailscale/routes.nix
+++ b/home-manager/modules/tailscale/routes.nix
@@ -1,0 +1,37 @@
+{
+  kyber = [
+    {
+      name = "openclaw";
+      httpsPort = 443;
+      localPort = 18789;
+      manager = "activation";
+    }
+    {
+      name = "t3";
+      httpsPort = 8443;
+      localPort = 3773;
+      manager = "t3-service";
+    }
+    {
+      name = "hermes";
+      httpsPort = 9443;
+      localPort = 9120;
+      manager = "activation";
+    }
+    {
+      name = "crabbox";
+      httpsPort = 10443;
+      localPort = 18080;
+      manager = "activation";
+    }
+  ];
+
+  matic = [
+    {
+      name = "t3";
+      httpsPort = 443;
+      localPort = 3773;
+      manager = "activation";
+    }
+  ];
+}

--- a/home-manager/modules/tailscale/serve-routes.nix
+++ b/home-manager/modules/tailscale/serve-routes.nix
@@ -22,36 +22,40 @@ let
   ];
 in
 {
-  assertions = [
-    {
-      assertion = lib.length routeNames == lib.length (lib.unique routeNames);
-      message = "Tailscale Serve route names must be unique for ${hostName}";
-    }
-    {
-      assertion = lib.length routePorts == lib.length (lib.unique routePorts);
-      message = "Tailscale Serve HTTPS ports must be unique for ${hostName}";
-    }
-    {
-      assertion = lib.all (route: lib.elem route.manager supportedManagers) hostServeRoutes;
-      message = "Tailscale Serve routes for ${hostName} use an unsupported manager";
-    }
-    {
-      assertion = lib.all (
-        route:
-        builtins.isInt route.httpsPort
-        && route.httpsPort > 0
-        && route.httpsPort <= 65535
-        && builtins.isInt route.localPort
-        && route.localPort > 0
-        && route.localPort <= 65535
-      ) hostServeRoutes;
-      message = "Tailscale Serve routes for ${hostName} must use valid ports";
-    }
-  ];
+  options.modules.tailscale.manageServeRoutes = lib.mkEnableOption "this host's Tailscale Serve routes";
 
-  home.activation.tailscaleServeRoutes = lib.mkIf (activationServeRoutes != [ ]) (
-    config.lib.dag.entryAfter [ "writeBoundary" ] ''
-      $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../activation/ensure-tailscale-serve.sh}" ${lib.escapeShellArgs activationServeRouteArgs}
-    ''
-  );
+  config = lib.mkIf config.modules.tailscale.manageServeRoutes {
+    assertions = [
+      {
+        assertion = lib.length routeNames == lib.length (lib.unique routeNames);
+        message = "Tailscale Serve route names must be unique for ${hostName}";
+      }
+      {
+        assertion = lib.length routePorts == lib.length (lib.unique routePorts);
+        message = "Tailscale Serve HTTPS ports must be unique for ${hostName}";
+      }
+      {
+        assertion = lib.all (route: lib.elem route.manager supportedManagers) hostServeRoutes;
+        message = "Tailscale Serve routes for ${hostName} use an unsupported manager";
+      }
+      {
+        assertion = lib.all (
+          route:
+          builtins.isInt route.httpsPort
+          && route.httpsPort > 0
+          && route.httpsPort <= 65535
+          && builtins.isInt route.localPort
+          && route.localPort > 0
+          && route.localPort <= 65535
+        ) hostServeRoutes;
+        message = "Tailscale Serve routes for ${hostName} must use valid ports";
+      }
+    ];
+
+    home.activation.tailscaleServeRoutes = lib.mkIf (activationServeRoutes != [ ]) (
+      config.lib.dag.entryAfter [ "writeBoundary" ] ''
+        $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../activation/ensure-tailscale-serve.sh}" ${lib.escapeShellArgs activationServeRouteArgs}
+      ''
+    );
+  };
 }

--- a/home-manager/modules/tailscale/serve-routes.nix
+++ b/home-manager/modules/tailscale/serve-routes.nix
@@ -1,0 +1,57 @@
+{
+  config,
+  inputs,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  serveRoutes = import ./routes.nix;
+  hostName = inputs.host.nodeName;
+  hostServeRoutes = serveRoutes.${hostName} or [ ];
+  activationServeRoutes = lib.filter (route: route.manager == "activation") hostServeRoutes;
+  activationServeRouteArgs = lib.concatMap (route: [
+    (toString route.httpsPort)
+    (toString route.localPort)
+  ]) activationServeRoutes;
+  routeNames = map (route: route.name) hostServeRoutes;
+  routePorts = map (route: route.httpsPort) hostServeRoutes;
+  supportedManagers = [
+    "activation"
+    "t3-service"
+  ];
+in
+{
+  assertions = [
+    {
+      assertion = lib.length routeNames == lib.length (lib.unique routeNames);
+      message = "Tailscale Serve route names must be unique for ${hostName}";
+    }
+    {
+      assertion = lib.length routePorts == lib.length (lib.unique routePorts);
+      message = "Tailscale Serve HTTPS ports must be unique for ${hostName}";
+    }
+    {
+      assertion = lib.all (route: lib.elem route.manager supportedManagers) hostServeRoutes;
+      message = "Tailscale Serve routes for ${hostName} use an unsupported manager";
+    }
+    {
+      assertion = lib.all (
+        route:
+        builtins.isInt route.httpsPort
+        && route.httpsPort > 0
+        && route.httpsPort <= 65535
+        && builtins.isInt route.localPort
+        && route.localPort > 0
+        && route.localPort <= 65535
+      ) hostServeRoutes;
+      message = "Tailscale Serve routes for ${hostName} must use valid ports";
+    }
+  ];
+
+  home.activation.tailscaleServeRoutes = lib.mkIf (activationServeRoutes != [ ]) (
+    config.lib.dag.entryAfter [ "writeBoundary" ] ''
+      $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../activation/ensure-tailscale-serve.sh}" ${lib.escapeShellArgs activationServeRouteArgs}
+    ''
+  );
+}

--- a/home-manager/services/t3-connect/default.nix
+++ b/home-manager/services/t3-connect/default.nix
@@ -45,6 +45,11 @@ let
   '';
 in
 {
+  assertions = lib.optional inputs.host.isKyber {
+    assertion = lib.length t3ServeRoutes == 1;
+    message = "Kyber must declare exactly one T3 service-owned Tailscale Serve route";
+  };
+
   # T3 prefers PATH read from an interactive login shell to its inherited PATH.
   # Run after fnm's shell setup so that hydration retains the scoped installer.
   programs.fish.interactiveShellInit = lib.mkIf pkgs.stdenv.hostPlatform.isLinux (

--- a/home-manager/services/t3-connect/default.nix
+++ b/home-manager/services/t3-connect/default.nix
@@ -1,7 +1,12 @@
 { inputs, pkgs, ... }:
 let
   inherit (pkgs) lib;
-  inherit (inputs.host) isKyber;
+  serveRoutes = import ../../modules/tailscale/routes.nix;
+  hostServeRoutes = serveRoutes.${inputs.host.nodeName} or [ ];
+  t3ServeRoutes = lib.filter (
+    route: route.name == "t3" && route.manager == "t3-service"
+  ) hostServeRoutes;
+  t3ServeRoute = if lib.length t3ServeRoutes == 1 then lib.head t3ServeRoutes else null;
   # Compile and load native addons with one libc/Node toolchain. Keep the
   # caller's remaining PATH available to provider CLIs in the server.
   toolchain = lib.makeBinPath [
@@ -65,9 +70,9 @@ in
           [Service]
           ExecStart=
           ExecStart=${launcher}
-          ${lib.optionalString isKyber ''
+          ${lib.optionalString (t3ServeRoute != null) ''
             Environment=T3CODE_TAILSCALE_SERVE=true
-            Environment=T3CODE_TAILSCALE_SERVE_PORT=8443
+            Environment=T3CODE_TAILSCALE_SERVE_PORT=${toString t3ServeRoute.httpsPort}
           ''}
         '';
       };

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -178,14 +178,6 @@ home-manager.lib.homeManagerConfiguration {
           $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./activate-user-service-priority.sh}"
         '';
 
-        # Publish the non-T3 Kyber gateways over tailnet-only HTTPS. T3 owns
-        # its :8443 route through the managed t3code.service configuration.
-        home.activation.tailscaleServeGateways = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-          $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-tailscale-serve.sh}" 443 18789
-          $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-tailscale-serve.sh}" 9443 9120
-          $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-tailscale-serve.sh}" 10443 18080
-        '';
-
         # Tailscale configuration
         # Using system-level service only (via installSystemService)
         # User services are disabled by leaving serviceConfig empty

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -184,6 +184,7 @@ home-manager.lib.homeManagerConfiguration {
         modules.tailscale = {
           enable = true;
           installSystemService = true;
+          manageServeRoutes = true;
           # Auth key will be provided via agenix secret
           # authKeyFile = config.age.secrets."keys/tailscale-auth.age".path;
           # Exit node kept; explicitly disable Tailscale SSH so long-lived Codex

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -485,6 +485,7 @@ import ../../hosts/nixos {
             host = (import ../../lib/host.nix) // {
               isDesktop = true;
               isMatic = true;
+              nodeName = "matic";
             };
           };
         };
@@ -592,13 +593,6 @@ import ../../hosts/nixos {
                 "${builtins.toString ../galactica/keys/id_ed25519.age}" \
                 "${config.home.homeDirectory}/.ssh/id_ed25519" \
                 "${pkgs.rage}/bin/rage"
-            '';
-
-            # Publish the T3 server over tailnet HTTPS so remote clients can
-            # reach https://matic.tail950b36.ts.net. Nothing else serves :443
-            # here, so T3 takes the root.
-            home.activation.tailscaleServeT3 = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-              $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${../../home-manager/activation/ensure-tailscale-serve.sh}" 443 3773
             '';
 
             # GPG agent configuration

--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -503,6 +503,8 @@ import ../../hosts/nixos {
               ../../home-manager
             ];
 
+            modules.tailscale.manageServeRoutes = true;
+
             # Animated wallpaper via Wallpaper Engine
             services.linux-wallpaperengine = {
               enable = true;

--- a/spec/tailscale_serve_spec.sh
+++ b/spec/tailscale_serve_spec.sh
@@ -83,10 +83,26 @@ case "${1:-}" in
 status) exit 0 ;;
 serve)
   if [ "${2:-}" = status ]; then
-    cat <<'EOF'
+    case "${MOCK_SERVE_STATUS:-exact}" in
+    non-root)
+      cat <<'EOF'
+https://kyber.tail950b36.ts.net (tailnet only)
+|-- /admin proxy http://127.0.0.1:3773
+EOF
+      ;;
+    port-prefix)
+      cat <<'EOF'
+https://kyber.tail950b36.ts.net (tailnet only)
+|-- / proxy http://127.0.0.1:37730
+EOF
+      ;;
+    *)
+      cat <<'EOF'
 https://kyber.tail950b36.ts.net (tailnet only)
 |-- / proxy http://127.0.0.1:3773
 EOF
+      ;;
+    esac
   fi
   exit 0
   ;;
@@ -116,6 +132,19 @@ When run bash -c "bash '$SCRIPT' 8443 3773 >/dev/null 2>&1; cat '$MOCK_LOG'"
 The output should include 'serve --yes --bg --https=8443 http://127.0.0.1:3773'
 The status should be success
 End
+
+It 'publishes when only a non-root handler has the target'
+When run bash -c "MOCK_SERVE_STATUS=non-root bash '$SCRIPT' 443 3773 >/dev/null 2>&1; cat '$MOCK_LOG'"
+The output should include 'serve --yes --bg --https=443 http://127.0.0.1:3773'
+The status should be success
+End
+
+It 'publishes when the configured target only shares the port prefix'
+When run bash -c "MOCK_SERVE_STATUS=port-prefix bash '$SCRIPT' 443 3773 >/dev/null 2>&1; cat '$MOCK_LOG'"
+The output should include 'serve --yes --bg --https=443 http://127.0.0.1:3773'
+The status should be success
+End
+
 It 'publishes every missing route in one invocation'
 When run bash -c "bash '$SCRIPT' 8443 3773 9443 9120 >/dev/null 2>&1; cat '$MOCK_LOG'"
 The output should include 'serve --yes --bg --https=8443 http://127.0.0.1:3773'

--- a/spec/tailscale_serve_spec.sh
+++ b/spec/tailscale_serve_spec.sh
@@ -3,8 +3,6 @@
 
 Describe 'activation/ensure-tailscale-serve.sh'
 SCRIPT="$PWD/home-manager/activation/ensure-tailscale-serve.sh"
-MATIC="$PWD/named-hosts/matic/default.nix"
-KYBER="$PWD/named-hosts/kyber/default.nix"
 
 Describe 'script properties'
 It 'uses strict mode (set -euo pipefail)'
@@ -16,6 +14,12 @@ It 'requires both ports as arguments'
 When run bash -c "cat '$SCRIPT'"
 The output should include 'https port required'
 The output should include 'local port required'
+End
+
+It 'rejects an incomplete route pair'
+When run bash "$SCRIPT" 443 3773 8443
+The status should equal 2
+The stderr should include 'require HTTPS/local port pairs'
 End
 End
 
@@ -112,34 +116,11 @@ When run bash -c "bash '$SCRIPT' 8443 3773 >/dev/null 2>&1; cat '$MOCK_LOG'"
 The output should include 'serve --yes --bg --https=8443 http://127.0.0.1:3773'
 The status should be success
 End
-End
-
-Describe 'host wiring'
-# matic has nothing else on :443, so T3 takes the serve root.
-It 'publishes T3 on 443 for matic'
-When run bash -c "cat '$MATIC'"
-The output should include 'ensure-tailscale-serve.sh}" 443 3773'
-End
-
-# Kyber owns all three current gateway routes declaratively.
-It 'publishes OpenClaw on 443 for kyber'
-When run bash -c "cat '$KYBER'"
-The output should include 'ensure-tailscale-serve.sh}" 443 18789'
-End
-
-It 'leaves the Kyber T3 route to the managed service'
-When run bash -c "grep -F ' 8443 3773' '$KYBER' || true"
-The output should equal ''
-End
-
-It 'publishes Hermes on 9443 for kyber'
-When run bash -c "cat '$KYBER'"
-The output should include 'ensure-tailscale-serve.sh}" 9443 9120'
-End
-
-It 'publishes the host Crabbox coordinator on 10443 for kyber'
-When run bash -c "cat '$KYBER'"
-The output should include 'ensure-tailscale-serve.sh}" 10443 18080'
+It 'publishes every missing route in one invocation'
+When run bash -c "bash '$SCRIPT' 8443 3773 9443 9120 >/dev/null 2>&1; cat '$MOCK_LOG'"
+The output should include 'serve --yes --bg --https=8443 http://127.0.0.1:3773'
+The output should include 'serve --yes --bg --https=9443 http://127.0.0.1:9120'
+The status should be success
 End
 End
 

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -205,6 +205,7 @@ let
           !(lib.hasInfix "T3CODE_TAILSCALE_SERVE"
             cfg.xdg.configFile."systemd/user/t3code.service.d/native-runtime.conf".text
           );
+        assert !(cfg.home.activation ? tailscaleServeRoutes);
         mkEvalCheck "home-linux-rust-linker" linux.activationPackage;
     }
     // lib.optionalAttrs (system == "x86_64-linux") {

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -6,6 +6,7 @@
 }:
 let
   isDarwin = lib.hasSuffix "darwin" system;
+  tailscaleServeRoutes = import ../home-manager/modules/tailscale/routes.nix;
 
   # Helper: reconstruct a darwin configuration from hosts/darwin
   mkDarwinConfig =
@@ -120,6 +121,16 @@ let
       assert beads.home.sessionVariables.BEADS_NODE_ID == "kyber";
       assert !(beads.systemd.user.services ? dolt);
       assert !(beads.systemd.user.services ? dolt-federation-sync);
+      assert
+        tailscaleServeRoutes.matic == [
+          {
+            name = "t3";
+            httpsPort = 443;
+            localPort = 3773;
+            manager = "activation";
+          }
+        ];
+      assert lib.hasInfix " 443 3773" beads.home.activation.tailscaleServeRoutes.data;
       mkEvalCheck "nixos-matic" cfg.system.build.toplevel;
 
     eval-nixos-viper =
@@ -326,6 +337,18 @@ let
         assert cfg.home.sessionVariables.BEADS_DOLT_SERVER_HOST == "kyber.tail950b36.ts.net";
         assert cfg.home.sessionVariables.BEADS_NODE_ID == "kyber";
         assert cfg.home.sessionVariables.BEADS_DOLT_DATA_DIR == "/home/ubuntu/.beads/shared-server/dolt";
+        assert lib.length tailscaleServeRoutes.kyber == 4;
+        assert
+          map (route: route.name) tailscaleServeRoutes.kyber == [
+            "openclaw"
+            "t3"
+            "hermes"
+            "crabbox"
+          ];
+        assert lib.hasInfix " 443 18789" cfg.home.activation.tailscaleServeRoutes.data;
+        assert lib.hasInfix " 9443 9120" cfg.home.activation.tailscaleServeRoutes.data;
+        assert lib.hasInfix " 10443 18080" cfg.home.activation.tailscaleServeRoutes.data;
+        assert !(lib.hasInfix " 8443 3773" cfg.home.activation.tailscaleServeRoutes.data);
         assert lib.hasInfix "Environment=T3CODE_TAILSCALE_SERVE=true"
           cfg.xdg.configFile."systemd/user/t3code.service.d/native-runtime.conf".text;
         assert lib.hasInfix "Environment=T3CODE_TAILSCALE_SERVE_PORT=8443"


### PR DESCRIPTION
## Summary

Centralize every declarative Tailscale Serve endpoint in `home-manager/modules/tailscale/routes.nix`. Host activation and the managed T3 service now derive their ports from the same inventory while preserving their separate lifecycle ownership.

### Tracker linkage

- Linear: none — direct operator-requested configuration maintenance
- Bead: df-q7baa

## Contract diagram

```mermaid
flowchart LR
  I[Host route inventory] --> A[Home Manager activation]
  I --> T[T3 service drop-in]
  A --> G[Activation-owned gateways]
  T --> S[Service-owned T3 route]
```

## Before / after

| Surface | Before | After |
| --- | --- | --- |
| Route definitions | Ports repeated across Kyber, Matic, and the T3 service | One per-host inventory under the Tailscale module |
| Activation routes | Three separate Kyber invocations and one Matic invocation | One generated multi-route invocation per host |
| T3 service route | Kyber port hard-coded in the service module | Derived from the inventory's `t3-service` route |
| Validation | Conflicts could be introduced across scattered declarations | Duplicate names/ports, unsupported managers, and invalid ports fail evaluation |

## Breaking and irreversible changes

- Behavioral: none intended; Kyber retains OpenClaw 443, T3 8443, Hermes 9443, and Crabbox 10443, while Matic retains T3 443.
- Compile-time: host inputs consumed by the shared module must expose their canonical `nodeName`; Matic now does so explicitly.
- Durable state and rollback: no migration is involved. Reverting and switching restores the prior declarations; this PR does not apply a host generation.

## Deliberate boundaries

- Preserves T3's service-owned lifecycle on Kyber; activation does not claim port 8443.
- Does not change endpoint ports, local targets, tailnet policy, or Tailscale operator permissions.
- Does not apply the Home Manager generation before merge.

## Verification

- `shellspec spec/tailscale_serve_spec.sh` — 10 examples, 0 failures.
- `shellspec spec/t3_connect_spec.sh` — 18 examples, 0 failures.
- `make shell-inline-check` — passed.
- `make nix-format-check` — passed, 654 files checked and 0 changed on the final run.
- `nix build .#checks.x86_64-linux.eval-home-kyber .#checks.x86_64-linux.eval-home-linux-rust-linker .#checks.x86_64-linux.eval-nixos-matic --impure --no-update-lock-file --show-trace` — passed.
- `make build HOST=kyber` — passed.
- Generated activation invokes one helper with `443 18789 9443 9120 10443 18080`, excludes `8443 3773`, and the generated T3 drop-in retains port 8443.
- Live Serve status remained OpenClaw 443, T3 8443, Hermes 9443, and Crabbox 10443 after the final build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes Tailscale Serve route definitions in `home-manager/modules/tailscale/routes.nix`, so host activation and the T3 service read ports from one inventory instead of repeated host-specific declarations. Each route declares an owner: activation applies only its `activation` routes in a single invocation, skipping any whose exact Serve root handler is already active, while the T3 service derives its port from its `t3-service` route. Route ports stay unchanged, and the inventory fails evaluation on duplicate names/ports, unsupported managers, or invalid ports.

**Migration**
- Hosts using the shared module must set `inputs.host.nodeName`; Matic now sets it.
- No generation is applied by this PR; a normal switch activates the inventory.

<sup>Written for commit 8bd1247a6d271009a0c455af9d1edfcc1159e2c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

