### PR TITLE
feat: register OpenFactor hooks from config/openfactor

### DIFF
--- a/config/default.nix
+++ b/config/default.nix
@@ -40,6 +40,7 @@ in
   ./npm
   ./obsidian
   ./omp
+  ./openfactor-hooks
   ./openclaw
   ./opencode
   ./pi

--- a/config/openfactor-hooks/default.nix
+++ b/config/openfactor-hooks/default.nix
@@ -1,0 +1,28 @@
+{
+  config,
+  pkgs,
+  ...
+}:
+{
+  # Hook configuration is owned by each harness, so register after their
+  # activation steps have materialized writable host files. The OpenFactor CLI
+  # remains the single adapter/receipt owner.
+  home.activation.openfactorHooks =
+    config.lib.dag.entryAfter
+      [
+        "antigravityCliSettings"
+        "claudeConfig"
+        "codexConfig"
+        "copilotConfig"
+        "cursorHooks"
+        "devinConfig"
+        "factorySettings"
+        "geminiSettings"
+        "grokConfig"
+        "installOpenCodePlugins"
+        "ompConfig"
+      ]
+      ''
+        $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${./install.sh}"
+      '';
+}

--- a/config/openfactor-hooks/install.sh
+++ b/config/openfactor-hooks/install.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Register OpenFactor's host-scoped orchestration hooks when the OpenFactor CLI
+# is installed. The CLI owns harness adapters and receipts; this wrapper only
+# provides the durable Home Manager activation boundary.
+set -euo pipefail
+
+OPENFACTOR_BIN="${OPENFACTOR_BIN:-}"
+if [[ -z $OPENFACTOR_BIN ]]; then
+  OPENFACTOR_BIN="$(PATH="$HOME/.local/bin:${PATH:-}" command -v openfactor 2>/dev/null || true)"
+fi
+
+if [[ -z $OPENFACTOR_BIN ]]; then
+  echo "OpenFactor CLI not found; skipping orchestration hook registration" >&2
+  exit 0
+fi
+
+if [[ ! -x $OPENFACTOR_BIN ]]; then
+  echo "OpenFactor CLI is not executable: $OPENFACTOR_BIN" >&2
+  exit 1
+fi
+
+exec "$OPENFACTOR_BIN" hooks install --scope host --json

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -340,6 +340,10 @@ It 'has spec file for config/codex/merge-orchestration-hooks.sh'
 The path "spec/activate_config_spec.sh" should be exist
 End
 
+It 'has spec file for config/openfactor-hooks/install.sh'
+The path "spec/openfactor_hooks_spec.sh" should be exist
+End
+
 It 'has spec file for config/herdr/install-integrations.sh'
 The path "spec/activate_config_spec.sh" should be exist
 End
@@ -540,6 +544,7 @@ config/devin/hooks/pushover.sh
 config/dsh/hydrate.sh
 config/codex/hooks/notify.sh
 config/codex/hooks/pushover.sh
+config/openfactor-hooks/install.sh
 config/shared/hooks/block-gh-settings.sh
 config/shared/hooks/block-git-push.sh
 config/shared/hooks/dcg-guard.sh

--- a/spec/openfactor_hooks_spec.sh
+++ b/spec/openfactor_hooks_spec.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+
+Describe 'config/openfactor-hooks/install.sh'
+SCRIPT="$PWD/config/openfactor-hooks/install.sh"
+BASH_BIN="$(command -v bash)"
+BASH_DIR="$(dirname "$BASH_BIN")"
+
+It 'uses the OpenFactor CLI as the single host hook installer'
+When run head -1 "$SCRIPT"
+The output should equal '#!/usr/bin/env bash'
+End
+
+It 'skips cleanly when the CLI is not installed'
+When run "$BASH_BIN" -c 'PATH="$2:/usr/bin:/bin" "$1"' _ "$SCRIPT" "$BASH_DIR"
+The status should be success
+The error should include 'OpenFactor CLI not found; skipping orchestration hook registration'
+End
+
+It 'delegates host registration to the CLI'
+TMP_HOME="$(mktemp -d)"
+TMP_BIN="$TMP_HOME/bin"
+mkdir -p "$TMP_BIN"
+cat >"$TMP_BIN/openfactor" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*"
+SH
+chmod +x "$TMP_BIN/openfactor"
+
+When run "$BASH_BIN" -c 'PATH="$1:$3" "$2"' _ "$TMP_BIN" "$SCRIPT" "$BASH_DIR"
+The output should equal 'hooks install --scope host --json'
+The status should be success
+End
+End


### PR DESCRIPTION
Consolidates host activation under config/openfactor/default.nix, removes the legacy Codex merge helper, and delegates harness registration to the OpenFactor CLI.