### PR TITLE
fix(upgrades): pass resolved GitHub CLI values to vendor hash probe

### DIFF
--- a/scripts/upgrade-overlays.sh
+++ b/scripts/upgrade-overlays.sh
@@ -152,6 +152,7 @@ validate_sri_checksum() {
 }
 
 github_cli_vendor_hash() {
+  local version="$1" rev="$2" source_hash="$3"
   local expression output
 
   if [ -n "${GH_VENDOR_HASH:-}" ]; then
@@ -159,7 +160,7 @@ github_cli_vendor_hash() {
     return 0
   fi
 
-  expression="let flake = builtins.getFlake (toString $REPO_ROOT); pkgs = flake.inputs.nixpkgs.legacyPackages.x86_64-linux; in pkgs.gh.overrideAttrs (_: { version = \"$GH_VERSION\"; src = pkgs.fetchFromGitHub { owner = \"cli\"; repo = \"cli\"; rev = \"$GH_REV\"; hash = \"$GH_SOURCE_HASH\"; }; vendorHash = \"sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\"; })"
+  expression="let flake = builtins.getFlake (toString $REPO_ROOT); pkgs = flake.inputs.nixpkgs.legacyPackages.x86_64-linux; in pkgs.gh.overrideAttrs (_: { version = \"$version\"; src = pkgs.fetchFromGitHub { owner = \"cli\"; repo = \"cli\"; rev = \"$rev\"; hash = \"$source_hash\"; }; vendorHash = \"sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\"; })"
   output="$(nix build --no-link --impure --print-build-logs --expr "$expression" 2>&1 || true)"
   printf '%s\n' "$output" | sed -n 's/.*got:[[:space:]]*\(sha256-[[:alnum:]+/]*=[=]*\).*/\1/p' | tail -1
 }
@@ -195,7 +196,7 @@ upgrade_gh() {
   fi
   validate_sri_checksum "gh-$version-source" "$source_hash"
 
-  vendor_hash="$(github_cli_vendor_hash)"
+  vendor_hash="$(github_cli_vendor_hash "$version" "$rev" "$source_hash")"
   validate_sri_checksum "gh-$version-vendor" "$vendor_hash"
   current_version="$(sed -n '/gh = prev.gh.overrideAttrs/,/^[[:space:]]*});/p' "$OVERLAY_FILE" | sed -n 's/.*version = "\([^"]*\)";.*/\1/p' | head -1)"
 

--- a/spec/upgrade_overlays_spec.sh
+++ b/spec/upgrade_overlays_spec.sh
@@ -181,6 +181,45 @@ cleanup() {
 Before 'setup'
 After 'cleanup'
 
+resolve_gh_release() {
+  cat >"$TEMP_DIR/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+*releases/latest*) printf '%s\n' 'v2.100.0' ;;
+*commits/v2.100.0*) printf '%s\n' '45437bc7eeeb3359bbfddd1742f79de7652fd3e2' ;;
+*) exit 1 ;;
+esac
+EOF
+  cat >"$TEMP_DIR/bin/nix-prefetch-url" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' '0p85n67mklxfvvh1v6sj047wcskxsagzmg6r0wdd4kibpvgbxdap'
+EOF
+  cat >"$TEMP_DIR/bin/nix" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = hash ]; then
+  printf '%s\n' 'sha256-9tnSQPSqllE+Ke6LKyNbnOF1drzdEwesEuPdmWD1X5c='
+else
+  printf '%s\n' "$@" >"$NIX_TEST_LOG"
+  printf '%s\n' 'got: sha256-ZqUs2BnasF3QBX0I2Sxh2A/CnO61Vy6gRn1hkf0n9AY=' >&2
+  exit 1
+fi
+EOF
+  chmod +x "$TEMP_DIR/bin/gh" "$TEMP_DIR/bin/nix-prefetch-url" "$TEMP_DIR/bin/nix"
+  env -u GH_VERSION -u GH_REV -u GH_SOURCE_HASH -u GH_VENDOR_HASH \
+    OVERLAY_FILE="$TEMP_DIR/overlays/default.nix" NIX_TEST_LOG="$TEMP_DIR/nix.log" \
+    bash "$SCRIPT" gh || return
+  cat "$TEMP_DIR/nix.log" "$TEMP_DIR/overlays/default.nix"
+}
+
+It 'uses resolved release values to calculate the GitHub CLI vendor hash'
+When run resolve_gh_release
+The output should include 'gh upgraded from 2.98.0 to 2.100.0'
+The output should include 'version = "2.100.0"; src = pkgs.fetchFromGitHub'
+The output should include 'rev = "45437bc7eeeb3359bbfddd1742f79de7652fd3e2"; hash = "sha256-9tnSQPSqllE+Ke6LKyNbnOF1drzdEwesEuPdmWD1X5c="'
+The output should include 'vendorHash = "sha256-ZqUs2BnasF3QBX0I2Sxh2A/CnO61Vy6gRn1hkf0n9AY=";'
+The status should be success
+End
+
 It 'updates every overlay hash from the all target'
 When run bash -c "env OVERLAY_FILE='$TEMP_DIR/overlays/default.nix' ASCII_BOX_CLI_VERSION='0.1.208' MOSHI_HOOK_CDN='file://$TEMP_DIR/cdn' BLACKSMITH_CLI_CDN='file://$TEMP_DIR/cdn/blacksmith' BLACKSMITH_CLI_VERSION='0.4.57' CRABBOX_RELEASE_CDN='file://$TEMP_DIR/cdn/crabbox' CRABBOX_VERSION='0.55.0' GH_VERSION='2.100.0' GH_REV='45437bc7eeeb3359bbfddd1742f79de7652fd3e2' GH_SOURCE_HASH='sha256-9tnSQPSqllE+Ke6LKyNbnOF1drzdEwesEuPdmWD1X5c=' GH_VENDOR_HASH='sha256-ZqUs2BnasF3QBX0I2Sxh2A/CnO61Vy6gRn1hkf0n9AY=' T3CODE_VERSION='0.0.36' T3CODE_PNPM_HASH='sha256-y/sJIluwbn65APmJ2p07FK1ScXpetCloTHtQzZMchDU=' bash '$SCRIPT' all && cat '$TEMP_DIR/overlays/default.nix'"
 The output should include 'moshi-hook upgraded from 0.2.55 to 0.2.69'


### PR DESCRIPTION
The overlay updater resolves the GitHub CLI release, revision and source hash locally, but the vendor-hash probe reads optional environment overrides instead. A normal invocation without those overrides exits with `GH_VERSION: unbound variable` before validation can complete.

Pass the resolved values into the probe explicitly. Existing overrides still feed the same resolution path.

Validation: all 9 overlay-updater examples pass, including a new end-to-end test that unsets every GitHub CLI override and checks the generated Nix expression and overlay. The same test fails against the original script with the reported unbound-variable error. ShellCheck and diff checks pass. Network and Nix-build boundaries are stubbed in the regression; hosted validation remains required.

Found while validating #2716. [T3 investigation thread](https://kyber.tail950b36.ts.net:8443/4dc26984-7b97-484d-989a-6f51098dec27/8e601efe-8f1b-4cbd-99bd-290d1ab24ff8).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the overlay updater so the vendor-hash probe receives the resolved GitHub CLI version, revision, and source hash instead of reading optional environment overrides, which caused normal invocations to exit with `GH_VERSION: unbound variable`.

- Adds a regression test that unsets every GitHub CLI override and verifies the generated Nix expression; the test fails against the original script.
- Existing overrides still flow through the same resolution path.
- All 9 overlay-updater examples pass; network and Nix-build boundaries are stubbed in the regression.
- Found while validating #2716.

<sup>Written for commit 6d3c75e6508d1089c5490c9d32b3f8926e6140d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

