### PR TITLE
fix(kyber): scope orchestration recovery to its storage disk

### DIFF
--- a/config/k3s/kyber-host-health.sh
+++ b/config/k3s/kyber-host-health.sh
@@ -14,6 +14,7 @@ readonly IO_SOME_AVG300_THRESHOLD=20
 readonly IO_FULL_AVG300_THRESHOLD=10
 readonly ORCHESTRATION_IO_SOME_AVG300_THRESHOLD=10
 readonly ORCHESTRATION_D_STATE_THRESHOLD=3
+readonly ORCHESTRATION_DISK_LATENCY_THRESHOLD_MS=20
 readonly ORCHESTRATION_FLAP_WINDOW_SECONDS=3600
 readonly ORCHESTRATION_FLAP_THRESHOLD=3
 readonly NODEFS_USAGE_THRESHOLD=70
@@ -29,11 +30,13 @@ readonly DISK_WEAR_CHECK_INTERVAL_SECONDS=21600
 IO_PRESSURE_UNHEALTHY=0
 IO_PRESSURE_CURRENT_UNHEALTHY=0
 D_STATE_UNHEALTHY=0
-CRI_UNHEALTHY=0
 ORCHESTRATION_IMPLICATED=0
 ORCHESTRATION_IO_SOME_AVG10=0
 ORCHESTRATION_IO_SOME_AVG300=0
 ORCHESTRATION_D_STATE_COUNT=0
+ORCHESTRATION_DISK_KNOWN=0
+ORCHESTRATION_DISK_UNHEALTHY=0
+ORCHESTRATION_DISK_SUMMARY="not measured"
 
 set_alert() {
   local key="$1"
@@ -189,7 +192,6 @@ check_cri() {
 
   started_at="$(date +%s)"
   if ! timeout 15 k3s crictl info >/dev/null 2>&1; then
-    CRI_UNHEALTHY=1
     set_alert "cri-health" "k3s crictl info failed or exceeded 15 seconds"
     return
   fi
@@ -200,10 +202,8 @@ check_cri() {
     grep -Eci 'DeadlineExceeded|deadline exceeded|FailedPrecondition|failed precondition|reserved (container )?name|failed to (create|stop|remove).*(sandbox|container)|cgroup.*(busy|failed)' || true)"
 
   if [ "$latency_seconds" -ge "$CRI_LATENCY_THRESHOLD_SECONDS" ] || [ "$error_count" -ge "$CRI_ERROR_THRESHOLD" ]; then
-    CRI_UNHEALTHY=1
     set_alert "cri-health" "CRI latency was ${latency_seconds}s with ${error_count} lifecycle errors in the last five minutes"
   else
-    CRI_UNHEALTHY=0
     clear_alert "cri-health"
   fi
 }
@@ -240,6 +240,8 @@ capture_orchestration_evidence() {
   install -d --mode 0700 "$evidence_root" "$evidence_dir"
 
   cat /proc/pressure/io >"$evidence_dir/io-pressure.txt"
+  cat /proc/diskstats >"$evidence_dir/diskstats.txt"
+  printf '%s\n' "$ORCHESTRATION_DISK_SUMMARY" >"$evidence_dir/worktree-disk.txt"
   ps -eo state,pid,ppid,uid,unit,cgroup,wchan:32,comm,args >"$evidence_dir/processes.txt"
   pidstat -d -p ALL 1 1 >"$evidence_dir/process-io.txt" 2>&1 || true
   systemd-cgtop --batch --iterations=1 --depth=6 --order=io >"$evidence_dir/cgroup-io.txt" 2>&1 || true
@@ -267,10 +269,69 @@ orchestration_cgroup_dir() {
     "$orchestration_uid" "$orchestration_uid" "$ORCHESTRATION_SLICE"
 }
 
-# Host PSI says the disk is saturated; it does not say by whom. Freezing the
-# orchestration slice only helps when the slice itself is stalled or holds the
-# uninterruptible tasks, otherwise the freeze pauses the control plane while
-# k3s, the beads Dolt server, or a pod keeps the host over threshold.
+# Read the physical disk backing the worktrees. Containerd has its own disk;
+# host PSI and CRI health cannot establish congestion on this one.
+orchestration_disk_path() {
+  local device disk
+  device="$(findmnt --noheadings --output MAJ:MIN --target / | tr -d '[:space:]')" || return 1
+  [[ $device =~ ^[0-9]+:[0-9]+$ ]] || return 1
+  disk="$(readlink -f "/sys/dev/block/$device")" || return 1
+  if [ -f "$disk/partition" ]; then
+    disk="$(dirname "$disk")"
+  fi
+  # A stacked device needs attribution to its underlying disks, not a guess.
+  [ -f "$disk/stat" ] && [ ! -d "$disk/dm" ] && [ ! -d "$disk/md" ] || return 1
+  printf '%s\n' "$disk"
+}
+
+read_orchestration_disk_stat() {
+  awk '
+    NF < 17 { exit 1 }
+    { for (i = 1; i <= 17; i++) if ($i !~ /^[0-9]+$/) exit 1 }
+    { print $1, $4, $5, $8, $12, $15, $16, $17, $9; found = 1 }
+    END { if (!found) exit 1 }
+  ' "$1/stat"
+}
+
+check_orchestration_disk() {
+  local disk before after result
+  ORCHESTRATION_DISK_KNOWN=0
+  ORCHESTRATION_DISK_UNHEALTHY=0
+  ORCHESTRATION_DISK_SUMMARY="measurement unavailable"
+  if ! disk="$(orchestration_disk_path)" ||
+    ! before="$(read_orchestration_disk_stat "$disk")"; then
+    set_alert "orchestration-disk-read" "unable to read the worktree disk; automatic freeze and thaw withheld"
+    return
+  fi
+  sleep 2
+  if ! after="$(read_orchestration_disk_stat "$disk")" ||
+    ! result="$(awk -v before="$before" -v after="$after" -v limit="$ORCHESTRATION_DISK_LATENCY_THRESHOLD_MS" '
+      BEGIN {
+        split(before, a); split(after, b)
+        for (i = 1; i <= 8; i++) if (b[i] < a[i]) exit 1
+        reads = b[1] - a[1]; writes = b[3] - a[3]
+        read_ms = reads ? (b[2] - a[2]) / reads : 0
+        write_ms = writes ? (b[4] - a[4]) / writes : 0
+        discards = b[5] - a[5]; flushes = b[7] - a[7]
+        discard_ms = discards ? (b[6] - a[6]) / discards : 0
+        flush_ms = flushes ? (b[8] - a[8]) / flushes : 0
+        stuck = !reads && !writes && !discards && !flushes && a[9] > 0 && b[9] > 0
+        printf "%d read_await=%.2fms write_await=%.2fms discard_await=%.2fms flush_await=%.2fms outstanding=%d", \
+          (read_ms >= limit || write_ms >= limit || discard_ms >= limit || flush_ms >= limit || stuck), \
+          read_ms, write_ms, discard_ms, flush_ms, b[9]
+      }
+    ')"; then
+    set_alert "orchestration-disk-read" "worktree disk counters unavailable or reset; automatic freeze and thaw withheld"
+    return
+  fi
+  ORCHESTRATION_DISK_KNOWN=1
+  ORCHESTRATION_DISK_UNHEALTHY="${result%% *}"
+  ORCHESTRATION_DISK_SUMMARY="$(basename "$disk") ${result#* }"
+  clear_alert "orchestration-disk-read"
+}
+
+# Cgroup PSI can include waiting for its own I/O limits. Combine it with
+# measured worktree-disk latency before treating the slice as a freeze candidate.
 check_orchestration_pressure() {
   local cgroup_dir some_avg10=0 some_avg300=0 d_state_count=0
 
@@ -297,7 +358,7 @@ check_orchestration_pressure() {
 }
 
 orchestration_pressure_summary() {
-  printf 'slice io some avg10=%s avg300=%s, slice D-state=%s' "$ORCHESTRATION_IO_SOME_AVG10" "$ORCHESTRATION_IO_SOME_AVG300" "$ORCHESTRATION_D_STATE_COUNT"
+  printf 'slice io some avg10=%s avg300=%s, slice D-state=%s; worktree disk %s' "$ORCHESTRATION_IO_SOME_AVG10" "$ORCHESTRATION_IO_SOME_AVG300" "$ORCHESTRATION_D_STATE_COUNT" "$ORCHESTRATION_DISK_SUMMARY"
 }
 
 record_orchestration_freeze() {
@@ -341,7 +402,7 @@ manage_orchestration_circuit_breaker() {
   local thaw_failure_alert="orchestration-thaw-failed"
   local evidence_dir recovery_samples=0 newly_frozen=0
 
-  if { { [ "$IO_PRESSURE_UNHEALTHY" -eq 1 ] && [ "$IO_PRESSURE_CURRENT_UNHEALTHY" -eq 1 ]; } || [ "$D_STATE_UNHEALTHY" -eq 1 ]; } && [ "$ORCHESTRATION_IMPLICATED" -eq 1 ]; then
+  if [ "$ORCHESTRATION_DISK_KNOWN" -eq 1 ] && [ "$ORCHESTRATION_DISK_UNHEALTHY" -eq 1 ] && { { [ "$IO_PRESSURE_UNHEALTHY" -eq 1 ] && [ "$IO_PRESSURE_CURRENT_UNHEALTHY" -eq 1 ]; } || [ "$D_STATE_UNHEALTHY" -eq 1 ]; } && [ "$ORCHESTRATION_IMPLICATED" -eq 1 ]; then
     printf '0\n' >"$recovery_file"
     if [ ! -s "$capture_file" ]; then
       evidence_dir="$(capture_orchestration_evidence)"
@@ -380,7 +441,9 @@ manage_orchestration_circuit_breaker() {
     return
   fi
 
-  if [ "$CRI_UNHEALTHY" -eq 1 ] || [ "$IO_PRESSURE_CURRENT_UNHEALTHY" -eq 1 ] || [ "$D_STATE_UNHEALTHY" -eq 1 ]; then
+  # Recovery belongs to the worktree disk. A fault on the separate container
+  # disk remains an alert, but cannot indefinitely suspend unrelated agents.
+  if [ "$ORCHESTRATION_DISK_KNOWN" -ne 1 ] || [ "$ORCHESTRATION_DISK_UNHEALTHY" -eq 1 ]; then
     printf '0\n' >"$recovery_file"
     return
   fi
@@ -457,10 +520,11 @@ main() {
   check_io_pressure
   check_d_state
   check_orchestration_pressure
+  check_orchestration_disk
+  manage_orchestration_circuit_breaker
   check_node_filesystem
   check_image_filesystem
   check_cri
-  manage_orchestration_circuit_breaker
   check_dns
   check_disk_wear
 }

--- a/named-hosts/kyber/README.md
+++ b/named-hosts/kyber/README.md
@@ -204,24 +204,27 @@ initial containment budgets, not latency guarantees; evaluate review completion
 time and disk pressure before tuning them. Desktop review concurrency and limits
 are unchanged. The dedicated containerd disk and K3s remain outside these limits.
 
-When sustained host I/O PSI or D-state pressure crosses the health threshold
-and the slice's own `io.pressure` or D-state count implicates it, the
-host-health check records PSI, process/`wchan`, per-process I/O, cgroup I/O,
-and recent k3s logs under `/run/kyber-host-health/evidence`, then freezes only
-that disposable slice. Host pressure that the slice is not implicated in
-(k3s, containerd, storage) leaves it running. It never freezes or restarts
-k3s, containerd, or storage services. The slice thaws after five consecutive
-pressure-free samples with a healthy CRI probe. Three freezes within an hour
-raise `orchestration-circuit-breaker-flapping`, which means the slice re-trips
-after every thaw and its top writers in the evidence captures need attention
-rather than another auto-thaw.
+The host-health check freezes `orchestration.slice` only when sustained host
+pressure, the slice's own stalls, and congestion on the physical worktree disk
+coincide. It resolves the root filesystem to its physical disk and samples the
+kernel's completion counters over two seconds. Average read, write, flush, or
+discard latency of at least 20 ms, or outstanding I/O with no completions throughout
+the sample, prevents recovery. This latency budget distinguishes storage stalls
+from waiting for the slice's own I/O limits; it is not a service latency promise.
 
-A PSI-triggered freeze requires both the five-minute pressure signal and
-current ten-second pressure to exceed the existing thresholds, including
-current pressure inside orchestration. A stale average alone cannot re-freeze
-a recovered slice. The sustained D-state trigger remains active. Automatic
-thaw requires five consecutive samples with current host pressure, D-state,
-and CRI checks healthy; long averages may decay during recovery.
+The check records PSI, process/`wchan`, per-process I/O, cgroup I/O, and recent
+K3s logs under `/run/kyber-host-health/evidence` before freezing. It never freezes
+or restarts K3s, containerd, or storage services. A PSI-triggered freeze requires
+both five-minute and current ten-second pressure, including current pressure
+inside orchestration. The sustained D-state trigger also requires congestion on
+the worktree disk. Three freezes within an hour raise a flapping alert.
+
+Automatic thaw requires five consecutive healthy worktree-disk samples. Host
+pressure or CRI failures on the separate containerd disk remain health alerts;
+they cannot keep unrelated root-disk agents frozen. Recovery runs before CRI
+checks. Missing, malformed, reset, or unsupported stacked-device measurements
+raise an alert and withhold both new freezes and automatic thaws. Existing I/O
+caps continue to apply throughout.
 
 T3-launched tools and SSH sessions also have read limits outside
 `orchestration.slice`. T3 and its children share 20 MB/s and 200 read IOPS;

--- a/spec/activate_kyber_spec.sh
+++ b/spec/activate_kyber_spec.sh
@@ -415,13 +415,14 @@ The output should include 'clear:disk-wear-sda'
 The output should not include 'unexpected-alert:'
 End
 
-It 'runs CRI and freezer recovery before probing disk endurance'
+It 'runs disk-local freezer recovery before unrelated CRI and endurance probes'
 When run env HEALTH_CHECK="$SCRIPT" bash -c '
   source "$HEALTH_CHECK"
   install() { :; }
   check_io_pressure() { :; }
   check_d_state() { :; }
   check_orchestration_pressure() { :; }
+  check_orchestration_disk() { :; }
   check_node_filesystem() { :; }
   check_image_filesystem() { :; }
   check_cri() { printf "cri\n"; }
@@ -431,6 +432,6 @@ When run env HEALTH_CHECK="$SCRIPT" bash -c '
   main
 '
 The status should be success
-The output should equal "$(printf 'cri\nrecovery\ndns\nsmart')"
+The output should equal "$(printf 'recovery\ncri\ndns\nsmart')"
 End
 End

--- a/spec/k3s_service_activate_spec.sh
+++ b/spec/k3s_service_activate_spec.sh
@@ -146,9 +146,11 @@ When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   state="$(mktemp -d)"
   export KYBER_HOST_HEALTH_STATE_DIR="$state"
   source "$HEALTH_CHECK"
+  ORCHESTRATION_DISK_KNOWN=1
   IO_PRESSURE_UNHEALTHY=1
   IO_PRESSURE_CURRENT_UNHEALTHY=1
   ORCHESTRATION_IMPLICATED=1
+  ORCHESTRATION_DISK_UNHEALTHY=1
   capture_orchestration_evidence() { printf "%s/evidence/test\n" "$STATE_DIR"; }
   orchestration_control() { test -e "$STATE_DIR/orchestration.frozen"; printf "control:%s\n" "$1"; }
   set_alert() { printf "alert:%s:%s\n" "$1" "$2"; }
@@ -168,6 +170,7 @@ When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   state="$(mktemp -d)"
   export KYBER_HOST_HEALTH_STATE_DIR="$state"
   source "$HEALTH_CHECK"
+  ORCHESTRATION_DISK_KNOWN=1
   IO_PRESSURE_UNHEALTHY=1
   IO_PRESSURE_CURRENT_UNHEALTHY=1
   D_STATE_UNHEALTHY=1
@@ -195,6 +198,7 @@ When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   state="$(mktemp -d)"
   export KYBER_HOST_HEALTH_STATE_DIR="$state"
   source "$HEALTH_CHECK"
+  ORCHESTRATION_DISK_KNOWN=1
   set_alert() { printf "alert:%s:%s\n" "$1" "$2"; }
   clear_alert() { printf "clear:%s\n" "$1"; }
   now="$(date +%s)"
@@ -215,9 +219,11 @@ When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   state="$(mktemp -d)"
   export KYBER_HOST_HEALTH_STATE_DIR="$state"
   source "$HEALTH_CHECK"
+  ORCHESTRATION_DISK_KNOWN=1
   IO_PRESSURE_UNHEALTHY=1
   IO_PRESSURE_CURRENT_UNHEALTHY=1
   ORCHESTRATION_IMPLICATED=1
+  ORCHESTRATION_DISK_UNHEALTHY=1
   capture_orchestration_evidence() { printf "%s/evidence/test\n" "$STATE_DIR"; }
   orchestration_control() { return 1; }
   set_alert() { printf "alert:%s:%s\n" "$1" "$2"; }
@@ -234,6 +240,7 @@ When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   state="$(mktemp -d)"
   export KYBER_HOST_HEALTH_STATE_DIR="$state"
   source "$HEALTH_CHECK"
+  ORCHESTRATION_DISK_KNOWN=1
   mkdir -p "$state/evidence"
   for stamp in 20260829T000001Z 20260829T000002Z 20260829T000003Z 20260829T000004Z 20260829T000005Z 20260829T000006Z 20260829T000007Z; do
     mkdir "$state/evidence/$stamp"
@@ -253,6 +260,7 @@ When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   state="$(mktemp -d)"
   export KYBER_HOST_HEALTH_STATE_DIR="$state"
   source "$HEALTH_CHECK"
+  ORCHESTRATION_DISK_KNOWN=1
   : >"$state/orchestration.frozen"
   printf "4\n" >"$state/orchestration.recovery-samples"
   orchestration_control() { printf "control:%s\n" "$1"; }
@@ -271,6 +279,7 @@ When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   state="$(mktemp -d)"
   export KYBER_HOST_HEALTH_STATE_DIR="$state"
   source "$HEALTH_CHECK"
+  ORCHESTRATION_DISK_KNOWN=1
   : >"$state/orchestration.frozen"
   printf "3\n" >"$state/orchestration.recovery-samples"
   orchestration_control() { printf "unexpected:%s\n" "$1"; }
@@ -283,21 +292,24 @@ The output should equal ''
 The status should be success
 End
 
-It 'keeps orchestration frozen while CRI remains unhealthy'
+It 'thaws on a healthy worktree disk even while the separate CRI is unhealthy'
 When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   state="$(mktemp -d)"
+  trap "rm -rf \"$state\"" EXIT
   export KYBER_HOST_HEALTH_STATE_DIR="$state"
   source "$HEALTH_CHECK"
-  CRI_UNHEALTHY=1
+  ORCHESTRATION_DISK_KNOWN=1
+  timeout() { return 1; }
+  set_alert() { printf "alert:%s\n" "$1"; }
+  check_cri
   : >"$state/orchestration.frozen"
   printf "4\n" >"$state/orchestration.recovery-samples"
-  orchestration_control() { printf "unexpected:%s\n" "$1"; }
+  orchestration_control() { printf "control:%s\n" "$1"; }
+  clear_alert() { :; }
   manage_orchestration_circuit_breaker
-  test "$(cat "$state/orchestration.recovery-samples")" = 0
-  test -e "$state/orchestration.frozen"
-  rm -rf "$state"
+  test ! -e "$state/orchestration.frozen"
 '
-The output should equal ''
+The output should equal "$(printf 'alert:cri-health\ncontrol:thaw')"
 The status should be success
 End
 
@@ -307,9 +319,11 @@ When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   trap "rm -rf \"$state\"" EXIT
   export KYBER_HOST_HEALTH_STATE_DIR="$state"
   source "$HEALTH_CHECK"
+  ORCHESTRATION_DISK_KNOWN=1
   IO_PRESSURE_UNHEALTHY=1
   IO_PRESSURE_CURRENT_UNHEALTHY=0
   ORCHESTRATION_IMPLICATED=1
+  ORCHESTRATION_DISK_UNHEALTHY=1
   orchestration_control() { printf "unexpected:%s\n" "$1"; }
   capture_orchestration_evidence() { printf "unexpected:capture\n"; }
   clear_alert() { :; }
@@ -326,8 +340,10 @@ When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   trap "rm -rf \"$state\"" EXIT
   export KYBER_HOST_HEALTH_STATE_DIR="$state"
   source "$HEALTH_CHECK"
+  ORCHESTRATION_DISK_KNOWN=1
   IO_PRESSURE_CURRENT_UNHEALTHY=1
   ORCHESTRATION_IMPLICATED=1
+  ORCHESTRATION_DISK_UNHEALTHY=1
   orchestration_control() { printf "unexpected:%s\n" "$1"; }
   clear_alert() { :; }
   manage_orchestration_circuit_breaker
@@ -343,8 +359,10 @@ When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   trap "rm -rf \"$state\"" EXIT
   export KYBER_HOST_HEALTH_STATE_DIR="$state"
   source "$HEALTH_CHECK"
+  ORCHESTRATION_DISK_KNOWN=1
   D_STATE_UNHEALTHY=1
   ORCHESTRATION_IMPLICATED=1
+  ORCHESTRATION_DISK_UNHEALTHY=1
   capture_orchestration_evidence() { printf "%s/evidence/test\n" "$STATE_DIR"; }
   orchestration_control() { printf "control:%s\n" "$1"; }
   set_alert() { :; }
@@ -356,18 +374,49 @@ The status should be success
 The output should equal 'control:freeze'
 End
 
-It 'resets recovery for current host PSI or sustained D-state outside orchestration'
+It 'does not let pressure on another disk block recovery'
 When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   state="$(mktemp -d)"
   trap "rm -rf \"$state\"" EXIT
   export KYBER_HOST_HEALTH_STATE_DIR="$state"
   source "$HEALTH_CHECK"
+  ORCHESTRATION_DISK_KNOWN=1
+  IO_PRESSURE_UNHEALTHY=1
+  IO_PRESSURE_CURRENT_UNHEALTHY=1
+  D_STATE_UNHEALTHY=1
+  ORCHESTRATION_IMPLICATED=1
   : >"$state/orchestration.frozen"
+  printf "4\n" >"$state/orchestration.recovery-samples"
+  orchestration_control() { printf "control:%s\n" "$1"; }
+  clear_alert() { :; }
+  manage_orchestration_circuit_breaker
+  test ! -e "$state/orchestration.frozen"
+'
+The status should be success
+The output should equal 'control:thaw'
+End
+
+It 'withholds freezing without disk attribution and recovery without a healthy disk'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  state="$(mktemp -d)"
+  trap "rm -rf \"$state\"" EXIT
+  export KYBER_HOST_HEALTH_STATE_DIR="$state"
+  source "$HEALTH_CHECK"
+  IO_PRESSURE_UNHEALTHY=1
+  IO_PRESSURE_CURRENT_UNHEALTHY=1
+  ORCHESTRATION_IMPLICATED=1
   orchestration_control() { printf "unexpected:%s\n" "$1"; }
-  for unhealthy in IO_PRESSURE_CURRENT_UNHEALTHY D_STATE_UNHEALTHY; do
-    IO_PRESSURE_CURRENT_UNHEALTHY=0
-    D_STATE_UNHEALTHY=0
-    printf -v "$unhealthy" %s 1
+  clear_alert() { :; }
+  for flags in "0 0" "1 0"; do
+    read -r ORCHESTRATION_DISK_KNOWN ORCHESTRATION_DISK_UNHEALTHY <<<"$flags"
+    manage_orchestration_circuit_breaker
+    test ! -e "$state/orchestration.frozen"
+  done
+  IO_PRESSURE_UNHEALTHY=0
+  IO_PRESSURE_CURRENT_UNHEALTHY=0
+  : >"$state/orchestration.frozen"
+  for flags in "0 0" "1 1"; do
+    read -r ORCHESTRATION_DISK_KNOWN ORCHESTRATION_DISK_UNHEALTHY <<<"$flags"
     printf "4\n" >"$state/orchestration.recovery-samples"
     manage_orchestration_circuit_breaker
     test "$(cat "$state/orchestration.recovery-samples")" = 0
@@ -384,6 +433,7 @@ When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   trap "rm -rf \"$state\"" EXIT
   export KYBER_HOST_HEALTH_STATE_DIR="$state"
   source "$HEALTH_CHECK"
+  ORCHESTRATION_DISK_KNOWN=1
   IO_PRESSURE_UNHEALTHY=1
   ORCHESTRATION_IMPLICATED=1
   : >"$state/orchestration.frozen"
@@ -403,6 +453,7 @@ When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   trap "rm -rf \"$state\"" EXIT
   export KYBER_HOST_HEALTH_STATE_DIR="$state"
   source "$HEALTH_CHECK"
+  ORCHESTRATION_DISK_KNOWN=1
   orchestration_cgroup_dir() { printf "%s\n" "$state"; }
   ps() { :; }
   printf "some avg10=1.00 avg60=10.00 avg300=30.00 total=0\n" >"$state/io.pressure"
@@ -426,6 +477,7 @@ When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   trap "rm -rf \"$state\"" EXIT
   export KYBER_HOST_HEALTH_STATE_DIR="$state"
   source "$HEALTH_CHECK"
+  ORCHESTRATION_DISK_KNOWN=1
   set_alert() { :; }
   clear_alert() { :; }
   awk() {
@@ -443,6 +495,77 @@ When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   printf "some avg10=0.00 avg60=0.00 avg300=0.00 total=0\nfull avg10=11.00 avg60=11.00 avg300=11.00 total=0\n" >"$state/io.pressure"
   check_io_pressure
   test "$IO_PRESSURE_UNHEALTHY:$IO_PRESSURE_CURRENT_UNHEALTHY" = 1:1
+'
+The status should be success
+The output should equal ''
+End
+
+It 'classifies disk latency from actual counter deltas, including outstanding I/O'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  state="$(mktemp -d)"
+  trap "rm -rf \"$state\"" EXIT
+  export KYBER_HOST_HEALTH_STATE_DIR="$state"
+  source "$HEALTH_CHECK"
+  orchestration_disk_path() { printf "%s\n" "$state"; }
+  set_alert() { printf "unexpected-alert:%s\n" "$1"; }
+  clear_alert() { :; }
+  sleep() { cp "$state/after" "$state/stat"; }
+  for row in \
+    "110 0 1000 110 110 0 1000 110 0 10000 10000 0 0 0 0 0 0:0" \
+    "110 0 1000 310 110 0 1000 110 0 10000 10000 0 0 0 0 0 0:1" \
+    "110 0 1000 110 110 0 1000 310 0 10000 10000 0 0 0 0 0 0:1" \
+    "100 0 1000 100 100 0 1000 100 1 10000 10000 0 0 0 0 0 0:1" \
+    "100 0 1000 100 100 0 1000 100 0 10000 10000 0 0 0 0 0 0:0" \
+    "110 0 1000 110 110 0 1000 110 0 10000 10000 0 0 0 0 1 21:1" \
+    "110 0 1000 110 110 0 1000 110 0 10000 10000 1 0 1 21 0 0:1"; do
+    printf "100 0 1000 100 100 0 1000 100 1 10000 10000 0 0 0 0 0 0\n" >"$state/stat"
+    printf "%s\n" "${row%:*}" >"$state/after"
+    check_orchestration_disk
+    test "$ORCHESTRATION_DISK_KNOWN:$ORCHESTRATION_DISK_UNHEALTHY" = "1:${row##*:}"
+  done
+'
+The status should be success
+The output should equal ''
+End
+
+It 'does not treat missing, reset or malformed disk counters as recovery'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  state="$(mktemp -d)"
+  trap "rm -rf \"$state\"" EXIT
+  export KYBER_HOST_HEALTH_STATE_DIR="$state"
+  source "$HEALTH_CHECK"
+  orchestration_disk_path() { printf "%s\n" "$state"; }
+  set_alert() { test "$1" = orchestration-disk-read; }
+  clear_alert() { printf "unexpected-clear:%s\n" "$1"; }
+  sleep() { cp "$state/after" "$state/stat"; }
+  for row in "99 0 1000 100 100 0 1000 100 0 10000 10000 0 0 0 0 0 0" "bad counters" ""; do
+    printf "100 0 1000 100 100 0 1000 100 0 10000 10000 0 0 0 0 0 0\n" >"$state/stat"
+    printf "%s\n" "$row" >"$state/after"
+    ORCHESTRATION_DISK_KNOWN=1
+    check_orchestration_disk
+    test "$ORCHESTRATION_DISK_KNOWN" = 0
+  done
+  orchestration_disk_path() { return 1; }
+  check_orchestration_disk
+  test "$ORCHESTRATION_DISK_KNOWN" = 0
+'
+The status should be success
+The output should equal ''
+End
+
+It 'resolves the physical root disk and refuses unsupported stacked devices'
+When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
+  state="$(mktemp -d)"
+  trap "rm -rf \"$state\"" EXIT
+  source "$HEALTH_CHECK"
+  mkdir -p "$state/disk/partition"
+  : >"$state/disk/stat"
+  : >"$state/disk/partition/partition"
+  findmnt() { test "$*" = "--noheadings --output MAJ:MIN --target /"; printf "  8:18 \n"; }
+  readlink() { test "$*" = "-f /sys/dev/block/8:18"; printf "%s/disk/partition\n" "$state"; }
+  test "$(orchestration_disk_path)" = "$state/disk"
+  mkdir "$state/disk/dm"
+  if orchestration_disk_path; then exit 1; fi
 '
 The status should be success
 The output should equal ''
@@ -530,6 +653,7 @@ HEALTH_CHECK="$PWD/config/k3s/kyber-host-health.sh"
 It 'clears the alert after available space recovers above 200 GiB'
 When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   source "$HEALTH_CHECK"
+  ORCHESTRATION_DISK_KNOWN=1
   df() {
     case "$*" in
       *--output=avail*) printf "Avail\n%s\n" "$((201 * 1024 * 1024 * 1024))" ;;
@@ -547,6 +671,7 @@ End
 It 'alerts at the 200 GiB warning threshold'
 When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   source "$HEALTH_CHECK"
+  ORCHESTRATION_DISK_KNOWN=1
   df() {
     case "$*" in
       *--output=avail*) printf "Avail\n%s\n" "$((200 * 1024 * 1024 * 1024))" ;;
@@ -564,6 +689,7 @@ End
 It 'alerts at seventy percent root usage with ample absolute headroom'
 When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   source "$HEALTH_CHECK"
+  ORCHESTRATION_DISK_KNOWN=1
   df() {
     case "$*" in
       *--output=avail*) printf "Avail\n%s\n" "$((500 * 1024 * 1024 * 1024))" ;;
@@ -581,6 +707,7 @@ End
 It 'alerts without clearing on malformed available-space output'
 When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   source "$HEALTH_CHECK"
+  ORCHESTRATION_DISK_KNOWN=1
   df() { printf "Avail\nnot-a-number\n"; }
   set_alert() { printf "alert:%s:%s\n" "$1" "$2"; }
   clear_alert() { printf "clear:%s\n" "$1"; }
@@ -593,6 +720,7 @@ End
 It 'alerts without aborting when df fails'
 When run env HEALTH_CHECK="$HEALTH_CHECK" bash -c '
   source "$HEALTH_CHECK"
+  ORCHESTRATION_DISK_KNOWN=1
   df() { return 1; }
   set_alert() { printf "alert:%s:%s\n" "$1" "$2"; }
   clear_alert() { printf "clear:%s\n" "$1"; }


### PR DESCRIPTION
Host-wide I/O pressure and container-runtime failures could prevent orchestration from recovering even while its separate worktree disk was healthy. Require measured congestion on the physical root disk before freezing, and thaw after five healthy samples from that disk. Keep host and CRI alerts, resource caps, current/sustained PSI checks, and incident evidence.

The disk probe samples read, write, discard, and flush latency over two seconds with a 20 ms budget, and detects outstanding I/O without completions. Missing, reset, malformed, or unsupported stacked-device measurements withhold automatic freezes and thaws. Recovery runs before unrelated CRI probes.

Validation: 82 focused ShellSpec examples pass; ShellCheck, diff checks, and scoped Gitleaks pass; the generated Nix health-check package and service build successfully. Live read-only probes resolve the root partition to its physical disk and report healthy latency while the container disk is busy.

This retains automatic freezing for worktree-disk congestion. It does not implement admission-only control or retire cluster workloads. The new monitor has not been activated.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes orchestration freeze and thaw decisions to the physical disk that backs the worktrees, so host-wide pressure or CRI failures on the separate container disk no longer keep orchestration frozen while the worktree disk is healthy.

**Behavior changes**
- Freezing now also requires measured worktree-disk latency above 20 ms (read, write, discard, or flush) or stuck I/O, on top of the existing pressure checks.
- Thawing now requires five consecutive healthy samples from the worktree disk.
- Missing, malformed, reset, or unsupported stacked-device measurements withhold automatic freezes and thaws and raise an alert.
- CRI and host pressure alerts still fire but no longer reset recovery on the healthy worktree disk.
- Recovery now runs before unrelated CRI probes.
- The new disk probe is not activated yet.

<sup>Written for commit 1d6d82d3040e8ffe7b39160d839a504638332de0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

