### PR TITLE
feat(matic): serve /bin and /usr/bin from envfs

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -395,6 +395,12 @@ import ../../hosts/nixos {
           options mt7925e disable_aspm=1
         '';
 
+        # Serve /bin and /usr/bin from the requesting process's PATH. Remote
+        # build and CI tooling that drives this host over SSH runs its helper
+        # scripts through hard-coded FHS paths such as /bin/bash and
+        # /usr/bin/git, which a stock NixOS root does not provide.
+        services.envfs.enable = true;
+
         # Enable nix-ld for running dynamically linked binaries
         programs.nix-ld.enable = true;
         programs.nix-ld.libraries = with pkgs; [


### PR DESCRIPTION
## Why

matic is the delegation target for remote CI over static SSH. The delegating
host leases it, syncs the checkout, and then runs helper scripts through
hard-coded FHS paths: an `env -i PATH=/usr/bin:/bin ...` wrapper around
`/bin/bash --noprofile --norc`, plus a prerequisite probe for `/bin/bash`,
`/bin/cat`, `/bin/mkdir`, `/bin/rm`, `/bin/mv`, `/bin/cp`, `/usr/bin/env`,
`/usr/bin/git`, `/usr/bin/find`, `/usr/bin/mktemp`, `/usr/bin/awk`, and
`/usr/bin/grep`.

A stock NixOS root has only `/bin/sh` and `/usr/bin/env`, so the run reaches
matic, acquires the lease, syncs 19042 files, and then dies:

```
warning: remote git seed failed: exit=127; continuing with file sync
remote sync finalize failed: env: No such file or directory: exit status 127
```

## What

`services.envfs.enable = true`. envfs is a FUSE filesystem that resolves
`/bin/*` and `/usr/bin/*` against the requesting process's PATH, so those
paths exist without hand-made symlinks drifting outside the configuration.

It sits next to the existing `programs.nix-ld`: nix-ld covers binaries that
assume an FHS dynamic loader, envfs covers the ones that assume FHS
interpreter and tool paths.

## Validation

- `make build`: succeeded, producing
  `/nix/store/fbg7a9a9j84d3vvd8xnfjbc4sp06nk8f-nixos-system-matic-26.11.20260829.e8be781`.
- Not yet activated. `make switch` needs sudo, which was unavailable in the
  authoring session. Post-switch verification is the delegating host's run
  reaching a clean finalize instead of exit 127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables `services.envfs` on the `matic` host so remote CI tooling can reach hard-coded FHS paths like `/bin/bash` and `/usr/bin/git` via FUSE, fixing the exit 127 failure during remote sync. This complements the existing `nix-ld` configuration for FHS compatibility.

<sup>Written for commit e9a85b043d182e80bb36cdd0e05ad96d7ea7dccc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

