### PR TITLE
feat(overlays): package the Devin CLI instead of curl|bash

### DIFF
--- a/home-manager/packages/default.nix
+++ b/home-manager/packages/default.nix
@@ -45,6 +45,7 @@ with pkgs;
   pkgs.llm-agents.cursor-agent
   dasel
   delta
+  devin
   difftastic
   dnsutils
   direnv

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -292,6 +292,33 @@
       meta.mainProgram = "crabbox";
     };
 
+    devin = prev.stdenvNoCC.mkDerivation rec {
+      pname = "devin";
+      version = "3000.10.21";
+      src = prev.fetchurl {
+        url = "https://static.devin.ai/cli/${version}/devin-${version}-${
+          if prev.stdenv.hostPlatform.isAarch64 then "aarch64" else "x86_64"
+        }-${if prev.stdenv.hostPlatform.isDarwin then "apple-darwin" else "unknown-linux"}.tar.gz";
+        sha256 =
+          {
+            "aarch64-darwin" = "c0b97f8197bf3ce895ff14aa19257c511154b49a0a195bba4962acb5e475c68e";
+            "x86_64-darwin" = "4725d6b0dbbf6f71d833b5489469dc8b5c4a4f929926f94d500952a4cb7bbad8";
+            "aarch64-linux" = "a63124ed2f8406a5d44a162fa2eb05b9c0f218a6b131e2ca1335d4a335c70a6c";
+            "x86_64-linux" = "7cac6f5739ba3a3e5542f3b7fa07ed902d6dfb96ca22e4c63ae84c03bb7db47c";
+          }
+          .${prev.stdenv.hostPlatform.system};
+      };
+      sourceRoot = ".";
+      dontConfigure = true;
+      dontBuild = true;
+      installPhase = ''
+        install -Dm755 bin/devin $out/bin/devin
+        mkdir -p $out/share
+        cp -r share/devin $out/share/devin
+      '';
+      meta.mainProgram = "devin";
+    };
+
     moshi-hook = prev.stdenv.mkDerivation rec {
       pname = "moshi-hook";
       version = "0.3.21";

--- a/scripts/upgrade-overlays.sh
+++ b/scripts/upgrade-overlays.sh
@@ -15,6 +15,7 @@ ASCII_BOX_CLI_RELEASE_URL="${ASCII_BOX_CLI_RELEASE_URL:-https://github.com/arian
 ASCII_BOX_CLI_RELEASE_CHANNEL="${ASCII_BOX_CLI_RELEASE_CHANNEL:-ascii-prod1}"
 CRABBOX_RELEASE_API="${CRABBOX_RELEASE_API:-https://api.github.com/repos/openclaw/crabbox/releases/latest}"
 CRABBOX_RELEASE_CDN="${CRABBOX_RELEASE_CDN:-https://github.com/openclaw/crabbox/releases/download}"
+DEVIN_CLI_CDN="${DEVIN_CLI_CDN:-https://static.devin.ai/cli}"
 GH_RELEASE_API="${GH_RELEASE_API:-repos/cli/cli/releases/latest}"
 
 # Colors for output
@@ -42,6 +43,7 @@ usage() {
   echo "  ascii-box-cli - Upgrade the pinned ASCII Box CLI binaries"
   echo "  blacksmith-testbox-cli - Upgrade the pinned Blacksmith Testbox CLI binaries"
   echo "  crabbox - Upgrade the pinned Crabbox binaries"
+  echo "  devin - Upgrade the pinned Devin CLI binaries"
   echo "  gh - Upgrade the pinned GitHub CLI release and Go vendor hash"
   echo "  moshi-hook - Upgrade the pinned moshi-hook binaries"
   echo "  t3code - Refresh the platform-specific t3code pnpm dependency hash"
@@ -518,6 +520,75 @@ upgrade_crabbox() {
   log_info "✅ crabbox upgraded from ${current_version:-unknown} to $version"
 }
 
+upgrade_devin() {
+  local version current_version manifest
+  local darwin_arm64 darwin_x86_64 linux_arm64 linux_x86_64
+
+  manifest="$(curl -fsSL "$DEVIN_CLI_CDN/${DEVIN_CLI_VERSION:-current}/manifest.json")"
+  version="${DEVIN_CLI_VERSION:-$(printf '%s' "$manifest" | jq -r '.version')}"
+
+  if [[ ! $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    log_error "Invalid Devin CLI version: ${version:-unknown}"
+    exit 1
+  fi
+
+  current_version="$(sed -n '/devin = prev.stdenvNoCC.mkDerivation rec {/,/meta.mainProgram = "devin"/p' "$OVERLAY_FILE" | sed -n 's/.*version = "\([^"]*\)";.*/\1/p' | head -1)"
+  echo "  Current version: ${current_version:-unknown}"
+  echo "  Latest version:  $version"
+
+  darwin_arm64="$(printf '%s' "$manifest" | jq -r '.platforms["aarch64-apple-darwin"].sha256')"
+  darwin_x86_64="$(printf '%s' "$manifest" | jq -r '.platforms["x86_64-apple-darwin"].sha256')"
+  linux_arm64="$(printf '%s' "$manifest" | jq -r '.platforms["aarch64-unknown-linux"].sha256')"
+  linux_x86_64="$(printf '%s' "$manifest" | jq -r '.platforms["x86_64-unknown-linux"].sha256')"
+  validate_checksum devin-aarch64-apple-darwin "$darwin_arm64"
+  validate_checksum devin-x86_64-apple-darwin "$darwin_x86_64"
+  validate_checksum devin-aarch64-unknown-linux "$linux_arm64"
+  validate_checksum devin-x86_64-unknown-linux "$linux_x86_64"
+
+  awk \
+    -v version="$version" \
+    -v darwin_arm64="$darwin_arm64" \
+    -v darwin_x86_64="$darwin_x86_64" \
+    -v linux_arm64="$linux_arm64" \
+    -v linux_x86_64="$linux_x86_64" '
+      /devin = prev.stdenvNoCC.mkDerivation rec \{/ { in_devin = 1 }
+      in_devin && /version = "[^"]*";/ {
+        sub(/version = "[^"]*";/, "version = \"" version "\";")
+      }
+      in_devin && /"aarch64-darwin" =/ {
+        sub(/"[^"]*";$/, "\"" darwin_arm64 "\";")
+        updated_hashes++
+      }
+      in_devin && /"x86_64-darwin" =/ {
+        sub(/"[^"]*";$/, "\"" darwin_x86_64 "\";")
+        updated_hashes++
+      }
+      in_devin && /"aarch64-linux" =/ {
+        sub(/"[^"]*";$/, "\"" linux_arm64 "\";")
+        updated_hashes++
+      }
+      in_devin && /"x86_64-linux" =/ {
+        sub(/"[^"]*";$/, "\"" linux_x86_64 "\";")
+        updated_hashes++
+      }
+      in_devin && /meta.mainProgram = "devin"/ { in_devin = 0 }
+      { print }
+      END {
+        if (updated_hashes != 4) {
+          print "expected four devin checksums in " FILENAME > "/dev/stderr"
+          exit 1
+        }
+      }
+    ' "$OVERLAY_FILE" >"$OVERLAY_FILE.tmp"
+  mv -f "$OVERLAY_FILE.tmp" "$OVERLAY_FILE"
+
+  if [[ $current_version == "$version" ]]; then
+    log_info "✅ devin hashes refreshed for $version"
+  else
+    log_info "✅ devin upgraded from ${current_version:-unknown} to $version"
+  fi
+}
+
 t3code_pnpm_hash() {
   local expression output
 
@@ -595,6 +666,13 @@ main() {
     require_command sed
     upgrade_crabbox
     ;;
+  devin)
+    require_command awk
+    require_command curl
+    require_command jq
+    require_command sed
+    upgrade_devin
+    ;;
   gh)
     require_command awk
     require_command nix
@@ -618,6 +696,7 @@ main() {
   all)
     require_command awk
     require_command curl
+    require_command jq
     require_command nix-prefetch-url
     require_command nix
     require_command sed
@@ -625,6 +704,7 @@ main() {
     upgrade_ascii_box_cli
     upgrade_blacksmith_testbox_cli
     upgrade_crabbox
+    upgrade_devin
     upgrade_gh
     upgrade_moshi_hook
     upgrade_t3code

--- a/spec/upgrade_overlays_spec.sh
+++ b/spec/upgrade_overlays_spec.sh
@@ -11,6 +11,7 @@ The output should include 'Usage:'
 The output should include 'upgrade-overlays.sh'
 The output should include 'blacksmith-testbox-cli'
 The output should include 'crabbox'
+The output should include 'devin'
 The output should include 'moshi-hook'
 The output should include 't3code'
 The output should include 'all'
@@ -52,6 +53,7 @@ setup() {
     "$TEMP_DIR/cdn/blacksmith/v0.4.57/darwin/amd64" \
     "$TEMP_DIR/cdn/blacksmith/v0.4.57/darwin/arm64" \
     "$TEMP_DIR/cdn/crabbox/v0.55.0" \
+    "$TEMP_DIR/cdn/devin/3000.10.21" \
     "$TEMP_DIR/overlays"
   cat >"$TEMP_DIR/bin/nix-prefetch-url" <<'EOF'
 #!/usr/bin/env bash
@@ -84,6 +86,17 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  crabbox_0.55.0
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  crabbox_0.55.0_linux_arm64.tar.gz
 cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  crabbox_0.55.0_darwin_arm64.tar.gz
 dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd  crabbox_0.55.0_darwin_amd64.tar.gz
+EOF
+  cat >"$TEMP_DIR/cdn/devin/3000.10.21/manifest.json" <<'EOF'
+{
+  "version": "3000.10.21",
+  "platforms": {
+    "aarch64-apple-darwin": { "sha256": "1111111111111111111111111111111111111111111111111111111111111111" },
+    "x86_64-apple-darwin": { "sha256": "2222222222222222222222222222222222222222222222222222222222222222" },
+    "aarch64-unknown-linux": { "sha256": "3333333333333333333333333333333333333333333333333333333333333333" },
+    "x86_64-unknown-linux": { "sha256": "4444444444444444444444444444444444444444444444444444444444444444" }
+  }
+}
 EOF
   cat >"$TEMP_DIR/overlays/default.nix" <<'EOF'
 { inputs }:
@@ -160,6 +173,19 @@ EOF
       };
       meta.mainProgram = "crabbox";
     };
+    devin = prev.stdenvNoCC.mkDerivation rec {
+      pname = "devin";
+      version = "3000.10.20";
+      src = prev.fetchurl {
+        sha256 = {
+          "aarch64-darwin" = "old-darwin-arm";
+          "x86_64-darwin" = "old-darwin-x86";
+          "aarch64-linux" = "old-linux-arm";
+          "x86_64-linux" = "old-linux-x86";
+        };
+      };
+      meta.mainProgram = "devin";
+    };
     # t3code 0.0.33 pins one pnpm deps hash
     t3code-test = let
       pnpmDepsHashes = {
@@ -221,9 +247,10 @@ The status should be success
 End
 
 It 'updates every overlay hash from the all target'
-When run bash -c "env OVERLAY_FILE='$TEMP_DIR/overlays/default.nix' ASCII_BOX_CLI_VERSION='0.1.208' MOSHI_HOOK_CDN='file://$TEMP_DIR/cdn' BLACKSMITH_CLI_CDN='file://$TEMP_DIR/cdn/blacksmith' BLACKSMITH_CLI_VERSION='0.4.57' CRABBOX_RELEASE_CDN='file://$TEMP_DIR/cdn/crabbox' CRABBOX_VERSION='0.55.0' GH_VERSION='2.100.0' GH_REV='45437bc7eeeb3359bbfddd1742f79de7652fd3e2' GH_SOURCE_HASH='sha256-9tnSQPSqllE+Ke6LKyNbnOF1drzdEwesEuPdmWD1X5c=' GH_VENDOR_HASH='sha256-ZqUs2BnasF3QBX0I2Sxh2A/CnO61Vy6gRn1hkf0n9AY=' T3CODE_VERSION='0.0.36' T3CODE_PNPM_HASH='sha256-y/sJIluwbn65APmJ2p07FK1ScXpetCloTHtQzZMchDU=' bash '$SCRIPT' all && cat '$TEMP_DIR/overlays/default.nix'"
+When run bash -c "env OVERLAY_FILE='$TEMP_DIR/overlays/default.nix' ASCII_BOX_CLI_VERSION='0.1.208' MOSHI_HOOK_CDN='file://$TEMP_DIR/cdn' BLACKSMITH_CLI_CDN='file://$TEMP_DIR/cdn/blacksmith' BLACKSMITH_CLI_VERSION='0.4.57' CRABBOX_RELEASE_CDN='file://$TEMP_DIR/cdn/crabbox' CRABBOX_VERSION='0.55.0' DEVIN_CLI_CDN='file://$TEMP_DIR/cdn/devin' DEVIN_CLI_VERSION='3000.10.21' GH_VERSION='2.100.0' GH_REV='45437bc7eeeb3359bbfddd1742f79de7652fd3e2' GH_SOURCE_HASH='sha256-9tnSQPSqllE+Ke6LKyNbnOF1drzdEwesEuPdmWD1X5c=' GH_VENDOR_HASH='sha256-ZqUs2BnasF3QBX0I2Sxh2A/CnO61Vy6gRn1hkf0n9AY=' T3CODE_VERSION='0.0.36' T3CODE_PNPM_HASH='sha256-y/sJIluwbn65APmJ2p07FK1ScXpetCloTHtQzZMchDU=' bash '$SCRIPT' all && cat '$TEMP_DIR/overlays/default.nix'"
 The output should include 'moshi-hook upgraded from 0.2.55 to 0.2.69'
 The output should include 'crabbox upgraded from 0.46.0 to 0.55.0'
+The output should include 'devin upgraded from 3000.10.20 to 3000.10.21'
 The output should include 't3code pnpm hash refreshed for 0.0.36'
 The output should include 'gh upgraded from 2.98.0 to 2.100.0'
 The output should include '45437bc7eeeb3359bbfddd1742f79de7652fd3e2'
@@ -240,6 +267,23 @@ The output should include '3903e2e5d1dba02f9e1f53df8cea6e2b3260e1581461b9a07ca65
 The output should include '0a30e081399543551bbd0ba3320f3b28be814a585e5c591e168f8fd6d9565f07'
 The output should include '52258126b675dad210a8f04b83d8e90b359951af37474ff985d2c3f49102d981'
 The output should include '7cf24d316bafffc59d30e05d6ad6b27d4c03c9953ce901056f57f03c25e4b83b'
+The status should be success
+End
+
+It 'updates the pinned Devin CLI version and all platform checksums'
+When run bash -c "env OVERLAY_FILE='$TEMP_DIR/overlays/default.nix' DEVIN_CLI_CDN='file://$TEMP_DIR/cdn/devin' DEVIN_CLI_VERSION='3000.10.21' bash '$SCRIPT' devin >/dev/null && cat '$TEMP_DIR/overlays/default.nix'"
+The output should include 'version = "3000.10.21"'
+The output should include '1111111111111111111111111111111111111111111111111111111111111111'
+The output should include '2222222222222222222222222222222222222222222222222222222222222222'
+The output should include '3333333333333333333333333333333333333333333333333333333333333333'
+The output should include '4444444444444444444444444444444444444444444444444444444444444444'
+The status should be success
+End
+
+It 'reads the Devin CLI version from the manifest when unpinned'
+When run bash -c "env OVERLAY_FILE='$TEMP_DIR/overlays/default.nix' DEVIN_CLI_CDN='file://$TEMP_DIR/cdn/devin' bash -c \"ln -s 3000.10.21 '$TEMP_DIR/cdn/devin/current' && bash '$SCRIPT' devin\""
+The output should include 'Latest version:  3000.10.21'
+The output should include 'devin upgraded from 3000.10.20 to 3000.10.21'
 The status should be success
 End
 


### PR DESCRIPTION
Replaces the `curl -fsSL https://cli.devin.ai/install.sh | bash` vendor installer with a pinned overlay package, per the repository-managed CLI priority in AGENTS.md.

## Changes

- `overlays/default.nix`: `devin` derivation pinned at `3000.10.21`, fetching the vendor tarball per platform with sha256s from the release manifest; installs `bin/devin` plus `share/devin/docs`. Mirrors the existing `ascii-box-cli` / `crabbox` packages.
- `home-manager/packages/default.nix`: `devin` added to the cross-platform package list.
- `scripts/upgrade-overlays.sh`: new `devin` target (also wired into `all`, so `make overlays-update` picks it up). Reads `https://static.devin.ai/cli/current/manifest.json`, validates the version and all four platform checksums, then rewrites the pin. Overridable via `DEVIN_CLI_CDN` / `DEVIN_CLI_VERSION`.
- `spec/upgrade_overlays_spec.sh`: fixture manifest plus coverage for the pinned-version upgrade, the manifest-derived version, and the `all` target.

## Verification

- `nix build` of the overlay package succeeds; `devin --version` from the store prints `devin 3000.10.21 (611c1cba)`.
- `shellspec spec/upgrade_overlays_spec.sh`: 11 examples, 0 failures.
- `nix flake check --system x86_64-linux --impure`: all checks passed (includes treefmt).
- `./scripts/upgrade-overlays.sh devin` against the live manifest is idempotent.

Closes df-ikic3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the `curl -fsSL https://cli.devin.ai/install.sh | bash` vendor installer with a pinned overlay package, making Devin CLI installs reproducible and part of the existing overlay update flow.

- Pins `devin` at `3000.10.21` with per-platform sha256 checksums from the release manifest.
- Adds a `devin` target to `scripts/upgrade-overlays.sh` (wired into `all`) that validates the version and all four platform checksums before rewriting the pin, overridable via `DEVIN_CLI_CDN` and `DEVIN_CLI_VERSION`.
- Adds shellspec coverage for the pinned-version upgrade, the manifest-derived version, and the `all` target.

Closes df-ikic3

<sup>Written for commit 1d0dea7228476d236df303a2371d25bc9fe1fbb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

