### PR TITLE
fix(kyber): restore a green shell and nix gate

### DIFF
--- a/named-hosts/kyber/find.sh
+++ b/named-hosts/kyber/find.sh
@@ -9,11 +9,11 @@ index=0
 while [ "$index" -lt "${#arguments[@]}" ]; do
   argument="${arguments[$index]}"
   case "$argument" in
-    -H | -L | -P | -O[0-3] | --) ;;
-    -D) index=$((index + 1)) ;;
-    -*) break ;;
-    '(' | '!') break ;;
-    *) roots+=("$argument") ;;
+  -H | -L | -P | -O[0-3] | --) ;;
+  -D) index=$((index + 1)) ;;
+  -*) break ;;
+  '(' | '!') break ;;
+  *) roots+=("$argument") ;;
   esac
   index=$((index + 1))
 done
@@ -30,11 +30,11 @@ fi
 depth_options=0
 for argument in "${arguments[@]}"; do
   case "$argument" in
-    -maxdepth) depth_options=$((depth_options + 1)) ;;
-    -files0-from)
-      echo "Kyber find: use explicit search roots so their scope can be checked." >&2
-      exit 2
-      ;;
+  -maxdepth) depth_options=$((depth_options + 1)) ;;
+  -files0-from)
+    echo "Kyber find: use explicit search roots so their scope can be checked." >&2
+    exit 2
+    ;;
   esac
 done
 if [ "$depth_options" -gt 1 ]; then bounded=0; fi
@@ -47,11 +47,11 @@ if [ "$bounded" -eq 0 ]; then
     root="$(realpath -m -- "$root")"
     broad=0
     case "$root" in
-      / | /home | /root | "$HOME" | "$HOME/.herdr" | "$HOME/.herdr/worktrees" | "$HOME/ghq" | "$HOME/ghq/github.com") broad=1 ;;
-      "$HOME/.herdr/worktrees/"*)
-        remaining="${root#"$HOME/.herdr/worktrees/"}"
-        if [[ "$remaining" != */* ]]; then broad=1; fi
-        ;;
+    / | /home | /root | "$HOME" | "$HOME/.herdr" | "$HOME/.herdr/worktrees" | "$HOME/ghq" | "$HOME/ghq/github.com") broad=1 ;;
+    "$HOME/.herdr/worktrees/"*)
+      remaining="${root#"$HOME/.herdr/worktrees/"}"
+      if [[ $remaining != */* ]]; then broad=1; fi
+      ;;
     esac
     if [ "$broad" -eq 1 ]; then
       echo "Kyber find: narrow the search to one project or state directory, or put -maxdepth 0, 1, or 2 before the filters." >&2

--- a/spec/activate_kyber_spec.sh
+++ b/spec/activate_kyber_spec.sh
@@ -129,8 +129,8 @@ When run bash -c "unit=\$(sed -n '/systemd.user.services.herdr-server =/,/Instal
 The status should be success
 End
 
-It 'keeps the Herdr slice unfrozen and moves only pane shells into the orchestration slice'
-When run bash -c "grep -qxF 'IOAccounting=yes' '$PWD/named-hosts/kyber/herdr.slice' && ! grep -q 'IOWriteBandwidthMax' '$PWD/named-hosts/kyber/herdr.slice' && grep -q 'systemd-run --user --quiet --scope --collect' '$PWD/named-hosts/kyber/default.nix' && grep -q -- '--slice=orchestration.slice --unit=herdr-pane-' '$PWD/named-hosts/kyber/default.nix' && grep -q 'set -q HERDR_ENV; and status is-interactive; and not set -q HERDR_PANE_SCOPED' '$PWD/named-hosts/kyber/default.nix'"
+It 'keeps the Herdr slice unfrozen and leaves its panes inside it'
+When run bash -c "grep -qxF 'IOAccounting=yes' '$PWD/named-hosts/kyber/herdr.slice' && ! grep -q 'IOWriteBandwidthMax' '$PWD/named-hosts/kyber/herdr.slice' && ! grep -q 'herdr-pane-' '$PWD/named-hosts/kyber/default.nix' && ! grep -q 'HERDR_PANE_SCOPED' '$PWD/named-hosts/kyber/default.nix'"
 The status should be success
 End
 

--- a/spec/coverage_spec.sh
+++ b/spec/coverage_spec.sh
@@ -416,6 +416,10 @@ It 'has spec file for named-hosts/kyber/activate-ip-forwarding.sh'
 The path "spec/activate_kyber_spec.sh" should be exist
 End
 
+It 'has spec file for named-hosts/kyber/find.sh'
+The path "spec/kyber_find_spec.sh" should be exist
+End
+
 It 'has spec file for home-manager/activation/ensure-tailscale-serve.sh'
 The path "spec/tailscale_serve_spec.sh" should be exist
 End
@@ -666,6 +670,7 @@ named-hosts/kyber/activate-fish-ssh-compat.sh
 named-hosts/kyber/activate-ip-forwarding.sh
 named-hosts/kyber/activate-sshd.sh
 named-hosts/kyber/activate-user-service-priority.sh
+named-hosts/kyber/find.sh
 named-hosts/kyber/prepare-containerd-disk.sh
 named-hosts/kyber/rekey-galactica.sh
 named-hosts/kyber/setup.sh

--- a/spec/kyber_find_spec.sh
+++ b/spec/kyber_find_spec.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+
+Describe 'kyber/find.sh'
+SCRIPT="$PWD/named-hosts/kyber/find.sh"
+
+# The wrapper execs the native find it is handed, so a stub prints the argv it
+# would have run and keeps the assertions independent of the host's findutils.
+# The stub has to be a script rather than a builtin, or findutils flags such as
+# --version would be consumed by the stub itself.
+setup_stub() {
+  STUB="$SHELLSPEC_TMPBASE/native-find"
+  printf '#!/usr/bin/env bash\nprintf "%%s\\n" "$@"\n' >"$STUB"
+  chmod +x "$STUB"
+}
+BeforeAll 'setup_stub'
+
+guarded_find() {
+  HOME=/home/tester bash "$SCRIPT" "$STUB" "$@"
+}
+
+Describe 'broad traversal rejection'
+It 'rejects the filesystem root'
+When run guarded_find /
+The status should eq 2
+The stderr should include 'narrow the search'
+End
+
+It 'rejects the home directory'
+When run guarded_find /home/tester
+The status should eq 2
+The stderr should include 'narrow the search'
+End
+
+It 'rejects a worktree collection without a project segment'
+When run guarded_find /home/tester/.herdr/worktrees/dotfiles
+The status should eq 2
+The stderr should include 'narrow the search'
+End
+
+It 'rejects a broad root reached through a relative path'
+When run guarded_find /home/tester/ghq/github.com/..
+The status should eq 2
+The stderr should include 'narrow the search'
+End
+
+It 'rejects a broad root hidden behind other roots'
+When run guarded_find /home/tester/src /
+The status should eq 2
+The stderr should include 'narrow the search'
+End
+End
+
+Describe 'permitted traversal'
+It 'allows a project directory'
+When run guarded_find /home/tester/ghq/github.com/owner/repo -name '*.ts'
+The status should be success
+The output should include '/home/tester/ghq/github.com/owner/repo'
+End
+
+It 'allows a worktree once it names a project'
+When run guarded_find /home/tester/.herdr/worktrees/dotfiles/lane-1
+The status should be success
+The output should include '/home/tester/.herdr/worktrees/dotfiles/lane-1'
+End
+
+It 'allows a broad root bounded by a leading depth limit'
+When run guarded_find / -maxdepth 1 -name 'etc'
+The status should be success
+The output should include '-maxdepth'
+End
+
+It 'defaults to the current directory when no root is given'
+When run guarded_find -name '*.sh'
+The status should be success
+The output should include '-name'
+End
+
+It 'passes option-only invocations through'
+When run guarded_find --version
+The status should be success
+The output should include '--version'
+End
+End
+
+Describe 'depth bound integrity'
+It 'ignores a depth limit that only appears after a filter'
+When run guarded_find / -name 'x' -maxdepth 1
+The status should eq 2
+The stderr should include 'narrow the search'
+End
+
+It 'rejects a depth bound weakened by a second -maxdepth'
+When run guarded_find / -maxdepth 1 -name 'x' -maxdepth 9
+The status should eq 2
+The stderr should include 'narrow the search'
+End
+
+It 'rejects a depth limit deeper than two levels'
+When run guarded_find / -maxdepth 3
+The status should eq 2
+The stderr should include 'narrow the search'
+End
+
+It 'rejects reading roots from a file'
+When run guarded_find -maxdepth 1 -files0-from roots.txt
+The status should eq 2
+The stderr should include 'explicit search roots'
+End
+End
+
+End


### PR DESCRIPTION
## Problem

`main` has been red on `shell-check` and `nix-check` since #2723/#2732, so no PR can pass required status checks.

Three separate breakages:

1. `named-hosts/kyber/find.sh` landed unformatted. `shfmt -i 2 -s` rewrites its `case` arm indentation, so `treefmt --fail-on-change` fails. This takes down both `nix-format` and `nix-test` (the flake's `checks.treefmt` attribute).
2. `find.sh` was never added to the coverage list in `spec/coverage_spec.sh` and has no spec file.
3. #2723 removed the Herdr pane re-exec from `named-hosts/kyber/default.nix` and updated the README to match, but left `spec/activate_kyber_spec.sh` asserting the deleted `systemd-run --slice=orchestration.slice --unit=herdr-pane-` wiring and the `HERDR_PANE_SCOPED` fish guard.

## Changes

- Format `find.sh` with the repository's `shfmt` settings. No behavior change.
- Add `spec/kyber_find_spec.sh` with 14 behavioral examples covering broad-root rejection (`/`, `$HOME`, a worktree collection without a project segment, a broad root reached via `..`, a broad root behind other roots), permitted traversal, `--version` passthrough, and depth-bound integrity (a trailing `-maxdepth`, a second `-maxdepth`, a depth over 2, and `-files0-from`). The spec execs a stub in place of the native find so assertions do not depend on the host's findutils.
- Register `find.sh` in both coverage lists.
- Retarget the Herdr slice assertion at the current contract: `herdr.slice` stays unthrottled and its panes stay inside it, with no pane re-exec in `default.nix`.

## Verification

- `shellspec spec/activate_kyber_spec.sh spec/coverage_spec.sh spec/kyber_find_spec.sh` -> 203 examples, 0 failures.
- `shfmt -i 2 -s -l` over every tracked and untracked `.sh` reports only `config/shared/hooks/rtk-rewrite.sh`, which `treefmt.toml` excludes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores green `shell-check` and `nix-check` on `main` so PRs can pass required status checks again.

**Changes**
- Formats `named-hosts/kyber/find.sh` with the repo's `shfmt` settings; no behavior change.
- Adds `spec/kyber_find_spec.sh` covering broad-root rejection, permitted traversal, and depth bound integrity without depending on host findutils.
- Registers `find.sh` in both coverage lists.
- Updates `spec/activate_kyber_spec.sh` to match the removed Herdr pane re-exec; it now asserts panes stay inside `herdr.slice` and that no `herdr-pane-` or `HERDR_PANE_SCOPED` wiring remains.

<sup>Written for commit 9c6863b611a27696deec84c73ab0a5f0982798c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

