### PR TITLE
fix(herdr): align hooks with managed client binary

### DIFF
--- a/config/herdr/default.nix
+++ b/config/herdr/default.nix
@@ -8,6 +8,11 @@ let
   installHerdrIntegrations = ./install-integrations.sh;
 in
 {
+  # Hooks and services must interrogate the same managed client. An explicit
+  # absolute selector prevents PATH precedence from selecting an older global
+  # Herdr binary after the package is upgraded.
+  home.sessionVariables.HERDR_BIN_PATH = "${pkgs.llm-agents.herdr}/bin/herdr";
+
   home.file.".config/herdr/config.toml" = {
     source = ./config.toml;
     force = true;

--- a/config/shared/hooks/herdr-worker-admission.py
+++ b/config/shared/hooks/herdr-worker-admission.py
@@ -2,6 +2,7 @@
 """Check local Herdr worker starts without executing the submitted command."""
 
 import json
+import os
 import re
 import shlex
 import shutil
@@ -126,10 +127,24 @@ def starts(command, depth=0, environment_changed=False):
                 )
 
 
-def probe(args):
+def herdr_binary():
+    configured = os.environ.get("HERDR_BIN_PATH")
+    if configured:
+        path = Path(configured).expanduser()
+        try:
+            if path.is_absolute() and path.is_file() and os.access(path, os.X_OK):
+                return str(path)
+        except OSError as error:
+            raise AdmissionError("configured Herdr binary is unavailable") from error
+        raise AdmissionError("configured Herdr binary is unavailable")
     binary = shutil.which("herdr")
     if binary is None:
         raise AdmissionError("Herdr metadata is unavailable")
+    return binary
+
+
+def probe(args):
+    binary = herdr_binary()
     try:
         result = subprocess.run(
             [binary, *args],

--- a/home-manager/services/herdr/default.nix
+++ b/home-manager/services/herdr/default.nix
@@ -6,6 +6,7 @@
 }:
 let
   homeDir = config.home.homeDirectory;
+  herdrBin = "${pkgs.llm-agents.herdr}/bin/herdr";
 in
 {
   launchd.agents.herdr-server = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
@@ -14,7 +15,7 @@ in
       ProgramArguments = [
         "${pkgs.bash}/bin/bash"
         "${./start.sh}"
-        "${pkgs.llm-agents.herdr}/bin/herdr"
+        herdrBin
       ];
       WorkingDirectory = homeDir;
       RunAtLoad = true;
@@ -22,6 +23,7 @@ in
       ThrottleInterval = 10;
       EnvironmentVariables = {
         HOME = homeDir;
+        HERDR_BIN_PATH = herdrBin;
         PATH = "${homeDir}/.local/bin:${homeDir}/.bun/bin:/etc/profiles/per-user/${config.home.username}/bin:${homeDir}/.nix-profile/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
       };
       StandardOutPath = "${homeDir}/.config/herdr/herdr-launchd.log";

--- a/spec/herdr_service_spec.sh
+++ b/spec/herdr_service_spec.sh
@@ -3,6 +3,7 @@ Describe 'Herdr server environment'
 SCRIPT="$PWD/home-manager/services/herdr/start.sh"
 PACKAGE_CONFIG="$PWD/home-manager/packages/default.nix"
 SERVICE_CONFIG="$PWD/home-manager/services/herdr/default.nix"
+HERDR_CONFIG="$PWD/config/herdr/default.nix"
 HOMEBREW_CONFIG="$PWD/nix-darwin/config/homebrew.nix"
 
 setup() {
@@ -48,8 +49,18 @@ The status should not be success
 End
 
 It 'launches the Nix-backed Herdr package on Darwin'
-When run grep -F '"${pkgs.llm-agents.herdr}/bin/herdr"' "$SERVICE_CONFIG"
-The output should include '"${pkgs.llm-agents.herdr}/bin/herdr"'
+When run grep -F 'herdrBin = "${pkgs.llm-agents.herdr}/bin/herdr";' "$SERVICE_CONFIG"
+The output should include 'herdrBin = "${pkgs.llm-agents.herdr}/bin/herdr";'
+End
+
+It 'exports the managed Herdr binary to hooks and services'
+When run grep -F 'HERDR_BIN_PATH = herdrBin;' "$SERVICE_CONFIG"
+The output should include 'HERDR_BIN_PATH = herdrBin;'
+End
+
+It 'exports the managed Herdr binary to interactive hooks'
+When run grep -F 'home.sessionVariables.HERDR_BIN_PATH = "${pkgs.llm-agents.herdr}/bin/herdr";' "$HERDR_CONFIG"
+The output should include 'home.sessionVariables.HERDR_BIN_PATH = "${pkgs.llm-agents.herdr}/bin/herdr";'
 End
 End
 End

--- a/spec/herdr_worker_admission_test.py
+++ b/spec/herdr_worker_admission_test.py
@@ -202,6 +202,26 @@ class WorkerAdmissionTests(unittest.TestCase):
         with self.assertRaises(admission.AdmissionError):
             admission.require_worker_worktree(self.args, read=unavailable)
 
+    def test_probe_prefers_declarative_binary_selector(self):
+        binary = self.home / "managed-herdr"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        result = subprocess.CompletedProcess([], 0, '{"result": {}}', "")
+        with patch.dict(os.environ, {"HERDR_BIN_PATH": str(binary)}), patch.object(
+            admission.subprocess, "run", return_value=result
+        ) as run:
+            self.assertEqual(admission.probe(["status", "server"]), {})
+        self.assertEqual(run.call_args.args[0][0], str(binary))
+
+    def test_invalid_declarative_binary_selector_is_refused(self):
+        with patch.dict(
+            os.environ, {"HERDR_BIN_PATH": str(self.home / "missing-herdr")}
+        ):
+            with self.assertRaisesRegex(
+                admission.AdmissionError, "configured Herdr binary"
+            ):
+                admission.probe(["status", "server"])
+
     def test_shell_commands_and_quoted_examples_are_distinguished(self):
         launch = "herdr agent start worker --kind codex --pane w1:p1"
         for command in (


### PR DESCRIPTION
Summary: honor declarative HERDR_BIN_PATH in worker admission; export the Nix-managed Herdr 0.9.0 binary to hooks and the Darwin service; add selector regression coverage. Validation: TMPDIR=/private/tmp python3 -m unittest spec/herdr_worker_admission_test.py; shellspec spec/herdr_service_spec.sh; shellcheck config/shared/hooks/security.sh home-manager/services/herdr/start.sh spec/herdr_service_spec.sh; nix eval --impure --raw .#homeConfigurations.kyber.config.home.sessionVariables.HERDR_BIN_PATH. Broader make python-test and make shell-test have unrelated baseline failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hooks and the Darwin service now use the Nix-managed Herdr binary instead of whatever `herdr` resolves to on `PATH`; previously an older global binary could win after an upgrade. Sets `HERDR_BIN_PATH` to the managed binary in the home session and launchd service, and makes the worker admission probe honor it.

**Side effect**
- If `HERDR_BIN_PATH` is set to a missing or non-executable file, worker admission fails instead of falling back to `PATH`.

<sup>Written for commit 400d2537842f3097e4edae4619fed3c8e544767f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

