### PR TITLE
fix(beads): keep one oversized Bead from failing every Linear sync

### DIFF
--- a/config/codex/merge-orchestration-hooks.sh
+++ b/config/codex/merge-orchestration-hooks.sh
@@ -16,7 +16,9 @@ if [ -z "$ORCHESTRATION_BIN" ]; then
   exit 0
 fi
 
-if ! rendered="$("$ORCHESTRATION_BIN" hooks render --harness codex)"; then
+# The renderer runs before the activation phase that puts Bun on PATH, and its
+# shebang resolves Bun through env, so supply the interpreter directory here.
+if ! rendered="$(PATH="$HOME/.bun/bin:$HOME/.local/bin:${PATH:-}" "$ORCHESTRATION_BIN" hooks render --harness codex)"; then
   echo "error: failed to render live Codex orchestration hooks" >&2
   exit 1
 fi

--- a/home-manager/services/dolt/linear-sync.sh
+++ b/home-manager/services/dolt/linear-sync.sh
@@ -8,6 +8,11 @@ linear_cli="@linear@"
 linear_workspace="@linearWorkspace@"
 linear_team_id="@linearTeamId@"
 linear_credentials_file="${XDG_CONFIG_HOME:-$HOME/.config}/linear/credentials.toml"
+# Linear rejects an issue body over 250,000 characters with a generic
+# "Argument Validation Error", which bd surfaces as a per-issue warning rather
+# than a failed run. Hold the oversized Bead back so one unpublishable record
+# cannot keep failing every batch it lands in.
+linear_body_limit=250000
 sync_state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/beads-linear-sync"
 reconciliation_state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/beads-reconciliation"
 
@@ -281,6 +286,8 @@ push_issue_batches() {
   local batch_number
   local batch_start
   local status
+  local rejected_status=0
+  local rejected_batches=0
   local -a issue_id_array
 
   if [ -z "$issue_ids" ]; then
@@ -311,9 +318,21 @@ push_issue_batches() {
         return 75
       fi
       log "Linear push failed with status $status"
-      return "$status"
+      # A rejected result is scoped to the Beads in that batch, so the
+      # remaining batches still publish and record their progress. Transport
+      # and timeout failures are not scoped that way and still stop the run.
+      if [ "$status" -ne 65 ]; then
+        return "$status"
+      fi
+      rejected_status="$status"
+      rejected_batches=$((rejected_batches + 1))
     fi
   done
+
+  if [ "$rejected_status" -ne 0 ]; then
+    log "Linear push rejected $rejected_batches of $batch_count $description batches"
+    return "$rejected_status"
+  fi
 }
 
 run_dolt_sql() {
@@ -530,7 +549,12 @@ if [ -s "$push_progress_file" ]; then
 fi
 # Keep deferred progress content out of jq's argv. The file may contain many
 # batches, so passing it with --arg exceeds Linux's per-argument limit.
-closed_push_entries="$(@jq@/bin/jq -r --arg previous_sync "$previous_sync" --rawfile pushed "$pushed_progress_input" '
+closed_push_selection="$(@jq@/bin/jq -r --arg previous_sync "$previous_sync" --argjson body_limit "$linear_body_limit" --rawfile pushed "$pushed_progress_input" '
+  def body_length:
+    ((.description // "") | length)
+    + ((.design // "") | length)
+    + ((.acceptance_criteria // "") | length)
+    + ((.notes // "") | length);
   (if type == "object" and has("issues") then .issues else . end)
   | ($pushed | split("\n") | map(select(length > 0))) as $already_pushed
   | [
@@ -546,11 +570,20 @@ closed_push_entries="$(@jq@/bin/jq -r --arg previous_sync "$previous_sync" --raw
           )
         )
       )
-    | "\(.id) \(.updated_at // "")"
-    | select(. as $entry | ($already_pushed | index($entry)) | not)
+    | {entry: "\(.id) \(.updated_at // "")", oversized: (body_length > $body_limit)}
+    | select(.entry as $entry | ($already_pushed | index($entry)) | not)
   ]
-  | join("\n")
+  | {
+    entries: (map(select(.oversized | not) | .entry) | join("\n")),
+    oversized: (map(select(.oversized)) | length),
+  }
+  | "\(.oversized)\n\(.entries)"
 ' <<<"$issues_before_pull")"
+oversized_push_count="$(@coreutils@/bin/head -n 1 <<<"$closed_push_selection")"
+closed_push_entries="$(@coreutils@/bin/tail -n +2 <<<"$closed_push_selection")"
+if [ "$oversized_push_count" -gt 0 ]; then
+  log "Holding back $oversized_push_count terminal Bead(s) whose body exceeds the Linear issue limit"
+fi
 closed_ids="$(printf '%s\n' "$closed_push_entries" | @gawk@/bin/awk 'NF { print $1 }' | @coreutils@/bin/paste -sd, -)"
 pending_completion_ids="$(@jq@/bin/jq -r '
   (if type == "object" and has("issues") then .issues else . end)

--- a/spec/beads_linear_sync_spec.sh
+++ b/spec/beads_linear_sync_spec.sh
@@ -128,6 +128,16 @@ When run bash -c "checkpoint=\$(grep -n '\"\$cycle_started\" >\"\$sync_checkpoin
 The status should be success
 End
 
+It 'holds back terminal Beads whose body exceeds the Linear issue limit'
+When run bash -c "grep -F 'linear_body_limit=250000' '$SCRIPT' >/dev/null && grep -F -- '--argjson body_limit \"\$linear_body_limit\"' '$SCRIPT' >/dev/null && grep -F 'oversized: (body_length > \$body_limit)' '$SCRIPT' >/dev/null && grep -F 'exceeds the Linear issue limit' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
+It 'publishes the remaining batches after a rejected batch'
+When run bash -c "grep -F 'if [ \"\$status\" -ne 65 ]; then' '$SCRIPT' >/dev/null && grep -F 'rejected_batches=\$((rejected_batches + 1))' '$SCRIPT' >/dev/null && grep -F 'return \"\$rejected_status\"' '$SCRIPT' >/dev/null"
+The status should be success
+End
+
 End
 
 Describe 'reconciliation behavior'


### PR DESCRIPTION
## Problem

`dolt-linear-sync.service` on kyber failed every 15-minute fire with exit 65 and had not checkpointed since `2026-09-05T23:17:00Z`.

One terminal Bead had a 268,446-character body. Linear rejects an issue body over its 250,000-character limit with a generic `Argument Validation Error`, which `bd` reports as a per-issue warning inside an otherwise `success: true` result:

```
Linear result rejected: category=unclean-result exit=0 cause=unknown operation=push
shape=object success=true stats=object errors=1 warnings=1 error=none families=push
```

That Bead landed in batch 1 of 36. `push_issue_batches` returned on the first rejected batch, so batches 2-36 never ran, no progress line was written, and the checkpoint never advanced. Every subsequent run repeated the same batch and failed identically.

## Changes

- **Hold back oversized Beads.** The terminal selection now sums description, design, acceptance criteria, and notes and excludes any Bead over `linear_body_limit` (250,000). The count is logged; no payload content reaches the log.
- **Publish the remaining batches after a rejected batch.** A rejected result (65) is scoped to the Beads in that batch, so the loop records progress and continues, then returns the rejection at the end. Transport and timeout failures still stop the run immediately, and the deferred rate-limit path (75) is unchanged.
- **Give the Codex activation hook renderer a Bun interpreter path.** `codexConfig` runs before the activation phase that puts Bun on PATH, so `orchestration hooks render` died on `/usr/bin/env: 'bun': No such file or directory` and aborted every `home-manager` switch on this host.

## Verification

- `shellspec spec/beads_linear_sync_spec.sh` - 78 examples, 0 failures (2 new).
- `make shell-test` - 1859 examples, 5 failures; all 5 reproduce unchanged on a clean `HEAD` worktree (`coverage_spec`, `activate_kyber_spec`, `handy_hydrate_spec`, `make_build_host_resolution_spec` x2).
- Activated on kyber. The service now publishes all 36 terminal batches and logs `Holding back 2 terminal Bead(s) whose body exceeds the Linear issue limit`.

The trimmed Bead pushes cleanly (`pushed 1, errors 0`); its full original body is archived on kyber at `~/.local/state/beads-linear-sync/oversized-backup/`.

A separate pull-side failure (`operation=pull warnings=6 families=dependency`) is now reachable for the first time since the push phase stopped short of it. It is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops a single oversized Bead from failing every `dolt-linear-sync` run. Previously, a Bead with a 268,446-character body exceeded Linear's 250,000-character limit, so the first batch was rejected, the remaining 35 batches never ran, and the checkpoint never advanced. Now oversized terminal Beads are held back and later batches still publish after a rejected batch.

**Bug Fixes**
- Holds back terminal Beads whose combined description, design, acceptance criteria, and notes exceed 250,000 characters, and logs the count without payload content.
- Continues publishing later batches after a rejected batch (exit 65) and returns the rejection at the end; transport and timeout failures still stop the run.
- Gives the Codex activation hook renderer a Bun interpreter path so `home-manager` switches no longer abort on `/usr/bin/env: 'bun': No such file or directory`.
- The trimmed Bead pushes cleanly; its full original body is archived on kyber.

<sup>Written for commit bb8965842917d2182c08c711f5d9ce662959be89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

