### PR TITLE
fix(kyber): contain scans and gate freezes on current pressure

### DIFF
--- a/config/k3s/kyber-host-health.sh
+++ b/config/k3s/kyber-host-health.sh
@@ -27,9 +27,11 @@ readonly DISK_WEAR_WARNING_PERCENT=10
 readonly DISK_WEAR_CHECK_INTERVAL_SECONDS=21600
 
 IO_PRESSURE_UNHEALTHY=0
+IO_PRESSURE_CURRENT_UNHEALTHY=0
 D_STATE_UNHEALTHY=0
 CRI_UNHEALTHY=0
 ORCHESTRATION_IMPLICATED=0
+ORCHESTRATION_IO_SOME_AVG10=0
 ORCHESTRATION_IO_SOME_AVG300=0
 ORCHESTRATION_D_STATE_COUNT=0
 
@@ -55,12 +57,24 @@ clear_alert() {
 }
 
 check_io_pressure() {
-  local some_avg300 full_avg300
+  local some_avg10 full_avg10 some_avg300 full_avg300
 
   # shellcheck disable=SC2016
   some_avg300="$(awk '$1 == "some" { for (i = 1; i <= NF; i++) if ($i ~ /^avg300=/) { sub(/^avg300=/, "", $i); print $i } }' /proc/pressure/io)"
   # shellcheck disable=SC2016
   full_avg300="$(awk '$1 == "full" { for (i = 1; i <= NF; i++) if ($i ~ /^avg300=/) { sub(/^avg300=/, "", $i); print $i } }' /proc/pressure/io)"
+
+  # A five-minute average can remain high after the offending work has ended.
+  # Require current stalls too before starting another freeze.
+  # shellcheck disable=SC2016
+  some_avg10="$(awk '$1 == "some" { for (i = 1; i <= NF; i++) if ($i ~ /^avg10=/) { sub(/^avg10=/, "", $i); print $i } }' /proc/pressure/io)"
+  # shellcheck disable=SC2016
+  full_avg10="$(awk '$1 == "full" { for (i = 1; i <= NF; i++) if ($i ~ /^avg10=/) { sub(/^avg10=/, "", $i); print $i } }' /proc/pressure/io)"
+  if awk -v some="$some_avg10" -v full="$full_avg10" -v some_limit="$IO_SOME_AVG300_THRESHOLD" -v full_limit="$IO_FULL_AVG300_THRESHOLD" 'BEGIN { exit !(some >= some_limit || full >= full_limit) }'; then
+    IO_PRESSURE_CURRENT_UNHEALTHY=1
+  else
+    IO_PRESSURE_CURRENT_UNHEALTHY=0
+  fi
 
   if awk -v some="$some_avg300" -v full="$full_avg300" -v some_limit="$IO_SOME_AVG300_THRESHOLD" -v full_limit="$IO_FULL_AVG300_THRESHOLD" 'BEGIN { exit !(some >= some_limit || full >= full_limit) }'; then
     IO_PRESSURE_UNHEALTHY=1
@@ -258,18 +272,23 @@ orchestration_cgroup_dir() {
 # uninterruptible tasks, otherwise the freeze pauses the control plane while
 # k3s, the beads Dolt server, or a pod keeps the host over threshold.
 check_orchestration_pressure() {
-  local cgroup_dir some_avg300=0 d_state_count=0
+  local cgroup_dir some_avg10=0 some_avg300=0 d_state_count=0
 
   cgroup_dir="$(orchestration_cgroup_dir)"
   if [ -r "$cgroup_dir/io.pressure" ]; then
     # shellcheck disable=SC2016
     some_avg300="$(awk '$1 == "some" { for (i = 1; i <= NF; i++) if ($i ~ /^avg300=/) { sub(/^avg300=/, "", $i); print $i } }' "$cgroup_dir/io.pressure")"
   fi
+  if [ -r "$cgroup_dir/io.pressure" ]; then
+    # shellcheck disable=SC2016
+    some_avg10="$(awk '$1 == "some" { for (i = 1; i <= NF; i++) if ($i ~ /^avg10=/) { sub(/^avg10=/, "", $i); print $i } }' "$cgroup_dir/io.pressure")"
+  fi
   d_state_count="$(ps --no-headers -eo stat=,cgroup= | awk -v slice="/$ORCHESTRATION_SLICE/" '$1 ~ /^D/ && index($2, slice) { count++ } END { print count + 0 }')"
 
+  ORCHESTRATION_IO_SOME_AVG10="${some_avg10:-0}"
   ORCHESTRATION_IO_SOME_AVG300="${some_avg300:-0}"
   ORCHESTRATION_D_STATE_COUNT="$d_state_count"
-  if awk -v some="$ORCHESTRATION_IO_SOME_AVG300" -v some_limit="$ORCHESTRATION_IO_SOME_AVG300_THRESHOLD" 'BEGIN { exit !(some >= some_limit) }' ||
+  if awk -v current="$ORCHESTRATION_IO_SOME_AVG10" -v sustained="$ORCHESTRATION_IO_SOME_AVG300" -v some_limit="$ORCHESTRATION_IO_SOME_AVG300_THRESHOLD" 'BEGIN { exit !(current >= some_limit && sustained >= some_limit) }' ||
     [ "$d_state_count" -ge "$ORCHESTRATION_D_STATE_THRESHOLD" ]; then
     ORCHESTRATION_IMPLICATED=1
   else
@@ -278,7 +297,7 @@ check_orchestration_pressure() {
 }
 
 orchestration_pressure_summary() {
-  printf 'slice io some avg300=%s, slice D-state=%s' "$ORCHESTRATION_IO_SOME_AVG300" "$ORCHESTRATION_D_STATE_COUNT"
+  printf 'slice io some avg10=%s avg300=%s, slice D-state=%s' "$ORCHESTRATION_IO_SOME_AVG10" "$ORCHESTRATION_IO_SOME_AVG300" "$ORCHESTRATION_D_STATE_COUNT"
 }
 
 record_orchestration_freeze() {
@@ -322,7 +341,7 @@ manage_orchestration_circuit_breaker() {
   local thaw_failure_alert="orchestration-thaw-failed"
   local evidence_dir recovery_samples=0 newly_frozen=0
 
-  if { [ "$IO_PRESSURE_UNHEALTHY" -eq 1 ] || [ "$D_STATE_UNHEALTHY" -eq 1 ]; } && [ "$ORCHESTRATION_IMPLICATED" -eq 1 ]; then
+  if { { [ "$IO_PRESSURE_UNHEALTHY" -eq 1 ] && [ "$IO_PRESSURE_CURRENT_UNHEALTHY" -eq 1 ]; } || [ "$D_STATE_UNHEALTHY" -eq 1 ]; } && [ "$ORCHESTRATION_IMPLICATED" -eq 1 ]; then
     printf '0\n' >"$recovery_file"
     if [ ! -s "$capture_file" ]; then
       evidence_dir="$(capture_orchestration_evidence)"
@@ -361,7 +380,7 @@ manage_orchestration_circuit_breaker() {
     return
   fi
 
-  if [ "$CRI_UNHEALTHY" -eq 1 ]; then
+  if [ "$CRI_UNHEALTHY" -eq 1 ] || [ "$IO_PRESSURE_CURRENT_UNHEALTHY" -eq 1 ] || [ "$D_STATE_UNHEALTHY" -eq 1 ]; then
     printf '0\n' >"$recovery_file"
     return
   fi

--- a/home-manager/services/t3-connect/default.nix
+++ b/home-manager/services/t3-connect/default.nix
@@ -1,6 +1,11 @@
 { inputs, pkgs, ... }:
 let
   inherit (pkgs) lib;
+  findPackage =
+    if inputs.host.isKyber then
+      import ../../../named-hosts/kyber/find.nix { inherit pkgs; }
+    else
+      pkgs.findutils;
   serveRoutes = import ../../modules/tailscale/routes.nix;
   hostServeRoutes = serveRoutes.${inputs.host.nodeName} or [ ];
   t3ServeRoutes = lib.filter (
@@ -12,7 +17,7 @@ let
   toolchain = lib.makeBinPath [
     pkgs.bash
     pkgs.coreutils
-    pkgs.findutils
+    findPackage
     pkgs.gawk
     pkgs.gcc
     pkgs.gnugrep
@@ -81,6 +86,17 @@ in
           ''}
         '';
       };
+
+  # Provider subprocesses inherit T3's cgroup. Bound their reads without
+  # freezing the server or throttling other managed user services.
+  xdg.configFile."systemd/user/t3code.service.d/read-io.conf" = lib.mkIf inputs.host.isKyber {
+    text = ''
+      [Service]
+      IOAccounting=true
+      IOReadBandwidthMax=/ 20M
+      IOReadIOPSMax=/ 200
+    '';
+  };
 
   systemd.user.services.t3-connect = lib.mkIf pkgs.stdenv.hostPlatform.isLinux {
     Unit = {

--- a/named-hosts/kyber/README.md
+++ b/named-hosts/kyber/README.md
@@ -216,6 +216,13 @@ raise `orchestration-circuit-breaker-flapping`, which means the slice re-trips
 after every thaw and its top writers in the evidence captures need attention
 rather than another auto-thaw.
 
+A PSI-triggered freeze requires both the five-minute pressure signal and
+current ten-second pressure to exceed the existing thresholds, including
+current pressure inside orchestration. A stale average alone cannot re-freeze
+a recovered slice. The sustained D-state trigger remains active. Automatic
+thaw requires five consecutive samples with current host pressure, D-state,
+and CRI checks healthy; long averages may decay during recovery.
+
 T3-launched tools and SSH sessions also have read limits outside
 `orchestration.slice`. T3 and its children share 20 MB/s and 200 read IOPS;
 each logind session scope gets 10 MB/s and 100 read IOPS, including commands

--- a/named-hosts/kyber/README.md
+++ b/named-hosts/kyber/README.md
@@ -216,6 +216,21 @@ raise `orchestration-circuit-breaker-flapping`, which means the slice re-trips
 after every thaw and its top writers in the evidence captures need attention
 rather than another auto-thaw.
 
+T3-launched tools and SSH sessions also have read limits outside
+`orchestration.slice`. T3 and its children share 20 MB/s and 200 read IOPS;
+each logind session scope gets 10 MB/s and 100 read IOPS, including commands
+run through `sudo`. These limits apply to reads only. Dolt and other managed
+user services keep their existing controls, and no service restart is needed.
+Session budgets are per session, so they do not impose a combined SSH ceiling.
+
+Kyber's managed `find` rejects recursive scans from `/`, `/home`, `/root`, the
+user home, and the shared worktree collection. Use an exact project/state path,
+or put `-maxdepth 0`, `1`, or `2` immediately after the roots for a shallow
+inventory. The same guard is included in T3's toolchain. This is an operational
+guard, not a security boundary: explicitly invoking another scanner can bypass
+it, while the cgroup read limits still apply. Rate limits reduce contention but
+do not guarantee filesystem journal latency or prevent every breaker event.
+
 Automatic agent trace uploads are currently disabled with
 `services.traces-agent-uploads.enable = false`. The shared hook dispatcher exits
 without scanning traces, enqueueing requests, or starting an uploader. The upload

--- a/named-hosts/kyber/activate-user-service-priority.sh
+++ b/named-hosts/kyber/activate-user-service-priority.sh
@@ -8,6 +8,7 @@ readonly USER_UID
 readonly SYSTEM_DROP_IN_FILE="/etc/systemd/system/system.slice.d/10-kyber-managed-services.conf"
 readonly USER_DROP_IN_FILE="/etc/systemd/system/user@${USER_UID}.service.d/10-kyber-managed-services.conf"
 readonly USER_SLICE_DROP_IN_FILE="/etc/systemd/system/user.slice.d/10-kyber-io-ceiling.conf"
+readonly SESSION_DROP_IN_FILE="/etc/systemd/system/session-.scope.d/20-kyber-read-io.conf"
 readonly BFQ_UDEV_RULE_FILE="/etc/udev/rules.d/60-kyber-bfq.rules"
 
 # IOWeight only expresses a ratio for the block device. It cannot bound how
@@ -56,6 +57,16 @@ EOF
 )
 USER_SLICE_CONTENT=$(
   printf '[Slice]\nIOWriteBandwidthMax=%s %s\n' "$USER_IO_WRITE_PATH" "$USER_IO_WRITE_MAX"
+)
+# The dash-prefix drop-in covers current and future logind/SSH session scopes,
+# including commands run through sudo, without capping managed service reads.
+SESSION_CONTENT=$(
+  cat <<'EOF'
+[Scope]
+IOAccounting=true
+IOReadBandwidthMax=/ 10M
+IOReadIOPSMax=/ 100
+EOF
 )
 BFQ_UDEV_CONTENT=$(
   cat <<'EOF'
@@ -134,6 +145,7 @@ select_bfq_scheduler() {
 install_drop_in "$SYSTEM_DROP_IN_FILE" "$SYSTEM_CONTENT"
 install_drop_in "$USER_DROP_IN_FILE" "$USER_CONTENT"
 install_drop_in "$USER_SLICE_DROP_IN_FILE" "$USER_SLICE_CONTENT"
+install_drop_in "$SESSION_DROP_IN_FILE" "$SESSION_CONTENT"
 if [ "$changed" -eq 1 ]; then
   run_root systemctl daemon-reload
 fi

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -56,6 +56,8 @@ home-manager.lib.homeManagerConfiguration {
           };
         };
 
+        home.file.".local/bin/find".source = "${import ./find.nix { inherit pkgs; }}/bin/find";
+
         # Pause trace scans and uploads while storage contention is unresolved.
         services.traces-agent-uploads.enable = false;
 

--- a/named-hosts/kyber/find.nix
+++ b/named-hosts/kyber/find.nix
@@ -1,0 +1,8 @@
+{ pkgs }:
+pkgs.writeShellApplication {
+  name = "find";
+  runtimeInputs = [ pkgs.coreutils ];
+  text = ''
+    exec ${pkgs.bash}/bin/bash ${./find.sh} ${pkgs.findutils}/bin/find "$@"
+  '';
+}

--- a/named-hosts/kyber/find.sh
+++ b/named-hosts/kyber/find.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Reject broad filesystem discovery before it can compete with host services.
+set -euo pipefail
+native_find="$1"
+shift
+arguments=("$@")
+roots=()
+index=0
+while [ "$index" -lt "${#arguments[@]}" ]; do
+  argument="${arguments[$index]}"
+  case "$argument" in
+    -H | -L | -P | -O[0-3] | --) ;;
+    -D) index=$((index + 1)) ;;
+    -*) break ;;
+    '(' | '!') break ;;
+    *) roots+=("$argument") ;;
+  esac
+  index=$((index + 1))
+done
+if [ "${#roots[@]}" -eq 0 ]; then
+  roots=(.)
+fi
+
+# Only a leading depth bound counts. A token inside -exec or another
+# predicate must not accidentally authorize a broad traversal.
+bounded=0
+if [ "${arguments[$index]:-}" = -maxdepth ]; then
+  case "${arguments[$((index + 1))]:-}" in 0 | 1 | 2) bounded=1 ;; esac
+fi
+depth_options=0
+for argument in "${arguments[@]}"; do
+  case "$argument" in
+    -maxdepth) depth_options=$((depth_options + 1)) ;;
+    -files0-from)
+      echo "Kyber find: use explicit search roots so their scope can be checked." >&2
+      exit 2
+      ;;
+  esac
+done
+if [ "$depth_options" -gt 1 ]; then bounded=0; fi
+if [ "${#arguments[@]}" -eq 1 ]; then
+  case "${arguments[0]}" in --help | --version) exec "$native_find" "$@" ;; esac
+fi
+
+if [ "$bounded" -eq 0 ]; then
+  for root in "${roots[@]}"; do
+    root="$(realpath -m -- "$root")"
+    broad=0
+    case "$root" in
+      / | /home | /root | "$HOME" | "$HOME/.herdr" | "$HOME/.herdr/worktrees" | "$HOME/ghq" | "$HOME/ghq/github.com") broad=1 ;;
+      "$HOME/.herdr/worktrees/"*)
+        remaining="${root#"$HOME/.herdr/worktrees/"}"
+        if [[ "$remaining" != */* ]]; then broad=1; fi
+        ;;
+    esac
+    if [ "$broad" -eq 1 ]; then
+      echo "Kyber find: narrow the search to one project or state directory, or put -maxdepth 0, 1, or 2 before the filters." >&2
+      exit 2
+    fi
+  done
+fi
+exec "$native_find" "$@"

--- a/spec/k3s_service_activate_spec.sh
+++ b/spec/k3s_service_activate_spec.sh
@@ -147,6 +147,7 @@ When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   export KYBER_HOST_HEALTH_STATE_DIR="$state"
   source "$HEALTH_CHECK"
   IO_PRESSURE_UNHEALTHY=1
+  IO_PRESSURE_CURRENT_UNHEALTHY=1
   ORCHESTRATION_IMPLICATED=1
   capture_orchestration_evidence() { printf "%s/evidence/test\n" "$STATE_DIR"; }
   orchestration_control() { test -e "$STATE_DIR/orchestration.frozen"; printf "control:%s\n" "$1"; }
@@ -168,6 +169,7 @@ When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   export KYBER_HOST_HEALTH_STATE_DIR="$state"
   source "$HEALTH_CHECK"
   IO_PRESSURE_UNHEALTHY=1
+  IO_PRESSURE_CURRENT_UNHEALTHY=1
   D_STATE_UNHEALTHY=1
   ORCHESTRATION_IMPLICATED=0
   capture_orchestration_evidence() { printf "%s/evidence/test\n" "$STATE_DIR"; }
@@ -214,6 +216,7 @@ When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   export KYBER_HOST_HEALTH_STATE_DIR="$state"
   source "$HEALTH_CHECK"
   IO_PRESSURE_UNHEALTHY=1
+  IO_PRESSURE_CURRENT_UNHEALTHY=1
   ORCHESTRATION_IMPLICATED=1
   capture_orchestration_evidence() { printf "%s/evidence/test\n" "$STATE_DIR"; }
   orchestration_control() { return 1; }
@@ -296,6 +299,153 @@ When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
 '
 The output should equal ''
 The status should be success
+End
+
+It 'does not freeze from stale host PSI after current stalls have cleared'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  state="$(mktemp -d)"
+  trap "rm -rf \"$state\"" EXIT
+  export KYBER_HOST_HEALTH_STATE_DIR="$state"
+  source "$HEALTH_CHECK"
+  IO_PRESSURE_UNHEALTHY=1
+  IO_PRESSURE_CURRENT_UNHEALTHY=0
+  ORCHESTRATION_IMPLICATED=1
+  orchestration_control() { printf "unexpected:%s\n" "$1"; }
+  capture_orchestration_evidence() { printf "unexpected:capture\n"; }
+  clear_alert() { :; }
+  manage_orchestration_circuit_breaker
+  test ! -e "$state/orchestration.frozen"
+'
+The status should be success
+The output should equal ''
+End
+
+It 'does not freeze on a current spike without sustained host pressure'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  state="$(mktemp -d)"
+  trap "rm -rf \"$state\"" EXIT
+  export KYBER_HOST_HEALTH_STATE_DIR="$state"
+  source "$HEALTH_CHECK"
+  IO_PRESSURE_CURRENT_UNHEALTHY=1
+  ORCHESTRATION_IMPLICATED=1
+  orchestration_control() { printf "unexpected:%s\n" "$1"; }
+  clear_alert() { :; }
+  manage_orchestration_circuit_breaker
+  test ! -e "$state/orchestration.frozen"
+'
+The status should be success
+The output should equal ''
+End
+
+It 'retains the sustained D-state freeze trigger independently of PSI'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  state="$(mktemp -d)"
+  trap "rm -rf \"$state\"" EXIT
+  export KYBER_HOST_HEALTH_STATE_DIR="$state"
+  source "$HEALTH_CHECK"
+  D_STATE_UNHEALTHY=1
+  ORCHESTRATION_IMPLICATED=1
+  capture_orchestration_evidence() { printf "%s/evidence/test\n" "$STATE_DIR"; }
+  orchestration_control() { printf "control:%s\n" "$1"; }
+  set_alert() { :; }
+  clear_alert() { :; }
+  manage_orchestration_circuit_breaker
+  test -e "$state/orchestration.frozen"
+'
+The status should be success
+The output should equal 'control:freeze'
+End
+
+It 'resets recovery for current host PSI or sustained D-state outside orchestration'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  state="$(mktemp -d)"
+  trap "rm -rf \"$state\"" EXIT
+  export KYBER_HOST_HEALTH_STATE_DIR="$state"
+  source "$HEALTH_CHECK"
+  : >"$state/orchestration.frozen"
+  orchestration_control() { printf "unexpected:%s\n" "$1"; }
+  for unhealthy in IO_PRESSURE_CURRENT_UNHEALTHY D_STATE_UNHEALTHY; do
+    IO_PRESSURE_CURRENT_UNHEALTHY=0
+    D_STATE_UNHEALTHY=0
+    printf -v "$unhealthy" %s 1
+    printf "4\n" >"$state/orchestration.recovery-samples"
+    manage_orchestration_circuit_breaker
+    test "$(cat "$state/orchestration.recovery-samples")" = 0
+    test -e "$state/orchestration.frozen"
+  done
+'
+The status should be success
+The output should equal ''
+End
+
+It 'can thaw after five healthy current samples while historical PSI decays'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  state="$(mktemp -d)"
+  trap "rm -rf \"$state\"" EXIT
+  export KYBER_HOST_HEALTH_STATE_DIR="$state"
+  source "$HEALTH_CHECK"
+  IO_PRESSURE_UNHEALTHY=1
+  ORCHESTRATION_IMPLICATED=1
+  : >"$state/orchestration.frozen"
+  printf "4\n" >"$state/orchestration.recovery-samples"
+  orchestration_control() { printf "control:%s\n" "$1"; }
+  clear_alert() { :; }
+  manage_orchestration_circuit_breaker
+  test ! -e "$state/orchestration.frozen"
+'
+The status should be success
+The output should equal 'control:thaw'
+End
+
+It 'requires current cgroup pressure or actual D-state to implicate orchestration'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  state="$(mktemp -d)"
+  trap "rm -rf \"$state\"" EXIT
+  export KYBER_HOST_HEALTH_STATE_DIR="$state"
+  source "$HEALTH_CHECK"
+  orchestration_cgroup_dir() { printf "%s\n" "$state"; }
+  ps() { :; }
+  printf "some avg10=1.00 avg60=10.00 avg300=30.00 total=0\n" >"$state/io.pressure"
+  check_orchestration_pressure
+  test "$ORCHESTRATION_IMPLICATED" = 0
+  printf "some avg10=30.00 avg60=30.00 avg300=30.00 total=0\n" >"$state/io.pressure"
+  check_orchestration_pressure
+  test "$ORCHESTRATION_IMPLICATED" = 1
+  printf "some avg10=0.00 avg60=0.00 avg300=0.00 total=0\n" >"$state/io.pressure"
+  ps() { printf "D 0::/orchestration.slice/test.scope\nD 0::/orchestration.slice/test.scope\nD 0::/orchestration.slice/test.scope\n"; }
+  check_orchestration_pressure
+  test "$ORCHESTRATION_IMPLICATED" = 1
+'
+The status should be success
+The output should equal ''
+End
+
+It 'separates current and historical host PSI using the same thresholds'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  state="$(mktemp -d)"
+  trap "rm -rf \"$state\"" EXIT
+  export KYBER_HOST_HEALTH_STATE_DIR="$state"
+  source "$HEALTH_CHECK"
+  set_alert() { :; }
+  clear_alert() { :; }
+  awk() {
+    local args=("$@") last
+    last=$((${#args[@]} - 1))
+    if [ "${args[$last]}" = /proc/pressure/io ]; then args[$last]="$state/io.pressure"; fi
+    command awk "${args[@]}"
+  }
+  printf "some avg10=1.00 avg60=10.00 avg300=30.00 total=0\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0\n" >"$state/io.pressure"
+  check_io_pressure
+  test "$IO_PRESSURE_UNHEALTHY:$IO_PRESSURE_CURRENT_UNHEALTHY" = 1:0
+  printf "some avg10=30.00 avg60=10.00 avg300=1.00 total=0\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=0\n" >"$state/io.pressure"
+  check_io_pressure
+  test "$IO_PRESSURE_UNHEALTHY:$IO_PRESSURE_CURRENT_UNHEALTHY" = 0:1
+  printf "some avg10=0.00 avg60=0.00 avg300=0.00 total=0\nfull avg10=11.00 avg60=11.00 avg300=11.00 total=0\n" >"$state/io.pressure"
+  check_io_pressure
+  test "$IO_PRESSURE_UNHEALTHY:$IO_PRESSURE_CURRENT_UNHEALTHY" = 1:1
+'
+The status should be success
+The output should equal ''
 End
 
 It 'runs the read-only reliability check every minute'

--- a/tests/test_kyber_find.py
+++ b/tests/test_kyber_find.py
@@ -1,0 +1,101 @@
+"""Exercise the scan guard without traversing any real search root."""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "named-hosts/kyber/find.sh"
+
+
+class KyberFindTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.home = Path(self.temporary.name) / "home"
+        self.home.mkdir()
+        self.project = self.home / "project"
+        self.project.mkdir()
+        self.native = Path(self.temporary.name) / "native-find"
+        self.native.write_text(
+            f"#!{sys.executable}\nimport json, sys\nprint(json.dumps(sys.argv[1:]))\n"
+        )
+        self.native.chmod(0o755)
+
+    def run_find(self, *arguments, cwd=None):
+        return subprocess.run(
+            ["bash", str(SCRIPT), str(self.native), *map(str, arguments)],
+            cwd=cwd or self.project,
+            env=os.environ | {"HOME": str(self.home)},
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+
+    def assert_blocked(self, result):
+        self.assertEqual(result.returncode, 2, result.stderr)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("Kyber find:", result.stderr)
+
+    def test_broad_roots_never_invoke_native_find(self):
+        for root in (
+            "/",
+            "/home",
+            "/root",
+            self.home,
+            self.home / ".herdr",
+            self.home / ".herdr/worktrees",
+            self.home / ".herdr/worktrees/repository",
+        ):
+            with self.subTest(root=root):
+                self.assert_blocked(self.run_find(root, "-name", "state.json"))
+
+    def test_default_root_and_relative_alias_are_checked(self):
+        self.assert_blocked(self.run_find(cwd=self.home))
+        self.assert_blocked(self.run_find("..", "-type", "f"))
+
+    def test_symlink_to_home_is_checked(self):
+        alias = self.project / "alias"
+        alias.symlink_to(self.home)
+        self.assert_blocked(self.run_find("-L", alias, "-type", "f"))
+
+    def test_project_arguments_are_forwarded_exactly(self):
+        args = [str(self.project), "-name", "file with spaces", "-print0"]
+        result = self.run_find(*args)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout), args)
+
+    def test_one_worktree_is_allowed(self):
+        root = self.home / ".herdr/worktrees/repository/worker"
+        result = self.run_find(root, "-type", "f")
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_shallow_inventory_is_allowed(self):
+        for depth in (0, 1, 2):
+            result = self.run_find("-H", self.home, "-maxdepth", depth, "-type", "d")
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_large_or_repeated_depth_does_not_authorize_scan(self):
+        self.assert_blocked(self.run_find("/", "-maxdepth", 3))
+        self.assert_blocked(self.run_find("/", "-maxdepth", 2, "-maxdepth", 99))
+
+    def test_depth_inside_exec_does_not_authorize_scan(self):
+        self.assert_blocked(self.run_find("/", "-exec", "echo", "-maxdepth", 2, ";"))
+
+    def test_one_broad_root_rejects_entire_invocation(self):
+        self.assert_blocked(self.run_find(self.project, self.home, "-print"))
+
+    def test_indirect_roots_are_rejected(self):
+        self.assert_blocked(self.run_find("-files0-from", "roots.txt", "-maxdepth", 1))
+
+    def test_help_and_version_are_allowed_from_home(self):
+        for flag in ("--help", "--version"):
+            self.assertEqual(self.run_find(flag, cwd=self.home).returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Broad filesystem searches launched by T3 providers and SSH sessions run outside the orchestration slice. They can compete with host storage even when review workers and trace uploads are capped. The breaker can also re-freeze recovered work because its five-minute PSI average remains high after current stalls clear.

On Kyber, install a managed `find` guard that rejects recursive discovery from the filesystem root, home roots, and shared worktree collections. Exact project/state paths remain supported; shallow inventories require a leading `-maxdepth 0`, `1`, or `2`. Include the same guard in T3's toolchain.

Add read-only cgroup ceilings for the two execution paths: T3 and its children share 20 MB/s and 200 read IOPS; each current or future logind/SSH session gets 10 MB/s and 100 read IOPS, including commands run through sudo. Shared user services retain their existing limits. SSH budgets are per session, and the command guard is operational guidance rather than a security boundary.

Require current ten-second pressure alongside sustained five-minute pressure before a PSI-triggered freeze, including current orchestration pressure. Preserve the existing thresholds and sustained D-state trigger. Automatic thaw still requires five healthy samples, now explicitly including current host pressure and D-state as well as CRI health.

Validation:
- 11 guard integration tests, 18 T3 ShellSpec examples, and all 70 host-health ShellSpec examples pass. Seven new monitor regression cases cover stale averages, short spikes, current host/slice attribution, D-state freezes, and recovery gating.
- Kyber Nix evaluation and the guard package build pass; Matic has neither the guard nor the T3 read-limit drop-in.
- ShellCheck, Nix formatting, Ruff, whitespace checks, and the scoped secret scan pass.
- Live kernel `io.max` verifies T3, an existing SSH scope, and a newly created harmless session scope. No T3 or user-manager restart was needed. The managed guard rejects a broad home scan in Bash and is selected by Fish.
- The combined existing activation/T3 suite reports 82 passes and one existing failure at `spec/activate_kyber_spec.sh:132`: its Herdr pane-wrapper strings are already absent on base `4716534e3cc96cb0d1def778de5434868bbd4a7f`. This change does not alter that behavior.

The guard, scoped read limits, and tested current-pressure monitor are already active during recovery. The monitor is selected through a task-owned service drop-in until normal configuration activation converges; its timer remains enabled. No K3s restart or CRI object mutation was performed. Rate limits do not guarantee journal latency or eliminate every breaker event. Traces remains disabled.
