### PR TITLE
fix(hooks): install live orchestration registrations

### DIFF
--- a/config/codex/activate.sh
+++ b/config/codex/activate.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Copy Codex config files and synchronize managed Desktop settings.
-# Usage: activate.sh <config_toml> <hooks_json> <desktop_settings_json> <jq_bin> <sync_script> <profiles_dir>
+# Copy Codex config files, add optional live orchestration hooks, and synchronize
+# managed Desktop settings.
+# Usage: activate.sh <config_toml> <hooks_json> <desktop_settings_json> <jq_bin> <sync_script> <profiles_dir> [merge_hooks_script]
 set -euo pipefail
 CONFIG_TOML="$1"
 HOOKS_JSON="$2"
@@ -8,6 +9,7 @@ DESKTOP_SETTINGS_JSON="$3"
 JQ_BIN="$4"
 SYNC_SCRIPT="$5"
 PROFILES_DIR="$6"
+MERGE_HOOKS_SCRIPT="${7:-$(dirname "${BASH_SOURCE[0]}")/merge-orchestration-hooks.sh}"
 
 mkdir -p ~/.codex/hooks
 for profile in "$PROFILES_DIR"/*.config.toml; do
@@ -19,5 +21,7 @@ cp -f "$CONFIG_TOML" ~/.codex/config.toml
 chmod 600 ~/.codex/config.toml
 cp -f "$HOOKS_JSON" ~/.codex/hooks.json
 chmod 644 ~/.codex/hooks.json
+
+"$MERGE_HOOKS_SCRIPT" "$HOME/.codex/hooks.json" "$JQ_BIN"
 
 "$SYNC_SCRIPT" "$DESKTOP_SETTINGS_JSON" "$JQ_BIN"

--- a/config/codex/default.nix
+++ b/config/codex/default.nix
@@ -9,6 +9,7 @@ let
   desktopSettingsAgentLabel = "org.nix-community.home.codex-desktop-settings-sync";
   syncDesktopSettings = ./sync-desktop-settings.sh;
   ensureDesktopSettingsAgent = ./ensure-desktop-settings-agent.sh;
+  mergeOrchestrationHooks = ./merge-orchestration-hooks.sh;
 in
 {
   # Use activation script instead of home.file symlink
@@ -20,7 +21,8 @@ in
       "${./desktop-settings.json}" \
       "${pkgs.jq}/bin/jq" \
       "${syncDesktopSettings}" \
-      "${./profiles}"
+      "${./profiles}" \
+      "${mergeOrchestrationHooks}"
   '';
 
   # Codex caches Desktop preferences in its persisted atom state and replaces

--- a/config/codex/merge-orchestration-hooks.sh
+++ b/config/codex/merge-orchestration-hooks.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016 # jq expressions intentionally contain $ variables.
+# Merge the optional orchestration prompt receipt into an existing live Codex
+# hooks file. The renderer is intentionally consulted only at activation time.
+# Usage: merge-orchestration-hooks.sh <hooks_json> <jq_bin> [orchestration_bin]
+set -euo pipefail
+
+HOOKS_JSON="${1:?live Codex hooks file required}"
+JQ_BIN="${2:?jq executable required}"
+ORCHESTRATION_BIN="${3:-}"
+
+if [ -z "$ORCHESTRATION_BIN" ]; then
+  ORCHESTRATION_BIN="$(PATH="$HOME/.local/bin:${PATH:-}" command -v orchestration 2>/dev/null || true)"
+fi
+if [ -z "$ORCHESTRATION_BIN" ]; then
+  exit 0
+fi
+
+if ! rendered="$("$ORCHESTRATION_BIN" hooks render --harness codex)"; then
+  echo "error: failed to render live Codex orchestration hooks" >&2
+  exit 1
+fi
+if ! "$JQ_BIN" -e '
+  (. | type) == "object"
+  and (.hooks | type) == "object"
+  and (.hooks.UserPromptSubmit | type) == "array"
+' <<<"$rendered" >/dev/null; then
+  echo "error: orchestration returned invalid Codex hook configuration" >&2
+  exit 1
+fi
+
+hooks_tmp="$(mktemp "${HOOKS_JSON}.tmp.XXXXXX")"
+trap 'rm -f "$hooks_tmp"' EXIT
+if ! "$JQ_BIN" -s '
+  .[0] as $base
+  | .[1] as $extra
+  | ($base.hooks // {}) as $base_hooks
+  | ($extra.hooks.UserPromptSubmit // []) as $extra_prompts
+  | $base
+  | .hooks = (
+      $base_hooks
+      | .UserPromptSubmit = (
+          (.UserPromptSubmit // []) as $existing
+          | reduce $extra_prompts[] as $hook
+              ($existing;
+                if any(.[]; . == $hook) then . else . + [$hook] end
+              )
+        )
+    )
+' "$HOOKS_JSON" <(printf '%s\n' "$rendered") >"$hooks_tmp"; then
+  echo "error: failed to merge live Codex orchestration hooks" >&2
+  exit 1
+fi
+
+if mode="$(stat -c '%a' "$HOOKS_JSON" 2>/dev/null)" || mode="$(stat -f '%Lp' "$HOOKS_JSON" 2>/dev/null)"; then
+  chmod "$mode" "$hooks_tmp"
+fi
+mv -f "$hooks_tmp" "$HOOKS_JSON"
+trap - EXIT

--- a/config/herdr/default.nix
+++ b/config/herdr/default.nix
@@ -4,6 +4,9 @@
   ...
 }:
 
+let
+  installHerdrIntegrations = ./install-integrations.sh;
+in
 {
   home.file.".config/herdr/config.toml" = {
     source = ./config.toml;
@@ -21,7 +24,6 @@
         "installOpenCodePlugins"
       ]
       ''
-        $DRY_RUN_CMD ${pkgs.llm-agents.herdr}/bin/herdr integration install codex
-        $DRY_RUN_CMD ${pkgs.llm-agents.herdr}/bin/herdr integration install opencode
+        $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${installHerdrIntegrations}" "${pkgs.llm-agents.herdr}/bin/herdr"
       '';
 }

--- a/config/herdr/default.nix
+++ b/config/herdr/default.nix
@@ -1,6 +1,26 @@
-_: {
+{
+  config,
+  pkgs,
+  ...
+}:
+
+{
   home.file.".config/herdr/config.toml" = {
     source = ./config.toml;
     force = true;
   };
+
+  # Install Herdr's native integrations only after both harness configuration
+  # owners have materialized their live files. The installer only updates hook
+  # and plugin registration; it does not restart a running harness.
+  home.activation.installHerdrIntegrations =
+    config.lib.dag.entryAfter
+      [
+        "codexConfig"
+        "installOpenCodePlugins"
+      ]
+      ''
+        $DRY_RUN_CMD ${pkgs.llm-agents.herdr}/bin/herdr integration install codex
+        $DRY_RUN_CMD ${pkgs.llm-agents.herdr}/bin/herdr integration install opencode
+      '';
 }

--- a/config/herdr/install-integrations.sh
+++ b/config/herdr/install-integrations.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Install Herdr's native Codex and OpenCode integrations.
+# Usage: install-integrations.sh <herdr_bin>
+set -euo pipefail
+
+HERDR_BIN="${1:?Herdr executable required}"
+
+"$HERDR_BIN" integration install codex
+"$HERDR_BIN" integration install opencode

--- a/scripts/update-moshi-hooks.sh
+++ b/scripts/update-moshi-hooks.sh
@@ -51,32 +51,6 @@ normalize_dcg_hooks() {
   done
 }
 
-install_orchestration_hooks() {
-  local harness rendered hook_config tmp_file
-  if ! command -v orchestration >/dev/null 2>&1; then
-    echo "error: orchestration CLI is required to render supplemental hooks" >&2
-    return 1
-  fi
-  for harness in claude codex; do
-    if [[ $harness == claude ]]; then
-      hook_config="$GENERATED_ROOT/claude/settings.json"
-    else
-      hook_config="$GENERATED_ROOT/codex/hooks.json"
-    fi
-    rendered="$(orchestration hooks render --harness "$harness")"
-    tmp_file="$(mktemp "${hook_config}.tmp.XXXXXX")"
-    jq -s '.[0] * {hooks: ((.[0].hooks // {}) * (.[1].hooks // {}))}' \
-      "$hook_config" <(printf '%s\n' "$rendered") >"$tmp_file"
-    mv -f "$tmp_file" "$hook_config"
-  done
-  rendered="$(orchestration hooks render --harness opencode)"
-  hook_config="$REPO_ROOT/config/opencode/hooks.json"
-  tmp_file="$(mktemp "${hook_config}.tmp.XXXXXX")"
-  jq -s '.[0] * {hooks: ((.[0].hooks // {}) * (.[1].hooks // {}))}' \
-    "$hook_config" <(printf '%s\n' "$rendered") >"$tmp_file"
-  mv -f "$tmp_file" "$hook_config"
-}
-
 if [[ ${1:-} == "--normalize-only" ]]; then
   shift
   if (($# == 0)); then
@@ -119,9 +93,6 @@ jq -s '.[0].hooks * .[1].hooks | {hooks: .}' \
   "$GENERATED_ROOT/grok/plugin/hooks/hooks.json" \
   /tmp/moshi-grok-hooks.json >/tmp/moshi-grok-merged.json
 mv /tmp/moshi-grok-merged.json "$GENERATED_ROOT/grok/plugin/hooks/hooks.json"
-
-echo "Rendering orchestration supplemental hooks..."
-install_orchestration_hooks
 
 # Generated files must remain portable and must not capture a machine-local
 # home directory. Moshi quotes absolute binaries in hook commands and embeds

--- a/scripts/update-moshi-hooks.sh
+++ b/scripts/update-moshi-hooks.sh
@@ -51,6 +51,32 @@ normalize_dcg_hooks() {
   done
 }
 
+install_orchestration_hooks() {
+  local harness rendered hook_config tmp_file
+  if ! command -v orchestration >/dev/null 2>&1; then
+    echo "error: orchestration CLI is required to render supplemental hooks" >&2
+    return 1
+  fi
+  for harness in claude codex; do
+    if [[ $harness == claude ]]; then
+      hook_config="$GENERATED_ROOT/claude/settings.json"
+    else
+      hook_config="$GENERATED_ROOT/codex/hooks.json"
+    fi
+    rendered="$(orchestration hooks render --harness "$harness")"
+    tmp_file="$(mktemp "${hook_config}.tmp.XXXXXX")"
+    jq -s '.[0] * {hooks: ((.[0].hooks // {}) * (.[1].hooks // {}))}' \
+      "$hook_config" <(printf '%s\n' "$rendered") >"$tmp_file"
+    mv -f "$tmp_file" "$hook_config"
+  done
+  rendered="$(orchestration hooks render --harness opencode)"
+  hook_config="$REPO_ROOT/config/opencode/hooks.json"
+  tmp_file="$(mktemp "${hook_config}.tmp.XXXXXX")"
+  jq -s '.[0] * {hooks: ((.[0].hooks // {}) * (.[1].hooks // {}))}' \
+    "$hook_config" <(printf '%s\n' "$rendered") >"$tmp_file"
+  mv -f "$tmp_file" "$hook_config"
+}
+
 if [[ ${1:-} == "--normalize-only" ]]; then
   shift
   if (($# == 0)); then
@@ -93,6 +119,9 @@ jq -s '.[0].hooks * .[1].hooks | {hooks: .}' \
   "$GENERATED_ROOT/grok/plugin/hooks/hooks.json" \
   /tmp/moshi-grok-hooks.json >/tmp/moshi-grok-merged.json
 mv /tmp/moshi-grok-merged.json "$GENERATED_ROOT/grok/plugin/hooks/hooks.json"
+
+echo "Rendering orchestration supplemental hooks..."
+install_orchestration_hooks
 
 # Generated files must remain portable and must not capture a machine-local
 # home directory. Moshi quotes absolute binaries in hook commands and embeds

--- a/spec/activate_config_spec.sh
+++ b/spec/activate_config_spec.sh
@@ -290,8 +290,35 @@ When run cat "$HERDR_DEFAULT_NIX"
 The output should include 'installHerdrIntegrations'
 The output should include 'codexConfig'
 The output should include 'installOpenCodePlugins'
+The output should include 'install-integrations.sh'
+The output should include 'llm-agents.herdr'
+End
+End
+
+Describe 'config/herdr/install-integrations.sh'
+HERDR_INSTALL_SCRIPT="$PWD/config/herdr/install-integrations.sh"
+
+It 'installs both native harness integrations through the supplied executable'
+TMP_HOME="$(mktemp -d)"
+MOCK_HERDR="$TMP_HOME/herdr"
+LOG_FILE="$TMP_HOME/integration.log"
+cat >"$MOCK_HERDR" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$HERDR_TEST_LOG"
+SH
+chmod +x "$MOCK_HERDR"
+
+When run bash -c 'HERDR_TEST_LOG="$1" bash "$2" "$3" && cat "$1"' _ "$LOG_FILE" "$HERDR_INSTALL_SCRIPT" "$MOCK_HERDR"
+The status should be success
 The output should include 'integration install codex'
 The output should include 'integration install opencode'
+End
+
+It 'requires an executable argument'
+When run bash "$HERDR_INSTALL_SCRIPT"
+The status should not be success
+The stderr should include 'Herdr executable required'
 End
 End
 

--- a/spec/activate_config_spec.sh
+++ b/spec/activate_config_spec.sh
@@ -5,6 +5,7 @@ Describe 'config/codex/activate.sh'
 SCRIPT="$PWD/config/codex/activate.sh"
 SYNC_SCRIPT="$PWD/config/codex/sync-desktop-settings.sh"
 ENSURE_AGENT_SCRIPT="$PWD/config/codex/ensure-desktop-settings-agent.sh"
+MERGE_SCRIPT="$PWD/config/codex/merge-orchestration-hooks.sh"
 HOOKS_JSON="$PWD/generated/hooks/moshi/codex/hooks.json"
 CONFIG_TOML="$PWD/config/codex/config.toml"
 DESKTOP_SETTINGS_JSON="$PWD/config/codex/desktop-settings.json"
@@ -28,6 +29,85 @@ End
 It 'copies hooks.json'
 When run bash -c "grep 'HOOKS_JSON' '$SCRIPT'"
 The output should include 'HOOKS_JSON'
+End
+
+It 'merges optional live orchestration hooks without replacing existing arrays'
+TMP_HOME="$(mktemp -d)"
+TMP_BIN="$TMP_HOME/bin"
+TMP_HOOKS="$TMP_HOME/hooks.json"
+TMP_RENDERED="$TMP_HOME/rendered.json"
+TMP_SYNC="$TMP_HOME/sync.sh"
+mkdir -p "$TMP_BIN"
+cat >"$TMP_HOOKS" <<'JSON'
+{
+  "description": "managed",
+  "other": {"preserved": true},
+  "hooks": {
+    "SessionStart": [{"hooks": [{"type": "command", "command": "existing-start"}]}],
+    "UserPromptSubmit": [{"hooks": [{"type": "command", "command": "existing-prompt"}]}]
+  }
+}
+JSON
+cat >"$TMP_RENDERED" <<'JSON'
+{
+  "description": "orchestration",
+  "hooks": {
+    "SessionStart": [{"hooks": [{"type": "command", "command": "should-not-install"}]}],
+    "UserPromptSubmit": [{"hooks": [{"type": "command", "command": "orchestration-prompt", "timeout": 5}]}]
+  }
+}
+JSON
+cat >"$TMP_BIN/orchestration" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ $* == 'hooks render --harness codex' ]]
+cat "$ORCHESTRATION_RENDERED"
+SH
+cat >"$TMP_SYNC" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+SH
+chmod +x "$TMP_BIN/orchestration" "$TMP_SYNC"
+
+When run bash -c 'cp "$1" "$2" && HOME="$3" PATH="$4:$PATH" ORCHESTRATION_RENDERED="$5" bash "$6" "$7" "$1" "$8" "$9" "${10}" "${11}" && cp "$3/.codex/hooks.json" "$2" && HOME="$3" PATH="$4:$PATH" ORCHESTRATION_RENDERED="$5" bash "$6" "$7" "$1" "$8" "$9" "${10}" "${11}" && cmp -s "$2" "$3/.codex/hooks.json" && jq -e '\''.description == "managed" and .other.preserved == true and (.hooks.SessionStart | length == 1) and (.hooks.UserPromptSubmit | length == 2) and ([.hooks.UserPromptSubmit[].hooks[] | .command] | sort == ["existing-prompt", "orchestration-prompt"])'\'' "$3/.codex/hooks.json" >/dev/null' _ "$TMP_HOOKS" "$TMP_HOME/first.json" "$TMP_HOME" "$TMP_BIN" "$TMP_RENDERED" "$SCRIPT" "$CONFIG_TOML" "$DESKTOP_SETTINGS_JSON" "$(command -v jq)" "$TMP_SYNC" "$PROFILES_DIR"
+The status should be success
+End
+
+It 'skips the optional live merge when orchestration is unavailable'
+TMP_HOME="$(mktemp -d)"
+TMP_SYNC="$TMP_HOME/sync.sh"
+mkdir -p "$TMP_HOME/bin"
+cat >"$TMP_SYNC" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+SH
+chmod +x "$TMP_SYNC"
+
+When run bash -c 'HOME="$1" PATH="$1/bin:/usr/bin:/bin" bash "$2" "$3" "$4" "$5" "$6" "$7" "$8" && cmp -s "$9" "$1/.codex/hooks.json"' _ "$TMP_HOME" "$SCRIPT" "$CONFIG_TOML" "$HOOKS_JSON" "$DESKTOP_SETTINGS_JSON" "$(command -v jq)" "$TMP_SYNC" "$PROFILES_DIR" "$HOOKS_JSON"
+The status should be success
+End
+
+It 'runs the live merge helper without recopying Codex configuration'
+TMP_HOME="$(mktemp -d)"
+TMP_BIN="$TMP_HOME/bin"
+TMP_HOOKS="$TMP_HOME/hooks.json"
+TMP_RENDERED="$TMP_HOME/rendered.json"
+mkdir -p "$TMP_BIN"
+cat >"$TMP_HOOKS" <<'JSON'
+{"model":"preserved","hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"existing"}]}]}}
+JSON
+cat >"$TMP_RENDERED" <<'JSON'
+{"description":"orchestration","hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"receipt","timeout":5}]}]}}
+JSON
+cat >"$TMP_BIN/orchestration" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+cat "$ORCHESTRATION_RENDERED"
+SH
+chmod +x "$TMP_BIN/orchestration"
+
+When run bash -c 'HOME="$1" PATH="$2:$PATH" ORCHESTRATION_RENDERED="$3" bash "$4" "$5" "$6" && cp "$5" "$1/first.json" && HOME="$1" PATH="$2:$PATH" ORCHESTRATION_RENDERED="$3" bash "$4" "$5" "$6" && cmp -s "$1/first.json" "$5" && jq -e '\''.model == "preserved" and (.hooks.UserPromptSubmit | length == 2)'\'' "$5" >/dev/null' _ "$TMP_HOME" "$TMP_BIN" "$TMP_RENDERED" "$MERGE_SCRIPT" "$TMP_HOOKS" "$(command -v jq)"
+The status should be success
 End
 
 It 'declares the Codex Desktop Git and worktree preferences'
@@ -199,6 +279,19 @@ It 'self-heals a missed Desktop settings LaunchAgent registration'
 When run cat "$DEFAULT_NIX"
 The output should include 'ensureDesktopSettingsAgent'
 The output should include 'entryAfter [ "setupLaunchAgents" ]'
+End
+End
+
+Describe 'config/herdr/default.nix'
+HERDR_DEFAULT_NIX="$PWD/config/herdr/default.nix"
+
+It 'installs native Codex and OpenCode integrations after harness activation'
+When run cat "$HERDR_DEFAULT_NIX"
+The output should include 'installHerdrIntegrations'
+The output should include 'codexConfig'
+The output should include 'installOpenCodePlugins'
+The output should include 'integration install codex'
+The output should include 'integration install opencode'
 End
 End
 

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -336,6 +336,10 @@ It 'has spec file for config/codex/activate.sh'
 The path "spec/activate_config_spec.sh" should be exist
 End
 
+It 'has spec file for config/codex/merge-orchestration-hooks.sh'
+The path "spec/activate_config_spec.sh" should be exist
+End
+
 It 'has spec file for config/codex/sync-desktop-settings.sh'
 The path "spec/activate_config_spec.sh" should be exist
 End
@@ -519,6 +523,7 @@ config/claude/hooks/atuin-history.sh
 config/claude/hooks/statusline.sh
 config/codex/activate.sh
 config/codex/ensure-desktop-settings-agent.sh
+config/codex/merge-orchestration-hooks.sh
 config/codex/sync-desktop-settings.sh
 config/copilot/activate.sh
 config/codex/hooks/atuin-history.sh

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -340,6 +340,10 @@ It 'has spec file for config/codex/merge-orchestration-hooks.sh'
 The path "spec/activate_config_spec.sh" should be exist
 End
 
+It 'has spec file for config/herdr/install-integrations.sh'
+The path "spec/activate_config_spec.sh" should be exist
+End
+
 It 'has spec file for config/codex/sync-desktop-settings.sh'
 The path "spec/activate_config_spec.sh" should be exist
 End
@@ -525,6 +529,7 @@ config/codex/activate.sh
 config/codex/ensure-desktop-settings-agent.sh
 config/codex/merge-orchestration-hooks.sh
 config/codex/sync-desktop-settings.sh
+config/herdr/install-integrations.sh
 config/copilot/activate.sh
 config/codex/hooks/atuin-history.sh
 config/dcg/activate.sh

--- a/spec/update_moshi_hooks_spec.sh
+++ b/spec/update_moshi_hooks_spec.sh
@@ -22,6 +22,11 @@ The output should include 'moshi-hook install'
 The status should be success
 End
 
+It 'does not render live orchestration hooks into tracked generated files'
+When run bash -c "! grep -qE 'install_orchestration_hooks|orchestration hooks render' '$SCRIPT'"
+The status should be success
+End
+
 It 'copies TypeScript plugin files'
 When run cat "$SCRIPT"
 The output should include 'omp'


### PR DESCRIPTION
## Summary

- Merge optional orchestration `UserPromptSubmit` registrations into the live Codex hooks file during activation.
- Install Herdr's native Codex and OpenCode integrations after both harness configuration entries have run.
- Keep generated hook artifacts independent of the optional orchestration CLI.

## Behavior

Home Manager copies the managed Codex configuration and then invokes a live-only merger. If the installed orchestration CLI is unavailable, ordinary activation continues. When it is available, the merger considers only Codex `UserPromptSubmit` registrations, preserves existing hook arrays and unrelated top-level data, deduplicates exact registrations, and replaces the file atomically.

The pinned Herdr integration installer runs after the Codex and OpenCode activation entries through an external activation helper. It updates native hook and plugin registration without restarting running harnesses. The Home Manager-managed OpenCode detection manifest remains included.

## Validation

- `shellspec spec/activate_config_spec.sh spec/update_moshi_hooks_spec.sh spec/coverage_spec.sh spec/activate_opencode_spec.sh spec/herdr_service_spec.sh spec/upgrade_overlays_spec.sh` — 213 examples, 0 failures.
- `make shell-inline-check` — passed.
- `python3 -m unittest tests.test_herdr_opencode_detection` — 5 tests, passed.
- `shellcheck` on changed shell scripts and specs — passed.
- `nix-instantiate --parse` and `nixfmt --check` for changed Nix modules — passed.
- Home Manager evaluation for `homeConfigurations.kyber.activationPackage` — passed with pinned `herdr-0.9.0` in the evaluated activation script.
