### PR TITLE
fix(grok): make copied plugin files writable before overwriting hooks

### DIFF
--- a/config/grok/default.nix
+++ b/config/grok/default.nix
@@ -8,6 +8,8 @@ let
   plugin = pkgs.runCommand "dotfiles-grok-plugin" { } ''
     mkdir -p "$out"
     cp -R ${./plugin}/. "$out/"
+    # Store sources are read-only, so the copied hooks.json can't be overwritten otherwise.
+    chmod -R u+w "$out"
     mkdir -p "$out/hooks"
     cp ${../../generated/hooks/moshi/grok/plugin/hooks/hooks.json} "$out/hooks/hooks.json"
   '';


### PR DESCRIPTION
## Summary
- `config/grok/plugin/hooks/hooks.json` (added in #2721) is copied into the plugin derivation by `cp -R`, which keeps the read-only mode from `/nix/store`. The following `cp` of the generated hooks.json then fails with `Permission denied`, breaking `make build`.
- Add `chmod -R u+w "$out"` after the copy so the generated hooks.json can overwrite it. The installed output is still the generated hooks.json, same as before #2721.

## Test plan
- [x] `nix build .#darwinConfigurations.galactica.system` succeeds (it failed on `dotfiles-grok-plugin` before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `make build` failing in the grok plugin derivation because the `hooks.json` copied from the nix store is read-only. The copied plugin files are now made writable with `chmod -R u+w` before the generated `hooks.json` is written, so the overwrite succeeds and the installed output remains the generated file as before.

<sup>Written for commit cb7d354dfa030cf8dff2edfcb93bd94501622252. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

