### PR TITLE
feat(kamino): enable tailscale ssh authentication

### DIFF
--- a/named-hosts/kamino/default.nix
+++ b/named-hosts/kamino/default.nix
@@ -26,7 +26,9 @@ let
   tailscaleUpArgs = [
     "--hostname=${name}"
     "--accept-dns=true"
-    "--ssh=false"
+    # Use Tailscale SSH identity policy for host login; ordinary SSH keys are
+    # not the fleet authorization mechanism.
+    "--ssh=true"
   ];
   authorizedKey = pkgs.writeText "kamino-authorized-key.pub" (
     (import ../pubkeys.nix).galactica + "\n"

--- a/tests/eval.nix
+++ b/tests/eval.nix
@@ -291,7 +291,7 @@ let
         assert lib.hasInfix "tailscale kamino100" cfg.home.activation.configureKaminoTailscale.data;
         assert lib.hasInfix "--hostname=kamino100" cfg.home.activation.configureKaminoTailscale.data;
         assert lib.hasInfix "--accept-dns=true" cfg.home.activation.configureKaminoTailscale.data;
-        assert lib.hasInfix "--ssh=false" cfg.home.activation.configureKaminoTailscale.data;
+        assert lib.hasInfix "--ssh=true" cfg.home.activation.configureKaminoTailscale.data;
         assert !(cfg.systemd.user.services ? dolt);
         assert !(cfg.systemd.user.services ? dolt-federation-sync);
         assert !(cfg.systemd.user.services ? dolt-linear-sync);

--- a/tests/test_kamino_activation.py
+++ b/tests/test_kamino_activation.py
@@ -40,7 +40,7 @@ class ActivationTests(unittest.TestCase):
                     [
                         "--hostname=kamino100",
                         "--accept-dns=true",
-                        "--ssh=false",
+                        "--ssh=true",
                     ]
                 )
             result = subprocess.run(
@@ -85,7 +85,7 @@ class ActivationTests(unittest.TestCase):
         result, log = self.run_phase("tailscale")
         self.assertEqual(result.returncode, 0)
         self.assertEqual(
-            log, ["tailscale up --hostname=kamino100 --accept-dns=true --ssh=false"]
+            log, ["tailscale up --hostname=kamino100 --accept-dns=true --ssh=true"]
         )
         result, _ = self.run_phase("tailscale", fail="tailscale")
         self.assertEqual(result.returncode, 3)


### PR DESCRIPTION
## Summary
Enable Tailscale SSH authentication on managed Kamino hosts.

### Tracker linkage
- Linear: none — no Linear issue exists for this host-authentication slice
- Bead: shunkakinokisoftware-ob121p

## Changes
- Kamino activation now runs `tailscale up --ssh=true`.
- Existing Tailscale-only fleet shortcuts and verification remain the managed client path.
- Tests and Nix evaluation assert the enabled server mode.

## Testing
- Focused activation tests: 2 passed
- `CI=true NIX_CONFIG_TARGET=home make build HOST=kamino1` passed
- `git diff --check` passed

## Operator requirement
The tailnet SSH ACL policy must allow the intended operator identity to log in as root. This PR does not invent or modify tailnet ACL policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Tailscale SSH authentication on managed Kamino hosts by setting `--ssh=true` during tailscale up, replacing the previous `--ssh=false`. This allows host login via Tailscale SSH identity policy rather than ordinary SSH keys.

- The tailnet SSH ACL policy must allow the intended operator identity to log in as root; this PR does not change that policy.
- Activation tests and Nix eval assertions were updated to expect the new flag.

<sup>Written for commit 5135f8a4e5d85c8b8c1c145117ed7edeea53128e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/shunkakinoki/dotfiles/pull/2753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

