### PR TITLE
fix(agentsview): avoid repeated scans of unchanged OpenCode sessions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.13"
 [dependency-groups]
 tools = [
   "aider-chat>=0.86.2",
-  "agentsview>=0.41.1",
+  "agentsview>=0.42.0",
   "claude-swap>=0.25.0",
   "git-remote-s3>=0.4.2",
   "graphifyy>=0.9.53",


### PR DESCRIPTION
Require AgentsView 0.42.0 to avoid repeatedly scanning unchanged messages while OpenCode sessions are active. The release includes [incremental container synchronization](https://github.com/kenn-io/agentsview/pull/1560) while retaining startup and periodic full verification.

Two host samples measured the old daemon using 67–105% of one CPU, reading 73–94 MiB/s through the filesystem cache and writing 1.55–2.35 MiB/s to disk. The live sync status reports one failed source, an Antigravity unknown-schema anomaly, and repeated batches of 503 synced sessions. A read-only archive query found no indexed OpenCode sessions, so the OpenCode-specific optimization is not established as the remedy for this host. Activation and measurement must determine the result. This source update has not been activated; host-wide improvement remains unproven.

Validation: 27 Python tests passed; Ruff lint and format checks passed; 25 existing global-tool installer checks passed; TOML parse and diff checks passed. The released 0.42.0 package supports the configured Python version. No scheduler, safety threshold, authentication, or cluster configuration changes.

Investigation: [T3 thread](https://kyber.tail950b36.ts.net:8443/4dc26984-7b97-484d-989a-6f51098dec27/8e601efe-8f1b-4cbd-99bd-290d1ab24ff8).

The upgrade pipeline exposed an existing unset-variable failure in the GitHub CLI vendor-hash probe; #2717 repairs that validation prerequisite.
