### PR TITLE
fix(roborev): move automatic PR polling to Matic

### DIFF
--- a/config/roborev/default.nix
+++ b/config/roborev/default.nix
@@ -9,7 +9,7 @@ let
   hydrateScript =
     let
       vars = {
-        ciEnabled = if inputs.host.isKyber then "true" else "false";
+        ciEnabled = if inputs.host.isMatic then "true" else "false";
         maxWorkers = if inputs.host.isKyber then "1" else "4";
         sed = "${pkgs.gnused}/bin/sed";
         template = "${./config.template.toml}";

--- a/spec/activate_roborev_spec.sh
+++ b/spec/activate_roborev_spec.sh
@@ -53,8 +53,8 @@ The output should include 'isGalactica || isKyber || isMatic'
 End
 
 It 'selects CI polling by host'
-When run bash -c "grep 'ciEnabled = if inputs.host.isKyber then \"true\" else \"false\";' '$PWD/config/roborev/default.nix'"
-The output should include 'ciEnabled = if inputs.host.isKyber then "true" else "false";'
+When run bash -c "grep 'ciEnabled = if inputs.host.isMatic then \"true\" else \"false\";' '$PWD/config/roborev/default.nix'"
+The output should include 'ciEnabled = if inputs.host.isMatic then "true" else "false";'
 End
 
 It 'serializes Kyber review workers'


### PR DESCRIPTION
Move automatic repository-wide PR polling from Kyber to Matic. The existing host selector now enables CI polling only on Matic; worker limits remain one on Kyber and four on Matic. Explicit and post-commit review configuration is unchanged.

Validation: 33 existing activation/hydration ShellSpec examples pass, Nix formatting and scoped Gitleaks pass, and direct evaluation of the owning Nix module with host/tool fixtures selects Kyber=false, Matic=true, other=false with unchanged worker counts. Full-system evaluation was stopped after it stalled; no full-system evaluation pass is claimed.

Runtime handoff is verified: Kyber stopped its poller before Matic started; Matic has enqueued PR panels and completed a review. Existing queued work was retained. Matic configuration was updated only in its CI section, preserving its review defaults and unrelated checkout edits.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves automatic PR polling from Kyber to Matic. CI polling is now enabled only when the host is Matic; worker limits stay at one on Kyber and four on Matic, and explicit and post-commit review configuration is unchanged.

<sup>Written for commit 1ecc79913fc15b37d03a97db15366dea1df1b7df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

