### PR TITLE
fix(kamino): make tailscale ssh the fleet default

### DIFF
--- a/home-manager/programs/kamino/default.nix
+++ b/home-manager/programs/kamino/default.nix
@@ -5,12 +5,12 @@ let
   shortcuts = lib.concatMap (machine: [
     {
       inherit (machine) name;
-      body = "ssh ${machine.name} $argv";
-      description = "SSH to ${machine.name} over Tailscale";
+      body = "tailscale ssh ${machine.name} $argv";
+      description = "SSH to ${machine.name} with Tailscale SSH";
     }
     {
       name = "${machine.name}d";
-      body = ''ssh -t ${machine.name} "tmux new-session -A -s desktop"'';
+      body = ''tailscale ssh ${machine.name} "tmux new-session -A -s desktop"'';
       description = "Attach to ${machine.name} tmux desktop session";
     }
     {
@@ -20,12 +20,12 @@ let
     }
     {
       name = "${machine.name}m";
-      body = ''ssh -t ${machine.name} "tmux new-session -A -s mobile"'';
+      body = ''tailscale ssh ${machine.name} "tmux new-session -A -s mobile"'';
       description = "Attach to ${machine.name} tmux mobile session";
     }
     {
       name = "${machine.name}z";
-      body = ''ssh -t ${machine.name} "zellij attach -c desktop"'';
+      body = ''tailscale ssh ${machine.name} "zellij attach -c desktop"'';
       description = "Attach to ${machine.name} Zellij desktop session";
     }
   ]) fleet.machines;
@@ -51,7 +51,9 @@ in
       value = {
         HostName = machine.hostname;
         User = machine.user;
-        StrictHostKeyChecking = "accept-new";
+        # Tailscale SSH performs identity and host-key verification through
+        # the tailnet; ordinary key-based SSH is not the managed default.
+        StrictHostKeyChecking = "yes";
       };
     }) fleet.machines
   );
@@ -62,6 +64,7 @@ in
       runtimeInputs = [
         pkgs.python3
         pkgs.openssh
+        pkgs.tailscale
       ];
       text = ''
         exec python3 ${../../../named-hosts/kamino/fleet.py} --inventory ${inventory} "$@"

--- a/named-hosts/kamino/fleet.py
+++ b/named-hosts/kamino/fleet.py
@@ -71,32 +71,17 @@ def verify_machine(machine, nodes, node_ids):
         return result
     addresses = node.get("TailscaleIPs")
     try:
-        address = str(ipaddress.ip_address(addresses[0]))
+        ipaddress.ip_address(addresses[0])
     except (ValueError, TypeError, IndexError, KeyError):
         result["reason"] = "missing or invalid Tailscale IP"
         return result
     try:
-        # Connect to the observed node IP, but authenticate its declared DNS name.
-        # Do not accept new keys or reuse a previously authenticated SSH socket.
+        # Use Tailscale SSH so identity and host-key verification come from the
+        # tailnet policy rather than a client SSH key or TCP/22 daemon.
         output = run(
             [
+                "tailscale",
                 "ssh",
-                "-o",
-                "BatchMode=yes",
-                "-o",
-                "StrictHostKeyChecking=yes",
-                "-o",
-                "UpdateHostKeys=no",
-                "-o",
-                "ConnectTimeout=10",
-                "-o",
-                "ConnectionAttempts=1",
-                "-o",
-                "ControlPath=none",
-                "-o",
-                f"HostName={address}",
-                "-o",
-                f"HostKeyAlias={machine['hostname']}",
                 f"{machine['user']}@{machine['hostname']}",
                 "/bin/sh -c 'export XDG_RUNTIME_DIR=/run/user/0; "
                 "id -un && hostname && "

--- a/tests/test_kamino_fleet.py
+++ b/tests/test_kamino_fleet.py
@@ -40,20 +40,13 @@ class FleetTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             fleet.select_machines(inventory, "kamino2")
 
-    def test_strict_ssh_bound_to_observed_node_and_tools(self):
+    def test_tailscale_ssh_uses_tailnet_identity_and_tools(self):
         with patch.object(fleet, "run", return_value=self.probe) as run:
             result = fleet.verify_machines([self.machine], [self.node])[0]
         self.assertEqual(result["status"], "pass")
         self.assertEqual(result["node_id"], "node-1")
         command = run.call_args.args[0]
-        for option in [
-            "StrictHostKeyChecking=yes",
-            "BatchMode=yes",
-            "ControlPath=none",
-            "HostName=100.64.0.1",
-            "HostKeyAlias=kamino1.example.ts.net",
-        ]:
-            self.assertIn(option, command)
+        self.assertEqual(command[:3], ["tailscale", "ssh", "root@kamino1.example.ts.net"])
         for probe in [
             "herdr --version",
             "tmux -V",


### PR DESCRIPTION
## Summary
Make Tailscale SSH the managed default for all generated Kamino fleet shortcuts and verification probes.

### Tracker linkage
- Linear: none — no Linear issue exists for this dotfiles slice
- Bead: shunkakinokisoftware-ob121p

## Changes
- Generated Kamino shortcuts now invoke `tailscale ssh` for interactive, tmux, and Zellij access.
- Kamino fleet verification uses Tailscale SSH identity and host-key policy instead of client SSH keys/TCP port 22.
- The managed package includes the Tailscale client.

## Testing
- `python3 -m unittest discover -s tests -p 'test_kamino_fleet.py'` (7 passed)\n- `git diff --check`\n\n## Scope\nThis PR is draft-only and does not change host activation state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Tailscale SSH the managed default for Kamino fleet shortcuts and verification, so access relies on tailnet identity and host-key policy instead of client SSH keys and TCP port 22. Generated shortcuts now call `tailscale ssh` for interactive, tmux, and Zellij sessions, and fleet verification runs `tailscale ssh` without the previous client SSH options. The managed package now includes `pkgs.tailscale`, and SSH config sets `StrictHostKeyChecking` to `"yes"`.

<sup>Written for commit f3efa391d94bd7ec3492266351a5e520254e039c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

