### PR TITLE
fix(roborev): remove antigravity and gemini routes

### DIFF
--- a/config/roborev/config.template.toml
+++ b/config/roborev/config.template.toml
@@ -22,11 +22,6 @@ model = 'free'
 review_type = 'default'
 allow_failure = true
 
-[review.subagents.antigravity]
-agent = 'acp.antigravity'
-review_type = 'default'
-allow_failure = true
-
 [review.subagents.opencode]
 agent = 'opencode'
 review_type = 'default'
@@ -39,8 +34,8 @@ allow_failure = true
 
 [review.panels.full]
 # Droid is useful when available, but its Kyber launcher is currently flaky.
-members = ['antigravity', 'opencode', 'droid', 'pi-oxalpha', 'pi']
-synthesis_agent = 'gemini'
+members = ['opencode', 'droid', 'pi-oxalpha', 'pi']
+synthesis_agent = 'opencode'
 
 [ci]
 enabled = true


### PR DESCRIPTION
## Summary\n- Remove the Antigravity RoboRev subagent route from the durable dotfiles template.\n- Remove Gemini panel synthesis and keep RoboRev hooks/daemon configuration intact.\n\n## Tracker\n- Bead: df-1l5li\n- Linear: none — no linked Linear issue was provided.\n\n## Validation\n- shellspec roborev hook/hydrate/activation specs — 38 examples, 0 failures.\n- Nix build/switch was attempted but interrupted before completion; no signoff receipt is claimed.\n\nAdmin merge requested to land the focused route removal.