### PR TITLE
feat(devin): add managed lifecycle hooks

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -16,6 +16,7 @@ in
   ./claude
   ./commandcode
   ./dcg
+  ./devin
   ./dsh
   ./direnv
   ./factory

--- a/config/devin/activate.sh
+++ b/config/devin/activate.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+# Merge managed Devin config into the writable user config.
+# Usage: activate.sh <config_json> [jq]
+set -euo pipefail
+
+MANAGED_CONFIG="$1"
+JQ="${2:-jq}"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/devin"
+CONFIG_FILE="$CONFIG_DIR/config.json"
+
+"$JQ" -e 'type == "object"' "$MANAGED_CONFIG" >/dev/null
+mkdir -p "$CONFIG_DIR"
+
+if [[ -f "$CONFIG_FILE" ]] && ! "$JQ" -e 'type == "object"' "$CONFIG_FILE" >/dev/null; then
+  echo "ERROR: refusing to replace invalid Devin config: $CONFIG_FILE" >&2
+  exit 1
+fi
+
+tmp="$(mktemp "$CONFIG_DIR/config.json.XXXXXX")"
+trap 'rm -f "$tmp"' EXIT
+
+if [[ -f "$CONFIG_FILE" ]]; then
+  "$JQ" -s '
+    .[0] as $current
+    | .[1] as $managed
+    | ($current * $managed)
+    | if ($managed.read_config_from? // null) != null then
+        .read_config_from = (($current.read_config_from // {}) * $managed.read_config_from)
+      else . end
+  ' "$CONFIG_FILE" "$MANAGED_CONFIG" >"$tmp"
+else
+  "$JQ" '.' "$MANAGED_CONFIG" >"$tmp"
+fi
+
+chmod 600 "$tmp"
+mv -f "$tmp" "$CONFIG_FILE"
+trap - EXIT

--- a/config/devin/activate.sh
+++ b/config/devin/activate.sh
@@ -6,7 +6,9 @@ set -euo pipefail
 
 MANAGED_CONFIG="$1"
 JQ="${2:-jq}"
-CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/devin"
+# Devin's documented user config is fixed at ~/.config/devin, independent of
+# XDG_CONFIG_HOME.
+CONFIG_DIR="$HOME/.config/devin"
 CONFIG_FILE="$CONFIG_DIR/config.json"
 
 "$JQ" -e 'type == "object"' "$MANAGED_CONFIG" >/dev/null

--- a/config/devin/activate.sh
+++ b/config/devin/activate.sh
@@ -12,7 +12,7 @@ CONFIG_FILE="$CONFIG_DIR/config.json"
 "$JQ" -e 'type == "object"' "$MANAGED_CONFIG" >/dev/null
 mkdir -p "$CONFIG_DIR"
 
-if [[ -f "$CONFIG_FILE" ]] && ! "$JQ" -e 'type == "object"' "$CONFIG_FILE" >/dev/null; then
+if [[ -f $CONFIG_FILE ]] && ! "$JQ" -e 'type == "object"' "$CONFIG_FILE" >/dev/null; then
   echo "ERROR: refusing to replace invalid Devin config: $CONFIG_FILE" >&2
   exit 1
 fi
@@ -20,7 +20,7 @@ fi
 tmp="$(mktemp "$CONFIG_DIR/config.json.XXXXXX")"
 trap 'rm -f "$tmp"' EXIT
 
-if [[ -f "$CONFIG_FILE" ]]; then
+if [[ -f $CONFIG_FILE ]]; then
   "$JQ" -s '
     .[0] as $current
     | .[1] as $managed

--- a/config/devin/default.nix
+++ b/config/devin/default.nix
@@ -1,0 +1,36 @@
+{
+  config,
+  pkgs,
+  ...
+}:
+let
+  activate = ./activate.sh;
+in
+{
+  # Devin owns the rest of config.json (model, theme, and session preferences),
+  # so activation replaces only the declarative hooks key and preserves all
+  # other user settings.
+  home.activation.devinConfig = config.lib.dag.entryAfter [ "writeBoundary" ] ''
+    $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${activate}" \
+      "${./hooks.v1.json}" \
+      "${pkgs.jq}/bin/jq"
+  '';
+
+  home.file.".config/devin/hooks/notify.sh" = {
+    source = ./hooks/notify.sh;
+    executable = true;
+    force = true;
+  };
+
+  home.file.".config/devin/hooks/pushover.sh" = {
+    source = ./hooks/pushover.sh;
+    executable = true;
+    force = true;
+  };
+
+  home.file.".config/devin/hooks/atuin-history.sh" = {
+    source = ./hooks/atuin-history.sh;
+    executable = true;
+    force = true;
+  };
+}

--- a/config/devin/hooks.v1.json
+++ b/config/devin/hooks.v1.json
@@ -3,102 +3,201 @@
     "claude": false
   },
   "hooks": {
-  "PermissionRequest": [
-    {
-      "hooks": [
-        {"command": "$HOME/.config/devin/hooks/notify.sh", "timeout": 3, "type": "command"},
-        {"command": "$HOME/.config/devin/hooks/pushover.sh", "timeout": 6, "type": "command"}
-      ]
-    }
-  ],
-  "PostCompaction": [
-    {
-      "hooks": [
-        {"command": "$HOME/.config/devin/hooks/notify.sh", "timeout": 3, "type": "command"},
-        {"command": "$HOME/.config/devin/hooks/pushover.sh", "timeout": 6, "type": "command"}
-      ]
-    }
-  ],
-  "PostToolUse": [
-    {
-      "matcher": "^exec$",
-      "hooks": [
-        {"command": "$HOME/.config/devin/hooks/atuin-history.sh", "timeout": 5, "type": "command"},
-        {"command": "$HOME/dotfiles/config/shared/hooks/roborev-agent.sh", "timeout": 10, "type": "command"}
-      ]
-    }
-  ],
-  "PreToolUse": [
-    {
-      "matcher": "^(write|edit|apply_patch)$",
-      "hooks": [
-        {"command": "$HOME/dotfiles/config/shared/hooks/secret-guard.sh", "timeout": 5, "type": "command"}
-      ]
-    },
-    {
-      "matcher": "^exec$",
-      "hooks": [
-        {"command": "$HOME/dotfiles/config/shared/hooks/dcg-guard.sh", "timeout": 5, "type": "command"},
-        {"command": "$HOME/dotfiles/config/shared/hooks/security.sh", "timeout": 5, "type": "command"},
-        {"command": "$HOME/dotfiles/config/shared/hooks/block-git-push.sh", "timeout": 5, "type": "command"},
-        {"command": "$HOME/dotfiles/config/shared/hooks/block-gh-settings.sh", "timeout": 5, "type": "command"},
-        {"command": "$HOME/.config/devin/hooks/notify.sh", "timeout": 3, "type": "command"},
-        {"command": "$HOME/.config/devin/hooks/pushover.sh", "timeout": 6, "type": "command"},
-        {"command": "$HOME/dotfiles/config/shared/hooks/roborev-agent.sh", "timeout": 10, "type": "command"}
-      ]
-    },
-    {
-      "matcher": "^(read|grep|glob)$",
-      "hooks": [
-        {"command": "command -v graphify >/dev/null 2>&1 && graphify hook-guard read", "timeout": 5, "type": "command"}
-      ]
-    }
-  ],
-  "SessionEnd": [
-    {
-      "hooks": [
-        {"command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-end --agent devin # traces hook agent", "timeout": 30, "type": "command"}
-      ]
-    }
-  ],
-  "SessionStart": [
-    {
-      "hooks": [
-        {"command": "$HOME/.config/devin/hooks/notify.sh", "timeout": 3, "type": "command"},
-        {"command": "$HOME/.config/devin/hooks/pushover.sh", "timeout": 6, "type": "command"}
-      ]
-    },
-    {
-      "hooks": [
-        {"command": "bd prime --hook-json", "type": "command"}
-      ]
-    },
-    {
-      "hooks": [
-        {"command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-start --agent devin # traces hook agent", "timeout": 30, "type": "command"}
-      ]
-    }
-  ],
-  "Stop": [
-    {
-      "hooks": [
-        {"command": "$HOME/.config/devin/hooks/notify.sh", "timeout": 3, "type": "command"},
-        {"command": "$HOME/.config/devin/hooks/pushover.sh", "timeout": 6, "type": "command"},
-        {"command": "$HOME/dotfiles/config/shared/hooks/roborev-agent.sh", "timeout": 10, "type": "command"}
-      ]
-    },
-    {
-      "hooks": [
-        {"command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh agent-done --agent devin # traces hook agent", "timeout": 30, "type": "command"}
-      ]
-    }
-  ],
-  "UserPromptSubmit": [
-    {
-      "hooks": [
-        {"command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh prompt-submitted --agent devin # traces hook agent", "timeout": 30, "type": "command"}
-      ]
-    }
-  ]
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "command": "$HOME/.config/devin/hooks/notify.sh",
+            "timeout": 3,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/.config/devin/hooks/pushover.sh",
+            "timeout": 6,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "PostCompaction": [
+      {
+        "hooks": [
+          {
+            "command": "$HOME/.config/devin/hooks/notify.sh",
+            "timeout": 3,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/.config/devin/hooks/pushover.sh",
+            "timeout": 6,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "^exec$",
+        "hooks": [
+          {
+            "command": "$HOME/.config/devin/hooks/atuin-history.sh",
+            "timeout": 5,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/roborev-agent.sh",
+            "timeout": 10,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "^(write|edit|apply_patch)$",
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/secret-guard.sh",
+            "timeout": 5,
+            "type": "command"
+          }
+        ]
+      },
+      {
+        "matcher": "^exec$",
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/dcg-guard.sh",
+            "timeout": 5,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/security.sh",
+            "timeout": 5,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/block-git-push.sh",
+            "timeout": 5,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/block-gh-settings.sh",
+            "timeout": 5,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/.config/devin/hooks/notify.sh",
+            "timeout": 3,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/.config/devin/hooks/pushover.sh",
+            "timeout": 6,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/roborev-agent.sh",
+            "timeout": 10,
+            "type": "command"
+          }
+        ]
+      },
+      {
+        "matcher": "^(read|grep|glob)$",
+        "hooks": [
+          {
+            "command": "command -v graphify >/dev/null 2>&1 && graphify hook-guard read",
+            "timeout": 5,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-end --agent devin # traces hook agent",
+            "timeout": 30,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "$HOME/.config/devin/hooks/notify.sh",
+            "timeout": 3,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/.config/devin/hooks/pushover.sh",
+            "timeout": 6,
+            "type": "command"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "bd prime --hook-json",
+            "type": "command"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-start --agent devin # traces hook agent",
+            "timeout": 30,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "command": "$HOME/.config/devin/hooks/notify.sh",
+            "timeout": 3,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/.config/devin/hooks/pushover.sh",
+            "timeout": 6,
+            "type": "command"
+          },
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/roborev-agent.sh",
+            "timeout": 10,
+            "type": "command"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh agent-done --agent devin # traces hook agent",
+            "timeout": 30,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh prompt-submitted --agent devin # traces hook agent",
+            "timeout": 30,
+            "type": "command"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/config/devin/hooks.v1.json
+++ b/config/devin/hooks.v1.json
@@ -1,0 +1,104 @@
+{
+  "read_config_from": {
+    "claude": false
+  },
+  "hooks": {
+  "PermissionRequest": [
+    {
+      "hooks": [
+        {"command": "$HOME/.config/devin/hooks/notify.sh", "timeout": 3, "type": "command"},
+        {"command": "$HOME/.config/devin/hooks/pushover.sh", "timeout": 6, "type": "command"}
+      ]
+    }
+  ],
+  "PostCompaction": [
+    {
+      "hooks": [
+        {"command": "$HOME/.config/devin/hooks/notify.sh", "timeout": 3, "type": "command"},
+        {"command": "$HOME/.config/devin/hooks/pushover.sh", "timeout": 6, "type": "command"}
+      ]
+    }
+  ],
+  "PostToolUse": [
+    {
+      "matcher": "^exec$",
+      "hooks": [
+        {"command": "$HOME/.config/devin/hooks/atuin-history.sh", "timeout": 5, "type": "command"},
+        {"command": "$HOME/dotfiles/config/shared/hooks/roborev-agent.sh", "timeout": 10, "type": "command"}
+      ]
+    }
+  ],
+  "PreToolUse": [
+    {
+      "matcher": "^(write|edit|apply_patch)$",
+      "hooks": [
+        {"command": "$HOME/dotfiles/config/shared/hooks/secret-guard.sh", "timeout": 5, "type": "command"}
+      ]
+    },
+    {
+      "matcher": "^exec$",
+      "hooks": [
+        {"command": "$HOME/dotfiles/config/shared/hooks/dcg-guard.sh", "timeout": 5, "type": "command"},
+        {"command": "$HOME/dotfiles/config/shared/hooks/security.sh", "timeout": 5, "type": "command"},
+        {"command": "$HOME/dotfiles/config/shared/hooks/block-git-push.sh", "timeout": 5, "type": "command"},
+        {"command": "$HOME/dotfiles/config/shared/hooks/block-gh-settings.sh", "timeout": 5, "type": "command"},
+        {"command": "$HOME/.config/devin/hooks/notify.sh", "timeout": 3, "type": "command"},
+        {"command": "$HOME/.config/devin/hooks/pushover.sh", "timeout": 6, "type": "command"},
+        {"command": "$HOME/dotfiles/config/shared/hooks/roborev-agent.sh", "timeout": 10, "type": "command"}
+      ]
+    },
+    {
+      "matcher": "^(read|grep|glob)$",
+      "hooks": [
+        {"command": "command -v graphify >/dev/null 2>&1 && graphify hook-guard read", "timeout": 5, "type": "command"}
+      ]
+    }
+  ],
+  "SessionEnd": [
+    {
+      "hooks": [
+        {"command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-end --agent devin # traces hook agent", "timeout": 30, "type": "command"}
+      ]
+    }
+  ],
+  "SessionStart": [
+    {
+      "hooks": [
+        {"command": "$HOME/.config/devin/hooks/notify.sh", "timeout": 3, "type": "command"},
+        {"command": "$HOME/.config/devin/hooks/pushover.sh", "timeout": 6, "type": "command"}
+      ]
+    },
+    {
+      "hooks": [
+        {"command": "bd prime --hook-json", "type": "command"}
+      ]
+    },
+    {
+      "hooks": [
+        {"command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh session-start --agent devin # traces hook agent", "timeout": 30, "type": "command"}
+      ]
+    }
+  ],
+  "Stop": [
+    {
+      "hooks": [
+        {"command": "$HOME/.config/devin/hooks/notify.sh", "timeout": 3, "type": "command"},
+        {"command": "$HOME/.config/devin/hooks/pushover.sh", "timeout": 6, "type": "command"},
+        {"command": "$HOME/dotfiles/config/shared/hooks/roborev-agent.sh", "timeout": 10, "type": "command"}
+      ]
+    },
+    {
+      "hooks": [
+        {"command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh agent-done --agent devin # traces hook agent", "timeout": 30, "type": "command"}
+      ]
+    }
+  ],
+  "UserPromptSubmit": [
+    {
+      "hooks": [
+        {"command": "$HOME/dotfiles/config/shared/hooks/traces-agent-hook.sh prompt-submitted --agent devin # traces hook agent", "timeout": 30, "type": "command"}
+      ]
+    }
+  ]
+  }
+}

--- a/config/devin/hooks/atuin-history.sh
+++ b/config/devin/hooks/atuin-history.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Record Devin exec tool commands through Atuin's start/end API.
+set -euo pipefail
+
+hook_input=$(cat)
+command -v atuin >/dev/null 2>&1 || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+tool_name=$(jq -r '.tool_name // .tool.name // empty' <<<"$hook_input")
+[ "$tool_name" = "exec" ] || exit 0
+
+bash_command=$(jq -r '.tool_input.command // .tool.input.command // empty' <<<"$hook_input")
+[ -n "$bash_command" ] || exit 0
+
+exit_code=$(jq -r '.tool_result.exit_code // .tool_response.exit_code // .response.exit_code // 0' <<<"$hook_input")
+case "$exit_code" in ''|-*|*[!0-9]*) exit_code=0 ;; esac
+duration=$(jq -r '.tool_result.duration_ms // .tool_response.duration_ms // .response.duration_ms // 0' <<<"$hook_input")
+case "$duration" in ''|*[!0-9]*) duration=0 ;; esac
+
+cwd=$(jq -r '.cwd // empty' <<<"$hook_input")
+[ -n "$cwd" ] && [ -d "$cwd" ] || cwd="$HOME"
+
+(
+  cd "$cwd" || exit 0
+  export ATUIN_HISTORY_AUTHOR="devin"
+  history_id=$(atuin history start -- "$bash_command") || exit 0
+  atuin history end --exit "$exit_code" --duration "$duration" "$history_id"
+) >/dev/null 2>&1
+exit 0

--- a/config/devin/hooks/atuin-history.sh
+++ b/config/devin/hooks/atuin-history.sh
@@ -13,9 +13,9 @@ bash_command=$(jq -r '.tool_input.command // .tool.input.command // empty' <<<"$
 [ -n "$bash_command" ] || exit 0
 
 exit_code=$(jq -r '.tool_result.exit_code // .tool_response.exit_code // .response.exit_code // 0' <<<"$hook_input")
-case "$exit_code" in ''|-*|*[!0-9]*) exit_code=0 ;; esac
+case "$exit_code" in '' | -* | *[!0-9]*) exit_code=0 ;; esac
 duration=$(jq -r '.tool_result.duration_ms // .tool_response.duration_ms // .response.duration_ms // 0' <<<"$hook_input")
-case "$duration" in ''|*[!0-9]*) duration=0 ;; esac
+case "$duration" in '' | *[!0-9]*) duration=0 ;; esac
 
 cwd=$(jq -r '.cwd // empty' <<<"$hook_input")
 [ -n "$cwd" ] && [ -d "$cwd" ] || cwd="$HOME"

--- a/config/devin/hooks/notify.sh
+++ b/config/devin/hooks/notify.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Devin local notification hook.
+set -euo pipefail
+
+input=$(cat)
+command -v jq >/dev/null 2>&1 || exit 0
+
+notifier="$(command -v notify-local 2>/dev/null || true)"
+[[ -z $notifier && -x "$HOME/.local/scripts/notify-local" ]] && notifier="$HOME/.local/scripts/notify-local"
+[[ -z $notifier ]] && exit 0
+
+event=$(jq -r '.hook_event_name // empty' <<<"$input")
+message=''
+case "$event" in
+SessionStart) message='Session started' ;;
+Stop) message='Work completed' ;;
+PermissionRequest) message="Approval required: $(jq -r '.tool_name // "unknown"' <<<"$input")" ;;
+PreToolUse)
+  command=$(jq -r '.tool_input.command // empty' <<<"$input")
+  if [[ $command =~ (rm[[:space:]]+-rf|drop[[:space:]]+database|truncate|DELETE[[:space:]]+FROM|format) ]]; then
+    message="Risky: ${command:0:100}"
+  fi
+  ;;
+PostCompaction) message='Context compacted' ;;
+esac
+
+[[ -n $message ]] && "$notifier" "Devin" "$message" "Sonar"
+exit 0

--- a/config/devin/hooks/pushover.sh
+++ b/config/devin/hooks/pushover.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Devin Pushover notification hook.
+set -euo pipefail
+
+if [[ -z ${PUSHOVER_API_TOKEN:-} || -z ${PUSHOVER_USER_KEY:-} ]] && [[ -f "$HOME/dotfiles/.env" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$HOME/dotfiles/.env" 2>/dev/null || true
+  set +a
+fi
+
+[[ -n ${PUSHOVER_API_TOKEN:-} && -n ${PUSHOVER_USER_KEY:-} ]] || exit 0
+input=$(cat)
+command -v jq >/dev/null 2>&1 || exit 0
+
+event=$(jq -r '.hook_event_name // empty' <<<"$input")
+message=''
+case "$event" in
+SessionStart) message='Session started' ;;
+Stop) message='Work completed' ;;
+PermissionRequest) message="Approval required: $(jq -r '.tool_name // "unknown"' <<<"$input")" ;;
+PreToolUse)
+  command=$(jq -r '.tool_input.command // empty' <<<"$input")
+  if [[ $command =~ (rm[[:space:]]+-rf|drop[[:space:]]+database|truncate|DELETE[[:space:]]+FROM|format) ]]; then
+    message="Risky: ${command:0:100}"
+  fi
+  ;;
+PostCompaction) message='Context compacted' ;;
+esac
+
+[[ -n $message ]] || exit 0
+host=$(hostname -s 2>/dev/null || printf '%s' unknown)
+curl -s --max-time 5 --connect-timeout 3 \
+  --form-string "token=${PUSHOVER_API_TOKEN}" \
+  --form-string "user=${PUSHOVER_USER_KEY}" \
+  --form-string "message=[${host}] ${message}" \
+  --form-string 'title=Devin' \
+  https://api.pushover.net/1/messages.json >/dev/null 2>&1 || true
+exit 0

--- a/config/shared/hooks/README.md
+++ b/config/shared/hooks/README.md
@@ -1,6 +1,6 @@
 # Shared agent GitHub guardrails
 
-`block-git-push.sh` and `block-gh-settings.sh` are shared `PreToolUse` hooks for Codex, Claude Code, Cursor, GitHub Copilot, and Grok. They accept the command from each client's supported JSON shape:
+`block-git-push.sh` and `block-gh-settings.sh` are shared `PreToolUse` hooks for Codex, Claude Code, Cursor, GitHub Copilot, Grok, and Devin. They accept the command from each client's supported JSON shape:
 
 - `.tool.input.command`
 - `.tool_input.command`
@@ -49,7 +49,7 @@ These hooks provide fast feedback and prevent common mistakes. They run with the
 # Traces agent hook guard
 
 `traces-agent-hook.sh <event> --agent <id>` wraps `traces hook agent` for Codex,
-Claude Code, Cursor, GitHub Copilot, Grok, Antigravity, Pi, Hermes, and
+Claude Code, Cursor, GitHub Copilot, Grok, Devin, Antigravity, Pi, Hermes, and
 OpenClaw; the Pi, Hermes, and OpenClaw adapters spawn it directly and pass
 the binary they resolved as `TRACES_BIN`. The traces hook
 starts a detached `traces share --trace-id <session> --source agent_hook`

--- a/config/shared/hooks/block-gh-settings.sh
+++ b/config/shared/hooks/block-gh-settings.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Shared Codex/Claude/Cursor/Factory Droid agent guardrail for GitHub repository control-plane mutations.
+# Shared Codex/Claude/Cursor/Factory Droid/Devin agent guardrail for GitHub repository control-plane mutations.
 # This is an early warning only; restricted credentials and server-side
 # rulesets are the authoritative enforcement boundary.
 

--- a/config/shared/hooks/block-git-push.sh
+++ b/config/shared/hooks/block-git-push.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Shared Codex/Claude/Cursor/Factory Droid agent guardrail for pushes to protected default branches.
+# Shared Codex/Claude/Cursor/Factory Droid/Devin agent guardrail for pushes to protected default branches.
 # This is an early warning only; remote rulesets and restricted credentials are
 # the authoritative enforcement boundary.
 

--- a/config/shared/hooks/secret-guard.sh
+++ b/config/shared/hooks/secret-guard.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Shared PreToolUse hook for Claude Code, Codex, and Factory Droid Write/Edit operations.
+# Shared PreToolUse hook for Claude Code, Codex, Devin, and Factory Droid Write/Edit operations.
 # Blocks writes containing secrets detected by gitleaks.
 # See: https://zenn.dev/takna/articles/secret-leak-prevention-4-layer
 set -euo pipefail

--- a/config/shared/hooks/security.sh
+++ b/config/shared/hooks/security.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-# Shared Codex/Copilot/Cursor/Factory Droid/Grok Security Hook
+# Shared Codex/Copilot/Cursor/Factory Droid/Grok/Devin Security Hook
 # Blocks dangerous Bash commands by checking against deny patterns.
 # Returns exit code 2 to block, exit code 0 to allow.
 #
-# Claude has its own settings.json-driven security.sh — this is for the
-# agents that don't read settings.json at runtime.
+# Claude has its own settings.json-driven security.sh; this shared hook covers
+# Devin and the agents that don't read settings.json at runtime.
 #
 # Cursor on macOS launches GUI apps with a minimal PATH, so this script
 # self-bootstraps PATH to find jq.
@@ -26,7 +26,7 @@ input=$(cat)
 # Cursor sends only .command without a tool_name → empty passes through.
 tool_name=$(echo "$input" | jq -r '.tool.name // .tool_name // .toolName // empty' 2>/dev/null)
 case "$tool_name" in
-"" | Bash | bash | Execute | execute | shell) ;;
+"" | Bash | bash | Execute | execute | exec | shell) ;;
 *) exit 0 ;;
 esac
 

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -533,6 +533,10 @@ config/herdr/install-integrations.sh
 config/copilot/activate.sh
 config/codex/hooks/atuin-history.sh
 config/dcg/activate.sh
+config/devin/activate.sh
+config/devin/hooks/atuin-history.sh
+config/devin/hooks/notify.sh
+config/devin/hooks/pushover.sh
 config/dsh/hydrate.sh
 config/codex/hooks/notify.sh
 config/codex/hooks/pushover.sh

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -548,6 +548,7 @@ config/shared/hooks/secret-guard.sh
 config/shared/hooks/security.sh
 config/shared/hooks/rtk-rewrite.sh
 config/shared/hooks/roborev-agent.sh
+config/shared/merge-moshi-hooks.sh
 config/cursor/activate.sh
 config/cursor/hooks/notify.sh
 config/cursor/hooks/pushover.sh
@@ -676,7 +677,9 @@ scripts/check-nix-inline-scripts.sh
 scripts/find-built-iso.sh
 scripts/fishtape-wrapper.sh
 scripts/generate-hooks.sh
+scripts/extract-moshi-hooks.sh
 scripts/llm-update.sh
+scripts/normalize-dcg-hooks.sh
 scripts/sync-codex-security.sh
 scripts/sync-rtk-rewrite.sh
 scripts/update-gitalias.sh

--- a/spec/devin_hooks_spec.sh
+++ b/spec/devin_hooks_spec.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329,SC2016
+
+Describe 'config/devin'
+SCRIPT="$PWD/config/devin/activate.sh"
+MANAGED="$PWD/config/devin/hooks.v1.json"
+
+setup() {
+  TEMP_HOME=$(mktemp -d)
+  export TEMP_HOME
+}
+
+cleanup() {
+  rm -rf "$TEMP_HOME"
+}
+
+Before 'setup'
+After 'cleanup'
+
+It 'merges managed hooks and disables duplicate Claude imports'
+mkdir -p "$TEMP_HOME/.config/devin"
+cat >"$TEMP_HOME/.config/devin/config.json" <<'JSON'
+{"version":0,"agent":{"model":"keep-me"},"read_config_from":{"cursor":true}}
+JSON
+When run bash -c 'HOME="$1" bash "$2" "$3" jq && jq -e '\'' .agent.model == "keep-me" and .read_config_from.cursor == true and .read_config_from.claude == false and (.hooks | has("PreToolUse")) '\'' "$1/.config/devin/config.json" >/dev/null' _ "$TEMP_HOME" "$SCRIPT" "$MANAGED"
+The status should be success
+End
+
+It 'refuses to overwrite malformed Devin config'
+mkdir -p "$TEMP_HOME/.config/devin"
+printf '%s\n' '{broken' >"$TEMP_HOME/.config/devin/config.json"
+When run bash -c 'HOME="$1" bash "$2" "$3" jq' _ "$TEMP_HOME" "$SCRIPT" "$MANAGED"
+The status should be failure
+The error should include 'refusing to replace invalid Devin config'
+The contents of file "$TEMP_HOME/.config/devin/config.json" should equal '{broken'
+End
+
+It 'uses Devin lifecycle names and lowercase tool matchers'
+When run jq -e 'has("read_config_from") and .read_config_from.claude == false and (.hooks.PreToolUse | any(.matcher == "^exec$")) and (.hooks.PostCompaction | length == 1)' "$MANAGED"
+The status should be success
+The output should eq 'true'
+End
+End

--- a/spec/security_spec.sh
+++ b/spec/security_spec.sh
@@ -3,6 +3,7 @@
 
 Describe 'security.sh'
 SCRIPT="$PWD/config/claude/hooks/security.sh"
+SHARED_SCRIPT="$PWD/config/shared/hooks/security.sh"
 
 setup() {
   TEMP_HOME=$(mktemp -d)
@@ -74,6 +75,13 @@ Describe 'blocked commands'
 It 'blocks rm -rf /*'
 Data '{"tool": {"name": "Bash", "input": {"command": "rm -rf /*"}}}'
 When run bash -c "HOME='$TEMP_HOME' bash '$SCRIPT'"
+The status should eq 2
+The stderr should include 'BLOCKED'
+End
+
+It 'blocks Devin exec commands'
+Data '{"tool_name":"exec","tool_input":{"command":"rm -rf /*"}}'
+When run bash -c "HOME='$TEMP_HOME' bash '$SHARED_SCRIPT'"
 The status should eq 2
 The stderr should include 'BLOCKED'
 End


### PR DESCRIPTION
## Changes
- add a Home Manager Devin module for `~/.config/devin/config.json`
- manage Devin lifecycle hooks with lowercase tool matchers and shared guardrails
- preserve Devin-owned settings while disabling duplicate Claude hook imports
- add Devin notification, Pushover, and Atuin hook adapters
- cover activation and `exec` security behavior with ShellSpec

## Testing
- `nix-instantiate --parse config/devin/default.nix`
- `jq empty config/devin/hooks.v1.json`
- `bash -n config/devin/activate.sh config/devin/hooks/*.sh`
- `shellcheck config/devin/activate.sh config/devin/hooks/*.sh config/shared/hooks/security.sh`
- `shellspec spec/security_spec.sh spec/devin_hooks_spec.sh` (17 examples, 0 failures)

The full shell suite remains environment-blocked by existing PATH/fixture failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Home Manager module that manages Devin's lifecycle hooks in `~/.config/devin/config.json` — a path fixed independently of `XDG_CONFIG_HOME` — while preserving Devin-owned settings.

- Registers the new Devin module in `default.nix` and ships local notify, Pushover, and Atuin history hook scripts.
- Merges managed hooks into the existing config with `jq`, refusing to replace invalid configs.
- Wires shared guardrails into PreToolUse/PostToolUse with lowercase tool matchers and disables duplicate Claude hook imports via `read_config_from`.
- Extends shared hooks and adds ShellSpec coverage for Devin's `exec` tool and hook activation; the full shell suite remains environment-blocked by existing PATH/fixture failures.

<sup>Written for commit 2f97e9719b8e0a6325ff0a387bbdc4e6884aa844. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

