### PR TITLE
fix(kyber): pause automatic agent trace uploads

### DIFF
--- a/config/shared/hooks/README.md
+++ b/config/shared/hooks/README.md
@@ -53,7 +53,13 @@ Claude Code, Cursor, GitHub Copilot, Grok, Devin, Antigravity, Pi, Hermes, and
 OpenClaw; the Pi, Hermes, and OpenClaw adapters spawn it directly and pass
 the binary they resolved as `TRACES_BIN`.
 
-On Kyber, the managed `traces-agent-uploads` helper writes hook requests into
+Automatic agent trace uploads are currently disabled on Kyber with
+`services.traces-agent-uploads.enable = false`. The managed dispatcher exits
+without reading the payload or starting Traces, and no upload service or timer
+is declared. Existing queued requests and trace data are retained. This setting
+does not remove agent-native transcripts or disable manually invoked Traces commands.
+
+When enabled on Kyber, the managed `traces-agent-uploads` helper writes hook requests into
 `~/.local/state/traces-agent-uploads` with private directory/file permissions
 (0700/0600). It preserves the resolved binary, working directory, arguments,
 stdin payload, and trace configuration environment overrides. Environment values

--- a/home-manager/services/traces-agent-uploads/default.nix
+++ b/home-manager/services/traces-agent-uploads/default.nix
@@ -7,6 +7,8 @@
 }:
 let
   homeDir = config.home.homeDirectory;
+  enabled = config.services.traces-agent-uploads.enable;
+  disabledHook = pkgs.writeShellScript "traces-agent-uploads-disabled" "exit 0";
   runner = pkgs.writeShellApplication {
     name = "traces-agent-uploads";
     runtimeInputs = [
@@ -19,44 +21,53 @@ let
     '';
   };
 in
-lib.mkIf inputs.host.isKyber {
-  home.file.".local/libexec/traces-agent-uploads".source = "${runner}/bin/traces-agent-uploads";
+{
+  options.services.traces-agent-uploads.enable = lib.mkEnableOption "automatic agent trace uploads";
 
-  systemd.user.slices.traces-uploads.Slice = {
-    IOAccounting = true;
-    IOReadBandwidthMax = "/ 5M";
-    IOWriteBandwidthMax = "/ 2M";
-    IOReadIOPSMax = "/ 100";
-    IOWriteIOPSMax = "/ 50";
-    CPUQuota = "100%";
-    MemoryHigh = "2G";
-    MemoryMax = "4G";
-    TasksMax = 128;
-  };
+  config = lib.mkIf inputs.host.isKyber {
+    # Keep the dispatcher installed while disabled so hooks cannot fall through
+    # to the unmanaged uploader. Existing queued requests remain on disk.
+    home.file.".local/libexec/traces-agent-uploads".source =
+      if enabled then "${runner}/bin/traces-agent-uploads" else disabledHook;
 
-  systemd.user.services.traces-agent-uploads = {
-    Unit.Description = "Drain coalesced agent trace uploads";
-    Service = {
-      Type = "exec";
-      ExecStart = "${runner}/bin/traces-agent-uploads drain";
-      Slice = "traces-uploads.slice";
-      TimeoutStartSec = 15;
-      TimeoutStopSec = 15;
-      Environment = [
-        "HOME=${homeDir}"
-        "PATH=${homeDir}/.local/bin:${homeDir}/.bun/bin:${homeDir}/.bun/install/global/node_modules/.bin:${config.home.profileDirectory}/bin:/usr/bin:/bin"
-      ];
+    systemd.user = lib.mkIf enabled {
+      slices.traces-uploads.Slice = {
+        IOAccounting = true;
+        IOReadBandwidthMax = "/ 5M";
+        IOWriteBandwidthMax = "/ 2M";
+        IOReadIOPSMax = "/ 100";
+        IOWriteIOPSMax = "/ 50";
+        CPUQuota = "100%";
+        MemoryHigh = "2G";
+        MemoryMax = "4G";
+        TasksMax = 128;
+      };
+
+      services.traces-agent-uploads = {
+        Unit.Description = "Drain coalesced agent trace uploads";
+        Service = {
+          Type = "exec";
+          ExecStart = "${runner}/bin/traces-agent-uploads drain";
+          Slice = "traces-uploads.slice";
+          TimeoutStartSec = 15;
+          TimeoutStopSec = 15;
+          Environment = [
+            "HOME=${homeDir}"
+            "PATH=${homeDir}/.local/bin:${homeDir}/.bun/bin:${homeDir}/.bun/install/global/node_modules/.bin:${config.home.profileDirectory}/bin:/usr/bin:/bin"
+          ];
+        };
+      };
+
+      # Recover a missed wakeup or a timed-out upload even after the final hook.
+      timers.traces-agent-uploads = {
+        Unit.Description = "Retry queued agent trace uploads";
+        Timer = {
+          OnStartupSec = "1m";
+          OnUnitInactiveSec = "1m";
+          Unit = "traces-agent-uploads.service";
+        };
+        Install.WantedBy = [ "timers.target" ];
+      };
     };
-  };
-
-  # Recover a missed wakeup or a timed-out upload even after the final hook.
-  systemd.user.timers.traces-agent-uploads = {
-    Unit.Description = "Retry queued agent trace uploads";
-    Timer = {
-      OnStartupSec = "1m";
-      OnUnitInactiveSec = "1m";
-      Unit = "traces-agent-uploads.service";
-    };
-    Install.WantedBy = [ "timers.target" ];
   };
 }

--- a/named-hosts/kyber/README.md
+++ b/named-hosts/kyber/README.md
@@ -216,13 +216,14 @@ raise `orchestration-circuit-breaker-flapping`, which means the slice re-trips
 after every thaw and its top writers in the evidence captures need attention
 rather than another auto-thaw.
 
-Coding-agent hooks are the usual writer behind a flapping slice: every hook
-event goes through `config/shared/hooks/traces-agent-hook.sh`. On Kyber it
-queues and coalesces events for a single uploader in `traces-uploads.slice`,
-including final session uploads. The upload remains in its bounded cgroup until
-all detached children finish. Root I/O is capped at 5 MB/s reads, 2 MB/s writes,
-100 read IOPS, and 50 write IOPS. The queue's one-minute timer retries failed
-launches and timeouts without requiring another agent event (see
+Automatic agent trace uploads are currently disabled with
+`services.traces-agent-uploads.enable = false`. The shared hook dispatcher exits
+without scanning traces, enqueueing requests, or starting an uploader. The upload
+service and timer are not declared; existing queued requests and source traces
+remain on disk. Other hosts and manually invoked Traces commands are unchanged.
+
+When re-enabled, the queue serializes uploads in `traces-uploads.slice`, retaining
+final events and enforcing its bandwidth, IOPS, CPU, and memory limits (see
 [shared hooks](../../config/shared/hooks/README.md)).
 
 This containment does not isolate ext4 journals. Kyber has two physical SSDs:

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -56,6 +56,9 @@ home-manager.lib.homeManagerConfiguration {
           };
         };
 
+        # Pause trace scans and uploads while storage contention is unresolved.
+        services.traces-agent-uploads.enable = false;
+
         # Agenix configuration
         age.identityPaths = [ "/home/${username}/.ssh/id_ed25519" ];
         age.secrets = builtins.mapAttrs (


### PR DESCRIPTION
Automatic agent trace uploads still compete with review cleanup and databases on Kyber despite the upload resource limits. Pause them with `services.traces-agent-uploads.enable = false`.

The disabled configuration retains a no-op hook dispatcher so installed agent hooks cannot fall through to unmanaged uploads, and omits the queue service, timer, and slice. Existing queued requests and source traces stay on disk. Other hosts and explicitly invoked Traces commands retain their behavior.

Validation: 13 hook examples pass; Nix evaluates the disabled Kyber configuration without upload units, the enabled configuration with its service and timer, and Matic without either the helper or upload service. The generated no-op helper builds and has been verified live to leave the queue unchanged. Nix formatting, whitespace checks, and the scoped secret scan pass.

Kyber is already paused through the generated no-op helper, a stopped timer, and a temporary service start condition. The temporary condition remains an operator hold until uploads are intentionally resumed; it must be removed as part of that resumption. No full Home Manager switch or orchestration thaw was performed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables automatic agent trace uploads on Kyber so they no longer compete with review cleanup and databases. The upload service, timer, and slice are no longer declared, and the installed hook dispatcher becomes a no-op that leaves queued requests and source traces on disk. Other hosts and manually invoked Traces commands are unchanged.

<sup>Written for commit 4f882abc34f75927cd11d17dcc709ebbb27c02ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

