### PR TITLE
fix(kyber): drop root-filesystem I/O caps from k3s

### DIFF
--- a/config/k3s/k3s-io.conf
+++ b/config/k3s/k3s-io.conf
@@ -1,10 +1,9 @@
 [Service]
-# The backup cluster yields disk capacity to host services.
+# The backup cluster yields disk capacity to host services by weight only.
+# Absolute root-filesystem caps are not work-conserving: throttled writeback
+# holds shared ext4 buffer and journal locks, stalling every host writer while
+# the disk sits idle.
 IOAccounting=yes
 IOWeight=25
-IOReadBandwidthMax=/ 4194304
-IOWriteBandwidthMax=/ 2097152
-IOReadIOPSMax=/ 100
-IOWriteIOPSMax=/ 100
 # Container images use a separate filesystem from the root/control-plane state.
 IOWriteBandwidthMax=/var/lib/rancher/k3s/agent/containerd 5242880

--- a/config/k3s/kubepods-io.conf
+++ b/config/k3s/kubepods-io.conf
@@ -1,8 +1,6 @@
 [Slice]
-# Pod I/O is outside k3s.service, so it needs its own aggregate budget.
+# Pod I/O is outside k3s.service, so it needs its own weight. Pod volumes live
+# on the root filesystem, where absolute caps stall host writers through shared
+# ext4 locks, so the slice yields by weight only.
 IOAccounting=yes
 IOWeight=25
-IOReadBandwidthMax=/ 4194304
-IOWriteBandwidthMax=/ 2097152
-IOReadIOPSMax=/ 100
-IOWriteIOPSMax=/ 100


### PR DESCRIPTION
Drop the absolute root-disk I/O caps that #2738 added to `k3s.service` and `kubepods.slice`. Keep `IOWeight=25` and the separate containerd disk write cap.

## Why

The caps are not work-conserving. Pod volumes (Postgres, Loki, Redis, Prometheus) sit on the root ext4 filesystem. When their writeback is throttled to 2 MiB/s and 100 IOPS, it keeps holding shared buffer and journal locks, so every host writer stalls while the disk idles.

## Evidence on Kyber (sdb, after the caps were applied at 17:21 UTC)

- Both groups are pinned at the cap: kubepods.slice writes at 2055 KB/s and k3s.service at 2046 KB/s, against a 2048 KB/s limit.
- About 875 MB of page cache is stuck in `Writeback`, and the flush kworkers for sdb are in D state.
- The whole disk moves only about 5 MB/s write and 1.7 MB/s read, yet I/O PSI is at `full` 77-80%.
- Unrelated tasks, including `find` and `grep` in user.slice, block in `__lock_buffer` and `__wait_on_buffer`.
- Hourly `rate(node_pressure_io_stalled_seconds_total[15m])` from Prometheus:
  - Before 17:21 it spiked but recovered (0.01-0.65).
  - Since 17:27 it has held at 0.60-0.81 without recovering.
- Local Beads Dolt `select 1` takes about 2 s, and remote reads time out, so fleet orchestration is stalled.

`IOWeight` still has effect because the disks run bfq (per #2484), so the backup cluster continues to yield proportionally under contention.

## Rollout

After activation, check that `/sys/fs/cgroup/kubepods.slice/io.max` and `/sys/fs/cgroup/system.slice/k3s.service/io.max` no longer list the `8:16` caps. A `daemon-reload` may keep a limit that was removed from a drop-in; if the caps are still there, reset the running groups once.

## Validation

- `shellspec spec/k3s_service_activate_spec.sh`: 74 examples, 0 failures.
- `git diff --check` is clean, and the diff is ASCII-only.
- No Nix files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the absolute root-disk I/O caps on `k3s.service` and `kubepods.slice`; the old 4/2 MiB/s and 100 IOPS limits throttled writeback on the shared ext4 filesystem and stalled every host writer while the disk idled. Keeps proportional `IOWeight=25` scheduling via bfq and the separate containerd disk write cap.

**Migration**
- After activation, confirm the `8:16` caps no longer appear in `/sys/fs/cgroup/kubepods.slice/io.max` or `/sys/fs/cgroup/system.slice/k3s.service/io.max`.
- If `daemon-reload` leaves a limit from a removed drop-in, reset the running groups once.

<sup>Written for commit e4fe9c8ca94cd8c0dba472edd6d718bf9c511adb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

