### PR TITLE
fix(kyber): stop the Dolt user unit through the host systemctl

### DIFF
--- a/home-manager/services/dolt/activate-system-service.sh
+++ b/home-manager/services/dolt/activate-system-service.sh
@@ -38,9 +38,11 @@ fi
 
 # The former user unit binds the same port, so it must release 3307 before the
 # system unit starts. Home Manager removes its unit file after this step.
-if @systemctl@ --user is-active --quiet dolt.service 2>/dev/null; then
+# Nix's newer systemctl cannot connect to the distribution's user manager, so
+# user-scope calls use the host binary.
+if /usr/bin/systemctl --user is-active --quiet dolt.service; then
   echo "Stopping the Dolt user service..."
-  @systemctl@ --user stop dolt.service
+  /usr/bin/systemctl --user stop dolt.service
 fi
 
 run_root @systemctl@ enable dolt.service

--- a/spec/dolt_system_service_spec.sh
+++ b/spec/dolt_system_service_spec.sh
@@ -56,7 +56,8 @@ fi
 EOF
   chmod +x "$TEST_ROOT/bin/sudo" "$TEST_ROOT/bin/systemctl"
   printf '[Service]\nUser=ubuntu\n' >"$TEST_ROOT/dolt.service"
-  sed -e "s|@systemctl@|$TEST_ROOT/bin/systemctl|g" \
+  sed -e "s|/usr/bin/systemctl|$TEST_ROOT/bin/systemctl|g" \
+    -e "s|@systemctl@|$TEST_ROOT/bin/systemctl|g" \
     -e "s|/etc/systemd/system/dolt.service|$TEST_ROOT/etc/dolt.service|g" \
     home-manager/services/dolt/activate-system-service.sh >"$TEST_ROOT/activate.sh"
 }


### PR DESCRIPTION
Fix the handover step from #2746, which never ran on Kyber. The Dolt activation now stops the old user unit with the host `/usr/bin/systemctl`, and a failure to reach the user manager is reported instead of hidden.

## Why

The Nix `systemctl` (systemd 261) cannot reach Kyber's systemd 255 user manager. It fails with `Failed to connect to user scope bus via local transport: Connection refused`. The `is-active` check swallowed that error, so the rollout of #2746 never stopped the user unit. The new system unit then looped on `database "beads" is locked by another dolt process`, while the orphaned user unit kept serving port 3307.

System-scope calls through `sudo` still work with the Nix binary, and they are unchanged.

## Validation

- `shellspec spec/dolt_system_service_spec.sh`: 9 examples, 0 failures.
- `shellcheck` is clean and `git diff --check` is clean.
- On Kyber, the host `systemctl --user is-system-running` reports `degraded` (reachable), while the Nix binary is refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Dolt service handover on Kyber so the old user unit is actually stopped before the system unit starts. The previous `is-active` check hid the error when Nix's `systemctl` couldn't reach Kyber's user manager, leaving the old user unit serving port 3307 while the new system unit looped on a locked database.

The activation script now uses the host `/usr/bin/systemctl` for user-scope commands and reports connection failures instead of swallowing them. System-scope calls through `sudo` are unchanged.

<sup>Written for commit f7556593b9179850bfdeafca1659c36a3bdc64ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

