### PR TITLE
fix(kyber): run Dolt as a prioritized system service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1405,11 +1405,10 @@ systemctl-docker-postgres: ## Restart docker-postgres systemd user service.
 	fi
 
 .PHONY: systemctl-dolt
-systemctl-dolt: ## Restart Dolt systemd user service.
+systemctl-dolt: ## Restart Dolt systemd system service.
 	@echo "🔄 Restarting dolt..."
 	@if [ "$(DETECTED_HOST)" = "kyber" ] || [ "$(HOST)" = "kyber" ]; then \
-		systemctl --user daemon-reload; \
-		systemctl --user restart dolt.service; \
+		sudo systemctl restart dolt.service; \
 	else \
 		echo "Skipping dolt.service (host not kyber)"; \
 	fi

--- a/home-manager/services/dolt/activate-system-service.sh
+++ b/home-manager/services/dolt/activate-system-service.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Install the authoritative Beads SQL server as a root-managed system unit.
+# @systemctl@ is substituted by pkgs.replaceVars.
+set -euo pipefail
+
+UNIT_FILE="$1"
+readonly SYSTEM_UNIT="/etc/systemd/system/dolt.service"
+
+ROOT_CMD=()
+if command -v sudo >/dev/null 2>&1; then
+  ROOT_CMD=(sudo -n)
+elif [ -x /run/wrappers/bin/sudo ]; then
+  ROOT_CMD=(/run/wrappers/bin/sudo -n)
+elif [ -x /usr/bin/sudo ]; then
+  ROOT_CMD=(/usr/bin/sudo -n)
+elif [ "$(id -u)" -ne 0 ]; then
+  echo "The Dolt system service requires root privileges." >&2
+  exit 1
+fi
+
+run_root() {
+  if [ "${#ROOT_CMD[@]}" -gt 0 ]; then
+    "${ROOT_CMD[@]}" "$@"
+  else
+    "$@"
+  fi
+}
+
+changed=0
+if [ ! -f "$SYSTEM_UNIT" ] || ! cmp -s "$UNIT_FILE" "$SYSTEM_UNIT"; then
+  echo "Installing $SYSTEM_UNIT..."
+  run_root mkdir -p "$(dirname "$SYSTEM_UNIT")"
+  run_root tee "$SYSTEM_UNIT" <"$UNIT_FILE" >/dev/null
+  run_root chmod 0644 "$SYSTEM_UNIT"
+  run_root @systemctl@ daemon-reload
+  changed=1
+fi
+
+# The former user unit binds the same port, so it must release 3307 before the
+# system unit starts. Home Manager removes its unit file after this step.
+if @systemctl@ --user is-active --quiet dolt.service 2>/dev/null; then
+  echo "Stopping the Dolt user service..."
+  @systemctl@ --user stop dolt.service
+fi
+
+run_root @systemctl@ enable dolt.service
+# Restart only for a changed unit; routine activations must not interrupt
+# Beads clients.
+if [ "$changed" -eq 1 ]; then
+  run_root @systemctl@ restart dolt.service
+else
+  run_root @systemctl@ start dolt.service
+fi

--- a/home-manager/services/dolt/default.nix
+++ b/home-manager/services/dolt/default.nix
@@ -38,6 +38,14 @@ let
     inherit beadsDir;
     inherit (pkgs) dolt;
   };
+  systemServiceUnit = pkgs.replaceVars ./dolt.service {
+    bash = "${pkgs.bash}/bin/bash";
+    user = config.home.username;
+    inherit repoDir startScript;
+  };
+  systemServiceScript = pkgs.replaceVars ./activate-system-service.sh {
+    systemctl = "${pkgs.systemd}/bin/systemctl";
+  };
   linearSyncScript = pkgs.replaceVars ./linear-sync.sh {
     bd = "${pkgs.beads}/bin/bd";
     linear = "${homeDir}/.bun/install/global/node_modules/.bin/linear";
@@ -88,37 +96,13 @@ in
     executable = true;
   };
 
-  systemd.user.services.dolt = lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && isKyber) {
-    Unit = {
-      Description = "Authoritative Beads SQL server";
-      After = [ "network.target" ];
-    };
-    Service = {
-      Type = "simple";
-      ExecStart = "${pkgs.bash}/bin/bash ${startScript}";
-      Restart = "always";
-      RestartSec = 5;
-      WorkingDirectory = repoDir;
-      # Kyber's WAN firewall drops all new public-interface ingress. Binding
-      # all addresses makes the SQL service reachable on
-      # tailscale0 while retaining the public-ingress deny boundary.
-      Environment = [
-        "BEADS_DOLT_LISTEN_HOST=0.0.0.0"
-        "DOLT_CLI_USER=root"
-        "DOLT_CLI_PASSWORD="
-      ];
-    }
-    // lib.optionalAttrs isKyber {
-      # DOLT_BACKUP performs the off-site snapshot inside the server process.
-      # Bound that bulk writer so it cannot starve Kine and PostgreSQL on the
-      # shared root disk; normal transactional writes remain far below 20 MB/s.
-      IOAccounting = true;
-      IOWriteBandwidthMax = "/ 20M";
-    };
-    Install = {
-      WantedBy = [ "default.target" ];
-    };
-  };
+  home.activation.installDoltSystemService =
+    lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && isKyber)
+      (
+        lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+          $DRY_RUN_CMD ${pkgs.bash}/bin/bash "${systemServiceScript}" "${systemServiceUnit}"
+        ''
+      );
 
   # Persist the same client selection in the user manager so Herdr, OpenClaw,
   # and other systemd-launched agents do not inherit a stale shared-server mode.
@@ -136,14 +120,8 @@ in
         Unit = {
           Description = "Synchronize Beads with Linear";
           X-SwitchMethod = "restart";
-          After = [
-            "dolt.service"
-            "network-online.target"
-          ];
-          Wants = [
-            "dolt.service"
-            "network-online.target"
-          ];
+          After = [ "network-online.target" ];
+          Wants = [ "network-online.target" ];
         };
         Service = {
           Type = "oneshot";

--- a/home-manager/services/dolt/dolt.service
+++ b/home-manager/services/dolt/dolt.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Authoritative Beads SQL server
+After=network.target
+# Beads has no standby authority, so systemd must never give up restarting it.
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+User=@user@
+WorkingDirectory=@repoDir@
+ExecStart=@bash@ @startScript@
+Restart=always
+RestartSec=2
+# Kyber's WAN firewall drops all new public-interface ingress. Binding all
+# addresses makes the SQL service reachable on tailscale0 while retaining the
+# public-ingress deny boundary.
+Environment=BEADS_DOLT_LISTEN_HOST=0.0.0.0
+Environment=DOLT_CLI_USER=root
+Environment=DOLT_CLI_PASSWORD=
+# A user manager can neither lower OOMScoreAdjust nor lift a unit out of
+# user.slice's write ceiling, which is why the server runs as a system unit.
+OOMScoreAdjust=-900
+CPUWeight=1000
+IOAccounting=yes
+# systemd maps IOWeight=10000 to the bfq maximum of 1000; IOWeight=1000 is only
+# bfq 181. The server gets no bandwidth cap: a throttled writer holds shared
+# ext4 journal locks and stalls every other writer on the root disk.
+IOWeight=10000
+
+[Install]
+WantedBy=multi-user.target

--- a/spec/dolt_system_service_spec.sh
+++ b/spec/dolt_system_service_spec.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+Describe 'authoritative Dolt system service'
+UNIT="$PWD/home-manager/services/dolt/dolt.service"
+MODULE="$PWD/home-manager/services/dolt/default.nix"
+
+Describe 'dolt.service'
+It 'runs as the Kyber login user under the system manager'
+When run bash -c "grep -qxF 'User=@user@' '$UNIT' && grep -qxF 'WantedBy=multi-user.target' '$UNIT'"
+The status should be success
+End
+
+It 'never stops restarting'
+When run bash -c "grep -qxF 'Restart=always' '$UNIT' && grep -qxF 'StartLimitIntervalSec=0' '$UNIT'"
+The status should be success
+End
+
+It 'is shielded from the OOM killer'
+When run grep -xF 'OOMScoreAdjust=-900' "$UNIT"
+The output should include 'OOMScoreAdjust=-900'
+End
+
+It 'takes the bfq maximum weight without a bandwidth cap'
+When run bash -c "grep -qxF 'IOWeight=10000' '$UNIT' && ! grep -Eq '^IO(Read|Write)(Bandwidth|IOPS)Max=' '$UNIT'"
+The status should be success
+End
+End
+
+Describe 'Home Manager wiring'
+It 'no longer defines a user unit for the server'
+When run bash -c "grep -F 'systemd.user.services.dolt =' '$MODULE'"
+The status should be failure
+End
+
+It 'does not make Linear sync depend on a user-manager Dolt unit'
+When run bash -c "sed -n '/systemd.user.services.dolt-linear-sync/,/^      };/p' '$MODULE' | grep -F 'dolt.service'"
+The status should be failure
+End
+End
+
+Describe 'activate-system-service.sh'
+setup() {
+  TEST_ROOT=$(mktemp -d)
+  mkdir -p "$TEST_ROOT/bin" "$TEST_ROOT/etc"
+  cat >"$TEST_ROOT/bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+[ "$1" = -n ] && shift
+exec "$@"
+EOF
+  cat >"$TEST_ROOT/bin/systemctl" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >>"$TEST_ROOT/calls"
+if [ "\$1 \$2" = "--user is-active" ]; then
+  [ -f "$TEST_ROOT/user-active" ]
+fi
+EOF
+  chmod +x "$TEST_ROOT/bin/sudo" "$TEST_ROOT/bin/systemctl"
+  printf '[Service]\nUser=ubuntu\n' >"$TEST_ROOT/dolt.service"
+  sed -e "s|@systemctl@|$TEST_ROOT/bin/systemctl|g" \
+    -e "s|/etc/systemd/system/dolt.service|$TEST_ROOT/etc/dolt.service|g" \
+    home-manager/services/dolt/activate-system-service.sh >"$TEST_ROOT/activate.sh"
+}
+cleanup() { rm -rf "$TEST_ROOT"; }
+Before setup
+After cleanup
+
+activate() {
+  PATH="$TEST_ROOT/bin:$PATH" bash "$TEST_ROOT/activate.sh" "$TEST_ROOT/dolt.service"
+}
+
+It 'installs a changed unit and restarts the server'
+When call activate
+The output should include 'Installing'
+The contents of file "$TEST_ROOT/etc/dolt.service" should equal "$(cat "$TEST_ROOT/dolt.service")"
+The contents of file "$TEST_ROOT/calls" should include 'daemon-reload'
+The contents of file "$TEST_ROOT/calls" should include 'restart dolt.service'
+End
+
+It 'stops the former user unit before starting the system unit'
+touch "$TEST_ROOT/user-active"
+When call activate
+The output should include 'Stopping the Dolt user service'
+The line 3 of contents of file "$TEST_ROOT/calls" should equal '--user stop dolt.service'
+The line 5 of contents of file "$TEST_ROOT/calls" should equal 'restart dolt.service'
+End
+
+It 'leaves a running server alone when the unit is unchanged'
+cp "$TEST_ROOT/dolt.service" "$TEST_ROOT/etc/dolt.service"
+When call activate
+The output should equal ''
+The contents of file "$TEST_ROOT/calls" should not include 'restart'
+The contents of file "$TEST_ROOT/calls" should include 'start dolt.service'
+End
+End
+End

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -329,7 +329,8 @@ let
             "--accept-dns=true"
             "--advertise-exit-node"
           ];
-        assert cfg.systemd.user.services ? dolt;
+        assert !(cfg.systemd.user.services ? dolt);
+        assert cfg.home.activation ? installDoltSystemService;
         assert cfg.systemd.user.services ? dolt-linear-sync;
         assert cfg.systemd.user.services.herdr-server.Service.Slice == "herdr.slice";
         assert !(lib.hasInfix "--slice=orchestration.slice" cfg.programs.fish.shellInit);


### PR DESCRIPTION
Run the Kyber Beads Dolt server as a root-managed system unit (`/etc/systemd/system/dolt.service`, `User=ubuntu`) instead of a Home Manager user unit. This gives it top disk and CPU priority and keeps systemd from ever giving up on it.

## Why

- The user unit lives under `user.slice`, which has a 150 MB/s write ceiling and a bfq weight of 100. The server also had its own 20 MB/s write cap. Under sdb contention, the Beads authority stalled and the fleet stopped.
- A user manager cannot lower `OOMScoreAdjust`, and it cannot move a unit out of `user.slice`.
- The 20 MB/s cap was justified by an in-process `DOLT_BACKUP` job that no longer runs anywhere.

## Unit policy

- `IOWeight=10000`: systemd maps this to bfq weight 1000, the maximum. `IOWeight=1000` would only give bfq 181.
- No I/O bandwidth caps. A throttled writer holds ext4 journal locks and stalls every other writer on the disk.
- `CPUWeight=1000` and `OOMScoreAdjust=-900`.
- `Restart=always`, `RestartSec=2`, and `StartLimitIntervalSec=0`, so systemd never stops restarting it.
- The data dir, port 3307, listen address, working directory, and environment are unchanged.

## Activation

- `home.activation.installDoltSystemService` runs on Kyber only:
  - installs the unit through `sudo -n` and runs `daemon-reload` when the file changed
  - stops the old user unit so port 3307 is free
  - enables the system unit
  - restarts it only when the unit changed, and otherwise just starts it
- `dolt-linear-sync` no longer declares `After`/`Wants` on `dolt.service`, because a user unit cannot depend on a system unit.
- `make systemctl-dolt` now restarts the system unit.

## Rollout

The first activation on Kyber restarts Dolt once, for a few seconds. After that, check:

- `systemctl is-active dolt.service` returns `active`, and `systemctl --user is-active dolt.service` returns `inactive`
- `/sys/fs/cgroup/system.slice/dolt.service/io.bfq.weight` is `default 1000` and `io.max` is empty
- `oom_score_adj` of the main PID is `-900`
- a Beads read through the authority, such as `select 1` on port 3307, succeeds

## Validation

- `shellspec spec/dolt_system_service_spec.sh spec/dolt_start_spec.sh spec/beads_linear_sync_spec.sh spec/beads_authority_spec.sh`: 90 examples, 0 failures.
- `nix eval .#checks.x86_64-linux.eval-home-kyber.drvPath` evaluates. It asserts the user unit is gone and the activation is present.
- `shellcheck` is clean, `git diff --check` is clean, and the diff is ASCII-only.
- Not built on Linux here. The unit template and activation script are exercised by shellspec with fake `systemctl` and `sudo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the Kyber Beads Dolt server from a Home Manager user unit to a root-managed systemd system unit, so it gets top disk and CPU priority and systemd never stops restarting it.

The old user unit lived under `user.slice` with a 150 MB/s write ceiling and bfq weight of 100, plus its own 20 MB/s write cap for a `DOLT_BACKUP` job that no longer runs. The new unit drops all I/O caps, sets `IOWeight=10000` (bfq 1000), `CPUWeight=1000`, and `OOMScoreAdjust=-900`. A new activation script installs the unit, stops the old user unit, and starts the system unit, restarting it only when the unit file changed. `dolt-linear-sync` no longer depends on `dolt.service` since a user unit cannot depend on a system unit.

**Migration**
- The first activation on Kyber restarts Dolt once, for a few seconds.
- Verify `systemctl is-active dolt.service` is `active`, the user unit is `inactive`, and a Beads read on port 3307 succeeds.

<sup>Written for commit f3c00f8dabf36ea6026fe0d3d85a68ee8931a3eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

