### PR TITLE
fix(home-manager): back up any file blocking Linux activation

### DIFF
--- a/hosts/linux/activate-backup-files.sh
+++ b/hosts/linux/activate-backup-files.sh
@@ -11,15 +11,24 @@ home_files=${1:?Home Manager home-files path is required}
 while IFS= read -r -d '' link; do
   target_path=${link#"$home_files/"}
   target="$HOME/$target_path"
-  [ -L "$target" ] || continue
-  link_target=$(readlink -- "$target")
-  case "$link_target" in
-  /nix/store/*-home-manager-generation/* | /nix/store/*-home-manager-files/*)
-    relative=${target#"$HOME/"}
-    echo "Removing stale Home Manager link $relative"
-    rm -f -- "$target"
-    ;;
-  esac
+  if [ -L "$target" ]; then
+    link_target=$(readlink -- "$target")
+    case "$link_target" in
+    /nix/store/*-home-manager-generation/* | /nix/store/*-home-manager-files/*)
+      echo "Removing stale Home Manager link $target_path"
+      rm -f -- "$target"
+      ;;
+    esac
+  elif [ -f "$target" ] && ! cmp -s -- "$link" "$target"; then
+    # Tools such as atuin write their own config on first run, and Home
+    # Manager aborts the whole activation on any unmanaged file in its way.
+    # A path under a linked store directory is read-only and not ours to move.
+    case "$(readlink -f -- "$target")" in
+    /nix/store/*) continue ;;
+    esac
+    echo "Backing up existing $target_path to $target_path.hm-backup"
+    mv -f -- "$target" "$target.hm-backup"
+  fi
 done < <(find -L "$home_files" -type f -print0)
 
 for file in .bashrc .profile .bash_profile; do

--- a/spec/activate_hosts_spec.sh
+++ b/spec/activate_hosts_spec.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2329
+# shellcheck disable=SC2016,SC2329
 
 Describe 'hosts/darwin/activate-remove-backups.sh'
 SCRIPT="$PWD/hosts/darwin/activate-remove-backups.sh"
@@ -78,6 +78,30 @@ End
 
 It 'uses the new generation manifest instead of scanning the home directory'
 When run bash -c "grep -F 'home_files=' '$SCRIPT' >/dev/null && grep -F 'find -L \"\$home_files\"' '$SCRIPT' >/dev/null && grep -F '\"\$newGenPath/home-files\"' '$PWD/hosts/linux/default.nix' >/dev/null"
+The status should be success
+End
+End
+
+Describe 'managed file collisions'
+setup() {
+  TEMP_DIR=$(mktemp -d)
+  mkdir -p "$TEMP_DIR/files/.config/atuin" "$TEMP_DIR/home/.config/atuin"
+  printf 'managed\n' >"$TEMP_DIR/files/.config/atuin/config.toml"
+  printf 'managed\n' >"$TEMP_DIR/files/.same"
+}
+cleanup() { rm -rf "$TEMP_DIR"; }
+Before 'setup'
+After 'cleanup'
+
+It 'backs up an unmanaged file that differs from the managed one'
+printf 'written by atuin\n' >"$TEMP_DIR/home/.config/atuin/config.toml"
+When run bash -c 'HOME="$1/home" bash "$2" "$1/files" && [ ! -e "$1/home/.config/atuin/config.toml" ] && cat "$1/home/.config/atuin/config.toml.hm-backup"' _ "$TEMP_DIR" "$SCRIPT"
+The output should include 'written by atuin'
+End
+
+It 'leaves an identical unmanaged file in place'
+printf 'managed\n' >"$TEMP_DIR/home/.same"
+When run bash -c 'HOME="$1/home" bash "$2" "$1/files" && [ -f "$1/home/.same" ] && [ ! -e "$1/home/.same.hm-backup" ]' _ "$TEMP_DIR" "$SCRIPT"
 The status should be success
 End
 End


### PR DESCRIPTION
## Summary

- The Linux pre-activation hook (`hosts/linux/activate-backup-files.sh`) now moves any unmanaged regular file that differs from its Home Manager target to `<file>.hm-backup`, instead of only a hardcoded list (`.bashrc`, `.profile`, `.bash_profile`, openclaw).
- Identical files and paths that resolve into `/nix/store` are left untouched.
- Adds behavioral specs: a differing atuin config is backed up; an identical file stays in place.

## Why

On kamino2, `make switch` aborted with:

```
Existing file '/root/.config/atuin/config.toml' would be clobbered
```

atuin writes its own `config.toml` on first run, and Home Manager fails the whole activation on any unmanaged file in the way. Because activation stopped before package installation, `devin` (and other new packages) were also missing afterward.

## Reviewer notes

- Applies to hosts using the shared script: generic Linux, kamino, andor, pod. `named-hosts/kyber/activate-backup-files.sh` is a separate copy and is unchanged.
- An existing `.hm-backup` is overwritten, matching the existing `.bashrc` behavior.
- `spec/coverage_spec.sh` currently fails on `main` independently of this change (`home-manager/services/dolt/activate-system-service.sh` from #2746 is missing from the coverage list).
- Could not evaluate `homeConfigurations.kamino2` from darwin (platform mismatch); verification is the next `make build && make switch` on kamino2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Linux Home Manager activation so any unmanaged regular file blocking a managed path is backed up instead of aborting the whole switch. Previously only a hardcoded set (`.bashrc`, `.profile`, `.bash_profile`, openclaw) was moved; now any differing file under a managed target becomes `<file>.hm-backup`, while identical files and paths under `/nix/store` are left untouched.

**Notes**

- Existing `.hm-backup` files are overwritten, matching the old `.bashrc` behavior.
- Applies to hosts using the shared script (`generic-linux`, `kamino`, `andor`, `pod`); `named-hosts/kyber/activate-backup-files.sh` is unchanged.

<sup>Written for commit c2fcea46e565b7b95f651b3c568dfeca7fdc4c1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

