### PR TITLE
fix(k3s): bound backup cluster disk contention

### DIFF
--- a/config/k3s/default.nix
+++ b/config/k3s/default.nix
@@ -95,6 +95,14 @@ in
     force = true;
   };
 
+  home.file.".config/k3s/k3s-io.conf" = lib.mkIf isKyber {
+    source = ./k3s-io.conf;
+  };
+
+  home.file.".config/k3s/kubepods-io.conf" = lib.mkIf isKyber {
+    source = ./kubepods-io.conf;
+  };
+
   home.file.".config/k3s/var-lib-rancher-k3s-agent-containerd.mount" = lib.mkIf isKyber {
     source = ./containerd.mount;
     force = true;

--- a/config/k3s/k3s-io.conf
+++ b/config/k3s/k3s-io.conf
@@ -1,0 +1,10 @@
+[Service]
+# The backup cluster yields disk capacity to host services.
+IOAccounting=yes
+IOWeight=25
+IOReadBandwidthMax=/ 4194304
+IOWriteBandwidthMax=/ 2097152
+IOReadIOPSMax=/ 100
+IOWriteIOPSMax=/ 100
+# Container images use a separate filesystem from the root/control-plane state.
+IOWriteBandwidthMax=/var/lib/rancher/k3s/agent/containerd 5242880

--- a/config/k3s/kubepods-io.conf
+++ b/config/k3s/kubepods-io.conf
@@ -1,0 +1,8 @@
+[Slice]
+# Pod I/O is outside k3s.service, so it needs its own aggregate budget.
+IOAccounting=yes
+IOWeight=25
+IOReadBandwidthMax=/ 4194304
+IOWriteBandwidthMax=/ 2097152
+IOReadIOPSMax=/ 100
+IOWriteIOPSMax=/ 100

--- a/home-manager/services/k3s/activate.sh
+++ b/home-manager/services/k3s/activate.sh
@@ -11,6 +11,8 @@ HEALTH_SERVICE_FILE="$5"
 HEALTH_TIMER_FILE="$6"
 SMARTD_SERVICE_FILE="$7"
 TMP_MOUNT_FILE="$8"
+RUNTIME_IO_FILE="$9"
+PODS_IO_FILE="${10}"
 SYSTEM_SERVICE="/etc/systemd/system/k3s.service"
 SYSTEM_MOUNT="/etc/systemd/system/var-lib-rancher-k3s-agent-containerd.mount"
 SYSTEM_JOURNALD="/etc/systemd/journald.conf.d/10-kyber-limits.conf"
@@ -18,6 +20,8 @@ SYSTEM_HEALTH_SERVICE="/etc/systemd/system/kyber-host-health.service"
 SYSTEM_HEALTH_TIMER="/etc/systemd/system/kyber-host-health.timer"
 SYSTEM_SMARTD_SERVICE="/etc/systemd/system/kyber-smartd.service"
 SYSTEM_TMP_MOUNT="/etc/systemd/system/tmp.mount"
+SYSTEM_RUNTIME_IO="/etc/systemd/system/k3s.service.d/50-kyber-io.conf"
+SYSTEM_PODS_IO="/etc/systemd/system/kubepods.slice.d/50-kyber-io.conf"
 SMARTCTL_LINK="/usr/local/bin/smartctl"
 MOUNT_POINT="/var/lib/rancher/k3s/agent/containerd"
 EXPECTED_CONTAINERD_UUID="90f29a7b-38ff-460b-b534-92a02f1412ec"
@@ -147,7 +151,9 @@ for systemd_file_pair in \
   "$HEALTH_SERVICE_FILE:$SYSTEM_HEALTH_SERVICE" \
   "$HEALTH_TIMER_FILE:$SYSTEM_HEALTH_TIMER" \
   "$SMARTD_SERVICE_FILE:$SYSTEM_SMARTD_SERVICE" \
-  "$TMP_MOUNT_FILE:$SYSTEM_TMP_MOUNT"; do
+  "$TMP_MOUNT_FILE:$SYSTEM_TMP_MOUNT" \
+  "$RUNTIME_IO_FILE:$SYSTEM_RUNTIME_IO" \
+  "$PODS_IO_FILE:$SYSTEM_PODS_IO"; do
   source_file="${systemd_file_pair%%:*}"
   target_file="${systemd_file_pair#*:}"
   if sync_root_file "$source_file" "$target_file"; then

--- a/home-manager/services/k3s/default.nix
+++ b/home-manager/services/k3s/default.nix
@@ -25,6 +25,8 @@ let
   healthTimerFile = "${homeDir}/.config/k3s/kyber-host-health.timer";
   smartdServiceFile = "${homeDir}/.config/k3s/kyber-smartd.service";
   tmpMountFile = "${homeDir}/.config/k3s/tmp.mount";
+  runtimeIoFile = "${homeDir}/.config/k3s/k3s-io.conf";
+  podsIoFile = "${homeDir}/.config/k3s/kubepods-io.conf";
 in
 lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && host.isK3sServer) {
   home.activation.setupK3s = config.lib.dag.entryAfter [ "writeBoundary" ] ''
@@ -36,6 +38,8 @@ lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && host.isK3sServer) {
       "${healthServiceFile}" \
       "${healthTimerFile}" \
       "${smartdServiceFile}" \
-      "${tmpMountFile}"
+      "${tmpMountFile}" \
+      "${runtimeIoFile}" \
+      "${podsIoFile}"
   '';
 }


### PR DESCRIPTION
The backup cluster currently has no disk budget, allowing runtime and pod I/O to compete with host services. Add Kyber-only systemd drop-ins for both `k3s.service` and `kubepods.slice`, installed by the existing activation path.

- Both groups: I/O weight 25; root reads/writes capped at 4/2 MiB/s and 100/100 IOPS per group.
- K3s/containerd: dedicated container filesystem writes capped at 5 MiB/s.
- A systemd configuration reload applies the limits to running groups. Host services and other cluster hosts are outside these controls.

Validation: 104 focused ShellSpec examples passed; ShellCheck, Bash syntax, Nix formatting, and whitespace checks passed; Kyber configuration evaluation and `eval-home-kyber` build passed; Andor evaluation confirms both budget files are absent. A temporary real systemd service and slice verified the exact kernel `io.max`, `io.weight`, and `io.bfq.weight` values after reload with the process PID unchanged; proof units were removed.

The budgets prioritize host availability at the cost of slower backup-cluster work. They bound disk demand but do not guarantee zero latency on shared hardware. Applied on Kyber from the merged files: both live kernel groups match the configured limits and weights; K3s and protected host-service PIDs remained unchanged. Three subsequent Beads probes passed in 10–29 ms; CLIProxy returned HTTP 200 on all three checks; remote Beads access and Kubernetes API readiness also passed. Guarded rollback is retained on the host. Broader hosted CI was still pending at the authorized admin merge.
