### PR TITLE
fix(herdr): detect OpenCode activity from the live footer

### DIFF
--- a/config/herdr/README.md
+++ b/config/herdr/README.md
@@ -1,0 +1,7 @@
+# OpenCode detection
+
+After Home Manager installs or changes the detection manifest, run
+`herdr server reload-agent-manifests` for the active server. This reloads
+rules without restarting agents. Verify the active manifest and state with
+`herdr agent explain <agent-name> --json`; local overrides take precedence
+over bundled and remote manifests.

--- a/config/herdr/agent-detection/opencode.toml
+++ b/config/herdr/agent-detection/opencode.toml
@@ -13,8 +13,31 @@ priority = 300
 region = "whole_recent"
 visible_blocker = true
 any = [
-  { contains = ["△ Permission required"] },
-  { contains = ["esc dismiss"], any = [{ contains = ["enter confirm"] }, { contains = ["enter submit"] }, { contains = ["enter toggle"] }], all = [{ any = [{ contains = ["↑↓ select"] }, { contains = ["⇆ tab"] }] }] },
+  { contains = [
+    "△ Permission required",
+  ] },
+  { contains = [
+    "esc dismiss",
+  ], any = [
+    { contains = [
+      "enter confirm",
+    ] },
+    { contains = [
+      "enter submit",
+    ] },
+    { contains = [
+      "enter toggle",
+    ] },
+  ], all = [
+    { any = [
+      { contains = [
+        "↑↓ select",
+      ] },
+      { contains = [
+        "⇆ tab",
+      ] },
+    ] },
+  ] },
 ]
 
 [[rules]]
@@ -24,10 +47,18 @@ priority = 110
 region = "bottom_non_empty_lines(3)"
 visible_working = true
 any = [
-  { contains = ["esc to interrupt"] },
-  { contains = ["ctrl+c to interrupt"] },
-  { contains = ["press esc to interrupt"] },
-  { line_regex = ['(?i).*opencode.*esc (again to )?interrupt'] },
+  { contains = [
+    "esc to interrupt",
+  ] },
+  { contains = [
+    "ctrl+c to interrupt",
+  ] },
+  { contains = [
+    "press esc to interrupt",
+  ] },
+  { line_regex = [
+    '(?i).*opencode.*esc (again to )?interrupt',
+  ] },
 ]
 
 [[rules]]

--- a/config/herdr/agent-detection/opencode.toml
+++ b/config/herdr/agent-detection/opencode.toml
@@ -1,0 +1,39 @@
+# OpenCode 1.18 keeps live activity in the footer; quoted tool output is history.
+# Retain the upstream permission rules from Herdr 0.9.0.
+id = "opencode"
+version = "2026.09.11.1"
+min_engine_version = 1
+updated_at = "2026-09-11T00:00:00Z"
+aliases = ["open-code", "herdr:opencode"]
+
+[[rules]]
+id = "permission_required"
+state = "blocked"
+priority = 300
+region = "whole_recent"
+visible_blocker = true
+any = [
+  { contains = ["△ Permission required"] },
+  { contains = ["esc dismiss"], any = [{ contains = ["enter confirm"] }, { contains = ["enter submit"] }, { contains = ["enter toggle"] }], all = [{ any = [{ contains = ["↑↓ select"] }, { contains = ["⇆ tab"] }] }] },
+]
+
+[[rules]]
+id = "interrupt_hint_working"
+state = "working"
+priority = 110
+region = "bottom_non_empty_lines(3)"
+visible_working = true
+any = [
+  { contains = ["esc to interrupt"] },
+  { contains = ["ctrl+c to interrupt"] },
+  { contains = ["press esc to interrupt"] },
+  { line_regex = ['(?i).*opencode.*esc (again to )?interrupt'] },
+]
+
+[[rules]]
+id = "progress_bar_working"
+state = "working"
+priority = 100
+region = "bottom_non_empty_lines(3)"
+visible_working = true
+regex = ['(■|⬝){4,}']

--- a/config/herdr/default.nix
+++ b/config/herdr/default.nix
@@ -3,4 +3,5 @@ _: {
     source = ./config.toml;
     force = true;
   };
+  home.file.".config/herdr/agent-detection/opencode.toml".source = ./agent-detection/opencode.toml;
 }

--- a/tests/test_herdr_opencode_detection.py
+++ b/tests/test_herdr_opencode_detection.py
@@ -1,0 +1,103 @@
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HERDR = shutil.which("herdr")
+MANIFEST = ROOT / "config/herdr/agent-detection/opencode.toml"
+IDLE_FOOTER = """  ┃
+  ┃
+  ┃  Build · Example model
+  ╹▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+   /workspace/org/repo                42K (4%) ctrl+p commands
+"""
+
+
+@unittest.skipUnless(HERDR, "Herdr is required for native detection regression tests")
+class OpenCodeDetectionTests(unittest.TestCase):
+    def detect(self, screen):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config = root / "config/herdr"
+            manifests = config / "agent-detection"
+            manifests.mkdir(parents=True)
+            shutil.copyfile(MANIFEST, manifests / "opencode.toml")
+            capture = root / "screen.txt"
+            capture.write_text(screen)
+            environment = dict(os.environ)
+            environment.update(
+                XDG_CONFIG_HOME=str(root / "config"),
+                XDG_STATE_HOME=str(root / "state"),
+                HERDR_CONFIG_PATH=str(config / "config.toml"),
+            )
+            result = subprocess.run(
+                [
+                    HERDR,
+                    "agent",
+                    "explain",
+                    "--file",
+                    str(capture),
+                    "--agent",
+                    "opencode",
+                    "--json",
+                ],
+                env=environment,
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=15,
+            )
+            decoded = json.loads(result.stdout)
+            self.assertIn(str(manifests), decoded["manifest_source"])
+            return decoded["state"]
+
+    def test_quoted_worker_interrupt_hint_does_not_keep_completed_turn_busy(self):
+        for hint in (
+            "esc to interrupt",
+            "ctrl+c to interrupt",
+            "press esc to interrupt",
+        ):
+            with self.subTest(hint=hint):
+                screen = (
+                    f"  ┃  • Working (6s • {hint})\n"
+                    "  ┃  Click to expand\n\n"
+                    "     Worker dispatched.\n\n"
+                    "     ▣ Build · Example model · 3m 36s\n" + IDLE_FOOTER
+                )
+                self.assertEqual(self.detect(screen), "idle")
+
+    def test_quoted_progress_bar_does_not_keep_completed_turn_busy(self):
+        screen = "  ┃  ⬝⬝⬝⬝⬝⬝⬝⬝ esc interrupt\n" + IDLE_FOOTER
+        self.assertEqual(self.detect(screen), "idle")
+
+    def test_native_busy_and_retry_footers_remain_working(self):
+        for footer in (
+            "   ⬝⬝⬝⬝⬝⬝⬝⬝ esc interrupt  • OpenCode 1.18.25\n",
+            "   ■■■■ Gateway Timeout [retrying in 25s] esc interrupt\n",
+            "   esc to interrupt\n",
+            "   ctrl+c to interrupt\n",
+            "   OpenCode esc again to interrupt\n",
+            "   ⬝⬝⬝⬝ esc interrupt\n   42K (4%) ctrl+p\n   commands\n",
+        ):
+            with self.subTest(footer=footer):
+                self.assertEqual(self.detect(IDLE_FOOTER + footer), "working")
+
+    def test_permission_prompt_remains_blocked_even_with_busy_footer(self):
+        screen = (
+            "  △ Permission required\n  Run shell command?\n"
+            + IDLE_FOOTER
+            + "   ⬝⬝⬝⬝ esc interrupt\n"
+        )
+        self.assertEqual(self.detect(screen), "blocked")
+
+    def test_confirmation_prompt_remains_blocked(self):
+        screen = "  esc dismiss  enter confirm  ↑↓ select\n" + IDLE_FOOTER
+        self.assertEqual(self.detect(screen), "blocked")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A completed OpenCode turn can quote another worker's `esc to interrupt` line or progress bar. Herdr currently searches the whole recent screen for those strings, so it keeps the completed agent busy and refuses the next orchestration dispatch.

Install a supported detection manifest that limits working indicators to the three nonempty footer lines. Keep the upstream permission rules intact. Home Manager owns the manifest, and Herdr can reload it without restarting agent processes.

Validation: five native-engine regression tests (multiple busy, retry, quoted-output, and permission cases) pass on Herdr 0.9.0. The original manifest reproduces the quoted-output failures; the corrected manifest classifies the captured completed screen as idle. Ruff, Nix formatting, module evaluation, and diff checks pass. Native tests explicitly skip when Herdr is unavailable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Herdr previously scanned the whole recent screen for working indicators like "esc to interrupt", so a completed OpenCode turn that quoted such a line kept the agent busy. The new detection manifest limits working indicators to the three nonempty footer lines, preserving upstream permission rules.

- Adds `config/herdr/agent-detection/opencode.toml` with footer-scoped rules.
- Installs the manifest via Home Manager in `config/herdr/default.nix` and documents reload via `herdr server reload-agent-manifests` in `config/herdr/README.md`.
- Adds regression tests for quoted output, retry footers, and permission prompts.

<sup>Written for commit 57efd4a4da1d55b3568572c490b387770ee77dc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

