### PR TITLE
fix(bun): exempt Claude and Codex from the release-age gate

### DIFF
--- a/config/bun/bunfig.toml
+++ b/config/bun/bunfig.toml
@@ -4,6 +4,19 @@ timeout = 300000
 [install]
 # Supply-chain hygiene: only install packages published at least 7 days ago.
 minimumReleaseAge = 604800
+# T3 Code updates these agent CLIs with `bun i -g <pkg>@latest` and compares
+# against the npm `latest` tag, so the age gate would pin them to a stale
+# release. Codex platform binaries are version aliases of `@openai/codex`.
+minimumReleaseAgeExcludes = [
+  "@anthropic-ai/claude-code",
+  "@anthropic-ai/claude-code-darwin-arm64",
+  "@anthropic-ai/claude-code-darwin-x64",
+  "@anthropic-ai/claude-code-linux-arm64",
+  "@anthropic-ai/claude-code-linux-arm64-musl",
+  "@anthropic-ai/claude-code-linux-x64",
+  "@anthropic-ai/claude-code-linux-x64-musl",
+  "@openai/codex",
+]
 # Use caret ranges when adding deps.
 exact = false
 # Install optionalDependencies. Required for platform-native binaries shipped


### PR DESCRIPTION
T3 Code updates Bun-installed agent CLIs with `bun i -g <pkg>@latest` and then checks the result against the npm `latest` tag. The global bunfig enforces a 7-day `minimumReleaseAge`, so Bun quietly resolves an older release and exits 0. The update reports success, but the provider still shows as outdated. For example, Claude Code stays at 2.1.261 while 2.1.269 is latest, and Codex stays at 0.153.4 while 0.154.0 is latest.

Add `minimumReleaseAgeExcludes` for `@anthropic-ai/claude-code`, its platform binary packages, and `@openai/codex`. Codex's platform binaries are published as version aliases of `@openai/codex`, so that one entry covers them. The 7-day gate still applies to every other package. The npm-globals activation already installs these packages with `--minimum-release-age 0`.

Validation: T3's exact update command was run in an isolated `BUN_INSTALL`/`HOME` with this bunfig. It installed `claude` 2.1.269 and `codex-cli` 0.154.0, with matching platform binaries. The same command with the current bunfig installed 2.1.261.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Bun global release-age gate causing T3 Code's agent CLI updates to silently keep Claude Code and Codex on stale releases despite reporting success.

- Adds `minimumReleaseAgeExcludes` entries for `@anthropic-ai/claude-code` and its platform binary packages, plus `@openai/codex`, in `config/bun/bunfig.toml`.
- Covers Codex's platform binaries since they are version aliases of `@openai/codex`.
- Leaves the 7-day gate active for all other packages.

<sup>Written for commit 1cc9cf468dccc5612cd4c8352b31e3aa99122fa6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

