### PR TITLE
refactor(generated): limit generated/ to moshi and traces hooks

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -1,0 +1,573 @@
+{
+  "cleanupPeriodDays": 99999,
+  "defaultMode": "bypassPermissions",
+  "effortLevel": "high",
+  "enabledPlugins": {
+    "clangd-lsp@claude-plugins-official": true,
+    "claude-mem@claude-mem": true,
+    "code-review@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": true,
+    "codex@openai-codex": true,
+    "commit-commands@claude-plugins-official": true,
+    "context7@claude-plugins-official": true,
+    "csharp-lsp@claude-plugins-official": true,
+    "feature-dev@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true,
+    "gopls-lsp@claude-plugins-official": true,
+    "jdtls-lsp@claude-plugins-official": true,
+    "kotlin-lsp@claude-plugins-official": true,
+    "lua-lsp@claude-plugins-official": true,
+    "mempalace@mempalace": true,
+    "php-lsp@claude-plugins-official": true,
+    "plan-export@cc-marketplace": true,
+    "pr-review-toolkit@claude-plugins-official": true,
+    "pyright-lsp@claude-plugins-official": true,
+    "qmd@qmd": true,
+    "ralph-loop@claude-plugins-official": true,
+    "ruby-lsp@claude-plugins-official": true,
+    "rust-analyzer-lsp@claude-plugins-official": true,
+    "safety-net@cc-marketplace": true,
+    "security-guidance@claude-plugins-official": true,
+    "serena@claude-plugins-official": true,
+    "skill-codex@skill-codex": true,
+    "superpowers@claude-plugins-official": true,
+    "swift-lsp@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true,
+    "worktrunk@worktrunk": true
+  },
+  "env": {
+    "AIKIDO_DISABLE": "true",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-sonnet-4-6",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-6",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6",
+    "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1",
+    "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
+    "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1",
+    "CLAUDE_CODE_DISABLE_AUTO_UPDATE": "1",
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_CODE_SUBAGENT_MODEL": "sonnet",
+    "NO_COLOR": "1",
+    "SAFE_CHAIN_LOGGING": "silent",
+    "TURBO_NO_UPDATE_NOTIFIER": "1"
+  },
+  "extraKnownMarketplaces": {
+    "cc-marketplace": {
+      "source": {
+        "repo": "kenryu42/cc-marketplace",
+        "source": "github"
+      }
+    },
+    "claude-mem": {
+      "source": {
+        "repo": "thedotmack/claude-mem",
+        "source": "github"
+      }
+    },
+    "claude-plugins-community": {
+      "source": {
+        "repo": "anthropics/claude-plugins-community",
+        "source": "github"
+      }
+    },
+    "mempalace": {
+      "source": {
+        "repo": "milla-jovovich/mempalace",
+        "source": "github"
+      }
+    },
+    "openai-codex": {
+      "source": {
+        "repo": "openai/codex-plugin-cc",
+        "source": "github"
+      }
+    },
+    "qmd": {
+      "source": {
+        "repo": "tobi/qmd",
+        "source": "github"
+      }
+    },
+    "skill-codex": {
+      "source": {
+        "repo": "skills-directory/skill-codex",
+        "source": "github"
+      }
+    },
+    "worktrunk": {
+      "source": {
+        "repo": "max-sixty/worktrunk",
+        "source": "github"
+      }
+    }
+  },
+  "hooks": {
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "$HOME/.claude/hooks/notify.sh",
+            "timeout": 3,
+            "type": "command"
+          },
+          {
+            "async": true,
+            "command": "$HOME/.claude/hooks/pushover.sh",
+            "timeout": 6,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "$HOME/.claude/hooks/notify.sh",
+            "timeout": 3,
+            "type": "command"
+          },
+          {
+            "async": true,
+            "command": "$HOME/.claude/hooks/pushover.sh",
+            "timeout": 6,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "git-ai checkpoint claude --hook-input stdin",
+            "timeout": 15,
+            "type": "command"
+          }
+        ],
+        "matcher": "Write|Edit|MultiEdit"
+      },
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "$HOME/.claude/hooks/atuin-history.sh",
+            "timeout": 5,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/roborev-agent.sh",
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "$HOME/.claude/hooks/notify.sh",
+            "timeout": 3,
+            "type": "command"
+          },
+          {
+            "async": true,
+            "command": "$HOME/.claude/hooks/pushover.sh",
+            "timeout": 6,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/dcg-guard.sh",
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/rtk-rewrite.sh",
+            "timeout": 5,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/dcg-guard.sh",
+            "timeout": 5,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/.claude/hooks/security.sh",
+            "timeout": 5,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/block-git-push.sh",
+            "timeout": 5,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/block-gh-settings.sh",
+            "timeout": 5,
+            "type": "command"
+          },
+          {
+            "async": true,
+            "command": "$HOME/.claude/hooks/notify.sh",
+            "timeout": 3,
+            "type": "command"
+          },
+          {
+            "async": true,
+            "command": "$HOME/.claude/hooks/pushover.sh",
+            "timeout": 6,
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/roborev-agent.sh",
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/secret-guard.sh",
+            "timeout": 5,
+            "type": "command"
+          },
+          {
+            "async": true,
+            "command": "git-ai checkpoint claude --hook-input stdin",
+            "timeout": 15,
+            "type": "command"
+          }
+        ],
+        "matcher": "Write|Edit|MultiEdit"
+      },
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/dcg-guard.sh",
+            "timeout": 5,
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
+            "command": "command -v graphify >/dev/null 2>&1 && graphify hook-guard search",
+            "timeout": 5,
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
+            "command": "command -v graphify >/dev/null 2>&1 && graphify hook-guard read",
+            "timeout": 5,
+            "type": "command"
+          }
+        ],
+        "matcher": "Read|Glob"
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "async": false,
+            "command": "caam-claude-snapshot",
+            "timeout": 10,
+            "type": "command"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-end --agent claude-code # traces hook agent",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "$HOME/.claude/hooks/notify.sh",
+            "timeout": 3,
+            "type": "command"
+          },
+          {
+            "async": true,
+            "command": "$HOME/.claude/hooks/pushover.sh",
+            "timeout": 6,
+            "type": "command"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "bd prime --hook-json",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      },
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-start --agent claude-code # traces hook agent",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "$HOME/.claude/hooks/notify.sh",
+            "timeout": 3,
+            "type": "command"
+          },
+          {
+            "async": true,
+            "command": "$HOME/.claude/hooks/pushover.sh",
+            "timeout": 6,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/roborev-agent.sh",
+            "type": "command"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh agent-done --agent claude-code # traces hook agent",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "command": "$HOME/.claude/hooks/auto-switch.sh",
+            "timeout": 10,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "$HOME/.claude/hooks/notify.sh",
+            "timeout": 3,
+            "type": "command"
+          },
+          {
+            "async": true,
+            "command": "$HOME/.claude/hooks/pushover.sh",
+            "timeout": 6,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "jq -c '{timestamp: (now | todate), prompt: .prompt[0:500]}' >> ~/.claude/prompt-history.jsonl",
+            "timeout": 3,
+            "type": "command"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh prompt-submitted --agent claude-code # traces hook agent",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "command": "bash -c 'NAME=$(jq -r .name); REPO=$(git rev-parse --show-toplevel); DIR=\"$REPO/.worktrees/$NAME\"; (wt switch --create \"$NAME\" --no-cd -y || wt switch \"$NAME\" --no-cd -y) >&2 && echo \"$DIR\"'",
+            "timeout": 30,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "command": "bash -c 'WORKTREE_PATH=$(jq -r .worktree_path); BRANCH=$(basename \"$WORKTREE_PATH\"); wt remove \"$BRANCH\" -y >&2'",
+            "timeout": 30,
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "outputStyle": "Concise",
+  "permissions": {
+    "allow": [
+      "Bash(bun:*)",
+      "Bash(cargo:*)",
+      "Bash(cat:*)",
+      "Bash(cp:*)",
+      "Bash(docker-compose:*)",
+      "Bash(docker:*)",
+      "Bash(env)",
+      "Bash(gh api:*)",
+      "Bash(gh auth:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh pr checkout:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr edit:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr merge:*)",
+      "Bash(gh pr review:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh release:*)",
+      "Bash(gh repo:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh run watch:*)",
+      "Bash(git add:*)",
+      "Bash(git branch:*)",
+      "Bash(git checkout:*)",
+      "Bash(git cherry-pick:*)",
+      "Bash(git commit:*)",
+      "Bash(git diff:*)",
+      "Bash(git fetch:*)",
+      "Bash(git log:*)",
+      "Bash(git merge:*)",
+      "Bash(git pull:*)",
+      "Bash(git push:*)",
+      "Bash(git rebase:*)",
+      "Bash(git reset:*)",
+      "Bash(git stash:*)",
+      "Bash(git status:*)",
+      "Bash(git tag:*)",
+      "Bash(git worktree:*)",
+      "Bash(grep:*)",
+      "Bash(kubectl:*)",
+      "Bash(lsof:*)",
+      "Bash(make:*)",
+      "Bash(mkdir:*)",
+      "Bash(nix-build:*)",
+      "Bash(nix-env:*)",
+      "Bash(nix-shell:*)",
+      "Bash(nix:*)",
+      "Bash(npm:*)",
+      "Bash(osascript:*)",
+      "Bash(pip:*)",
+      "Bash(pip3:*)",
+      "Bash(pnpm:*)",
+      "Bash(scutil:*)",
+      "Bash(timeout:*)",
+      "Bash(uv:*)",
+      "Bash(uvx:*)",
+      "Bash(yarn:*)",
+      "mcp__serena",
+      "WebFetch(domain:docs.anthropic.com)"
+    ],
+    "deny": [
+      "Bash(chmod -R 777:*)",
+      "Bash(dd if=:*)",
+      "Bash(docker system prune -a:*)",
+      "Bash(docker system prune -f:*)",
+      "Bash(git push --force origin main:*)",
+      "Bash(git push --force origin master:*)",
+      "Bash(git push --force-with-lease origin main:*)",
+      "Bash(git push --force-with-lease origin master:*)",
+      "Bash(git push -f origin main:*)",
+      "Bash(git push -f origin master:*)",
+      "Bash(mkfs:*)",
+      "Bash(rm -rf /*:*)",
+      "Bash(rm -rf ~/*:*)",
+      "Bash(sudo:*)",
+      "Read(.conf)",
+      "Read(.conf*)",
+      "Read(.env)",
+      "Read(.env.*)",
+      "Read(**/*credential*)",
+      "Read(**/*.key)",
+      "Read(**/*.pem)",
+      "Read(**/secrets/*)"
+    ],
+    "read": {
+      "deny": [
+        "**/.env",
+        "**/.env.local",
+        "**/*.pem",
+        "**/*.key",
+        "**/secrets/**",
+        "**/credentials/**",
+        "**/.aws/**",
+        "**/.ssh/**",
+        "**/docker-compose*.yml",
+        "**/config/database.yml"
+      ]
+    },
+    "write": {
+      "deny": [
+        "**/secrets/**",
+        "**/credentials/**",
+        "**/.ssh/**",
+        "**/config/database.yml",
+        "**/docker-compose*.yml"
+      ]
+    }
+  },
+  "skipDangerousModePermissionPrompt": true,
+  "statusLine": {
+    "command": "$HOME/.claude/hooks/statusline.sh",
+    "type": "command"
+  }
+}

--- a/config/codex/hooks.json
+++ b/config/codex/hooks.json
@@ -1,0 +1,250 @@
+{
+  "hooks": {
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "command": "bd codex-hook PostCompact",
+            "statusMessage": "Scheduling Beads context refresh",
+            "type": "command"
+          }
+        ],
+        "matcher": "manual|auto"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "$HOME/.codex/hooks/atuin-history.sh",
+            "timeout": 5,
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/roborev-agent.sh",
+            "timeout": 10,
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "command": "bd codex-hook PreCompact",
+            "statusMessage": "Checking Beads context",
+            "type": "command"
+          }
+        ],
+        "matcher": "manual|auto"
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/secret-guard.sh",
+            "timeout": 5,
+            "type": "command"
+          }
+        ],
+        "matcher": "Write|Edit|MultiEdit"
+      },
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/rtk-rewrite.sh",
+            "timeout": 5,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/dcg-guard.sh",
+            "timeout": 5,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/security.sh",
+            "timeout": 5,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/block-git-push.sh",
+            "timeout": 5,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/block-gh-settings.sh",
+            "timeout": 5,
+            "type": "command"
+          },
+          {
+            "async": true,
+            "command": "$HOME/.codex/hooks/notify.sh",
+            "timeout": 3,
+            "type": "command"
+          },
+          {
+            "async": true,
+            "command": "$HOME/.codex/hooks/pushover.sh",
+            "timeout": 6,
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/roborev-agent.sh",
+            "timeout": 10,
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
+            "command": "command -v graphify >/dev/null 2>&1 && graphify hook-guard search",
+            "timeout": 5,
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
+            "command": "command -v graphify >/dev/null 2>&1 && graphify hook-guard read",
+            "timeout": 5,
+            "type": "command"
+          }
+        ],
+        "matcher": "Read"
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-end --agent codex # traces hook agent",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "$HOME/.codex/hooks/notify.sh",
+            "timeout": 3,
+            "type": "command"
+          },
+          {
+            "async": true,
+            "command": "$HOME/.codex/hooks/pushover.sh",
+            "timeout": 6,
+            "type": "command"
+          }
+        ],
+        "matcher": "startup|resume"
+      },
+      {
+        "hooks": [
+          {
+            "command": "bd codex-hook SessionStart",
+            "statusMessage": "Loading Beads context",
+            "type": "command"
+          }
+        ],
+        "matcher": "startup|resume|clear"
+      },
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-start --agent codex # traces hook agent",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "$HOME/.codex/hooks/notify.sh",
+            "timeout": 3,
+            "type": "command"
+          },
+          {
+            "async": true,
+            "command": "$HOME/.codex/hooks/pushover.sh",
+            "timeout": 6,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/roborev-agent.sh",
+            "timeout": 10,
+            "type": "command"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh agent-done --agent codex # traces hook agent",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "async": true,
+            "command": "jq -c '{timestamp: (now | todate), prompt: .prompt[0:500]}' >> ~/.codex/prompt-history.jsonl",
+            "timeout": 3,
+            "type": "command"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "bd codex-hook UserPromptSubmit",
+            "statusMessage": "Refreshing Beads context",
+            "type": "command"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh prompt-submitted --agent codex # traces hook agent",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ]
+  }
+}

--- a/config/cursor/hooks.json
+++ b/config/cursor/hooks.json
@@ -1,0 +1,88 @@
+{
+  "hooks": {
+    "afterFileEdit": [
+      {
+        "command": "$HOME/.cargo/bin/git-ai checkpoint cursor --hook-input stdin",
+        "timeout": 15
+      }
+    ],
+    "beforeReadFile": [
+      {
+        "command": "command -v graphify >/dev/null 2>&1 && graphify hook-guard read",
+        "timeout": 5
+      }
+    ],
+    "beforeShellExecution": [
+      {
+        "command": "command -v graphify >/dev/null 2>&1 && graphify hook-guard search",
+        "timeout": 5
+      },
+      {
+        "command": "$HOME/dotfiles/config/shared/hooks/security.sh",
+        "timeout": 5
+      },
+      {
+        "command": "$HOME/dotfiles/config/shared/hooks/block-git-push.sh",
+        "timeout": 5
+      },
+      {
+        "command": "$HOME/dotfiles/config/shared/hooks/block-gh-settings.sh",
+        "timeout": 5
+      },
+      {
+        "command": "$HOME/.cursor/hooks/notify.sh",
+        "timeout": 3
+      },
+      {
+        "command": "$HOME/.cursor/hooks/pushover.sh",
+        "timeout": 6
+      }
+    ],
+    "beforeSubmitPrompt": [
+      {
+        "command": "$HOME/.cargo/bin/git-ai checkpoint cursor --hook-input stdin",
+        "timeout": 15
+      },
+      {
+        "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh prompt-submitted --agent cursor # traces hook agent"
+      }
+    ],
+    "postToolUse": [
+      {
+        "command": "bd cursor-hook postToolUse"
+      }
+    ],
+    "preCompact": [
+      {
+        "command": "bd cursor-hook preCompact"
+      }
+    ],
+    "sessionEnd": [
+      {
+        "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-end --agent cursor # traces hook agent"
+      }
+    ],
+    "sessionStart": [
+      {
+        "command": "bd cursor-hook sessionStart"
+      },
+      {
+        "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-start --agent cursor # traces hook agent"
+      }
+    ],
+    "stop": [
+      {
+        "command": "$HOME/.cursor/hooks/notify.sh",
+        "timeout": 3
+      },
+      {
+        "command": "$HOME/.cursor/hooks/pushover.sh",
+        "timeout": 6
+      },
+      {
+        "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh agent-done --agent cursor # traces hook agent"
+      }
+    ]
+  },
+  "version": 1
+}

--- a/config/gemini/settings.json
+++ b/config/gemini/settings.json
@@ -1,0 +1,85 @@
+{
+  "contextFileName": "AGENTS.md",
+  "hooks": {
+    "AfterTool": [
+      {
+        "command": "git-ai checkpoint gemini --hook-input stdin",
+        "matcher": "write_file|replace"
+      }
+    ],
+    "BeforeTool": [
+      {
+        "command": "git-ai checkpoint gemini --hook-input stdin",
+        "matcher": "write_file|replace"
+      },
+      {
+        "command": "command -v graphify >/dev/null 2>&1 && graphify hook-guard gemini",
+        "matcher": "read_file|list_directory"
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "bd prime --hook-json",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ]
+  },
+  "mcpServers": {
+    "ChromeDevtools": {
+      "args": [
+        "--autoConnect",
+        "--channel=beta"
+      ],
+      "command": "chrome-devtools-mcp"
+    },
+    "Codex": {
+      "args": [
+        "mcp-server"
+      ],
+      "command": "codex"
+    },
+    "Context7": {
+      "args": [],
+      "command": "context7-mcp"
+    },
+    "GitHub": {
+      "args": [
+        "-c",
+        "exec mcp-remote 'https://api.githubcopilot.com/mcp/' --header \"Authorization:Bearer $(gh auth token)\""
+      ],
+      "command": "sh"
+    },
+    "MemPalace": {
+      "args": [
+        "-m",
+        "mempalace.mcp_server"
+      ],
+      "command": "python3-mempalace"
+    },
+    "Serena": {
+      "args": [
+        "start-mcp-server"
+      ],
+      "command": "serena"
+    },
+    "XcodeBuildMCP": {
+      "args": [
+        "mcp"
+      ],
+      "command": "xcodebuildmcp"
+    }
+  },
+  "security": {
+    "auth": {
+      "selectedType": "oauth-personal"
+    }
+  },
+  "tools": {
+    "enableHooks": true
+  }
+}

--- a/config/grok/plugin/hooks/hooks.json
+++ b/config/grok/plugin/hooks/hooks.json
@@ -1,0 +1,71 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/security.sh",
+            "type": "command"
+          },
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/block-git-push.sh",
+            "type": "command"
+          },
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/block-gh-settings.sh",
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash|bash|shell"
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-end --agent grok # traces hook agent",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-start --agent grok # traces hook agent",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh agent-done --agent grok # traces hook agent",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh prompt-submitted --agent grok # traces hook agent",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ]
+  }
+}

--- a/config/shared/merge-moshi-hooks.sh
+++ b/config/shared/merge-moshi-hooks.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Merge a generated Moshi hook fragment into a hand-maintained agent config and
+# print the result on stdout.
+#
+# `generated/hooks/moshi/<agent>` only carries Moshi hook entries; the rest of
+# each agent's configuration lives under `config/<agent>`. Activation stitches
+# the two halves back together so the live file stays a single document.
+#
+# Every supported agent stores hooks as `.hooks.<Event>` arrays, so merging is a
+# per-event append that skips entries already present in the base config.
+#
+# Usage: merge-moshi-hooks.sh <base_json> <moshi_fragment_json> [jq_bin]
+set -euo pipefail
+
+BASE_JSON="${1:?base agent config required}"
+FRAGMENT_JSON="${2:?moshi hook fragment required}"
+JQ_BIN="${3:-jq}"
+
+# shellcheck disable=SC2016 # $base/$fragment/$event/$hook are jq variables.
+if ! "$JQ_BIN" -s '
+  .[0] as $base
+  | .[1] as $fragment
+  | $base
+  | .hooks = (
+      reduce (($fragment.hooks // {}) | to_entries[]) as $event
+        (($base.hooks // {});
+          .[$event.key] = (
+            reduce $event.value[] as $hook
+              ((.[$event.key] // []);
+                if any(.[]; . == $hook) then . else . + [$hook] end)
+          )
+        )
+    )
+' "$BASE_JSON" "$FRAGMENT_JSON"; then
+  echo "error: failed to merge $FRAGMENT_JSON into $BASE_JSON" >&2
+  exit 1
+fi

--- a/scripts/extract-moshi-hooks.sh
+++ b/scripts/extract-moshi-hooks.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Extract the Moshi-only hook entries from a live agent config.
+#
+# `generated/hooks` is reserved for machine-generated adapters: Moshi hooks
+# under `generated/hooks/moshi` and Traces hooks under `generated/hooks/traces`.
+# Everything else an agent needs (permissions, env, MCP servers, the shared
+# security hooks, Traces entries) is hand-maintained under `config/<agent>` and
+# is merged back in at activation time by config/shared/merge-moshi-hooks.sh.
+#
+# Usage: extract-moshi-hooks.sh <live_config> <moshi_fragment_out>
+set -euo pipefail
+
+LIVE_CONFIG="${1:?live agent config required}"
+FRAGMENT_OUT="${2:?moshi fragment output path required}"
+
+read -r -d '' MOSHI_DEFS <<'JQ' || true
+def cmds: [.. | objects | .command? // empty | select(type == "string")];
+def is_moshi: (cmds | length > 0 and all(test("moshi-hook")));
+JQ
+
+mkdir -p "$(dirname "$FRAGMENT_OUT")"
+
+# A hook entry belongs to Moshi only when every command it carries invokes
+# moshi-hook. A mixed entry would drag unrelated commands into the generated
+# fragment, so fail loudly instead of guessing.
+if jq -e "$MOSHI_DEFS"'
+  (.hooks // {})
+  | to_entries[]
+  | .value[]
+  | select((cmds | length) > 0)
+  | select((cmds | any(test("moshi-hook"))) and (cmds | any(test("moshi-hook") | not)))
+' "$LIVE_CONFIG" >/dev/null; then
+  echo "error: $LIVE_CONFIG mixes moshi and non-moshi commands in one hook entry" >&2
+  exit 1
+fi
+
+fragment_tmp="$(mktemp "${FRAGMENT_OUT}.tmp.XXXXXX")"
+trap 'rm -f "$fragment_tmp"' EXIT
+
+jq -S --indent 2 "$MOSHI_DEFS"'
+  { hooks: (
+      (.hooks // {})
+      | map_values(map(select(is_moshi)))
+      | with_entries(select(.value | length > 0))
+    )
+  }
+' "$LIVE_CONFIG" >"$fragment_tmp"
+
+mv -f "$fragment_tmp" "$FRAGMENT_OUT"
+trap - EXIT

--- a/scripts/normalize-dcg-hooks.sh
+++ b/scripts/normalize-dcg-hooks.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016 # The generated hook command must contain literal $HOME.
+# Route every dcg hook command in an agent config through the tracked
+# fail-closed wrapper.
+#
+# dcg's installer may emit a resolved path, a bare invocation, or a conditional
+# lookup. All three degrade to an unguarded, non-blocking hook when dcg is
+# missing, so rewrite them to config/shared/hooks/dcg-guard.sh instead.
+#
+# Usage: normalize-dcg-hooks.sh <hook_config> [hook_config ...]
+set -euo pipefail
+
+if (($# == 0)); then
+  echo "usage: $0 <hook_config> [hook_config ...]" >&2
+  exit 1
+fi
+
+for hook_config in "$@"; do
+  if [[ ! -f $hook_config ]]; then
+    echo "error: hook config not found: $hook_config" >&2
+    exit 1
+  fi
+
+  tmp_file="$(mktemp "${hook_config}.tmp.XXXXXX")"
+  if ! sed \
+    -e 's|"command": "dcg"|"command": "$HOME/dotfiles/config/shared/hooks/dcg-guard.sh"|g' \
+    -e 's|"command": "[^"[:space:]]*/dcg"|"command": "$HOME/dotfiles/config/shared/hooks/dcg-guard.sh"|g' \
+    -e 's|"command": "command -v dcg >/dev/null 2>&1 && dcg"|"command": "$HOME/dotfiles/config/shared/hooks/dcg-guard.sh"|g' \
+    -e 's|"command": "command -v dcg \\u003e/dev/null 2\\u003e\\u00261 \\u0026\\u0026 dcg"|"command": "$HOME/dotfiles/config/shared/hooks/dcg-guard.sh"|g' \
+    "$hook_config" >"$tmp_file"; then
+    rm -f "$tmp_file"
+    exit 1
+  fi
+
+  if ! jq empty "$tmp_file"; then
+    echo "error: dcg hook normalization produced invalid JSON: $hook_config" >&2
+    rm -f "$tmp_file"
+    exit 1
+  fi
+
+  if jq -e '
+    .. | objects | .command? // empty
+    | select(
+        . == "command -v dcg >/dev/null 2>&1 && dcg"
+        or test("(^|/)dcg$")
+      )
+  ' "$tmp_file" >/dev/null; then
+    echo "error: unguarded dcg hook remains in $hook_config" >&2
+    rm -f "$tmp_file"
+    exit 1
+  fi
+  mv -f "$tmp_file" "$hook_config"
+done

--- a/spec/moshi_hook_split_spec.sh
+++ b/spec/moshi_hook_split_spec.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016,SC2329,SC2034
+
+Describe 'moshi hook split'
+EXTRACT="$PWD/scripts/extract-moshi-hooks.sh"
+MERGE="$PWD/config/shared/merge-moshi-hooks.sh"
+
+setup() {
+  TEMP_DIR=$(mktemp -d)
+  LIVE="$TEMP_DIR/live.json"
+  MIXED="$TEMP_DIR/mixed.json"
+  INVALID="$TEMP_DIR/invalid.json"
+  EMPTY_FRAGMENT="$TEMP_DIR/empty-fragment.json"
+  FRAGMENT="$TEMP_DIR/fragment.json"
+  BASE="$TEMP_DIR/base.json"
+
+  cat >"$LIVE" <<'JSON'
+{
+  "permissions": { "allow": ["Bash"] },
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [{ "type": "command", "command": "moshi-hook session-start" }] },
+      { "hooks": [{ "type": "command", "command": "security.sh" }] }
+    ],
+    "Stop": [
+      { "hooks": [{ "type": "command", "command": "moshi-hook stop" }] }
+    ],
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": [{ "type": "command", "command": "dcg-guard.sh" }] }
+    ]
+  }
+}
+JSON
+
+  cat >"$MIXED" <<'JSON'
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "moshi-hook stop" },
+          { "type": "command", "command": "notify.sh" }
+        ]
+      }
+    ]
+  }
+}
+JSON
+
+  printf 'not json\n' >"$INVALID"
+  printf '{"hooks":{}}\n' >"$EMPTY_FRAGMENT"
+}
+
+cleanup() {
+  rm -rf "$TEMP_DIR"
+}
+
+Before 'setup'
+After 'cleanup'
+
+Describe 'extract-moshi-hooks.sh'
+It 'exists and is executable'
+The path "$EXTRACT" should be exist
+The path "$EXTRACT" should be executable
+End
+
+It 'keeps only moshi hook entries and drops everything else'
+When run bash -c 'bash "$1" "$2" "$3" && jq -cS "." "$3"' _ "$EXTRACT" "$LIVE" "$FRAGMENT"
+The status should be success
+The output should eq '{"hooks":{"SessionStart":[{"hooks":[{"command":"moshi-hook session-start","type":"command"}]}],"Stop":[{"hooks":[{"command":"moshi-hook stop","type":"command"}]}]}}'
+End
+
+It 'fails when a single hook entry mixes moshi and non-moshi commands'
+When run bash "$EXTRACT" "$MIXED" "$FRAGMENT"
+The status should be failure
+The stderr should include 'mixes moshi and non-moshi commands'
+End
+End
+
+Describe 'merge-moshi-hooks.sh'
+It 'exists and is executable'
+The path "$MERGE" should be exist
+The path "$MERGE" should be executable
+End
+
+It 'round-trips the split back into the original set of commands'
+When run bash -c '
+  bash "$1" "$2" "$3" || exit 1
+  jq -S "delpaths([[\"hooks\",\"SessionStart\",0],[\"hooks\",\"Stop\"]])" "$2" >"$4" || exit 1
+  bash "$5" "$4" "$3" jq |
+    jq -e --slurpfile live "$2" "([.. | objects | .command? // empty] | sort) == (\$live[0] | [.. | objects | .command? // empty] | sort)" >/dev/null
+' _ "$EXTRACT" "$LIVE" "$FRAGMENT" "$BASE" "$MERGE"
+The status should be success
+End
+
+It 'preserves non-hook configuration from the base document'
+When run bash -c '
+  bash "$1" "$2" "$3" || exit 1
+  bash "$4" "$2" "$3" jq | jq -c ".permissions"
+' _ "$EXTRACT" "$LIVE" "$FRAGMENT" "$MERGE"
+The status should be success
+The output should eq '{"allow":["Bash"]}'
+End
+
+It 'is idempotent and does not duplicate an already merged entry'
+When run bash -c '
+  bash "$1" "$2" "$3" || exit 1
+  bash "$4" "$2" "$3" jq >"$5" || exit 1
+  bash "$4" "$5" "$3" jq | jq -e --slurpfile once "$5" ". == \$once[0]" >/dev/null
+' _ "$EXTRACT" "$LIVE" "$FRAGMENT" "$MERGE" "$BASE"
+The status should be success
+End
+
+It 'fails when the base document is not valid JSON'
+When run bash "$MERGE" "$INVALID" "$EMPTY_FRAGMENT" jq
+The status should be failure
+The stderr should include 'failed to merge'
+End
+End
+End


### PR DESCRIPTION
## Problem

`generated/` was supposed to hold machine-generated hook artifacts only, but `generated/hooks/moshi/<agent>/` had drifted into full dumps of each live agent config: permissions, env, enabled plugins, MCP servers, statusline, and all the hand-written shared security hooks were checked in under a directory labeled "generated".

## Change

`generated/` now holds exactly two things:

- `generated/hooks/moshi/<agent>/` - Moshi hook fragments only (`{"hooks": {<Event>: [...moshi entries]}}`), plus the already-pure TS adapters for `omp`, `pi`, `opencode`
- `generated/hooks/traces/` - unchanged, rendered from `config/*/hooks/traces/*.tpl`

Everything else moves to `config/<agent>/`:

| Agent | Hand-maintained base | Generated Moshi fragment |
| --- | --- | --- |
| claude | `config/claude/settings.json` | `generated/hooks/moshi/claude/settings.json` |
| codex | `config/codex/hooks.json` | `generated/hooks/moshi/codex/hooks.json` |
| cursor | `config/cursor/hooks.json` | `generated/hooks/moshi/cursor/hooks.json` |
| gemini | `config/gemini/settings.json` | `generated/hooks/moshi/gemini/settings.json` |
| grok | `config/grok/plugin/hooks/hooks.json` | `generated/hooks/moshi/grok/plugin/hooks/hooks.json` |

The two halves are stitched back into a single live document by `config/shared/merge-moshi-hooks.sh`, called from each agent's `activate.sh`. Grok merges at build time inside its `pkgs.runCommand` plugin derivation instead.

New scripts:

- `config/shared/merge-moshi-hooks.sh` - per-event append with dedupe (every supported agent stores hooks as `.hooks.<Event>` arrays)
- `scripts/extract-moshi-hooks.sh` - regeneration path; fails loudly if one hook entry mixes moshi and non-moshi commands rather than guessing
- `scripts/normalize-dcg-hooks.sh` - the old `update-moshi-hooks.sh --normalize-only` mode, extracted standalone

## Verification

- shellspec: `2597 examples, 48 failures` vs pristine-HEAD baseline `2584 examples, 48 failures` - identical failure set, all pre-existing and unrelated (`beads_linear_sync` x40, `code_syncer`, `obsidian_git_trigger`, `rtk_rewrite` x2, `traces_agent_hook` x2, `activate_config`, `auto_switch`)
- New `spec/moshi_hook_split_spec.sh` covers extract, merge, round-trip, idempotence, and both failure paths; all three new scripts registered in `spec/coverage_spec.sh`
- `make shell-check` clean, `nix fmt` reports 0 changed
- All five agents' activation scripts evaluate under `nixosConfigurations.matic`; the grok plugin derivation builds and its merged `hooks.json` equals base union fragment
- Live runs of claude/cursor/gemini/codex `activate.sh` against temp `$HOME`s each produce exactly the base union fragment command set

Only behavioral change: Moshi entries now append at the end of each `.hooks.<Event>` array instead of sitting at their original index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up `generated/` so it holds only machine-generated hook artifacts instead of full agent config dumps. Hand-maintained settings move under `config/<agent>/` and are merged back for activation; the only behavior change is that Moshi hooks now append at the end of each `.hooks.<Event>` array.

**Refactors**
- `generated/hooks/moshi/<agent>/` now holds only Moshi hook fragments plus the existing `omp`/`pi`/`opencode` adapters; permissions, env, MCP servers, statusline, and the shared security hooks moved to `config/<agent>/`.
- `config/shared/merge-moshi-hooks.sh` re-stitches base and fragment with per-event dedupe at activation time; grok merges at build time inside its plugin derivation.
- `scripts/extract-moshi-hooks.sh` regenerates fragments and fails on mixed Moshi/non-Moshi entries; `scripts/normalize-dcg-hooks.sh` extracts the old normalize-only mode.
- `spec/moshi_hook_split_spec.sh` covers extract, merge, round-trip, idempotence, and both failure paths.

<sup>Written for commit 9e41b2b46bc36f6b316a2f4d21374470a139a7a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

