### PR TITLE
fix(kyber): reload user units via host systemctl and prune untraversable dirs

### DIFF
--- a/home-manager/modules/secure-dotenv/secure-dotenv.sh
+++ b/home-manager/modules/secure-dotenv/secure-dotenv.sh
@@ -7,11 +7,15 @@ HOME_DIR="$1"
 # ~/Library is pruned: on macOS, opening app group containers blocks forever
 # on TCC app-data mediation, hanging activation. Dotenv files live in code
 # checkouts, never under Library.
+# Directories this user cannot traverse (root services write 0700 log
+# directories under home) are pruned: descending into them makes find exit
+# non-zero, and pipefail turns that into an activation failure.
 @find@ "${HOME_DIR}" \
   -maxdepth 4 \
   -path "${HOME_DIR}/Library" -prune -o \
-  \( -name '.env' -o -name '.env.*' -o -name '*.env' \) -print \
-  2>/dev/null | while IFS= read -r f; do
+  -type d \( ! -readable -o ! -executable \) -prune -o \
+  \( -name '.env' -o -name '.env.*' -o -name '*.env' \) -print |
+  while IFS= read -r f; do
   if [ -f "$f" ] && [ ! -L "$f" ]; then
     current=$(@stat@ -c '%a' "$f")
     if [ "$current" != "600" ]; then

--- a/named-hosts/kyber/default.nix
+++ b/named-hosts/kyber/default.nix
@@ -58,6 +58,13 @@ home-manager.lib.homeManagerConfiguration {
 
         home.file.".local/bin/find".source = "${import ./find.nix { inherit pkgs; }}/bin/find";
 
+        # The user manager is the distro systemd. Nix systemctl (260+) reaches
+        # it only through the manager's private socket and reports the session
+        # as not running when that socket is unreachable, which makes
+        # reloadSystemd skip sd-switch. The host client matches the manager and
+        # falls back to the user D-Bus.
+        systemd.user.systemctlPath = "/usr/bin/systemctl";
+
         # Pause trace scans and uploads while storage contention is unresolved.
         services.traces-agent-uploads.enable = false;
 

--- a/spec/secure_dotenv_spec.sh
+++ b/spec/secure_dotenv_spec.sh
@@ -3,6 +3,7 @@
 
 Describe 'home-manager/modules/secure-dotenv/secure-dotenv.sh'
 SCRIPT="$PWD/home-manager/modules/secure-dotenv/secure-dotenv.sh"
+no_gnu_find() { ! find . -maxdepth 0 -readable >/dev/null 2>&1; }
 
 Describe 'script properties'
 It 'uses bash shebang'
@@ -41,6 +42,7 @@ End
 End
 
 Describe 'functional behavior'
+Skip if 'the script requires GNU find (activation substitutes pkgs.findutils)' no_gnu_find
 setup() {
   TEST_HOME="$(mktemp -d)"
   # Create .env files with non-600 permissions
@@ -121,6 +123,11 @@ It 'does not follow symlinks'
 When run bash -c "bash '$PROCESSED_SCRIPT' '$TEST_HOME' && test -L '$TEST_HOME/.env.link' && echo 'still-symlink'"
 The output should equal 'still-symlink'
 End
+
+It 'skips directories it cannot traverse and still secures other files'
+When run bash -c "mkdir '$TEST_HOME/locked' && chmod 000 '$TEST_HOME/locked'; bash '$PROCESSED_SCRIPT' '$TEST_HOME'; rc=\$?; chmod 700 '$TEST_HOME/locked'; [ \$rc -eq 0 ] && '$STAT_WRAPPER' -c '%a' '$TEST_HOME/app.env'"
+The output should equal '600'
+End
 End
 
 Describe 'depth limit'
@@ -137,6 +144,7 @@ The output should include '-prune'
 End
 
 It 'skips .env files under Library'
+Skip if 'the script requires GNU find (activation substitutes pkgs.findutils)' no_gnu_find
 TEST_HOME="$(mktemp -d)"
 mkdir -p "$TEST_HOME/Library/Group Containers/app"
 echo "SECRET=value" >"$TEST_HOME/Library/Group Containers/app/.env"

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -329,6 +329,7 @@ let
             "--accept-dns=true"
             "--advertise-exit-node"
           ];
+        assert cfg.systemd.user.systemctlPath == "/usr/bin/systemctl";
         assert !(cfg.systemd.user.services ? dolt);
         assert cfg.home.activation ? installDoltSystemService;
         assert cfg.systemd.user.services ? dolt-linear-sync;


### PR DESCRIPTION
## Summary

Fixes two Home Manager activation failures on Kyber.

### 1. `reloadSystemd` always logs "User systemd daemon not running. Skipping reload."

**Root cause.** The problem isn't a protocol mismatch between systemd 261 and 255. It's a stale private socket on the host:

- Nix systemctl 260+ reaches the user manager only through `$XDG_RUNTIME_DIR/systemd/private`. Both systemd-260.2 and 261.2 fail the same way.
- On Kyber that socket is stale. Its mtime is 2026-09-12 12:36, but the running `systemd --user` started on Sep 9, and `ss` shows the listener with no owning process.
- `connect()` therefore gets `ECONNREFUSED`. Home Manager's `ensureSystemd` treats that as "not running" and skips sd-switch.
- Host systemctl 255 falls back from the private socket to the user D-Bus and reports `degraded`. `ensureSystemd` accepts `degraded`, and sd-switch then talks to the manager over D-Bus.

**Fix.** Set `systemd.user.systemctlPath = "/usr/bin/systemctl"` for Kyber only, in `named-hosts/kyber/default.nix`. The option exists in the pinned Home Manager (`modules/systemd.nix`). `ensureSystemd` now runs with `PATH="/usr/bin:$PATH"`. `tests/eval.nix` asserts the value.

### 2. `secureDotenv` fails `dotfiles-updater` and `./install.sh` with status 2

**Root cause.**

- `find "$HOME" -maxdepth 4 ...` descends into 0700 directories under home that belong to root services.
- GNU find prints `Permission denied` and exits 1. `set -euo pipefail` over `find | while` turns that into an activation failure.
- `make install`, which both `install.sh` and the updater run, then exits 2.
- `2>/dev/null` was hiding the cause.
- On Kyber, the old invocation exits 1 with 4 permission errors. The new one exits 0 with no stderr.

**Fix.** Prune directories the user can't read or traverse (`-type d \( ! -readable -o ! -executable \) -prune`), and drop `2>/dev/null` so any remaining find error is visible.

## Validation

- `shellspec spec/secure_dotenv_spec.sh spec/activate_kyber_spec.sh` under GNU findutils: 80 examples, 0 failures.
- Under macOS BSD find: 0 failures. The functional examples are skipped, because the script needs GNU find and activation substitutes `pkgs.findutils`.
- Regression check: the new "skips directories it cannot traverse" example fails against the `origin/main` script with status 1 and passes with the fix.
- `nix eval .#checks.x86_64-linux.eval-home-kyber.drvPath` gives `/nix/store/syxhlxg35w368a5j5a48dhm90w5ypnx3-eval-home-kyber.drv`.
- `shellcheck`, `nixfmt --check` and `statix check` are clean on the changed files.
- Kyber checks were read-only.

## Not changed, for the operator

- **Why the user manager is `degraded`:** only `mempalace-exporter.service` has failed. Python segfaults in `mempalace.exporter.export_palace`, which the twice-daily timer runs. That is a separate issue.
- **Optional host repair:** restarting `user@1000.service` recreates the private socket, so the Nix systemctl would work again. This is a Kyber mutation and needs operator approval, so it wasn't done. The fix in this PR doesn't depend on it.
- **Also seen:** the user manager logs inotify `No space left on device` errors, meaning the watch limit is exhausted. That is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two Home Manager activation failures on Kyber: user units now reload via the host systemctl instead of being skipped, and `secureDotenv` no longer fails when it encounters directories the user can't traverse.

**Bug Fixes**
- Sets `systemd.user.systemctlPath` to `/usr/bin/systemctl` for Kyber so `reloadSystemd` reaches the user manager over D-Bus.
- Prunes unreadable and unexecutable directories in `secure-dotenv.sh` and removes `2>/dev/null` so remaining find errors surface.

<sup>Written for commit 5412588a94307889c216ab0e71152446c7ec111e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

