### PR TITLE
fix(matic): pin the FHS toolchain into the envfs fallback

### DIFF
--- a/named-hosts/matic/default.nix
+++ b/named-hosts/matic/default.nix
@@ -401,6 +401,33 @@ import ../../hosts/nixos {
         # /usr/bin/git, which a stock NixOS root does not provide.
         services.envfs.enable = true;
 
+        # The PATH lookup is useless to a process that was started with a
+        # scrubbed environment: `env -i PATH=/usr/bin:/bin /bin/bash` leaves
+        # the shell asking envfs to resolve `git` against the very directories
+        # envfs serves, so only the fallback set exists. Upstream ships just
+        # `env` and `sh` there, which is short of what those helper scripts
+        # call, so pin the rest of the FHS toolchain into the fallback.
+        services.envfs.extraFallbackPathCommands = ''
+          for fallbackPackage in ${
+            lib.concatStringsSep " " (
+              with pkgs;
+              [
+                bashInteractive
+                coreutils
+                findutils
+                gawk
+                git
+                gnugrep
+                gnused
+              ]
+            )
+          }; do
+            for fallbackBinary in "$fallbackPackage"/bin/*; do
+              ln -sfn "$fallbackBinary" "$out/$(basename "$fallbackBinary")"
+            done
+          done
+        '';
+
         # Enable nix-ld for running dynamically linked binaries
         programs.nix-ld.enable = true;
         programs.nix-ld.libraries = with pkgs; [


### PR DESCRIPTION
## Why

The previous change enabled envfs on matic. Verified on the running host, it
half-works: all twelve hard-coded FHS paths resolve from an ordinary login
shell, but envfs resolves them against the *requesting process's* PATH, and
the remote tooling that drives this host over SSH deliberately scrubs that
PATH.

```
$ /usr/bin/env -i PATH=/usr/bin:/bin LANG=C LC_ALL=C BASH_ENV=/dev/null \
    ENV=/dev/null /bin/bash --noprofile --norc /tmp/scrub-test.sh
scrubbed-ok
/tmp/scrub-test.sh: line 3: git: command not found
/tmp/scrub-test.sh: line 4: awk: command not found
/tmp/scrub-test.sh: line 4: head: command not found
/tmp/scrub-test.sh: line 5: mktemp: command not found
```

`/bin/bash` resolves because `env` is still holding its own login environment
at the moment of the lookup. Once inside that shell, PATH is `/usr/bin:/bin`,
so every further lookup recurses into the directories envfs itself serves and
falls through to the fallback path, which upstream populates with exactly two
entries:

```
$ ls /nix/store/...-fallback-path/
env -> .../coreutils-9.11/bin/env
sh  -> .../bash-interactive-5.3p15/bin/sh
```

## What

`services.envfs.extraFallbackPathCommands` symlinks bash, coreutils,
findutils, gawk, git, gnugrep, and gnused into that fallback. It is the
option upstream provides for this case, so nothing is hand-maintained outside
the configuration.

## Validation

- `make build`: succeeded, producing
  `/nix/store/khmw1wvxbjjkql44zscp7yzgzdw61bs1-nixos-system-matic-26.11.20260829.e8be781`.
- The built generation's `/etc/fstab` points at a fallback path with 128
  entries, including every path the remote helpers call: `bash`, `cat`,
  `mkdir`, `rm`, `mv`, `cp`, `env`, `git`, `find`, `mktemp`, `awk`, `grep`.
- Post-switch verification is the same scrubbed-environment script exiting 0,
  and the delegating host's run reaching a clean finalize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes matic's `envfs` fallback so hard-coded FHS paths resolve even when the caller has a scrubbed `PATH`. Previously, `envfs` resolved `/usr/bin` and `/bin` against the requesting process's `PATH`; the SSH tooling that drives matic scrubs `PATH` to `/usr/bin:/bin`, so `/bin/bash` resolved but `git`, `awk`, `mktemp`, and `head` all failed. The fallback path now includes binaries from `bashInteractive`, `coreutils`, `findutils`, `gawk`, `git`, `gnugrep`, and `gnused`, covering every hard-coded path those remote helpers call.

<sup>Written for commit 2fd6fb63fc3db55ee3abce4a1563cbef58f94631. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

