### PR TITLE
fix(kyber): bound review and trace upload disk I/O

### DIFF
--- a/config/shared/hooks/README.md
+++ b/config/shared/hooks/README.md
@@ -51,7 +51,38 @@ These hooks provide fast feedback and prevent common mistakes. They run with the
 `traces-agent-hook.sh <event> --agent <id>` wraps `traces hook agent` for Codex,
 Claude Code, Cursor, GitHub Copilot, Grok, Devin, Antigravity, Pi, Hermes, and
 OpenClaw; the Pi, Hermes, and OpenClaw adapters spawn it directly and pass
-the binary they resolved as `TRACES_BIN`. The traces hook
+the binary they resolved as `TRACES_BIN`.
+
+On Kyber, the managed `traces-agent-uploads` helper writes hook requests into
+`~/.local/state/traces-agent-uploads` with private directory/file permissions
+(0700/0600). It preserves the resolved binary, working directory, arguments,
+stdin payload, and trace configuration environment overrides. Environment values
+are passed outside process arguments. Registration precedes the latest pending
+progress event, followed
+by `session-end`. Progress events for the same session, agent, and working
+directory coalesce; a final event is retained behind an in-flight upload instead
+of canceling it or bypassing the concurrency limit.
+
+One drainer holds an OS file lock through the entire hook invocation. A single
+transient `traces-agent-upload.service` uses `ExitType=cgroup`, so the slot stays
+occupied until the upstream hook's detached uploader also exits. The
+`traces-uploads.slice` budget is 5 MB/s reads, 2 MB/s writes, 100 read IOPS, and
+50 write IOPS on the root filesystem, plus one CPU, 2 GiB memory high, 4 GiB
+memory maximum, and 128 tasks. It is separate from agent and coordinator services.
+
+Each upload has a 15-minute deadline. Failed launches and timeouts retain the
+request with a bounded retry delay; a one-minute timer recovers missed wakeups
+and retries even after the last hook event. Pending requests survive service
+restarts. Requests whose working directories have been removed stay queued for
+operator resolution. Before a final hook, the queue retains its resolved trace ID from
+`traces-active.json`; if that hook removes the registration and then times out,
+the retry uses `traces share --trace-id` for that same trace. Stopping the drainer
+also stops its upload unit. Completion means the
+hook and its children exited; the upstream hook's best-effort remote delivery
+does not provide an upload acknowledgement through its exit status. Visibility,
+destination rules, and authentication remain owned by `traces`.
+
+On other hosts, the existing process guard remains in use. The traces hook
 starts a detached `traces share --trace-id <session> --source agent_hook`
 upload on every `prompt-submitted`, `agent-done`, and `session-end` event and
 never checks whether one is already running; each upload rescans the shared

--- a/config/shared/hooks/traces-agent-hook.sh
+++ b/config/shared/hooks/traces-agent-hook.sh
@@ -13,6 +13,14 @@
 # real hook. It always exits 0: telemetry must never block an agent.
 set -u
 
+# Kyber's managed queue owns the hook and its detached uploader together.
+# Other hosts retain the process guard below.
+queue="${HOME}/.local/libexec/traces-agent-uploads"
+if [ -x "$queue" ]; then
+  "$queue" enqueue "$@" || true
+  exit 0
+fi
+
 event="${1:-}"
 shift || true
 

--- a/home-manager/services/default.nix
+++ b/home-manager/services/default.nix
@@ -37,6 +37,7 @@ let
   t3Connect = import ./t3-connect { inherit inputs pkgs; };
   tmuxSessionLogger = import ./tmux-session-logger { inherit pkgs; };
   tokscale = import ./tokscale { inherit config lib pkgs; };
+  tracesAgentUploads = ./traces-agent-uploads;
 in
 [
   brewUpgrader
@@ -70,4 +71,5 @@ in
   t3Connect
   tmuxSessionLogger
   tokscale
+  tracesAgentUploads
 ]

--- a/home-manager/services/roborev/default.nix
+++ b/home-manager/services/roborev/default.nix
@@ -72,6 +72,14 @@ lib.mkIf enabled {
       TimeoutStopSec = 30;
       TasksMax = 2048;
       CPUQuota = "1600%";
+      # One review worker runs at a time, including queued panel members.
+      # Bound its child tools and daemon housekeeping together; small random
+      # reads and writes need IOPS limits as well as bandwidth limits.
+      IOAccounting = true;
+      IOReadBandwidthMax = "/ 20M";
+      IOWriteBandwidthMax = "/ 10M";
+      IOReadIOPSMax = "/ 200";
+      IOWriteIOPSMax = "/ 100";
       # Kyber serializes review workers; desktop hosts retain four workers.
       # MemoryHigh throttles via reclaim before MemoryMax kills the cgroup.
       MemoryHigh = "24G";

--- a/home-manager/services/traces-agent-uploads/default.nix
+++ b/home-manager/services/traces-agent-uploads/default.nix
@@ -1,0 +1,62 @@
+{
+  config,
+  inputs,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  homeDir = config.home.homeDirectory;
+  runner = pkgs.writeShellApplication {
+    name = "traces-agent-uploads";
+    runtimeInputs = [
+      pkgs.git
+      pkgs.python3
+      pkgs.systemd
+    ];
+    text = ''
+      exec python3 ${./queue.py} --state-dir ${lib.escapeShellArg "${homeDir}/.local/state/traces-agent-uploads"} "$@"
+    '';
+  };
+in
+lib.mkIf inputs.host.isKyber {
+  home.file.".local/libexec/traces-agent-uploads".source = "${runner}/bin/traces-agent-uploads";
+
+  systemd.user.slices.traces-uploads.Slice = {
+    IOAccounting = true;
+    IOReadBandwidthMax = "/ 5M";
+    IOWriteBandwidthMax = "/ 2M";
+    IOReadIOPSMax = "/ 100";
+    IOWriteIOPSMax = "/ 50";
+    CPUQuota = "100%";
+    MemoryHigh = "2G";
+    MemoryMax = "4G";
+    TasksMax = 128;
+  };
+
+  systemd.user.services.traces-agent-uploads = {
+    Unit.Description = "Drain coalesced agent trace uploads";
+    Service = {
+      Type = "exec";
+      ExecStart = "${runner}/bin/traces-agent-uploads drain";
+      Slice = "traces-uploads.slice";
+      TimeoutStartSec = 15;
+      TimeoutStopSec = 15;
+      Environment = [
+        "HOME=${homeDir}"
+        "PATH=${homeDir}/.local/bin:${homeDir}/.bun/bin:${homeDir}/.bun/install/global/node_modules/.bin:${config.home.profileDirectory}/bin:/usr/bin:/bin"
+      ];
+    };
+  };
+
+  # Recover a missed wakeup or a timed-out upload even after the final hook.
+  systemd.user.timers.traces-agent-uploads = {
+    Unit.Description = "Retry queued agent trace uploads";
+    Timer = {
+      OnStartupSec = "1m";
+      OnUnitInactiveSec = "1m";
+      Unit = "traces-agent-uploads.service";
+    };
+    Install.WantedBy = [ "timers.target" ];
+  };
+}

--- a/home-manager/services/traces-agent-uploads/queue.py
+++ b/home-manager/services/traces-agent-uploads/queue.py
@@ -1,0 +1,294 @@
+"""Serialize hook uploads, retaining coalesced events until their unit finishes."""
+
+import argparse
+import contextlib
+import fcntl
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+SLOTS = ("start", "progress", "end")
+SERVICE = "traces-agent-uploads.service"
+
+
+def session_identity(payload, arguments):
+    agent = None
+    for index, argument in enumerate(arguments):
+        if argument == "--agent" and index + 1 < len(arguments):
+            agent = arguments[index + 1]
+        elif argument.startswith("--agent="):
+            agent = argument.removeprefix("--agent=")
+    # Native hook formats, as consumed by traces' agent adapters.
+    fields = {
+        "codex": ("id", "session_id", "sessionId"),
+        "cursor": ("conversation_id", "session_id", "sessionId"),
+        "antigravity": ("conversationId", "conversation_id", "session_id", "sessionId"),
+        "openclaw": ("sessionKey", "session_id", "sessionId"),
+    }.get(agent, ("session_id", "sessionId"))
+    session = next((payload[name] for name in fields if payload.get(name)), None)
+    return agent, session if isinstance(session, str) else None
+
+
+class Queue:
+    def __init__(self, directory):
+        self.directory = Path(directory)
+        self.directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+    @contextlib.contextmanager
+    def lock(self, name="queue.lock", blocking=True):
+        descriptor = os.open(self.directory / name, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            flags = fcntl.LOCK_EX | (0 if blocking else fcntl.LOCK_NB)
+            fcntl.flock(descriptor, flags)
+            yield
+        finally:
+            os.close(descriptor)
+
+    def write(self, path, value):
+        temporary = path.with_suffix(".tmp")
+        descriptor = os.open(temporary, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+        with os.fdopen(descriptor, "w") as output:
+            json.dump(value, output)
+        os.replace(temporary, path)
+
+    def enqueue(self, event, arguments, payload, binary, cwd, environment=None):
+        slot = {
+            "session-start": "start",
+            "prompt-submitted": "progress",
+            "agent-done": "progress",
+            "session-end": "end",
+        }[event]
+        parsed = json.loads(payload)
+        if not isinstance(parsed, dict):
+            raise ValueError("Trace hook payload must be an object")
+        _, session = session_identity(parsed, arguments)
+        # Never coalesce unrelated native payloads without a session identity.
+        identity = session if isinstance(session, str) else uuid.uuid4().hex
+        key = hashlib.sha256(
+            json.dumps([cwd, arguments, identity]).encode()
+        ).hexdigest()
+        path = self.directory / (key + ".json")
+        with self.lock():
+            record = json.loads(path.read_text()) if path.exists() else {}
+            if slot != "end" and "end" in record:
+                return
+            trace_id = record.get(slot, {}).get("trace_id")
+            record[slot] = {
+                "id": uuid.uuid4().hex,
+                "event": event,
+                "arguments": arguments,
+                "payload": payload,
+                "binary": binary,
+                "cwd": cwd,
+                "environment": environment or {},
+                "created": time.time(),
+                "retry_at": 0,
+                "failures": 0,
+            }
+            if slot == "end" and trace_id:
+                record[slot]["trace_id"] = trace_id
+            self.write(path, record)
+
+    def next_event(self):
+        candidates = []
+        # Atomic replacements let the sole drainer scan without blocking hooks.
+        # finish() checks the event identity again before acknowledging it.
+        for path in self.directory.glob("*.json"):
+            record = json.loads(path.read_text())
+            for slot in SLOTS:
+                if slot not in record:
+                    continue
+                event = record[slot]
+                if event["retry_at"] <= time.time():
+                    candidates.append((path, slot, event))
+                # Registration/progress must finish before session-end.
+                break
+        return min(candidates, key=lambda item: item[2]["created"], default=None)
+
+    def finish(self, path, slot, event, succeeded):
+        with self.lock():
+            record = json.loads(path.read_text())
+            if record.get(slot, {}).get("id") != event["id"]:
+                return  # A newer event arrived during this upload.
+            if succeeded:
+                del record[slot]
+            else:
+                event["failures"] += 1
+                event["retry_at"] = time.time() + min(300, 30 * event["failures"])
+                record[slot] = event
+            if record:
+                self.write(path, record)
+            else:
+                path.unlink()
+
+    def drain(self, run, prepare=None):
+        try:
+            with self.lock("worker.lock", blocking=False):
+                while candidate := self.next_event():
+                    path, slot, event = candidate
+                    try:
+                        if slot == "end" and prepare:
+                            prepare(event)
+                            with self.lock():
+                                record = json.loads(path.read_text())
+                                if record.get(slot, {}).get("id") != event["id"]:
+                                    continue
+                                record[slot] = event
+                                self.write(path, record)
+                        succeeded = run(event)
+                    except (OSError, subprocess.SubprocessError, ValueError, KeyError):
+                        succeeded = False
+                    self.finish(path, slot, event, succeeded)
+        except BlockingIOError:
+            return  # Another drainer retains the slot through child completion.
+
+
+def prepare_final(event):
+    agent, session = session_identity(json.loads(event["payload"]), event["arguments"])
+    if not agent or not session:
+        return
+    result = subprocess.run(
+        ["git", "rev-parse", "--absolute-git-dir"],
+        cwd=event["cwd"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=True,
+        env=os.environ | event["environment"],
+    )
+    active = Path(result.stdout.strip()) / "traces-active.json"
+    try:
+        sessions = json.loads(active.read_text())["sessions"]
+    except FileNotFoundError:
+        sessions = []
+    registered = next(
+        (
+            item.get("traceId")
+            for item in sessions
+            if item.get("agentId") == agent and item.get("agentSessionId") == session
+        ),
+        None,
+    )
+    if registered:
+        event["trace_id"] = registered
+    # A timed-out final hook may already have removed its registration. Keep
+    # the upstream-resolved ID on disk before starting that first final hook.
+    event["share_retry"] = not registered and bool(event.get("trace_id"))
+
+
+def run_hook(event):
+    # ExitType=cgroup includes the uploader detached by `traces hook agent`.
+    # BindsTo also stops it if the queue service crashes or is stopped.
+    environment = os.environ | event["environment"]
+    environment["TRACES_DISABLE_AUTOUPDATE"] = "1"
+    arguments = ["hook", "agent", event["event"], *event["arguments"]]
+    if event.get("share_retry"):
+        arguments = [
+            "share",
+            "--trace-id",
+            event["trace_id"],
+            "--source",
+            "agent_hook",
+            "--json",
+        ]
+    command = [
+        "systemd-run",
+        "--user",
+        "--quiet",
+        "--wait",
+        "--pipe",
+        "--collect",
+        "--service-type=exec",
+        "--expand-environment=no",
+        # A single unit name also prevents overlap after a drainer crash.
+        "--unit=traces-agent-upload",
+        "--description=Upload agent trace",
+        "--slice=traces-uploads.slice",
+        "--property=ExitType=cgroup",
+        "--property=RuntimeMaxSec=900",
+        "--property=TimeoutStopSec=10",
+        "--property=KillMode=control-group",
+        "--property=BindsTo=" + SERVICE,
+        "--property=After=" + SERVICE,
+        *["--setenv=" + name for name in event["environment"]],
+        "--setenv=TRACES_DISABLE_AUTOUPDATE",
+        "--working-directory=" + event["cwd"],
+        "--",
+        event["binary"],
+        *arguments,
+    ]
+    result = subprocess.run(
+        command,
+        input="" if event.get("share_retry") else event["payload"],
+        text=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=environment,
+        check=False,
+    )
+    if result.returncode:
+        print("Trace hook failed or timed out; retaining queued event", file=sys.stderr)
+    return result.returncode == 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--state-dir", required=True)
+    parser.add_argument("operation", choices=("enqueue", "drain"))
+    parser.add_argument("event", nargs="?")
+    parser.add_argument("arguments", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    queue = Queue(args.state_dir)
+    if args.operation == "drain":
+        queue.drain(run_hook, prepare_final)
+        return
+    binary = shutil.which(os.environ.get("TRACES_BIN", "traces"))
+    if not binary:
+        return
+    payload = sys.stdin.read(1_048_577)
+    if len(payload.encode()) > 1_048_576:
+        raise ValueError("Trace hook payload exceeds 1 MiB")
+    # Preserve trace routing/auth overrides without putting their values in
+    # process arguments. The private queue is removed after hook completion.
+    environment = {
+        name: value
+        for name, value in os.environ.items()
+        if name.startswith("TRACES_")
+        or name
+        in {
+            "HOME",
+            "PATH",
+            "XDG_CONFIG_HOME",
+            "XDG_DATA_HOME",
+            "XDG_CACHE_HOME",
+            "XDG_STATE_HOME",
+        }
+    }
+    queue.enqueue(args.event, args.arguments, payload, binary, os.getcwd(), environment)
+    try:
+        subprocess.run(
+            ["systemctl", "--user", "start", "--no-block", SERVICE],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        pass  # The timer retries a failed wakeup without another agent event.
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, ValueError, KeyError) as error:
+        # Do not include the payload or command arguments in hook diagnostics.
+        print(
+            "Trace upload queue unavailable: " + type(error).__name__, file=sys.stderr
+        )
+        sys.exit(1)

--- a/named-hosts/kyber/README.md
+++ b/named-hosts/kyber/README.md
@@ -217,9 +217,13 @@ after every thaw and its top writers in the evidence captures need attention
 rather than another auto-thaw.
 
 Coding-agent hooks are the usual writer behind a flapping slice: every hook
-event goes through `config/shared/hooks/traces-agent-hook.sh`, which bounds
-the detached `traces share` uploads that the traces hook otherwise spawns
-without limit (see [shared hooks](../../config/shared/hooks/README.md)).
+event goes through `config/shared/hooks/traces-agent-hook.sh`. On Kyber it
+queues and coalesces events for a single uploader in `traces-uploads.slice`,
+including final session uploads. The upload remains in its bounded cgroup until
+all detached children finish. Root I/O is capped at 5 MB/s reads, 2 MB/s writes,
+100 read IOPS, and 50 write IOPS. The queue's one-minute timer retries failed
+launches and timeouts without requiring another agent event (see
+[shared hooks](../../config/shared/hooks/README.md)).
 
 This containment does not isolate ext4 journals. Kyber has two physical SSDs:
 the root/PVC filesystem and the dedicated containerd filesystem. Moving k3s

--- a/named-hosts/kyber/README.md
+++ b/named-hosts/kyber/README.md
@@ -187,7 +187,23 @@ Kyber hosts coordinators rather than worker lanes. The Herdr server and its
 pane processes inherit `herdr.slice`, which the circuit breaker never
 freezes, so coordinators can keep inspecting and recovering the fleet.
 RoboRev and its child processes remain in the separate `orchestration.slice`,
-which caps aggregate writes to 20 MB/s and aggregate tasks to 2,048.
+which caps aggregate tasks to 2,048 and bounds root-filesystem I/O. RoboRev's
+single worker serializes review jobs, including panel members. Its service
+cgroup bounds the active review, child tools, and daemon housekeeping together:
+
+| Root-filesystem limit | RoboRev service | Orchestration slice aggregate |
+| --- | --- | --- |
+| Read bandwidth | 20 MB/s | 40 MB/s |
+| Write bandwidth | 10 MB/s | 20 MB/s |
+| Read operations | 200 IOPS | 400 IOPS |
+| Write operations | 100 IOPS | 200 IOPS |
+
+The service and parent limits both apply. IOPS limits bound small random
+operations that can saturate a disk below its bandwidth ceiling. These are
+initial containment budgets, not latency guarantees; evaluate review completion
+time and disk pressure before tuning them. Desktop review concurrency and limits
+are unchanged. The dedicated containerd disk and K3s remain outside these limits.
+
 When sustained host I/O PSI or D-state pressure crosses the health threshold
 and the slice's own `io.pressure` or D-state count implicates it, the
 host-health check records PSI, process/`wchan`, per-process I/O, cgroup I/O,

--- a/named-hosts/kyber/orchestration.slice
+++ b/named-hosts/kyber/orchestration.slice
@@ -4,7 +4,10 @@ Description=Disposable Kyber review and orchestration workloads
 [Slice]
 CPUWeight=100
 IOWeight=10
+IOReadBandwidthMax=/ 40M
 IOWriteBandwidthMax=/ 20M
+IOReadIOPSMax=/ 400
+IOWriteIOPSMax=/ 200
 IOAccounting=yes
 TasksAccounting=yes
 TasksMax=2048

--- a/spec/traces_agent_hook_spec.sh
+++ b/spec/traces_agent_hook_spec.sh
@@ -8,7 +8,8 @@ setup() {
   TEMP_BIN="$TEMP_ROOT/bin"
   HOOK_LOG="$TEMP_ROOT/hook.log"
   PS_TABLE="$TEMP_ROOT/ps.txt"
-  mkdir -p "$TEMP_BIN"
+  export HOME="$TEMP_ROOT/home"
+  mkdir -p "$TEMP_BIN" "$HOME"
   : >"$PS_TABLE"
   cat >"$TEMP_BIN/traces" <<'STUB'
 #!/usr/bin/env bash
@@ -53,6 +54,23 @@ When call run_guard trace-a session-start
 The status should be success
 The contents of file "$HOOK_LOG" should include 'args:hook agent session-start --agent claude-code'
 The contents of file "$HOOK_LOG" should include 'stdin:{"session_id":"trace-a"}'
+End
+
+It 'uses the managed queue for final events and preserves the hook input'
+mkdir -p "$HOME/.local/libexec"
+cp "$TEMP_BIN/traces" "$HOME/.local/libexec/traces-agent-uploads"
+When call run_guard trace-a session-end
+The status should be success
+The contents of file "$HOOK_LOG" should include 'args:enqueue session-end --agent claude-code'
+The contents of file "$HOOK_LOG" should include 'stdin:{"session_id":"trace-a"}'
+End
+
+It 'keeps queue failures from failing an agent hook'
+mkdir -p "$HOME/.local/libexec"
+printf '#!/usr/bin/env bash\nexit 1\n' >"$HOME/.local/libexec/traces-agent-uploads"
+chmod +x "$HOME/.local/libexec/traces-agent-uploads"
+When call run_guard trace-a session-end
+The status should be success
 End
 
 It 'skips prompt-submitted while the same trace is already uploading'

--- a/tests/test_traces_agent_uploads.py
+++ b/tests/test_traces_agent_uploads.py
@@ -1,0 +1,299 @@
+import importlib.util
+import io
+import json
+import multiprocessing
+import os
+import subprocess
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "home-manager/services/traces-agent-uploads/queue.py"
+)
+SPEC = importlib.util.spec_from_file_location("traces_upload_queue", SCRIPT)
+queue_module = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(queue_module)
+Queue = queue_module.Queue
+
+
+def enqueue_process(directory, session):
+    Queue(directory).enqueue(
+        "session-end",
+        ["--agent", "codex"],
+        json.dumps({"session_id": session}),
+        "/bin/true",
+        "/tmp",
+    )
+
+
+class TraceUploadQueueTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.queue = Queue(Path(self.temporary.name) / "queue")
+
+    def enqueue(self, event, session="session-a", **payload):
+        self.queue.enqueue(
+            event,
+            ["--agent", "codex"],
+            json.dumps({"session_id": session, **payload}),
+            "/bin/true",
+            "/tmp",
+        )
+
+    def test_progress_coalesces_but_registration_and_end_survive(self):
+        self.enqueue("session-start")
+        self.enqueue("prompt-submitted", generation=1)
+        self.enqueue("agent-done", generation=2)
+        self.enqueue("session-end")
+        self.enqueue("agent-done", generation=3)
+        observed = []
+        self.queue.drain(lambda event: observed.append(event) or True)
+        self.assertEqual(
+            [event["event"] for event in observed],
+            ["session-start", "agent-done", "session-end"],
+        )
+        self.assertEqual(json.loads(observed[1]["payload"])["generation"], 2)
+        self.assertIsNone(self.queue.next_event())
+
+    def test_new_event_during_upload_is_not_removed_by_old_completion(self):
+        self.enqueue("prompt-submitted", generation=1)
+        path, slot, event = self.queue.next_event()
+        self.enqueue("agent-done", generation=2)
+        self.enqueue("session-end")
+        self.queue.finish(path, slot, event, True)
+        observed = []
+        self.queue.drain(lambda item: observed.append(item) or True)
+        self.assertEqual(len(observed), 2)
+        self.assertEqual(json.loads(observed[0]["payload"])["generation"], 2)
+        self.assertEqual(observed[1]["event"], "session-end")
+
+    def test_final_event_waits_for_active_upload_and_second_drainer_exits(self):
+        self.enqueue("agent-done")
+        started = threading.Event()
+        release = threading.Event()
+        observed = []
+
+        def run(event):
+            observed.append(event["event"])
+            if event["event"] == "agent-done":
+                started.set()
+                self.assertTrue(release.wait(5))
+            return True
+
+        worker = threading.Thread(target=self.queue.drain, args=(run,))
+        worker.start()
+        try:
+            self.assertTrue(started.wait(5))
+            self.enqueue("session-end")
+            competing = []
+            Queue(self.queue.directory).drain(
+                lambda event: competing.append(event) or True
+            )
+            self.assertEqual(competing, [])
+            self.assertEqual(observed, ["agent-done"])
+        finally:
+            release.set()
+            worker.join(5)
+        self.assertFalse(worker.is_alive())
+        self.assertEqual(observed, ["agent-done", "session-end"])
+
+    def test_concurrent_final_events_are_retained_and_private(self):
+        context = multiprocessing.get_context("fork")
+        processes = [
+            context.Process(
+                target=enqueue_process,
+                args=(self.queue.directory, "session-" + str(index)),
+            )
+            for index in range(12)
+        ]
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(5)
+            self.assertEqual(process.exitcode, 0)
+        records = list(self.queue.directory.glob("*.json"))
+        self.assertEqual(len(records), 12)
+        self.assertEqual(os.stat(self.queue.directory).st_mode & 0o777, 0o700)
+        for path in records:
+            self.assertEqual(os.stat(path).st_mode & 0o777, 0o600)
+        observed = []
+        self.queue.drain(lambda event: observed.append(event) or True)
+        self.assertEqual(len(observed), 12)
+
+    def test_failed_final_event_retries_without_another_hook(self):
+        self.enqueue("session-end")
+        self.queue.drain(lambda event: False)
+        self.assertIsNone(self.queue.next_event())
+        with patch.object(queue_module.time, "time", return_value=10**12):
+            restarted = Queue(self.queue.directory)
+            observed = []
+            restarted.drain(lambda event: observed.append(event) or True)
+        self.assertEqual([item["event"] for item in observed], ["session-end"])
+        self.assertEqual(list(self.queue.directory.glob("*.json")), [])
+
+    def test_failed_progress_blocks_final_for_same_trace_only(self):
+        self.enqueue("agent-done")
+        self.enqueue("session-end")
+        self.enqueue("session-end", session="session-b")
+        observed = []
+
+        def run(event):
+            observed.append(event["event"])
+            return event["event"] == "session-end"
+
+        self.queue.drain(run)
+        self.assertEqual(observed, ["agent-done", "session-end"])
+        record = json.loads(next(self.queue.directory.glob("*.json")).read_text())
+        self.assertIn("progress", record)
+        self.assertIn("end", record)
+
+    def test_runner_retains_exact_arguments_and_waits_for_cgroup(self):
+        self.enqueue("session-end", value="$UNCHANGED")
+        event = self.queue.next_event()[2]
+        event["environment"] = {"TRACES_API_URL": "https://example.invalid/private"}
+        with patch.object(queue_module.subprocess, "run") as run:
+            run.return_value.returncode = 0
+            self.assertTrue(queue_module.run_hook(event))
+        command = run.call_args.args[0]
+        self.assertIn("--property=ExitType=cgroup", command)
+        self.assertIn("--wait", command)
+        self.assertIn("--property=RuntimeMaxSec=900", command)
+        self.assertIn("--slice=traces-uploads.slice", command)
+        self.assertIn("--expand-environment=no", command)
+        self.assertEqual(
+            command[-5:], ["hook", "agent", "session-end", "--agent", "codex"]
+        )
+        self.assertEqual(run.call_args.kwargs["input"], event["payload"])
+        self.assertIn("--setenv=TRACES_API_URL", command)
+        self.assertNotIn("https://example.invalid/private", " ".join(command))
+        self.assertEqual(
+            run.call_args.kwargs["env"]["TRACES_API_URL"],
+            "https://example.invalid/private",
+        )
+
+    def test_failed_wakeup_keeps_final_payload_for_timer(self):
+        payload = '{"session_id":"final-session","value":"$UNCHANGED"}'
+        with (
+            patch.object(
+                queue_module.sys,
+                "argv",
+                [
+                    str(SCRIPT),
+                    "--state-dir",
+                    str(self.queue.directory),
+                    "enqueue",
+                    "session-end",
+                    "--agent",
+                    "codex",
+                ],
+            ),
+            patch.object(queue_module.sys, "stdin", io.StringIO(payload)),
+            patch.object(queue_module.shutil, "which", return_value="/bin/true"),
+            patch.object(
+                queue_module.subprocess,
+                "run",
+                side_effect=subprocess.TimeoutExpired("systemctl", 2),
+            ),
+        ):
+            queue_module.main()
+        observed = []
+        Queue(self.queue.directory).drain(lambda event: observed.append(event) or True)
+        self.assertEqual(len(observed), 1)
+        self.assertEqual(observed[0]["payload"], payload)
+        self.assertEqual(observed[0]["arguments"], ["--agent", "codex"])
+
+    def test_final_retry_keeps_resolved_id_after_registration_is_removed(self):
+        repo = Path(self.temporary.name) / "repo"
+        subprocess.run(["git", "init", "--quiet", str(repo)], check=True)
+        active = repo / ".git/traces-active.json"
+        active.write_text(
+            json.dumps(
+                {
+                    "sessions": [
+                        {
+                            "agentId": "codex",
+                            "agentSessionId": "native-session",
+                            "traceId": "resolved-trace-id",
+                        }
+                    ]
+                }
+            )
+        )
+        self.queue.enqueue(
+            "session-end",
+            ["--agent", "codex"],
+            '{"session_id":"native-session"}',
+            "/bin/true",
+            str(repo),
+        )
+
+        def timeout_after_removal(event):
+            saved = json.loads(next(self.queue.directory.glob("*.json")).read_text())
+            self.assertEqual(saved["end"]["trace_id"], "resolved-trace-id")
+            self.assertFalse(event["share_retry"])
+            active.unlink()
+            return False
+
+        self.queue.drain(timeout_after_removal, queue_module.prepare_final)
+        with patch.object(queue_module.time, "time", return_value=10**12):
+            restarted = Queue(self.queue.directory)
+            observed = []
+            restarted.drain(
+                lambda event: observed.append(event) or True, queue_module.prepare_final
+            )
+        self.assertTrue(observed[0]["share_retry"])
+        with patch.object(queue_module.subprocess, "run") as run:
+            run.return_value.returncode = 0
+            queue_module.run_hook(observed[0])
+        self.assertEqual(
+            run.call_args.args[0][-6:],
+            [
+                "share",
+                "--trace-id",
+                "resolved-trace-id",
+                "--source",
+                "agent_hook",
+                "--json",
+            ],
+        )
+        self.assertEqual(run.call_args.kwargs["input"], "")
+
+    def test_native_session_fields_coalesce_for_supported_hooks(self):
+        for agent, field in (
+            ("codex", "id"),
+            ("cursor", "conversation_id"),
+            ("antigravity", "conversationId"),
+            ("openclaw", "sessionKey"),
+        ):
+            for event in ("prompt-submitted", "agent-done", "session-end"):
+                self.queue.enqueue(
+                    event,
+                    ["--agent=" + agent],
+                    json.dumps({field: "session"}),
+                    "/bin/true",
+                    "/tmp",
+                )
+        self.assertEqual(len(list(self.queue.directory.glob("*.json"))), 4)
+        observed = []
+        self.queue.drain(lambda event: observed.append(event) or True)
+        self.assertEqual(len(observed), 8)
+
+    def test_coalesced_final_preserves_prepared_trace_identity(self):
+        self.enqueue("session-end", generation=1)
+        path, slot, event = self.queue.next_event()
+        event["trace_id"] = "resolved-trace-id"
+        self.queue.write(path, {slot: event})
+        self.enqueue("session-end", generation=2)
+        self.queue.finish(path, slot, event, True)
+        newer = self.queue.next_event()[2]
+        self.assertEqual(newer["trace_id"], "resolved-trace-id")
+        self.assertEqual(json.loads(newer["payload"])["generation"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Kyber review activity could issue unlimited root-disk reads and random I/O, while agent trace hooks raced their process-count cap and let final uploads bypass it. This change bounds review disk activity and queues agent-hook uploads under an independent resource budget.

| Root-disk limit | RoboRev service | Orchestration slice | Trace uploads |
| --- | --- | --- | --- |
| Read bandwidth | 20 MB/s | 40 MB/s | 5 MB/s |
| Write bandwidth | 10 MB/s | 20 MB/s | 2 MB/s |
| Read IOPS | 200 | 400 | 100 |
| Write IOPS | 100 | 200 | 50 |

RoboRev retains its existing single-worker queue and CPU/memory/task limits. Agent hooks on Kyber use a private disk queue with atomic locking. Progress events coalesce; registration and final events remain ordered. One systemd upload unit holds the slot until the hook and its detached children exit, with a 15-minute deadline. Failed launches and timeouts remain queued for the one-minute retry timer. Final requests retain the resolved trace ID so retries still work after upstream removes the session registration.

The trace slice also limits aggregate CPU to one core, memory high/max to 2/4 GiB, and tasks to 128. Hook payloads and trace configuration overrides retain private file permissions; environment values are passed outside process arguments. Desktop hook behavior and the host freezer policy are unchanged.

Validation:
- 11 Python queue tests cover concurrent producers, coalescing, final-event ordering, a competing drainer, failed wakeups, retry persistence, native session identities, and final retries after registration removal.
- 35 existing/extended ShellSpec examples pass for trace hooks and RoboRev hydration/hooks; Ruff, ShellCheck, Nix formatting, whitespace, and the two-commit secret scan pass.
- Kyber Nix evaluation and the generated helper package build pass. Matic evaluation confirms the upload helper/service are absent.
- Real temporary systemd units verified kernel I/O limits, waiting for a detached child, timeout cleanup, and parent-stop propagation.
- An end-to-end test using the actual queue and a fake detached uploader serialized registration/progress/final and emptied the queue. No real trace uploads were performed during validation.

Activation is pending. Budgets are initial containment settings, not measured throughput optima. Completed upstream hooks retain best-effort remote delivery semantics; their exit status does not acknowledge an upload. Requests whose working directories disappear remain queued for operator resolution. Manual trace sharing and Git publish hooks are outside this agent-hook queue.
