### PR TITLE
fix(kyber): keep Herdr coordinator panes outside workload freezes

### DIFF
--- a/named-hosts/kyber/README.md
+++ b/named-hosts/kyber/README.md
@@ -183,11 +183,11 @@ cleaner:
   probe latency, recent CRI lifecycle errors, and host DNS (Tailscale must not
   own `/etc/resolv.conf`).
 
-The Herdr server runs in `herdr.slice`, which is never frozen: it is the
-control plane for every lane and must keep answering API calls. Its pane
-shells re-exec themselves into `orchestration.slice` through the kyber fish
-init, so lane work, RoboRev, and their child processes share one disposable
-slice that caps aggregate writes to 20 MB/s and aggregate tasks to 2,048.
+Kyber hosts coordinators rather than worker lanes. The Herdr server and its
+pane processes inherit `herdr.slice`, which the circuit breaker never
+freezes, so coordinators can keep inspecting and recovering the fleet.
+RoboRev and its child processes remain in the separate `orchestration.slice`,
+which caps aggregate writes to 20 MB/s and aggregate tasks to 2,048.
 When sustained host I/O PSI or D-state pressure crosses the health threshold
 and the slice's own `io.pressure` or D-state count implicates it, the
 host-health check records PSI, process/`wchan`, per-process I/O, cgroup I/O,

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -109,11 +109,9 @@ home-manager.lib.homeManagerConfiguration {
 
         programs.home-manager.enable = true;
 
-        # Review daemons and agent lane shells own disposable work and may be
-        # frozen by the host health circuit breaker without interrupting
-        # production services. The Herdr server itself is the control plane
-        # for every lane, so it lives in its own never-frozen slice and only
-        # the panes it spawns are moved into orchestration.slice.
+        # Kyber hosts coordinators, so Herdr and its panes stay outside the
+        # host health circuit breaker's freeze domain. Review daemons retain
+        # their separate, disposable workload slice.
         home.file.".config/systemd/user/orchestration.slice".source = ./orchestration.slice;
         home.file.".config/systemd/user/herdr.slice".source = ./herdr.slice;
         home.file.".config/systemd/user/roborev.service.d/10-orchestration.conf".source =
@@ -150,18 +148,6 @@ home-manager.lib.homeManagerConfiguration {
         # because it needs to be evaluated dynamically per shell session
         programs.fish.interactiveShellInit = lib.mkAfter ''
           set -gx GPG_TTY (tty)
-        '';
-
-        # Herdr pane shells inherit herdr.slice from the server. Re-exec them
-        # into orchestration.slice so the circuit breaker can freeze lane work
-        # without freezing the server that owns the panes.
-        programs.fish.shellInit = lib.mkAfter ''
-          if set -q HERDR_ENV; and status is-interactive; and not set -q HERDR_PANE_SCOPED; and test -r /proc/self/cgroup; and not string match -q '*/orchestration.slice/*' (cat /proc/self/cgroup)
-            set -gx HERDR_PANE_SCOPED 1
-            exec ${pkgs.systemd}/bin/systemd-run --user --quiet --scope --collect \
-              --slice=orchestration.slice --unit=herdr-pane-$fish_pid \
-              ${pkgs.fish}/bin/fish
-          end
         '';
 
         # Enable XDG directories

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -331,6 +331,8 @@ let
           ];
         assert cfg.systemd.user.services ? dolt;
         assert cfg.systemd.user.services ? dolt-linear-sync;
+        assert cfg.systemd.user.services.herdr-server.Service.Slice == "herdr.slice";
+        assert !(lib.hasInfix "--slice=orchestration.slice" cfg.programs.fish.shellInit);
         assert !(cfg.systemd.user.services ? dolt-federation-sync);
         assert !(cfg.systemd.user.services ? dolt-federation-hub);
         assert !(cfg.systemd.user.services ? dolt-federation-access);


### PR DESCRIPTION
Kyber hosts coordinators, but its Fish startup hook moved every Herdr pane into the workload slice that the host-health breaker freezes. Remove that hook so new panes inherit the Herdr server's protected `herdr.slice`; review processes keep their existing workload slice.

Validation: evaluated the Kyber Home Manager configuration and confirmed `herdr.slice` plus absence of the pane-scoping hook; added evaluation assertions, checked Nix formatting, and validated the live Fish configuration's syntax. The hook was also removed inline on Kyber. Existing panes were terminated at the operator's request; Herdr itself was not restarted.

[T3 thread](https://kyber.tail950b36.ts.net:8443/4dc26984-7b97-484d-989a-6f51098dec27/8e601efe-8f1b-4cbd-99bd-290d1ab24ff8)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Kyber so Herdr coordinator panes stay in the never-frozen `herdr.slice` instead of being re-exec'd into the workload slice that the host-health circuit breaker can freeze. Review processes keep their existing workload slice.

<sup>Written for commit 0597b3bdda6f0e2472ed7a76f598a3db2171158e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

