### PR TITLE
feat(kamino): make tailnet membership the SSH authentication gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,13 @@ cp -rf source dest          # NOT: cp -r source dest
 - Do not embed incident-specific migrations, recovery commands, or temporary repair workarounds into recurring services or activation scripts.
 - Before adding cross-host SSH access, verify the existing trust and provisioning model. Inbound `authorized_keys` does not provide an outbound private identity. Keep reverse access machine-local when existing trust is machine-local unless declarative management is explicitly requested. Approval for access does not imply approval to expand its persistence or scope.
 
+## Tailnet Access Policy
+
+- The tailnet ACL is operator-owned. Never edit, apply, or attempt to apply it, and never use a Tailscale API credential to change policy. Agents may read `tailscale status` and local preferences for diagnosis only.
+- A change that depends on an ACL rule is delivered as configuration plus the exact rule the operator must add. State the rule; do not apply it and do not treat its absence as a failure to work around.
+- Tailscale SSH rules must use `"action": "accept"`. `"check"` requires a browser re-authentication, which every non-interactive client fails.
+- Tailscale SSH intercepts tailnet-originated port 22 and does not fall through to OpenSSH when the ACL denies. Enabling it on a host whose clients the ACL does not cover locks them out. Enable one host, prove a real connection, then roll forward.
+
 ## Repository Privacy Guidance
 
 - Never record private repository names, identifiers, checkout paths, or references in any tracked file, documentation, fixture, example, log, or generated configuration in this repository.

--- a/named-hosts/kamino/README.md
+++ b/named-hosts/kamino/README.md
@@ -25,18 +25,34 @@ The installer runs the host-specific Tailscale enrollment command during its
 `make nix-switch` phase:
 
 ```sh
-tailscale up --hostname=kamino1 --accept-dns=true --ssh=false
+tailscale up --hostname=kamino1 --accept-dns=true --ssh=true
 ```
 
 On a fresh machine, follow the login URL printed during activation and choose
 the intended tailnet. On an enrolled machine, the command reapplies the declared
 name and preferences without creating a new device.
 
-This keeps the existing OpenSSH server/login policy, not Tailscale SSH. Activation
-adds the declared Galactica public key from `named-hosts/pubkeys.nix` to root's
-`authorized_keys`, preserving provider keys and other existing entries. It sets
-the SSH directory/file permissions to `700`/`600` and does not copy private keys.
-Clients with a different key still need that public key provisioned separately.
+Tailnet membership is the authentication gate: `--ssh=true` puts Tailscale SSH
+in front of port 22 for tailnet-originated connections, so a newly provisioned
+worker authorizes its clients from the tailnet ACL rather than from distributed
+key material. The ACL must grant `root` on these hosts with `"action": "accept"`;
+`"check"` demands a browser re-authentication that any non-interactive client
+fails. **Tailnet ACL edits are operator-owned** (see [AGENTS.md](../../AGENTS.md)).
+
+Tailscale SSH does not fall through to OpenSSH when the ACL denies, so a rule
+that does not cover a client locks it out of root over the tailnet. Enable one
+worker first, prove a real connection, then roll the rest forward.
+
+Activation still adds the declared client public keys from
+`named-hosts/pubkeys.nix` to root's `authorized_keys`, preserving provider keys
+and other existing entries. They are the recovery path if Tailscale SSH is
+turned back off; they are not consulted while it is on. Activation sets the SSH
+directory/file permissions to `700`/`600` and does not copy private keys.
+
+Each client keeps its own `known_hosts` entry for these workers. Tailscale SSH
+presents a different host key than OpenSSH, and `StrictHostKeyChecking
+accept-new` refuses a changed key, so run `ssh-keygen -R <worker>.<tailnet>`
+once per client after enabling it.
 Preserve each machine's `/var/lib/tailscale`, `/etc/ssh`, `/etc/machine-id`, and
 `/root` across restart/recreation. Never clone enrolled Tailscale state or SSH
 private host keys into a second machine. DNS names alone are not cryptographic
@@ -199,7 +215,7 @@ The final command below is run automatically by `make nix-switch`:
 ```sh
 hostname                          # must print kamino1
 systemctl is-active tailscaled    # must print active
-tailscale up --hostname=kamino1 --accept-dns=true --ssh=false
+tailscale up --hostname=kamino1 --accept-dns=true --ssh=true
 ```
 
 Open the login URL printed by the switch in your browser and choose the intended

--- a/named-hosts/kamino/activate.sh
+++ b/named-hosts/kamino/activate.sh
@@ -22,16 +22,20 @@ authorize-ssh)
   key_file="${2:?public key file required}"
   ssh_dir="${3:?SSH directory required}"
   ssh_keygen="${4:?ssh-keygen binary required}"
-  key="$(cat "$key_file")"
   "$ssh_keygen" -lf "$key_file" >/dev/null
   mkdir -p "$ssh_dir"
   chmod 700 "$ssh_dir"
   touch "$ssh_dir/authorized_keys"
   chmod 600 "$ssh_dir/authorized_keys"
   chown root:root "$ssh_dir" "$ssh_dir/authorized_keys"
-  if ! grep -qxF "$key" "$ssh_dir/authorized_keys"; then
-    printf '\n%s\n' "$key" >>"$ssh_dir/authorized_keys"
-  fi
+  # The key file holds one client per line, so match per line: a whole-file
+  # comparison would re-append every key whenever any one of them changed.
+  while IFS= read -r key; do
+    [ -n "$key" ] || continue
+    if ! grep -qxF "$key" "$ssh_dir/authorized_keys"; then
+      printf '\n%s\n' "$key" >>"$ssh_dir/authorized_keys"
+    fi
+  done <"$key_file"
   ;;
 user-manager)
   hostnamectl set-hostname "${2:?name required}"

--- a/named-hosts/kamino/default.nix
+++ b/named-hosts/kamino/default.nix
@@ -23,13 +23,27 @@ let
     k3s = null;
     nodeName = name;
   };
+  # Tailscale SSH makes tailnet membership the authentication gate, so a newly
+  # provisioned worker needs no key distribution at all. It also carries the
+  # clients that cannot present a key: Crabbox runs every transfer under a
+  # generated `ssh -F` config excluding ~/.ssh/config, and auth lands on the
+  # `none` method before publickey is ever offered.
   tailscaleUpArgs = [
     "--hostname=${name}"
     "--accept-dns=true"
-    "--ssh=false"
+    "--ssh=true"
   ];
-  authorizedKey = pkgs.writeText "kamino-authorized-key.pub" (
-    (import ../pubkeys.nix).galactica + "\n"
+  pubkeys = import ../pubkeys.nix;
+  # Every client that drives a Kamino worker over SSH. Tailscale SSH authorizes
+  # them from the tailnet ACL, so these are the recovery path for turning it
+  # back off, not the live gate.
+  authorizedClients = [
+    "galactica"
+    "kyber"
+    "matic"
+  ];
+  authorizedKey = pkgs.writeText "kamino-authorized-keys.pub" (
+    pkgs.lib.concatMapStrings (client: pubkeys.${client} + "\n") authorizedClients
   );
 in
 inputs.home-manager.lib.homeManagerConfiguration {

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -291,7 +291,7 @@ let
         assert lib.hasInfix "tailscale kamino100" cfg.home.activation.configureKaminoTailscale.data;
         assert lib.hasInfix "--hostname=kamino100" cfg.home.activation.configureKaminoTailscale.data;
         assert lib.hasInfix "--accept-dns=true" cfg.home.activation.configureKaminoTailscale.data;
-        assert lib.hasInfix "--ssh=false" cfg.home.activation.configureKaminoTailscale.data;
+        assert lib.hasInfix "--ssh=true" cfg.home.activation.configureKaminoTailscale.data;
         assert !(cfg.systemd.user.services ? dolt);
         assert !(cfg.systemd.user.services ? dolt-federation-sync);
         assert !(cfg.systemd.user.services ? dolt-linear-sync);

--- a/tests/test_kamino_activation.py
+++ b/tests/test_kamino_activation.py
@@ -40,7 +40,7 @@ class ActivationTests(unittest.TestCase):
                     [
                         "--hostname=kamino100",
                         "--accept-dns=true",
-                        "--ssh=false",
+                        "--ssh=true",
                     ]
                 )
             result = subprocess.run(
@@ -85,7 +85,7 @@ class ActivationTests(unittest.TestCase):
         result, log = self.run_phase("tailscale")
         self.assertEqual(result.returncode, 0)
         self.assertEqual(
-            log, ["tailscale up --hostname=kamino100 --accept-dns=true --ssh=false"]
+            log, ["tailscale up --hostname=kamino100 --accept-dns=true --ssh=true"]
         )
         result, _ = self.run_phase("tailscale", fail="tailscale")
         self.assertEqual(result.returncode, 3)
@@ -169,6 +169,27 @@ class AuthorizedKeyTests(unittest.TestCase):
         self.assertEqual(
             authorized.read_text().splitlines(),
             [existing, self.public_key.read_text().strip()],
+        )
+
+    def test_multiple_keys_each_authorize_independently(self):
+        second = self.root / "second"
+        subprocess.run(
+            [self.ssh_keygen, "-q", "-t", "ed25519", "-N", "", "-f", str(second)],
+            check=True,
+            capture_output=True,
+        )
+        first_key = self.public_key.read_text().strip()
+        second_key = Path(str(second) + ".pub").read_text().strip()
+        self.public_key.write_text(first_key + "\n" + second_key + "\n")
+        self.ssh_dir.mkdir()
+        authorized = self.ssh_dir / "authorized_keys"
+        authorized.write_text(first_key + "\n")
+        for _ in range(2):
+            result = self.authorize()
+            self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            authorized.read_text().splitlines(),
+            [first_key, "", second_key],
         )
 
     def test_invalid_public_key_fails_before_creating_ssh_directory(self):


### PR DESCRIPTION
## Summary

Enable Tailscale SSH on the Kamino workers, making tailnet membership the authentication gate. A newly provisioned worker then needs no key distribution at all.

This replaces the three-PR stack (#2736 -> #2737 -> #2739) with its net result. That stack added an age-encrypted private SSH key and then deleted it two commits later; merging it would have embedded the key in git history permanently for zero net benefit.

## Why

Crabbox renders its own `ssh_config` per transfer and runs `ssh -F` against it, so it never reads `~/.ssh/config` and cannot be pointed at an identity from the outside. Tailscale SSH authenticates such a client on the `none` method, before publickey is ever offered.

## Changes

- `named-hosts/kamino/default.nix`: `--ssh=true`; `authorizedClients` covers galactica, kyber and matic.
- `named-hosts/kamino/activate.sh`: match `authorized_keys` per line, so changing one client no longer re-appends the others.
- `AGENTS.md`: record the tailnet ACL as operator-owned.
- `named-hosts/kamino/README.md`: document the gate, the `"action": "accept"` requirement, and the lockout risk.
- Tests updated for `--ssh=true`.

## Verification

Proven end to end before merge, with Tailscale SSH enabled on kamino4 only behind a 420s dead-man switch:

- galactica -> kamino4, no key: `remote software version Tailscale` / `Authenticated ... using "none"`.
- matic -> kamino4, `-o IdentityFile=none`: same, `root@kamino4`.
- A real delegated Crabbox run from galactica with `CRABBOX_SSH_KEY` unset: `sync complete in 1m4.64s`, `exit=0`, including the `finalize` step that runs under `env -i`.

Local gates: `nix fmt --fail-on-change` clean, `eval-home-kamino` and `eval-home-kamino100` build, 7/8 activation tests pass (the failure is pre-existing on `origin/main`).

Stacked on #2740, which fixes the formatter failure present on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Tailscale SSH on Kamino workers so tailnet membership is the SSH authentication gate and a newly provisioned worker needs no key distribution.

- Crabbox cannot present an identity (it runs `ssh` with its own `-F` config excluding `~/.ssh/config`), and Tailscale SSH authenticates it on the `none` method before publickey is offered.
- The `authorized_keys` entries stay as a recovery path for turning Tailscale SSH off; the activation script now matches them per line so changing one client no longer re-appends the rest.
- The tailnet ACL must grant `root` with `"action": "accept"`; `"check"` requires a browser login that every non-interactive client fails.
- The ACL is operator-owned: this PR documents the required rule and does not apply it.
- Tailscale SSH does not fall through to OpenSSH when denied, so enable one host first and prove a real connection to avoid locking out clients the ACL does not cover.
- Clients see a different host key once Tailscale SSH is on; run `ssh-keygen -R <worker>.<tailnet>` once per client.

<sup>Written for commit 4203bd6d96761e32dd42655f139fb179e8854123. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

